### PR TITLE
GAWB-3432 Attempting to fix flakey test 

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
@@ -305,7 +307,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     // Make the different users a member of some of the groups owned by the other user
     // Create some resources owned by different users
     // List Managed Group memberships for users and assert that memberships are only returned for managed groups
-    val newResourceType = managedGroupResourceType.copy(name = ResourceTypeName("somethingElse"))
+    val newResourceType = managedGroupResourceType.copy(name = ResourceTypeName(UUID.randomUUID().toString))
     makeResourceType(newResourceType)
     val resTypes = resourceTypes + (newResourceType.name -> newResourceType)
 


### PR DESCRIPTION
ResourceType created with random UUID name rather than a static string.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
