### PR TITLE
delete google groups on group (policy) deletion

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -160,6 +160,10 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
     } yield ()
   }
 
+  override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] = {
+    googleDirectoryDAO.deleteGroup(groupEmail)
+  }
+
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
   def createUserPetServiceAccount(user: WorkbenchUser): Future[PetServiceAccount] = createUserPetServiceAccount(user, petServiceAccountConfig.googleProject)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -28,6 +28,8 @@ trait CloudExtensions {
 
   def onGroupUpdate(groupIdentities: Seq[WorkbenchGroupIdentity]): Future[Unit]
 
+  def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit]
+
   def onUserCreate(user: WorkbenchUser): Future[Unit]
 
   def getUserStatus(user: WorkbenchUser): Future[Boolean]
@@ -60,6 +62,8 @@ trait NoExtensions extends CloudExtensions {
   override def onBoot(samApplication: SamApplication)(implicit system: ActorSystem): Future[Unit] = Future.successful(())
 
   override def onGroupUpdate(groupIdentities: Seq[WorkbenchGroupIdentity]): Future[Unit] = Future.successful(())
+
+  override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] = Future.successful(())
 
   override def onUserCreate(user: WorkbenchUser): Future[Unit] = Future.successful(())
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -59,6 +59,7 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
       policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource)
       _ <- Future.traverse(policiesToDelete) {accessPolicyDAO.deletePolicy}
       _ <- accessPolicyDAO.deleteResource(resource)
+      _ <- Future.traverse(policiesToDelete) { policy => cloudExtensions.onGroupDelete(policy.email) }
     } yield ()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -407,6 +407,21 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 */
   }
 
+
+  it should "do Googley stuff onGroupDelete" in {
+    val mockDirectoryDAO = mock[DirectoryDAO]
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
+    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, null, mockGoogleDirectoryDAO, null, null, null, null, googleServicesConfig, null, null)
+
+    val testPolicy = BasicWorkbenchGroup(WorkbenchGroupName("blahblahblah"), Set.empty, WorkbenchEmail(s"blahblahblah@test.firecloud.org"))
+
+    when(mockDirectoryDAO.deleteGroup(testPolicy.id)).thenReturn(Future.successful(()))
+
+    googleExtensions.onGroupDelete(testPolicy.email)
+
+    verify(mockGoogleDirectoryDAO).deleteGroup(testPolicy.email)
+  }
+
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
     implicit val patienceConfig = PatienceConfig(1 second)
     val dirDAO = new JndiDirectoryDAO(directoryConfig)


### PR DESCRIPTION
There's been some effort lately to make sure that every test that adds a user to a group also removes that user from the group, either by direct removal or group deletion. We had still been getting the dreaded "PRECONDITION_FAILED" error from Google, so clearly we missed something. After a bit of investigation I realized that we never actually delete Google groups in sam. This PR fixes that.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
