### PR TITLE
GAWB-3568 ActionPatterns described as objects

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,106 +1,246 @@
 akka.http.server.idle-timeout = 180 s
 akka.http.server.request-timeout = 60 s
 
-resourceTypes =
-  {
-    workspace = {
-      actionPatterns = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "read_policy::owner", "read_policy::project-owner"]
-      ownerRoleName = "owner"
-      roles = {
-        owner = {
-          roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "read_policy::project-owner"]
-        },
-        writer = {
-          roleActions = ["read_policy::owner", "read_policy::project-owner"]
-        },
-        reader = {
-          roleActions = ["read_policy::owner", "read_policy::project-owner"]
-        }
+resourceTypes = {
+  workspace = {
+    actionPatterns = {
+      delete = {
+        description = "Delete this workspace"
       }
-      reuseIds = false
-    },
-    managed-group = {
-      actionPatterns = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
-      ownerRoleName = "admin"
-      roles = {
-        admin = {
-          roleActions = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
-        },
-        member = {
-          roleActions = []
-        }
+      read_policies = {
+        description = "View all policies and policy details for this workspace"
       }
-      reuseIds = true
-    },
-    workflow-collection = {
-      actionPatterns = ["delete", "add", "view", "abort", "update", "alter_policies", "read_policies"]
-      ownerRoleName = "owner"
-      roles = {
-        owner = {
-          roleActions = ["delete", "add", "view", "abort", "update", "alter_policies", "read_policies"]
-        },
-        reader = {
-          roleActions = ["view"]
-        },
-        writer = {
-          roleActions = ["view", "add", "delete", "abort", "update"]
-        }
+      "share_policy::owner" = {
+        description = "Add/remove members to/from the owner policy for this workspace"
       }
-      reuseIds = false
-    },
-    caas = {
-      actionPatterns = ["get_whitelist", "alter_policies", "read_policies"]
-      ownerRoleName = "owner"
-      roles = {
-       owner = {
-        roleActions = ["alter_policies", "read_policies"]
-       },
-       cromiam = {
-        roleActions = ["get_whitelist"]
-       }
+      "share_policy::writer" = {
+        description = "Add/remove members to/from the writer policy for this workspace"
       }
-      reuseIds = false
-    },
-    billing-project = {
-      actionPatterns = ["create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "stop_start_notebook_cluster", "alter_google_role", "share_policy::.+", "read_policy::.+"]
-      ownerRoleName = "owner"
-      roles = {
-        owner = {
-          roleActions = ["create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "alter_google_role"]
-        },
-        workspace-creator = {
-          roleActions = ["create_workspace", "share_policy::can-compute-user", "read_policy::can-compute-user"]
-        },
-        batch-compute-user = {
-          roleActions = ["launch_batch_compute"]
-        },
-        notebook-user = {
-          roleActions = ["launch_notebook_cluster"]
-        }
+      "share_policy::reader" = {
+        description = "Add/remove members to/from the reader policy for this workspace"
       }
-      reuseIds = true
-    },
-    notebook-cluster = {
-      actionPatterns = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]
-      ownerRoleName = "creator"
-      roles = {
-        creator = {
-          roleActions = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]
-        }
+      "read_policy::owner" = {
+        description = "View the details of the owner policy for this workspace"
       }
-      reuseIds = true
-    },
-    cloud-extension = {
-      actionPatterns = ["get_pet_private_key", "alter_policies", "read_policies"]
-      ownerRoleName = "owner"
-      roles = {
-        owner = {
-          roleActions = ["alter_policies", "read_policies"]
-        },
-        google = {
-          roleActions = ["get_pet_private_key"]
-        }
+      "read_policy::project-owner" = {
+        description = "View the details of the project-owner policy for this workspace"
       }
-      reuseIds = false
     }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "read_policy::project-owner"]
+      },
+      writer = {
+        roleActions = ["read_policy::owner", "read_policy::project-owner"]
+      },
+      reader = {
+        roleActions = ["read_policy::owner", "read_policy::project-owner"]
+      }
+    }
+    reuseIds = false
   }
+  managed-group = {
+    actionPatterns = {
+      delete = {
+        description = "Delete this group"
+      }
+      read_policies = {
+        description = "View all policies and policy details for this group"
+      }
+      "share_policy::admin" = {
+        description = "Add/remove members to/from the admin policy for this group"
+      }
+      "share_policy::member" = {
+        description = "Add/remove members to/from the member policy for this group"
+      }
+      "read_policy::admin" = {
+        # Doug Said this may be redundant with "read_policies" and could be removed
+        description = "View the details of the admin policy for this group"
+      }
+      "read_policy::member" = {
+        # Doug Said this may be redundant with "read_policies" and could be removed
+        description = "View the details of the member policy for this group"
+      }
+    }
+    ownerRoleName = "admin"
+    roles = {
+      admin = {
+        roleActions = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
+      },
+      member = {
+        roleActions = []
+      }
+    }
+    reuseIds = true
+  }
+  workflow-collection = {
+    actionPatterns = {
+      delete = {
+        description = "Delete this workflow-collection"
+      }
+      add = {
+        description = ""
+      }
+      view = {
+        description = ""
+      }
+      abort = {
+        description = ""
+      }
+      update = {
+        description = ""
+      }
+      alter_policies = {
+        description = "Create and delete policies on this workflow-collection"
+      }
+      read_policies = {
+        description = "View all policies and policy details for this workflow-collection"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "add", "view", "abort", "update", "alter_policies", "read_policies"]
+      },
+      reader = {
+        roleActions = ["view"]
+      },
+      writer = {
+        roleActions = ["view", "add", "delete", "abort", "update"]
+      }
+    }
+    reuseIds = false
+  }
+  caas = {
+    actionPatterns = {
+      get_whitelist = {
+        description = ""
+      }
+      alter_policies = {
+        description = "Create and delete policies for this caas"
+      }
+      read_policies = {
+        description = "View all policies and policy details for this caas"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["alter_policies", "read_policies"]
+      },
+      cromiam = {
+        roleActions = ["get_whitelist"]
+      }
+    }
+    reuseIds = false
+  }
+  billing-project = {
+    actionPatterns = {
+      create_workspace = {
+        description = "Create new workspaces in this billing-project"
+      }
+      alter_policies = {
+        description = "Create and delete policies for this billing-project"
+      }
+      read_policies = {
+        description = "List all policies and policy details for this billing-project"
+      }
+      launch_batch_compute = {
+        description = ""
+      }
+      list_notebook_cluster = {
+        description = ""
+      }
+      launch_notebook_cluster = {
+        description = ""
+      }
+      sync_notebook_cluster = {
+        description = ""
+      }
+      delete_notebook_cluster = {
+        description = ""
+      }
+      stop_start_notebook_cluster = {
+        description = ""
+      }
+      alter_google_role = {
+        description = ""
+      }
+      "share_policy::.+" = {
+        description = ""
+      }
+      "read_policy::.+" = {
+        description = ""
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "alter_google_role"]
+      },
+      workspace-creator = {
+        roleActions = ["create_workspace", "share_policy::can-compute-user", "read_policy::can-compute-user"]
+      },
+      batch-compute-user = {
+        roleActions = ["launch_batch_compute"]
+      },
+      notebook-user = {
+        roleActions = ["launch_notebook_cluster"]
+      }
+    }
+    reuseIds = true
+  }
+  notebook-cluster = {
+    actionPatterns = {
+      status = {
+        description = ""
+      }
+      connect = {
+        description = ""
+      }
+      sync = {
+        description = ""
+      }
+      delete = {
+        description = ""
+      }
+      read_policies = {
+        description = ""
+      }
+      stop_start = {
+        description = ""
+      }
+    }
+    ownerRoleName = "creator"
+    roles = {
+      creator = {
+        roleActions = ["status", "connect", "sync", "delete", "read_policies", "stop_start"]
+      }
+    }
+    reuseIds = true
+  }
+  cloud-extension = {
+    actionPatterns = {
+      get_pet_private_key = {
+        description = ""
+      }
+      alter_policies = {
+        description = ""
+      }
+      read_policies = {
+        description = ""
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["alter_policies", "read_policies"]
+      },
+      google = {
+        roleActions = ["get_pet_private_key"]
+      }
+    }
+    reuseIds = false
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -80,16 +80,16 @@ resourceTypes = {
         description = "Delete this workflow-collection"
       }
       add = {
-        description = ""
+        description = "Add workflows to this workflow-collection"
       }
       view = {
-        description = ""
+        description = "List workflows and workflow details in this workflow-collection"
       }
       abort = {
-        description = ""
+        description = "Abort any workflow in this workflow-collection"
       }
       update = {
-        description = ""
+        description = "Update any workflow in this workflow-collection"
       }
       alter_policies = {
         description = "Create and delete policies on this workflow-collection"
@@ -115,7 +115,7 @@ resourceTypes = {
   caas = {
     actionPatterns = {
       get_whitelist = {
-        description = ""
+        description = "View the whitelist"
       }
       alter_policies = {
         description = "Create and delete policies for this caas"
@@ -147,7 +147,7 @@ resourceTypes = {
         description = "List all policies and policy details for this billing-project"
       }
       launch_batch_compute = {
-        description = ""
+        description = "Launch workflows in this billing-project"
       }
       list_notebook_cluster = {
         description = ""
@@ -162,16 +162,16 @@ resourceTypes = {
         description = ""
       }
       stop_start_notebook_cluster = {
-        description = ""
+        description = "Stop and start notebook clusters in this billing-project"
       }
       alter_google_role = {
-        description = ""
+        description = "Modify the role of users on the google project (only a fixed set of roles are permitted)"
       }
       "share_policy::.+" = {
-        description = ""
+        description = "Modify the membership of the specified policy"
       }
       "read_policy::.+" = {
-        description = ""
+        description = "View the membership of the specified policy"
       }
     }
     ownerRoleName = "owner"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,25 +5,25 @@ resourceTypes = {
   workspace = {
     actionPatterns = {
       delete = {
-        description = "Delete this workspace"
+        description = "delete this workspace"
       }
       read_policies = {
-        description = "View all policies and policy details for this workspace"
+        description = "view all policies and policy details for this workspace"
       }
       "share_policy::owner" = {
-        description = "Add/remove members to/from the owner policy for this workspace"
+        description = "change the membership of the owner policy for this workspace"
       }
       "share_policy::writer" = {
-        description = "Add/remove members to/from the writer policy for this workspace"
+        description = "change the membership of the writer policy for this workspace"
       }
       "share_policy::reader" = {
-        description = "Add/remove members to/from the reader policy for this workspace"
+        description = "change the membership of the reader policy for this workspace"
       }
       "read_policy::owner" = {
-        description = "View the details of the owner policy for this workspace"
+        description = "view the details of the owner policy for this workspace"
       }
       "read_policy::project-owner" = {
-        description = "View the details of the project-owner policy for this workspace"
+        description = "view the details of the project-owner policy for this workspace"
       }
     }
     ownerRoleName = "owner"
@@ -46,21 +46,21 @@ resourceTypes = {
         description = "Delete this group"
       }
       read_policies = {
-        description = "View all policies and policy details for this group"
+        description = "view all policies and policy details for this group"
       }
       "share_policy::admin" = {
-        description = "Add/remove members to/from the admin policy for this group"
+        description = "add/remove members to/from the admin policy for this group"
       }
       "share_policy::member" = {
-        description = "Add/remove members to/from the member policy for this group"
+        description = "add/remove members to/from the member policy for this group"
       }
       "read_policy::admin" = {
         # Doug Said this may be redundant with "read_policies" and could be removed
-        description = "View the details of the admin policy for this group"
+        description = "view the details of the admin policy for this group"
       }
       "read_policy::member" = {
         # Doug Said this may be redundant with "read_policies" and could be removed
-        description = "View the details of the member policy for this group"
+        description = "view the details of the member policy for this group"
       }
     }
     ownerRoleName = "admin"
@@ -77,25 +77,25 @@ resourceTypes = {
   workflow-collection = {
     actionPatterns = {
       delete = {
-        description = "Delete this workflow-collection"
+        description = "delete this workflow-collection"
       }
       add = {
-        description = "Add workflows to this workflow-collection"
+        description = "add workflows to this workflow-collection"
       }
       view = {
-        description = "List workflows and workflow details in this workflow-collection"
+        description = "list workflows and workflow details in this workflow-collection"
       }
       abort = {
-        description = "Abort any workflow in this workflow-collection"
+        description = "abort any workflow in this workflow-collection"
       }
       update = {
-        description = "Update any workflow in this workflow-collection"
+        description = "update any workflow in this workflow-collection"
       }
       alter_policies = {
-        description = "Create and delete policies on this workflow-collection"
+        description = "create and delete policies on this workflow-collection"
       }
       read_policies = {
-        description = "View all policies and policy details for this workflow-collection"
+        description = "view all policies and policy details for this workflow-collection"
       }
     }
     ownerRoleName = "owner"
@@ -115,13 +115,13 @@ resourceTypes = {
   caas = {
     actionPatterns = {
       get_whitelist = {
-        description = "View the whitelist"
+        description = "view the whitelist"
       }
       alter_policies = {
-        description = "Create and delete policies for this caas"
+        description = "create and delete policies for this caas"
       }
       read_policies = {
-        description = "View all policies and policy details for this caas"
+        description = "view all policies and policy details for this caas"
       }
     }
     ownerRoleName = "owner"
@@ -138,22 +138,22 @@ resourceTypes = {
   billing-project = {
     actionPatterns = {
       create_workspace = {
-        description = "Create new workspaces in this billing-project"
+        description = "create new workspaces in this billing-project"
       }
       alter_policies = {
-        description = "Create and delete policies for this billing-project"
+        description = "create and delete policies for this billing-project"
       }
       read_policies = {
-        description = "List all policies and policy details for this billing-project"
+        description = "list all policies and policy details for this billing-project"
       }
       launch_batch_compute = {
-        description = "Launch workflows in this billing-project"
+        description = "launch workflows in this billing-project"
       }
       list_notebook_cluster = {
-        description = ""
+        description = "list all notebook clusters in this billing-project"
       }
       launch_notebook_cluster = {
-        description = ""
+        description = "launch a new notebook cluster in this billing-project"
       }
       sync_notebook_cluster = {
         description = ""
@@ -162,16 +162,16 @@ resourceTypes = {
         description = ""
       }
       stop_start_notebook_cluster = {
-        description = "Stop and start notebook clusters in this billing-project"
+        description = "stop and start notebook clusters in this billing-project"
       }
       alter_google_role = {
-        description = "Modify the role of users on the google project (only a fixed set of roles are permitted)"
+        description = "modify the role of users on the google project (only a fixed set of roles are permitted)"
       }
       "share_policy::.+" = {
-        description = "Modify the membership of the specified policy"
+        description = "modify the membership of the specified policy"
       }
       "read_policy::.+" = {
-        description = "View the membership of the specified policy"
+        description = "view the membership of the specified policy"
       }
     }
     ownerRoleName = "owner"
@@ -194,22 +194,22 @@ resourceTypes = {
   notebook-cluster = {
     actionPatterns = {
       status = {
-        description = ""
+        description = "view notebook cluster status details and configuration"
       }
       connect = {
-        description = ""
+        description = "connect to the Jupyter notebook running on the notebook cluster"
       }
       sync = {
-        description = ""
+        description = "sync files to/from the notebook cluster VMs"
       }
       delete = {
-        description = ""
+        description = "delete the notebook cluster"
       }
       read_policies = {
-        description = ""
+        description = "view all policies and policy details for the notebook cluster"
       }
       stop_start = {
-        description = ""
+        description = "stop and start the notebook cluster VMs"
       }
     }
     ownerRoleName = "creator"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -57,15 +57,6 @@ object SamResourceActions {
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")
 }
 
-object SamResourceActionPatterns {
-  val readPolicies = ResourceActionPattern("read_policies", "", false)
-  val alterPolicies = ResourceActionPattern("alter_policies", "", false)
-  val delete = ResourceActionPattern("delete", "", false)
-  
-  val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
-  val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
-}
-
 case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API
 case class UserStatus(userInfo: UserStatusDetails, enabled: Map[String, Boolean])
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -11,7 +11,7 @@ object SamJsonSupport {
   import DefaultJsonProtocol._
   import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
-  implicit val ResourceActionPatternFormat = ValueObjectFormat(ResourceActionPattern)
+  implicit val ResourceActionPatternFormat = jsonFormat3(ResourceActionPattern)
 
   implicit val ResourceActionFormat = ValueObjectFormat(ResourceAction)
 
@@ -58,20 +58,19 @@ object SamResourceActions {
 }
 
 object SamResourceActionPatterns {
-  val readPolicies = ResourceActionPattern("read_policies")
-  val alterPolicies = ResourceActionPattern("alter_policies")
-  val delete = ResourceActionPattern("delete")
+  val readPolicies = ResourceActionPattern("read_policies", "", false)
+  val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+  val delete = ResourceActionPattern("delete", "", false)
   
-  val sharePolicy = ResourceActionPattern("share_policy::.+")
-  val readPolicy = ResourceActionPattern("read_policy::.+")
+  val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+  val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
 }
 
 case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API
 case class UserStatus(userInfo: UserStatusDetails, enabled: Map[String, Boolean])
 
-case class ResourceActionPattern(value: String) extends ValueObject {
-  lazy val regex = value.r
-  def matches(other: ResourceAction) = regex.pattern.matcher(other.value).matches()
+case class ResourceActionPattern(value: String, description: String, authDomainConstrained: Boolean) {
+  def matches(other: ResourceAction) = value.r.pattern.matcher(other.value).matches()
 }
 case class ResourceAction(value: String) extends ValueObject
 case class ResourceRoleName(value: String) extends ValueObject

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -47,3 +47,29 @@ petServiceAccount {
   googleProject = "my-pet-project"
   serviceAccountUsers = ["some-other-sa@test.iam.gserviceaccount.com"]
 }
+
+testStuff = {
+  resourceTypes = {
+    testType = {
+      actionPatterns = {
+        alter_policies = {
+          description = ""
+          authDomainConstrained = true
+        }
+        read_policies = {
+          description = ""
+        }
+      }
+      ownerRoleName = "owner"
+      roles = {
+        owner = {
+          roleActions = ["alter_policies", "read_policies"]
+        },
+        nonOwner = {
+          roleActions = []
+        }
+      }
+      reuseIds = false
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -20,7 +20,7 @@ class ManagedGroupRoutesSpec extends FlatSpec with Matchers with ScalatestRouteT
   private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName)
   private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
   private val resourceActions = Set(ResourceAction("delete")) union policyActions
-  private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value))
+  private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
   private val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
   private val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
   private val defaultRoles = Set(defaultOwnerRole, defaultMemberRole)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -56,7 +56,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "POST /api/resource/{resourceType}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))))
@@ -71,7 +71,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "400 when resource type allows id reuse" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))))
@@ -81,7 +81,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "POST /api/resource/{resourceType}/{resourceId}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -96,7 +96,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/roles" should "200 on list resource roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -110,7 +110,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "404 on list resource roles when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resource/doesntexist/foo/roles") ~> samRoutes.route ~> check {
@@ -204,7 +204,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "PUT /api/resource/{resourceType}/{resourceId}/policies/{policyName}" should "201 on a new policy being created for a resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -223,7 +223,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "201 on a policy being updated" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -248,7 +248,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "400 on a policy being created with invalid actions" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -270,7 +270,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "400 on a policy being created with invalid roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -292,7 +292,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "400 on a policy being created with invalid member emails" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -314,7 +314,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "403 when creating a policy on a resource when the user doesn't have alter_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val members = AccessPolicyMembership(Set(WorkbenchEmail("me@me.me")), Set(ResourceAction("can_compute")), Set.empty)
 
@@ -338,7 +338,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0))
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
@@ -355,7 +355,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/policies" should "200 when listing policies for a resource and user has read_policies permission" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     //Create a resource
@@ -370,7 +370,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "403 when listing policies for a resource and user lacks read_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     //Create a resource that doesn't have the read_policies action on any roles
@@ -394,7 +394,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "404 when listing policies for a resource when user can't see the resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0))
 
@@ -478,7 +478,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
   }
 
   "GET /api/resource/{resourceType}" should "200" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     //Create a resource
@@ -532,7 +532,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   it should "400 adding unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
 
@@ -562,7 +562,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   it should "404 adding without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
 
@@ -577,7 +577,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   "DELETE /api/resource/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 deleting a member" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
 
@@ -594,7 +594,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   it should "204 deleting a member with can share" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
 
@@ -611,7 +611,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   it should "400 deleting unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
 
@@ -645,7 +645,7 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   it should "404 removing without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -23,6 +23,15 @@ class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest 
 
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
 
+  private object SamResourceActionPatterns {
+    val readPolicies = ResourceActionPattern("read_policies", "", false)
+    val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+    val delete = ResourceActionPattern("delete", "", false)
+
+    val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+    val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
+  }
+
   private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo) = {
     val accessPolicyDAO = new MockAccessPolicyDAO()
     val directoryDAO = new MockDirectoryDAO()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -140,6 +140,15 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
     }
   }
 
+  private object SamResourceActionPatterns {
+    val readPolicies = ResourceActionPattern("read_policies", "", false)
+    val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+    val delete = ResourceActionPattern("delete", "", false)
+
+    val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+    val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
+  }
+
   private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
   private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -140,8 +140,8 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
     }
   }
 
-  private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute"), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
-  private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute"), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+  private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+  private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
 
   "POST /api/google/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
     val resourceTypes = Map(resourceType.name -> resourceType)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -40,7 +40,7 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName)
     val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
     val resourceActions: Set[ResourceAction] = Set(ResourceAction("delete")) union policyActions
-    val resourceActionPatterns: Set[ResourceActionPattern] = resourceActions.map(action => ResourceActionPattern(action.value))
+    val resourceActionPatterns: Set[ResourceActionPattern] = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
     val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
     val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
     val defaultRoles = Set(defaultOwnerRole, defaultMemberRole)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -34,6 +34,15 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
   val service = new ResourceService(Map(defaultResourceType.name -> defaultResourceType, otherResourceType.name -> otherResourceType), policyDAO, dirDAO, NoExtensions, "example.com")
 
+  private object SamResourceActionPatterns {
+    val readPolicies = ResourceActionPattern("read_policies", "", false)
+    val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+    val delete = ResourceActionPattern("delete", "", false)
+
+    val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+    val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
+  }
+
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     runAndWait(schemaDao.init())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -5,30 +5,30 @@ import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
-import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, _}
+import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.JndiAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
 
 /**
   * Created by dvoet on 6/27/17.
   */
 class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
-  val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
+  val config = ConfigFactory.load()
+  val directoryConfig = config.as[DirectoryConfig]("directory")
   val dirDAO = new JndiDirectoryDAO(directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig)
 
   private val defaultResourceTypeActions = Set(ResourceAction("alter_policies"), ResourceAction("delete"), ResourceAction("read_policies"), ResourceAction("view"), ResourceAction("non_owner_action"))
-  private val defaultResourceTypeActionPatterns = Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.delete, SamResourceActionPatterns.readPolicies, ResourceActionPattern("view"), ResourceActionPattern("non_owner_action"))
+  private val defaultResourceTypeActionPatterns = Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.delete, SamResourceActionPatterns.readPolicies, ResourceActionPattern("view", "", false), ResourceActionPattern("non_owner_action", "", false))
   private val defaultResourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), defaultResourceTypeActionPatterns, Set(ResourceRole(ResourceRoleName("owner"), defaultResourceTypeActions - ResourceAction("non_owner_action")), ResourceRole(ResourceRoleName("other"), Set(ResourceAction("view"), ResourceAction("non_owner_action")))), ResourceRoleName("owner"))
   private val otherResourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), defaultResourceTypeActionPatterns, Set(ResourceRole(ResourceRoleName("owner"), defaultResourceTypeActions - ResourceAction("non_owner_action")), ResourceRole(ResourceRoleName("other"), Set(ResourceAction("view"), ResourceAction("non_owner_action")))), ResourceRoleName("owner"))
 
@@ -56,6 +56,13 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val initialMembers = if(role.roleName.equals(resourceType.ownerRoleName)) Set(dummyUserInfo.userId.asInstanceOf[WorkbenchSubject]) else Set[WorkbenchSubject]()
     val group = BasicWorkbenchGroup(WorkbenchGroupName(role.roleName.value), initialMembers, toEmail(resource.resourceTypeName.value, resource.resourceId.value, role.roleName.value))
     Set(AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName(role.roleName.value)), group.members, group.email, Set(role.roleName), Set.empty))
