### PR TITLE
code review

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -606,6 +606,38 @@ paths:
       operationId: listResourcesAndPolicies
       tags:
         - Resources
+    post:
+      summary: Create a new resource
+      responses:
+        204:
+          description: Successfully created resource
+        400:
+          description: Invalid policies
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        409:
+          description: Resource already exists
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      parameters:
+        - in: path
+          description: Type of resource to create
+          name: resourceTypeName
+          required: true
+          type: string
+        - in: body
+          description: The details of the resource
+          name: resourceCreate
+          required: true
+          schema:
+            $ref: '#/definitions/CreateResourceRequest'
+      operationId: createResource
+      tags:
+        - Resources
 
   /api/resource/{resourceTypeName}/{resourceId}:
     delete:
@@ -632,7 +664,7 @@ paths:
       tags:
         - Resources
     post:
-      summary: Create a new resource
+      summary: Create a new resource with default owner policy
       responses:
         204:
           description: Successfully created resource
@@ -655,7 +687,7 @@ paths:
           name: resourceId
           required: true
           type: string
-      operationId: createResource
+      operationId: createResourceWithDefaults
       tags:
         - Resources
 
@@ -1020,6 +1052,21 @@ definitions:
       - person@company.com
       - group_name@company.com
       - foo@bar.com
+
+  CreateResourceRequest:
+    description: information to create a resource
+    required:
+      - resourceId
+      - policies
+    properties:
+      resourceId:
+        type: string
+        description: id of the resource to create
+      policies:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/AccessPolicyMembership'
+        description: map of initial policies to create
 
   Enabled:
     description: the status of the user's account

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -607,12 +607,12 @@ paths:
       tags:
         - Resources
     post:
-      summary: Create a new resource
+      summary: Create a new resource, cannot be used when resource type allows id reuse
       responses:
         204:
           description: Successfully created resource
         400:
