### PR TITLE
GAWB-3049: Lock schema during boot

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SchemaLockConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SchemaLockConfig.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.workbench.sam.config
+
+/**
+  * Created by mbemis on 2/27/18.
+  */
+
+/**
+  * Schema lock configuration.
+  * @param lockSchemaOnBoot Set to false to disable schema locking altogether
+  * @param recheckTimeInterval The number of seconds to wait before retrying the lock (should be less than or equal to maxTimeToWait)
+  * @param maxTimeToWait The number of seconds to wait before giving up
+  * @param instanceId The id of the instance that is dealing with the lock
+  * @param schemaVersion The version of the schema, to be incremented each time the schema changes
+  */
+case class SchemaLockConfig(lockSchemaOnBoot: Boolean,
+                            recheckTimeInterval: Int,
+                            maxTimeToWait: Int,
+                            instanceId: String,
+                            schemaVersion: Int)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
@@ -96,4 +96,14 @@ package object config {
       config.getInt("monitor.workerCount")
     )
   }
+
+  implicit val schemaLockConfig: ValueReader[SchemaLockConfig] = ValueReader.relative { config =>
+    SchemaLockConfig(
+      config.getBoolean("lockSchemaOnBoot"),
+      config.getInt("recheckTimeInterval"),
+      config.getInt("maxTimeToWait"),
+      config.getString("instanceId"),
+      config.getInt("schemaVersion")
+    )
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectorySubjectNameSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectorySubjectNameSupport.scala
@@ -16,6 +16,7 @@ trait DirectorySubjectNameSupport extends JndiSupport {
   val peopleOu = s"ou=people,${directoryConfig.baseDn}"
   val groupsOu = s"ou=groups,${directoryConfig.baseDn}"
   val resourcesOu = s"ou=resources,${directoryConfig.baseDn}"
+  val schemaLockOu = s"ou=schemaLock,${directoryConfig.baseDn}"
 
   protected def groupDn(groupId: WorkbenchGroupIdentity) = {
     groupId match {
@@ -28,6 +29,7 @@ trait DirectorySubjectNameSupport extends JndiSupport {
   protected def petDn(petServiceAccountId: PetServiceAccountId) = s"${Attr.project}=${petServiceAccountId.project.value},${userDn(petServiceAccountId.userId)}"
   protected def resourceTypeDn(resourceTypeName: ResourceTypeName) = s"${Attr.resourceType}=${resourceTypeName.value},$resourcesOu"
   protected def resourceDn(resource: Resource) = s"${Attr.resourceId}=${resource.resourceId.value},${resourceTypeDn(resource.resourceTypeName)}"
+  protected def schemaLockDn(schemaVersion: Int) = s"schemaVersion=$schemaVersion,$schemaLockOu"
   protected def policyDn(resourceAndPolicyName: ResourceAndPolicyName): String = s"${Attr.policy}=${resourceAndPolicyName.accessPolicyName.value},${resourceDn(resourceAndPolicyName.resource)}"
 
   protected def subjectDn(subject: WorkbenchSubject) = subject match {

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -43,6 +43,14 @@ googleServices {
   }
 }
 
+schemaLock {
+  lockSchemaOnBoot = true
+  recheckTimeInterval = 5
+  maxTimeToWait = 60
+  instanceId = "sam-local"
+  schemaVersion = 1
+}
+
 petServiceAccount {
   googleProject = "my-pet-project"
   serviceAccountUsers = ["some-other-sa@test.iam.gserviceaccount.com"]

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/JndiDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/JndiDirectoryDAOSpec.scala
@@ -8,7 +8,7 @@ import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.JndiAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -21,8 +21,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
   */
 class JndiDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dao = new JndiDirectoryDAO(directoryConfig)
-  val schemaDao = new JndiSchemaDAO(directoryConfig)
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -47,6 +47,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   lazy val config = ConfigFactory.load()
   lazy val directoryConfig = config.as[DirectoryConfig]("directory")
+  lazy val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
   lazy val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
 
@@ -229,7 +230,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   private def initPetTest: (JndiDirectoryDAO, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchUserId, WorkbenchEmail, WorkbenchEmail, WorkbenchUser) = {
     val dirDAO = new JndiDirectoryDAO(directoryConfig)
-    val schemaDao = new JndiSchemaDAO(directoryConfig)
+    val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
     runAndWait(schemaDao.init())
@@ -462,7 +463,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
     implicit val patienceConfig = PatienceConfig(1 second)
     val dirDAO = new JndiDirectoryDAO(directoryConfig)
-    val schemaDao = new JndiSchemaDAO(directoryConfig)
+    val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
     runAndWait(schemaDao.init())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/JndiAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/JndiAccessPolicyDAOSpec.scala
@@ -6,9 +6,9 @@ import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.model.{WorkbenchGroup, WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroup, WorkbenchGroupName, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 
@@ -19,9 +19,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
   */
 class JndiAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dao = new JndiAccessPolicyDAO(directoryConfig)
   val dirDao = new JndiDirectoryDAO(directoryConfig)
-  val schemaDao = new JndiSchemaDAO(directoryConfig)
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -21,7 +21,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
   */
 class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig: DirectoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
-  val schemaDao = new JndiSchemaDAO(directoryConfig)
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
@@ -1,0 +1,70 @@
+package org.broadinstitute.dsde.workbench.sam.schema
+
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
+import org.broadinstitute.dsde.workbench.sam.schema.SchemaStatus.SchemaStatus
+import org.broadinstitute.dsde.workbench.sam.schema.SchemaStatus._
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.Duration
+
+/**
+  * Created by mbemis on 3/12/18.
+  */
+class JndiSchemaDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+  val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    runAndWait(schemaDao.init())
+  }
+
+  before {
+    runAndWait(schemaDao.clearDatabase())
+    runAndWait(schemaDao.createOrgUnits())
+  }
+
+  "JndiSchemaDAO" should "insert a schema version record when applying a new schema" in {
+    //First check to make sure that the schema can be applied
+    Await.result(schemaDao.readSchemaStatus(), Duration.Inf) shouldEqual Proceed
+
+    //Apply the schema for the first time
+    Await.result(schemaDao.initWithSchemaLock(), Duration.Inf)
+
+    //We've applied the schema, so if we read the status it should tell us to ignore
+    Await.result(schemaDao.readSchemaStatus(), Duration.Inf) shouldEqual Ignore
+  }
+
+  it should "not update the schema when trying to apply an out-of-date version" in {
+    val schemaLockConfigChanged = schemaLockConfig.copy(schemaVersion = schemaLockConfig.schemaVersion - 1)
+    val schemaDaoOlder = new JndiSchemaDAO(directoryConfig, schemaLockConfigChanged)
+
+    //First check to make sure that the schema can be applied
+    Await.result(schemaDaoOlder.readSchemaStatus(), Duration.Inf) shouldEqual Proceed
+
+    //Apply schema version 0 for the first time
+    Await.result(schemaDaoOlder.initWithSchemaLock(), Duration.Inf)
+
+    //Make sure it was applied
+    Await.result(schemaDaoOlder.readSchemaStatus(), Duration.Inf) shouldEqual Ignore
+
+    //First check to make sure that the schema can be applied
+    Await.result(schemaDao.readSchemaStatus(), Duration.Inf) shouldEqual Proceed
+
+    //Apply schema version 1 for the first time
+    Await.result(schemaDao.initWithSchemaLock(), Duration.Inf)
+
+    //Make sure it was applied
+    Await.result(schemaDao.readSchemaStatus(), Duration.Inf) shouldEqual Ignore
+
+    //Try to re-apply schema version 0 after we've updated to version 1
+    Await.result(schemaDaoOlder.readSchemaStatus(), Duration.Inf) shouldEqual Ignore
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -28,9 +28,10 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures with OptionValues {
 
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dirDAO = new JndiDirectoryDAO(directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
-  val schemaDao = new JndiSchemaDAO(directoryConfig)
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val resourceId = ResourceId("myNewGroup")
   private val expectedResource = Resource(ManagedGroupService.managedGroupTypeName, resourceId)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.JndiAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -23,9 +23,10 @@ import scala.util.Try
   */
 class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dirDAO = new JndiDirectoryDAO(directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
-  val schemaDao = new JndiSchemaDAO(directoryConfig)
+  val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val defaultResourceTypeActions = Set(ResourceAction("alter_policies"), ResourceAction("delete"), ResourceAction("read_policies"), ResourceAction("view"), ResourceAction("non_owner_action"))
   private val defaultResourceTypeActionPatterns = Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.delete, SamResourceActionPatterns.readPolicies, ResourceActionPattern("view"), ResourceActionPattern("non_owner_action"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, PetServiceAccountConfig}
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, PetServiceAccountConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, JndiDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, UserStatus, UserStatusDetails}
@@ -37,9 +37,10 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
   lazy val config = ConfigFactory.load()
   lazy val directoryConfig = config.as[DirectoryConfig]("directory")
+  lazy val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
   lazy val dirDAO = new JndiDirectoryDAO(directoryConfig)
-  lazy val schemaDao = new JndiSchemaDAO(directoryConfig)
+  lazy val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   var service: UserService = _
   var googleExtensions: GoogleExtensions = _


### PR DESCRIPTION
Also see https://github.com/broadinstitute/firecloud-develop/pull/1010

Note: Let Jackie know when this is being merged into dev. There is a dsp-toolbox PR that must go in with it

How this works:

- Add an entry for a schemaLock to LDAP. If it already exists, some other instance must be updating the schema so we will wait for the configured amount of time. 
- If the lock becomes available while we are still waiting, we proceed and update the schema. If it doesn't, we throw an exception. Currently this does not kill the instance (see open questions)
- After we're done updating the schema, we remove the record of the lock so other instances can do their thing

OPEN QUESTIONS:

- Should this operation block everything else? Right now we also initialize things like Google group sync. Liquibase will prevent anything else from happening until the lock is released. Perhaps this is the way we want this mechanism to behave as well.
- I still feel like there is a slight vulnerability here. Say sam101 and sam102 are deployed but then sam102 needs a redeploy for some reason. sam102 may destroy and recreate the schema while somebody is communicating with sam101. This would cause problems, no? A **solution** I can think of is to insert a new entry for each "version" of the schema and not remove it, much like the DATABASECHANGELOG table that Liquibase uses. If a second instance tries to deploy and sees that OpenDJ already has the current schema, it will bypass the operation altogether. The only downside is that it would require us to manually increment a schemaVersion integer somewhere in config or in code whenever we change the schema.

If the answer to both of these questions is "let's do them both" (and I think doing both is the right thing to do), then there is obviously a little bit more work but not much. Just want to solicit feedback before proceeding further.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
