### PR TITLE
GAWB-3389 Allowing/disallowing resource ID reuse is configurable

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -29,6 +29,7 @@ resourceTypes =
           roleActions = []
         }
       }
+      reuseIds = true
     },
     workflow-collection = {
       actionPatterns = ["delete", "add", "view", "abort", "alter_policies", "read_policies"]
@@ -44,6 +45,7 @@ resourceTypes =
           roleActions = ["view", "add", "delete", "abort"]
         }
       }
+      reuseIds = false
     },
     caas = {
       actionPatterns = ["get_whitelist", "alter_policies", "read_policies"]
@@ -56,6 +58,7 @@ resourceTypes =
         roleActions = ["get_whitelist"]
        }
       }
+      reuseIds = false
     },
     billing-project = {
       actionPatterns = ["create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "stop_start_notebook_cluster", "alter_google_role", "share_policy::.+", "read_policy::.+"]
@@ -74,6 +77,7 @@ resourceTypes =
           roleActions = ["launch_notebook_cluster"]
         }
       }
+      reuseIds = false
     },
     notebook-cluster = {
       actionPatterns = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]
@@ -83,6 +87,7 @@ resourceTypes =
           roleActions = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]
         }
       }
+      reuseIds = true
     },
     cloud-extension = {
       actionPatterns = ["get_pet_private_key", "alter_policies", "read_policies"]
@@ -95,5 +100,6 @@ resourceTypes =
           roleActions = ["get_pet_private_key"]
         }
       }
+      reuseIds = false
     }
   }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -17,6 +17,7 @@ resourceTypes =
           roleActions = ["read_policy::owner", "read_policy::project-owner"]
         }
       }
+      reuseIds = false
     },
     managed-group = {
       actionPatterns = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -78,7 +78,7 @@ resourceTypes =
           roleActions = ["launch_notebook_cluster"]
         }
       }
-      reuseIds = false
+      reuseIds = true
     },
     notebook-cluster = {
       actionPatterns = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
@@ -38,7 +38,8 @@ package object config {
         ResourceTypeName(uqPath),
         config.as[Set[String]](s"$uqPath.actionPatterns").map(ResourceActionPattern),
         config.as[Map[String, ResourceRole]](s"$uqPath.roles").values.toSet,
-        ResourceRoleName(config.getString(s"$uqPath.ownerRoleName"))
+        ResourceRoleName(config.getString(s"$uqPath.ownerRoleName")),
+        config.getBoolean(s"$uqPath.reuseIds")
       )
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -21,7 +21,7 @@ object SamJsonSupport {
 
   implicit val ResourceTypeNameFormat = ValueObjectFormat(ResourceTypeName)
 
-  implicit val ResourceTypeFormat = jsonFormat4(ResourceType)
+  implicit val ResourceTypeFormat = jsonFormat5(ResourceType)
 
   implicit val UserStatusDetailsFormat = jsonFormat2(UserStatusDetails)
 
@@ -76,7 +76,7 @@ case class ResourceRole(roleName: ResourceRoleName, actions: Set[ResourceAction]
 case class ResourceTypeName(value: String) extends ValueObject
 
 case class Resource(resourceTypeName: ResourceTypeName, resourceId: ResourceId)
-case class ResourceType(name: ResourceTypeName, actionPatterns: Set[ResourceActionPattern], roles: Set[ResourceRole], ownerRoleName: ResourceRoleName)
+case class ResourceType(name: ResourceTypeName, actionPatterns: Set[ResourceActionPattern], roles: Set[ResourceRole], ownerRoleName: ResourceRoleName, reuseIds: Boolean = false)
 
 case class ResourceId(value: String) extends ValueObject
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -76,12 +76,12 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     for {
       policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource)
       _ <- Future.traverse(policiesToDelete) {accessPolicyDAO.deletePolicy}
-      _ <- attemptDeleteResource(resource)
+      _ <- maybeDeleteResource(resource)
       _ <- Future.traverse(policiesToDelete) { policy => cloudExtensions.onGroupDelete(policy.email) }
     } yield ()
   }
 
-  private def attemptDeleteResource(resource: Resource): Future[Unit] = {
+  private def maybeDeleteResource(resource: Resource): Future[Unit] = {
     resourceTypes.get(resource.resourceTypeName) match {
       case Some(resourceType) if resourceType.reuseIds => accessPolicyDAO.deleteResource(resource)
       case _ => Future.successful()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -68,13 +68,24 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     accessPolicyDAO.listAccessPolicies(resourceType.name, userInfo.userId)
   }
 
+  // IF Resource ID reuse is allowed (as defined by the Resource Type), then we can delete the resource
+  // ELSE Resource ID reuse is not allowed, and we enforce this by deleting all policies associated with the Resource,
+  //      but not the Resource itself, thereby orphaning the Resource so that it cannot be used or accessed anymore and
+  //      preventing a new Resource with the same ID from being created
   def deleteResource(resource: Resource): Future[Unit] = {
     for {
       policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource)
       _ <- Future.traverse(policiesToDelete) {accessPolicyDAO.deletePolicy}
-      _ <- accessPolicyDAO.deleteResource(resource)
+      _ <- attemptDeleteResource(resource)
       _ <- Future.traverse(policiesToDelete) { policy => cloudExtensions.onGroupDelete(policy.email) }
     } yield ()
+  }
+
+  private def attemptDeleteResource(resource: Resource): Future[Unit] = {
+    resourceTypes.get(resource.resourceTypeName) match {
+      case Some(resourceType) if resourceType.reuseIds => accessPolicyDAO.deleteResource(resource)
+      case _ => Future.successful()
+    }
   }
 
   def hasPermission(resource: Resource, action: ResourceAction, userInfo: UserInfo): Future[Boolean] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, _}
 import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -25,7 +25,8 @@ import scala.concurrent.Future
 class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSugar
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures with OptionValues {
 
-  val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  private val config = ConfigFactory.load()
+  val directoryConfig = config.as[DirectoryConfig]("directory")
   val dirDAO = new JndiDirectoryDAO(directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig)
@@ -34,18 +35,15 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   private val expectedResource = Resource(ManagedGroupService.managedGroupTypeName, resourceId)
   private val adminPolicy = ResourceAndPolicyName(expectedResource, ManagedGroupService.adminPolicyName)
   private val memberPolicy = ResourceAndPolicyName(expectedResource, ManagedGroupService.memberPolicyName)
-  private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName)
-  private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
-  private val resourceActions = Set(ResourceAction("delete")) union policyActions
-  private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value))
-  private val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
-  private val defaultRoles = Set(defaultOwnerRole, ResourceRole(ManagedGroupService.memberRoleName, Set.empty))
-  private val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName, true)
-  private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
-  private val testDomain = "example.com"
-  private val resourceService = new ResourceService(resourceTypes, policyDAO, dirDAO, NoExtensions, testDomain)
 