+  }
+
+  "ResourceType config" should "allow constraining policies to an auth domain" in {
+    val resourceTypes = config.as[Map[String, ResourceType]]("testStuff.resourceTypes").values.toSet
+    val rt = resourceTypes.find(_.name == ResourceTypeName("testType")).getOrElse(fail("Missing test resource type, please check src/test/resources/reference.conf"))
+    val constrainedAction = rt.actionPatterns.find(_.value == "alter_policies").getOrElse(fail("Missing action pattern, please check src/test/resources/reference.conf"))
+    constrainedAction.authDomainConstrained shouldEqual true
   }
 
   "ResourceService" should "create and delete resource" in {
@@ -125,7 +132,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
   "createResource" should "detect conflict on create" in {
     val ownerRoleName = ResourceRoleName("owner")
-    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view")), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
+    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view", "", false)), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
     val resourceName = ResourceId("resource")
 
     runAndWait(service.createResourceType(resourceType))
@@ -144,7 +151,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
   it should "create resource with custom policies" in {
     val ownerRoleName = ResourceRoleName("owner")
-    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view")), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
+    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view", "", false)), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
     val resourceName = ResourceId("resource")
 
     runAndWait(service.createResourceType(resourceType))
@@ -167,7 +174,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
   it should "prevent ownerless resource" in {
     val ownerRoleName = ResourceRoleName("owner")
-    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view")), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
+    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(SamResourceActionPatterns.delete, ResourceActionPattern("view", "", false)), Set(ResourceRole(ownerRoleName, Set(ResourceAction("delete"), ResourceAction("view")))), ownerRoleName)
     val resourceName = ResourceId("resource")
 
     runAndWait(service.createResourceType(resourceType))
@@ -209,7 +216,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
   it should "return an empty set when the resource doesn't exist" in {
     val ownerRoleName = ResourceRoleName("owner")
-    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("a1")), Set(ResourceRole(ownerRoleName, Set(ResourceAction("a1")))), ownerRoleName)
+    val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("a1", "", false)), Set(ResourceRole(ownerRoleName, Set(ResourceAction("a1")))), ownerRoleName)
     val resourceName = ResourceId("resource")
 
     val roles = runAndWait(service.listUserResourceRoles(Resource(resourceType.name, resourceName), dummyUserInfo))