-          description: Invalid policies
+          description: Invalid policies or resource type allows id reuse
           schema:
             $ref: '#/definitions/ErrorReport'
         409:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -51,6 +51,9 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
               } ~
               post {
                 entity(as[CreateResourceRequest]) { createResourceRequest =>
+                  if (resourceType.reuseIds) {
+                    throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow id reuse"))
+                  }
                   complete(resourceService.createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, userInfo).map(_ => StatusCodes.NoContent))
                 }
               }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -46,7 +46,14 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
         pathPrefix(Segment) { resourceTypeName =>
           withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
             pathEndOrSingleSlash {
-              complete(resourceService.listUserAccessPolicies(resourceType, userInfo))
+              get {
+                complete(resourceService.listUserAccessPolicies(resourceType, userInfo))
+              } ~
+              post {
+                entity(as[CreateResourceRequest]) { createResourceRequest =>
+                  complete(resourceService.createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, userInfo).map(_ => StatusCodes.NoContent))
+                }
+              }
             } ~
             pathPrefix(Segment) { resourceId =>
 
@@ -59,9 +66,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                   }
                 } ~
                 post {
-                  withOptionalEntity(as[Map[AccessPolicyName, AccessPolicyMembership]]) { policies =>
-                    complete(resourceService.createResource(resourceType, ResourceId(resourceId), policies, userInfo).map(_ => StatusCodes.NoContent))
-                  }
+                  complete(resourceService.createResource(resourceType, ResourceId(resourceId), userInfo).map(_ => StatusCodes.NoContent))
                 }
               } ~
               pathPrefix("action") {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -88,7 +88,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
 
       _ <- samApplication.resourceService.createResourceType(extensionResourceType)
 
-      _ <- samApplication.resourceService.createResource(extensionResourceType, GoogleExtensions.resourceId, policiesOpt = None, serviceAccountUserInfo) recover {
+      _ <- samApplication.resourceService.createResource(extensionResourceType, GoogleExtensions.resourceId, serviceAccountUserInfo) recover {
         case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) =>
       }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -44,6 +44,8 @@ object SamJsonSupport {
   implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry)
 
   implicit val GroupSyncResponseFormat = jsonFormat1(GroupSyncResponse)
+
+  implicit val CreateResourceRequestFormat = jsonFormat2(CreateResourceRequest)
 }
 
 object SamResourceActions {
@@ -87,6 +89,7 @@ case class ResourceAndPolicyName(resource: Resource, accessPolicyName: AccessPol
   override def toString: String = s"${accessPolicyName.value}.${resource.resourceId.value}.${resource.resourceTypeName.value}"
 }
 case class AccessPolicyName(value: String) extends ValueObject
+case class CreateResourceRequest(resourceId: ResourceId, policies: Map[AccessPolicyName, AccessPolicyMembership])
 
 /*
 Note that AccessPolicy IS A group, does not have a group. This makes the ldap query to list all a user's policies

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -27,7 +27,7 @@ class ManagedGroupService(private val resourceService: ResourceService, private 
     val adminPolicy = AccessPolicyName(adminRole.value) -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(adminRole))
 
     for {
-      managedGroup <- resourceService.createResource(managedGroupType, groupId, Option(Map(adminPolicy, memberPolicy)), userInfo)
+      managedGroup <- resourceService.createResource(managedGroupType, groupId, Map(adminPolicy, memberPolicy), userInfo)
       policies <- accessPolicyDAO.listAccessPolicies(managedGroup)
       workbenchGroup <- createAggregateGroup(managedGroup, policies)
       _ <- cloudExtensions.publishGroup(workbenchGroup.id)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -30,30 +30,38 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     accessPolicyDAO.createResourceType(resourceType.name)
   }
 
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, policiesOpt: Option[Map[AccessPolicyName, AccessPolicyMembership]] = None, userInfo: UserInfo): Future[Resource] = {
-    accessPolicyDAO.createResource(Resource(resourceType.name, resourceId)) flatMap { resource =>
-      policiesOpt match {
-        case Some(policies) =>
-          Future.traverse(policies) { case (accessPolicyName, accessPolicyMembership) =>
-            val resourceAndPolicyName = ResourceAndPolicyName(Resource(resourceType.name, resourceId), accessPolicyName)
-            val loadedSubjects = Future.traverse(accessPolicyMembership.memberEmails) { directoryDAO.loadSubjectFromEmail }.map(subjOpts => subjOpts.collect { case Some(subj) => subj })
-            val roles = accessPolicyMembership.roles
-            val actions = accessPolicyMembership.actions
+  /**
+    * Create a resource with default policies. The default policies contain 1 policy with the same name as the
+    * owner role for the resourceType, has the owner role, membership contains only userInfo
+    * @param resourceType
+    * @param resourceId
+    * @param userInfo
+    * @return
+    */
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: UserInfo): Future[Resource] = {
+    val ownerRole = resourceType.roles.find(_.roleName == resourceType.ownerRoleName).getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
+    val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(ownerRole.roleName)))
+    createResource(resourceType, resourceId, defaultPolicies, userInfo)
+  }
 
-            loadedSubjects.flatMap { subjects =>
-              createPolicy(resourceAndPolicyName, subjects, roles, actions)
-            }
-          }.map {_ => Resource(resourceType.name, resourceId)}
-
-        //if the user didn't specify policies to create, default to just creating the owner policy
-        case None =>
-          val role = resourceType.roles.find(_.roleName == resourceType.ownerRoleName).getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
-          val subjects: Set[WorkbenchSubject] = Set(userInfo.userId)
-          val resourceAndPolicyName = ResourceAndPolicyName(resource, AccessPolicyName(role.roleName.value))
-
-          createPolicy(resourceAndPolicyName, subjects, Set(role.roleName), Set.empty).map {_ => Resource(resourceType.name, resourceId)}
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, policies: Map[AccessPolicyName, AccessPolicyMembership], userInfo: UserInfo): Future[Resource] = {
+    for {
+      // validate policies first, overwritePolicy below will do this again but we do it first to avoid rollback
+      _ <- Future.traverse(policies) { case (_, policyMembership) =>
+        mapEmailsToSubjects(policyMembership.memberEmails).map { members: Map[WorkbenchEmail, Option[WorkbenchSubject]] =>
+          validatePolicy(resourceType, policyMembership, members)
+        }
       }
+
+      resource <- accessPolicyDAO.createResource(Resource(resourceType.name, resourceId))
+
+      _ <- Future.traverse(policies) { case (accessPolicyName, accessPolicyMembership) =>
+        overwritePolicy(resourceType, accessPolicyName, resource, accessPolicyMembership)
+      }
+    } yield {
+      resource
     }
+
   }
 
   def createPolicy(resourceAndPolicyName: ResourceAndPolicyName, members: Set[WorkbenchSubject], roles: Set[ResourceRoleName], actions: Set[ResourceAction]): Future[AccessPolicy] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -44,7 +44,7 @@ object TestSamRoutes {
     val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val mockUserService = new UserService(directoryDAO, NoExtensions)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
-
+    mockUserService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail))
     val allUsersGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(directoryDAO))
     TestSupport.runAndWait(googleDirectoryDAO.createGroup(allUsersGroup.id.toString, allUsersGroup.email))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -78,6 +78,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   before {
     runAndWait(schemaDao.clearDatabase())
     runAndWait(schemaDao.createOrgUnits())
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
   }
 
   "ManagedGroupService create" should "create a managed group with admin and member policies" in {
@@ -187,7 +188,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   }
 
   "ManagedGroupService listPolicyMemberEmails" should "return a list of email addresses for the groups admin policy" in {
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
     val managedGroup = assertMakeGroup()
     runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(dummyUserInfo.userEmail)
     runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.memberPolicyName)) shouldEqual Set.empty
