### PR TITLE
fix flakey failingExtension test

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -353,6 +353,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   "GoogleKeyCache" should "create a service account key and return the same key when called again" in {
+    implicit val patienceConfig = PatienceConfig(1 second)
     val (googleExtensions, service) = setupGoogleKeyCacheTests
 
     val defaultUserId = WorkbenchUserId("newuser")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
@@ -38,10 +38,12 @@ class StatusServiceSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
   }
 
   def failingExtension = {
-    val service = new StatusService(new MockDirectoryDAO, new NoExtensions {
+    val directoryDAO = new MockDirectoryDAO
+    runAndWait(directoryDAO.createGroup(BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, allUsersEmail)))
+
+    val service = new StatusService(directoryDAO, new NoExtensions {
       override def checkStatus: Map[Subsystems.Subsystem, Future[SubsystemStatus]] = Map(Subsystems.GoogleGroups -> Future.failed(new WorkbenchException("bad google")))
     })
-    runAndWait(service.directoryDAO.createGroup(BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, allUsersEmail)))
     service
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
@@ -3,10 +3,10 @@ package org.broadinstitute.dsde.workbench.sam.service
 import akka.actor.ActorSystem
 import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, MockDirectoryDAO}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, FreeSpec, Matchers}
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
-import org.broadinstitute.dsde.workbench.model.{WorkbenchException, WorkbenchGroup, WorkbenchEmail, WorkbenchGroupName}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException, WorkbenchGroup, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
 import org.broadinstitute.dsde.workbench.util.health.{StatusCheckResponse, SubsystemStatus, Subsystems}
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.{GoogleGroups, OpenDJ}
@@ -25,29 +25,30 @@ class StatusServiceSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
     system.terminate()
   }
 
-  def noOpenDJGroups = {
-    new StatusService(new MockDirectoryDAO, new NoExtensions {
+  private def newStatusService(directoryDAO: DirectoryDAO) = {
+    new StatusService(directoryDAO, new NoExtensions {
       override def checkStatus: Map[Subsystems.Subsystem, Future[SubsystemStatus]] = Map(Subsystems.GoogleGroups -> Future.successful(SubsystemStatus(true, None)))
     }, pollInterval = 10 milliseconds)
   }
 
-  def ok = {
-    val service = noOpenDJGroups
-    runAndWait(service.directoryDAO.createGroup(BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, allUsersEmail)))
-    service
-  }
-
-  def failingExtension = {
+  private def directoryDAOWithAllUsersGroup = {
     val directoryDAO = new MockDirectoryDAO
     runAndWait(directoryDAO.createGroup(BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, allUsersEmail)))
+    directoryDAO
+  }
 
-    val service = new StatusService(directoryDAO, new NoExtensions {
+  private def noOpenDJGroups = newStatusService(new MockDirectoryDAO)
+
+  private def ok = newStatusService(directoryDAOWithAllUsersGroup)
+
+  private def failingExtension = {
+    val service = new StatusService(directoryDAOWithAllUsersGroup, new NoExtensions {
       override def checkStatus: Map[Subsystems.Subsystem, Future[SubsystemStatus]] = Map(Subsystems.GoogleGroups -> Future.failed(new WorkbenchException("bad google")))
     })
     service
   }
 
-  def failingOpenDJ = {
+  private def failingOpenDJ = {
     val service = new StatusService(new MockDirectoryDAO {
       override def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] = Future.failed(new WorkbenchException("bad opendj"))
     }, NoExtensions)


### PR DESCRIPTION
The failingExtension test flakes sometimes saying it can't find the all users group. The fix creates the group before instantiating the status service to ensure it is there before the monitor actor starts.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
