### PR TITLE
GAWB-2529 Added route to trigger Sync of managed-group with Google

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,11 +4,11 @@ akka.http.server.request-timeout = 60 s
 resourceTypes =
   {
     managed-group = {
-      actionPatterns = ["delete", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
+      actionPatterns = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
       ownerRoleName = "admin"
       roles = {
         admin = {
-          roleActions = ["delete", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
+          roleActions = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
         },
         member = {
           roleActions = []

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -222,6 +222,32 @@ paths:
       tags:
         - Group
 
+  /api/google/group/{groupName}/sync:
+    post:
+      summary: Synchronize a managed-group with google group
+      responses:
+        200:
+          description: Successfully synchronized group
+          schema:
+            $ref: '#/definitions/SyncReport'
+        404:
+          description: Group could not be found
+          schema:
+            $ref: #/definition/ErrorReport'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      parameters:
+        - in: path
+          description: Name of group
+          name: groupName
+          required: true
+          type: string
+      operationId: syncManagedGroup
+      tags:
+        - Google
+
   /api/google/petServiceAccount/{project}/{userEmail}:
     get:
       summary: gets a key for the user's pet service account, get_pet_private_key action on cloud-extension/google required

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUser}
+import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SecurityDirectives, UserInfoDirectives}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
@@ -25,14 +25,14 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
     pathPrefix("user") {
       requireUserInfo { userInfo =>
         path("petServiceAccount") {
-          get {
+          get { // NOTE: This endpoint is not visible in Swagger
             complete {
               googleExtensions.createUserPetServiceAccount(WorkbenchUser(userInfo.userId, userInfo.userEmail)).map { petSA =>
                 StatusCodes.OK -> petSA.serviceAccount.email
               }
             }
           } ~
-          delete {
+          delete { // NOTE: This endpoint is not visible in Swagger
             complete {
               googleExtensions.deleteUserPetServiceAccount(userInfo.userId).map(_ => StatusCodes.NoContent)
             }
@@ -82,7 +82,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   }
                 }
               } ~
-              delete {
+              delete { // NOTE: This endpoint is not visible in Swagger
                 complete {
                   googleExtensions.deleteUserPetServiceAccount(userInfo.userId, GoogleProject(project)).map(_ => StatusCodes.NoContent)
                 }
@@ -98,30 +98,41 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
             }
           }
         } ~
-          pathPrefix("resource") {
-            path(Segment / Segment / Segment / "sync") { (resourceTypeName, resourceId, accessPolicyName) =>
-              val resource = Resource(ResourceTypeName(resourceTypeName), ResourceId(resourceId))
-              val resourceAndPolicyName = ResourceAndPolicyName(resource, AccessPolicyName(accessPolicyName))
-              pathEndOrSingleSlash {
-                post {
-                  complete {
-                    import GoogleModelJsonSupport._
-                    googleExtensions.synchronizeGroupMembers(resourceAndPolicyName).map { syncReport =>
-                      StatusCodes.OK -> syncReport
-                    }
+        pathPrefix("resource") {
+          path(Segment / Segment / Segment / "sync") { (resourceTypeName, resourceId, accessPolicyName) =>
+            val resource = Resource(ResourceTypeName(resourceTypeName), ResourceId(resourceId))
+            val resourceAndPolicyName = ResourceAndPolicyName(resource, AccessPolicyName(accessPolicyName))
+            pathEndOrSingleSlash {
+              post {
+                complete {
+                  import GoogleModelJsonSupport._
+                  googleExtensions.synchronizeGroupMembers(resourceAndPolicyName).map { syncReport =>
+                    StatusCodes.OK -> syncReport
                   }
-                } ~
-                get {
-                  complete {
-                    googleExtensions.getSynchronizedDate(resourceAndPolicyName).map {
-                      case Some(date) => StatusCodes.OK -> Option(GroupSyncResponse(date.toString))
-                      case None => StatusCodes.NoContent -> None
-                    }
+                }
+              } ~
+              get {
+                complete {
+                  googleExtensions.getSynchronizedDate(resourceAndPolicyName).map {
+                    case Some(date) => StatusCodes.OK -> Option(GroupSyncResponse(date.toString))
+                    case None => StatusCodes.NoContent -> None
                   }
                 }
               }
             }
           }
+        } ~
+        path("group" / Segment / "sync") { groupName =>
+          val groupId = WorkbenchGroupName(groupName)
+          post {
+            complete {
+              import GoogleModelJsonSupport._
+              googleExtensions.synchronizeGroupMembers(groupId).map { syncReport =>
+                StatusCodes.OK -> syncReport
+              }
+            }
+          }
+        }
       }
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -415,4 +415,60 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
     }
   }
 
+  "POST /api/google/group/{groupName}/sync" should "respond with a 200 when successful" in {
+    val ownerRoleName = ResourceRoleName("admin")
+    val ownerPolicyName = AccessPolicyName(ownerRoleName.value)
+    val memberPolicyName = AccessPolicyName(ManagedGroupService.memberRoleName.value)
+    val accessPolicyNames = Set(ownerPolicyName, memberPolicyName)
+    val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val resourceActions = Set(ResourceAction("delete")) union policyActions
+    val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value))
+    val defaultOwnerRole = ResourceRole(ownerRoleName, resourceActions)
+    val defaultRoles = Set(defaultOwnerRole, ResourceRole(ManagedGroupService.memberRoleName, Set.empty))
+    val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ownerRoleName)
+
+    val resourceTypes = Map(resourceType.name -> resourceType, ManagedGroupService.managedGroupTypeName -> managedGroupResourceType)
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val mockUserService = new UserService(directoryDAO, googleExt)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    val groupName = "myNewGroup"
+
+    Post(s"/api/group/$groupName") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    Get(s"/api/group/$groupName") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    Post(s"/api/google/group/$groupName/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  it should "respond with 404 when the group cannot be found" in withDefaultRoutes { samRoutes =>
+    val groupName = "totallyMadeUp"
+
+    Post(s"/api/google/group/$groupName/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
 }


### PR DESCRIPTION
NOTE! - For readability of this PR, I have it set to merge back into my branch for GAWB-2526 because this code needed to be built from the code in that branch, which has not been merged yet.  

1.  Added `"read_policies"` action to managed-group owner policy so that we can call `/api/resource/{resourceTypeName}/{resourceId}/policies` for a managed-group, which was useful in showing the policies in the managed-group and therefore confirming that the sync with google worked properly
2.  While going through the `GoogleExtensionsRoutes`, I noticed that there are a few endpoints we support that are not available in Swagger.  Not sure if this was intentional or a sign of some cleanup we can/should do?

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