@@ -203,7 +203,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     val dummyAdmin = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
     val otherAdmin = WorkbenchUser(WorkbenchUserId("admin2"), WorkbenchEmail("admin2@foo.test"))
     val someGroupEmail = WorkbenchEmail("someGroup@some.org")
-    runAndWait(dirDAO.createUser(dummyAdmin))
     runAndWait(dirDAO.createUser(otherAdmin))
     val managedGroup = assertMakeGroup()
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("someGroup"), Set.empty, someGroupEmail)))
@@ -248,7 +247,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   "ManagedGroupService addSubjectToPolicy" should "successfully add the subject to the existing policy for the group" in {
     val adminUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
-    runAndWait(dirDAO.createUser(adminUser))
 
     val managedGroup = assertMakeGroup()
 
@@ -264,7 +262,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   it should "succeed without changing if the email address is already in the policy" in {
     val adminUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
-    runAndWait(dirDAO.createUser(adminUser))
 
     val managedGroup = assertMakeGroup()
 
@@ -277,7 +274,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   // The correct behavior is enforced in the routing, but is that the right place?  Should it be enforced in the Service class?
   it should "succeed even if the subject is doesn't exist" in {
     val adminUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
-    runAndWait(dirDAO.createUser(adminUser))
 
     val managedGroup = assertMakeGroup()
 
@@ -289,7 +285,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   "ManagedGroupService removeSubjectFromPolicy" should "successfully remove the subject from the policy for the group" in {
     val adminUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
-    runAndWait(dirDAO.createUser(adminUser))
 
     val managedGroup = assertMakeGroup()
 
@@ -302,7 +297,6 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   it should "not do anything if the subject is not a member of the policy" in {
     val adminUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
-    runAndWait(dirDAO.createUser(adminUser))
 
     val managedGroup = assertMakeGroup()
 
@@ -313,7 +307,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(adminUser.email)
   }
 
-  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: UserInfo): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, None, userInfo))
+  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: UserInfo): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, userInfo))
 
   "ManagedGroupService listGroups" should "return the list of groups that passed user belongs to" in {
     // Setup multiple managed groups owned by different users.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -39,12 +39,13 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     runAndWait(schemaDao.init())
   }
 
+  private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
+
   before {
     runAndWait(schemaDao.clearDatabase())
     runAndWait(schemaDao.createOrgUnits())
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
   }
-
-  private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
 
   def toEmail(resourceType: String, resourceName: String, policyName: String) = {
     WorkbenchEmail("policy-randomuuid@example.com")
@@ -63,7 +64,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
     runAndWait(service.createResourceType(defaultResourceType))
 
-    runAndWait(service.createResource(defaultResourceType, resourceName, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUserInfo))
 
     assertResult(constructExpectedPolicies(defaultResourceType, resource)) {
       runAndWait{policyDAO.listAccessPolicies(resource)}.map(_.copy(email=WorkbenchEmail("policy-randomuuid@example.com")))
@@ -82,12 +83,10 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resourceName1 = ResourceId("resource1")
     val resourceName2 = ResourceId("resource2")
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
-
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resourceName1, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resourceName1, dummyUserInfo))
 