-  private val managedGroupService = new ManagedGroupService(resourceService, resourceTypes, policyDAO, dirDAO, NoExtensions, testDomain)
+  //Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.
+  private val resourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.toSet
+  private val resourceTypeMap = resourceTypes.map(rt => rt.name -> rt).toMap
+  private val managedGroupResourceType = resourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+  private val testDomain = "example.com"
+
+  private val resourceService = new ResourceService(resourceTypeMap, policyDAO, dirDAO, NoExtensions, testDomain)
+  private val managedGroupService = new ManagedGroupService(resourceService, resourceTypeMap, policyDAO, dirDAO, NoExtensions, testDomain)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
 
@@ -102,7 +100,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   it should "sync the new group with Google" in {
     val mockGoogleExtensions = mock[GoogleExtensions]
-    val managedGroupService = new ManagedGroupService(resourceService, resourceTypes, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
+    val managedGroupService = new ManagedGroupService(resourceService, resourceTypeMap, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
     val groupName = WorkbenchGroupName(resourceId.value)
 
     when(mockGoogleExtensions.publishGroup(groupName)).thenReturn(Future.successful(()))
@@ -160,7 +158,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     val mockGoogleExtensions = mock[GoogleExtensions]
     when(mockGoogleExtensions.onGroupDelete(groupEmail)).thenReturn(Future.successful(()))
     when(mockGoogleExtensions.publishGroup(WorkbenchGroupName(resourceId.value))).thenReturn(Future.successful(()))
-    val managedGroupService = new ManagedGroupService(resourceService, resourceTypes, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
+    val managedGroupService = new ManagedGroupService(resourceService, resourceTypeMap, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
 
     assertMakeGroup(managedGroupService = managedGroupService)
     runAndWait(managedGroupService.deleteManagedGroup(resourceId))
@@ -324,7 +322,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     // List Managed Group memberships for users and assert that memberships are only returned for managed groups
     val newResourceType = managedGroupResourceType.copy(name = ResourceTypeName("somethingElse"))
     makeResourceType(newResourceType)
-    val resTypes = resourceTypes + (newResourceType.name -> newResourceType)
+    val resTypes = resourceTypeMap + (newResourceType.name -> newResourceType)
 
     val resService = new ResourceService(resTypes, policyDAO, dirDAO, NoExtensions, testDomain)
     val mgService = new ManagedGroupService(resService, resTypes, policyDAO, dirDAO, NoExtensions, testDomain)


### PR DESCRIPTION
ManageGroups are treated special, as is the case with Managed Groups in SAM.  They have their own test, but this test does NOT use configuration defined in `reference.conf`.  Should it?  

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
