### PR TITLE
GAWB-3336 SAM /api/groups lists groups for user

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -157,6 +157,20 @@ paths:
       tags:
         - Admin
 
+  /api/groups:
+    get:
+      summary: Show all the groups the requesting user belongs to and their policy membership in each group
+      responses:
+        200:
+          description: Managed Group memberships
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      operationId: listGroupMemberships
+      tags:
+        - Group
+
   /api/group/{groupName}:
     get:
       summary: Show email address of the group

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -163,6 +163,10 @@ paths:
       responses:
         200:
           description: Managed Group memberships
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ResourceAndAccessPolicy'
         500:
           description: Internal Error
           schema:
@@ -1078,7 +1082,6 @@ definitions:
       accessPolicyName:
         type: string
         description: User's policy for the resource
-
 
   ResourceRole:
     type: object

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, _}
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.ManagedGroupPolicyName
 import spray.json.DefaultJsonProtocol._
@@ -60,7 +61,16 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
           }
         }
       }
+    } ~
+    path("groups") {
+      get {
+        handleListGroups(userInfo)
+      }
     }
+  }
+
+  def handleListGroups(userInfo: UserInfo): Route = {
+    complete(managedGroupService.listGroups(userInfo.userId).map(StatusCodes.OK -> _))
   }
 
   private def handleGetGroup(managedGroup: Resource): Route = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -87,6 +87,10 @@ class ManagedGroupService(private val resourceService: ResourceService, private 
     } yield ()
   }
 
+  def listGroups(userId: WorkbenchUserId): Future[Set[ResourceIdAndPolicyName]] = {
+    accessPolicyDAO.listAccessPolicies(ManagedGroupService.managedGroupTypeName, userId)
+  }
+
   def listPolicyMemberEmails(resourceId: ResourceId, policyName: ManagedGroupPolicyName): Future[Set[WorkbenchEmail]] = {
     val resourceAndPolicyName = ResourceAndPolicyName(Resource(ManagedGroupService.managedGroupTypeName, resourceId), policyName)
     accessPolicyDAO.loadPolicy(resourceAndPolicyName) flatMap {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -481,4 +481,27 @@ class ManagedGroupRoutesSpec extends FlatSpec with Matchers with ScalatestRouteT
       status shouldEqual StatusCodes.NotFound
     }
   }
+
+  "GET /api/groups" should "respond with 200 and a list of managed groups the authenticated user belongs to" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    val groupNames = Set("foo", "bar", "baz")
+    groupNames.foreach(assertCreateGroup(samRoutes, _))
+
+    Get("/api/groups") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val res = responseAs[String]
+      groupNames.foreach(res should include (_))
+      res should include ("admin")
+      res shouldNot include ("member")
+    }
+  }
+
+  it should "respond with 200 and an empty list if the user is not a member of any managed groups" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    Get("/api/groups") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] shouldEqual "[]"
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -46,7 +46,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def listAccessPolicies(resourceTypeName: ResourceTypeName, user: WorkbenchUserId): Future[Set[ResourceIdAndPolicyName]] = Future {
     policies.collect {
-      case (riapn@ResourceAndPolicyName(Resource(`resourceTypeName`, _), _), _) => ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
+      case (riapn@ResourceAndPolicyName(Resource(`resourceTypeName`, _), _), accessPolicy) if accessPolicy.members.contains(user) => ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
     }.toSet
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -1,0 +1,92 @@
+package org.broadinstitute.dsde.workbench.sam.openam
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.directory._
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
+import org.broadinstitute.dsde.workbench.sam.service.{ManagedGroupService, NoExtensions, ResourceService, UserService}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * Created by dvoet on 6/26/17.
+  */
+class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+  val directoryConfig: DirectoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val schemaDao = new JndiSchemaDAO(directoryConfig)
+
+  private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    runAndWait(schemaDao.init())
+  }
+
+  before {
+    runAndWait(schemaDao.clearDatabase())
+    runAndWait(schemaDao.createOrgUnits())
+  }
+
+  def sharedFixtures = new {
+    val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()
+    val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName)
+    val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val resourceActions: Set[ResourceAction] = Set(ResourceAction("delete")) union policyActions
+    val resourceActionPatterns: Set[ResourceActionPattern] = resourceActions.map(action => ResourceActionPattern(action.value))
+    val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
+    val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
+    val defaultRoles = Set(defaultOwnerRole, defaultMemberRole)
+    val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+    val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
+    val emailDomain = "example.com"
+  }
+
+  def jndiServicesFixture = new {
+    val shared = sharedFixtures
+    val jndiPolicyDao = new JndiAccessPolicyDAO(directoryConfig)
+    val jndiDirDao = new JndiDirectoryDAO(directoryConfig)
+    val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(jndiDirDao))
+
+    val resourceService = new ResourceService(shared.resourceTypes, jndiPolicyDao, jndiDirDao, NoExtensions, shared.emailDomain)
+    val userService = new UserService(jndiDirDao, NoExtensions)
+    val managedGroupService = new ManagedGroupService(resourceService, shared.resourceTypes, jndiPolicyDao, jndiDirDao, NoExtensions, shared.emailDomain)
+    shared.resourceTypes foreach {case (_, resourceType) => runAndWait(resourceService.createResourceType(resourceType)) }
+  }
+
+  def mockServicesFixture = new {
+    val shared = sharedFixtures
+    val mockDirDao = new MockDirectoryDAO(shared.groups)
+    val mockPolicyDAO = new MockAccessPolicyDAO(shared.groups)
+    val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(mockDirDao))
+
+    val resourceService = new ResourceService(shared.resourceTypes, mockPolicyDAO, mockDirDao, NoExtensions, shared.emailDomain)
+    val userService = new UserService(mockDirDao, NoExtensions)
+    val managedGroupService = new ManagedGroupService(resourceService, shared.resourceTypes, mockPolicyDAO, mockDirDao, NoExtensions, shared.emailDomain)
+  }
+
+  "JndiAccessPolicyDao and MockAccessPolicyDao" should "return the same results for the same methods" in {
+    val jndi = jndiServicesFixture
+    val mock = mockServicesFixture
+
+    val groupName = "fooGroup"
+    val intendedResource = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupName))
+    runAndWait(jndi.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUserInfo)) shouldEqual intendedResource
+    runAndWait(mock.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUserInfo)) shouldEqual intendedResource
+
+    val dummyUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
+    runAndWait(jndi.userService.createUser(dummyUser))
+    runAndWait(mock.userService.createUser(dummyUser))
+
+    val expectedGroups = Set(ResourceIdAndPolicyName(ResourceId(groupName), ManagedGroupService.adminPolicyName))
+    runAndWait(jndi.managedGroupService.listGroups(dummyUserInfo.userId)) shouldEqual expectedGroups
+    runAndWait(mock.managedGroupService.listGroups(dummyUserInfo.userId)) shouldEqual expectedGroups
+  }
+}


### PR DESCRIPTION
Found a bug in `MockAccessPolicyDao.listAccessPolicies` where it was taking in a `WorkbenchUserId` but wasn't doing anything with it.  I wrote a spec file for `MockAccessPolicyDao`, which is admittedly weird writing tests for your tests...but I identified that the `listAccessPolicies` method in `MockAccessPolicyDao` as behaving differently than the same method in `JndiAccessPolicyDao`.  Therefore, this new spec file exists for verify the behavior of the `MockAccessPolicyDao`.  

Also note that the new endpoint is `api/groups/` (plural) whereas the other group apis are `api/group/` (singular).  I think its fine, but I'm not sure if anyone else has an opinion,

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