-    val policies2 = runAndWait(service.createResource(defaultResourceType, resourceName2, None, dummyUserInfo))
+    val policies2 = runAndWait(service.createResource(defaultResourceType, resourceName2, dummyUserInfo))
 
     runAndWait(policyDAO.createPolicy(AccessPolicy(ResourceAndPolicyName(policies2, AccessPolicyName(otherRoleName.value)), Set(dummyUserInfo.userId), WorkbenchEmail("a@b.c"), Set(otherRoleName), Set.empty)))
 
@@ -107,13 +106,12 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   it should "list the user's actions for a resource with nested groups" in {
     val resourceName1 = ResourceId("resource1")
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
     val user = runAndWait(dirDAO.createUser(WorkbenchUser(WorkbenchUserId("asdfawefawea"), WorkbenchEmail("asdfawefawea@foo.bar"))))
     val group = BasicWorkbenchGroup(WorkbenchGroupName("g"), Set(user.id), WorkbenchEmail("foo@bar.com"))
     runAndWait(dirDAO.createGroup(group))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    val resource = runAndWait(service.createResource(defaultResourceType, resourceName1, None, dummyUserInfo))
+    val resource = runAndWait(service.createResource(defaultResourceType, resourceName1, dummyUserInfo))
     val nonOwnerAction = ResourceAction("non_owner_action")
     runAndWait(service.overwritePolicy(defaultResourceType, AccessPolicyName("new_policy"), resource, AccessPolicyMembership(Set(group.email), Set(nonOwnerAction), Set.empty)))
 
@@ -131,13 +129,12 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resourceName = ResourceId("resource")
 
     runAndWait(service.createResourceType(resourceType))
-    runAndWait(service.createResource(resourceType, resourceName, None, dummyUserInfo))
+    runAndWait(service.createResource(resourceType, resourceName, dummyUserInfo))
 
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(service.createResource(
         resourceType,
         resourceName,
-        None,
         dummyUserInfo
       ))
     }
@@ -149,10 +146,8 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resourceName = ResourceId("resource")
     val resource = Resource(defaultResourceType.name, resourceName)
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
-
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resourceName, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUserInfo))
 
     val roles = runAndWait(service.listUserResourceRoles(resource, dummyUserInfo))
 
@@ -163,8 +158,6 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val ownerRoleName = ResourceRoleName("owner")
     val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("a1")), Set(ResourceRole(ownerRoleName, Set(ResourceAction("a1")))), ownerRoleName)
     val resourceName = ResourceId("resource")
-
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
 
     val roles = runAndWait(service.listUserResourceRoles(Resource(resourceType.name, resourceName), dummyUserInfo))
 
@@ -177,7 +170,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val policies = runAndWait(policyDAO.listAccessPolicies(resource)).map(_.copy(email=WorkbenchEmail("policy-randomuuid@example.com")))
 
@@ -188,24 +181,23 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
     val ownerRole = defaultResourceType.roles.find(_.roleName == defaultResourceType.ownerRoleName).get
     val forcedEmail = WorkbenchEmail("policy-randomuuid@example.com")
-    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set.empty, Set.empty, Set(ownerRole.roleName)), forcedEmail)
+    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(ownerRole.roleName)), forcedEmail)
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val policies = runAndWait(service.listResourcePolicies(resource)).map(_.copy(email = forcedEmail))
     policies shouldEqual Set(expectedPolicy)
   }
 
-  "listResourcePolicies" should "list policies for a newly created resource with the member email addresses if the User has been added" in {
+  it should "list policies for a newly created resource with the member email addresses if the User has been added" in {
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
     val ownerRole = defaultResourceType.roles.find(_.roleName == defaultResourceType.ownerRoleName).get
     val forcedEmail = WorkbenchEmail("policy-randomuuid@example.com")
     val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(ownerRole.roleName)), forcedEmail)
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val policies = runAndWait(service.listResourcePolicies(resource)).map(_.copy(email = forcedEmail))
     policies shouldEqual Set(expectedPolicy)