@@ -273,7 +280,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   }
 
   it should "succeed with a regex action" in {
-    val rt = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("foo-.+-bar")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("foo-biz-bar")))), ResourceRoleName("owner"))
+    val rt = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("foo-.+-bar", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("foo-biz-bar")))), ResourceRoleName("owner"))
     val resource = Resource(rt.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(rt))
@@ -312,7 +319,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   }
 
   it should "fail when given an invalid regex action" in {
-    val rt = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("foo-.+-bar")), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("foo-biz-bar")))), ResourceRoleName("owner"))
+    val rt = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("foo-.+-bar", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("foo-biz-bar")))), ResourceRoleName("owner"))
     val resource = Resource(rt.name, ResourceId("my-resource"))
 
     runAndWait(service.createResourceType(rt))
@@ -353,7 +360,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("non_owner_action")))
-    
+
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(service.overwritePolicy(defaultResourceType, newPolicy.id.accessPolicyName, newPolicy.id.resource, AccessPolicyMembership(Set(WorkbenchEmail("null@null.com")), Set.empty, Set.empty)))
     }


### PR DESCRIPTION
None of the currently defined actions are Auth Domain constrained yet, as is reflected in `reference.conf`.  All actions will default to `false` in terms of being constrained.  

Please review the descriptions I have provided and provide descriptions for those that are missing.  As a framework for writing these descriptions, I wrote the them so that we could potentially generate text like `s"Users who can perform ${action.name} may ${action.description}".  Feel free to rewrite or let me know how you'd like me to rewrite them.
  
Please also look at `SamResourceActionPatterns` in `SamModel.scala`, I'm not sure if we need to provide descriptions for those ActionPatterns.  

Note also that I created a test in `ResourceServiceSpec.scala` for making sure that the `authDomainConstrained` attribute can be read properly.  It felt a little weird putting it there, but I didn't know where to put it.  

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