@@ -215,7 +207,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("non_owner_action")))
@@ -232,7 +224,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(rt.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(rt))
-    runAndWait(service.createResource(rt, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(rt, resource.resourceId, dummyUserInfo))
 
     val actions = Set(ResourceAction("foo-bang-bar"))
     val newPolicy = runAndWait(service.overwritePolicy(rt, AccessPolicyName("foo"), resource, AccessPolicyMembership(Set.empty, actions, Set.empty)))
@@ -250,7 +242,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("INVALID_ACTION")))
@@ -271,7 +263,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(rt.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(rt))
-    runAndWait(service.createResource(rt, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(rt, resource.resourceId, dummyUserInfo))
 
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(service.overwritePolicy(rt, AccessPolicyName("foo"), resource, AccessPolicyMembership(Set.empty, Set(ResourceAction("foo--bar")), Set.empty)))
@@ -284,7 +276,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName("foo")), group.members, group.email, Set(ResourceRoleName("INVALID_ROLE")), Set.empty)
@@ -304,7 +296,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("non_owner_action")))
@@ -324,7 +316,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource = Resource(defaultResourceType.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     assert(runAndWait(policyDAO.listAccessPolicies(resource)).nonEmpty)
 
@@ -339,11 +331,11 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     defaultResourceType.reuseIds shouldEqual false
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
     runAndWait(service.deleteResource(resource))
 
     val err = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+      runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
     }
     err.getMessage should include ("resource of this type and name already exists")
   }
@@ -357,13 +349,13 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
     val resource = Resource(reusableResourceType.name, ResourceId("my-resource"))
 
-    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUserInfo))
     runAndWait(policyDAO.listAccessPolicies(resource)) should not be empty
 
     runAndWait(localService.deleteResource(resource))
     runAndWait(policyDAO.listAccessPolicies(resource)) shouldBe empty
 
-    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUserInfo))
     runAndWait(policyDAO.listAccessPolicies(resource)) should not be empty
   }
 
@@ -373,15 +365,13 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val resource3 = Resource(otherResourceType.name, ResourceId("my-resource1"))
     val resource4 = Resource(otherResourceType.name, ResourceId("my-resource2"))
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
-
     runAndWait(service.createResourceType(defaultResourceType))
     runAndWait(service.createResourceType(otherResourceType))
 
-    runAndWait(service.createResource(defaultResourceType, resource1.resourceId, None, dummyUserInfo))
-    runAndWait(service.createResource(defaultResourceType, resource2.resourceId, None, dummyUserInfo))
-    runAndWait(service.createResource(otherResourceType, resource3.resourceId, None, dummyUserInfo))
-    runAndWait(service.createResource(otherResourceType, resource4.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource1.resourceId, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource2.resourceId, dummyUserInfo))
+    runAndWait(service.createResource(otherResourceType, resource3.resourceId, dummyUserInfo))
+    runAndWait(service.createResource(otherResourceType, resource4.resourceId, dummyUserInfo))
 
     runAndWait(service.overwritePolicy(defaultResourceType, AccessPolicyName("in-it"), resource1, AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("alter_policies")), Set.empty)))
     runAndWait(service.overwritePolicy(defaultResourceType, AccessPolicyName("not-in-it"), resource1, AccessPolicyMembership(Set.empty, Set(ResourceAction("alter_policies")), Set.empty)))
@@ -398,11 +388,10 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val policyName = AccessPolicyName(defaultResourceType.ownerRoleName.value)
     val otherUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("otheruserid"), WorkbenchEmail("otheruser@company.com"), 0)
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
     runAndWait(dirDAO.createUser(WorkbenchUser(otherUserInfo.userId, otherUserInfo.userEmail)))
 
     runAndWait(service.createResourceType(defaultResourceType))
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, None, dummyUserInfo))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))
 
     // assert baseline
     assertResult(Set.empty) {


### PR DESCRIPTION
I made the changes to create resource we talked about including validating that the incoming policies are valid. This validates even the default policy we make. And it turns out that our tests have been making invalid policies because the calling user does not exist yet. So I centralized the creation of the default user.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
