### PR TITLE
Missing admin-notifier actions for managed group admins

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -75,7 +75,7 @@ resourceTypes = {
     ownerRoleName = "admin"
     roles = {
       admin = {
-        roleActions = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "read_policy::admin", "read_policy::member"]
+        roleActions = ["delete", "read_policies", "share_policy::admin", "share_policy::member", "share_policy::admin-notifier", "read_policy::admin", "read_policy::member", "read_policy::admin-notifier"]
       }
       member = {
         roleActions = []

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -44,7 +44,7 @@ object TestSamRoutes {
     val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val mockUserService = new UserService(directoryDAO, NoExtensions)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
-    mockUserService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail))
+    TestSupport.runAndWait(mockUserService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)))
     val allUsersGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(directoryDAO))
     TestSupport.runAndWait(googleDirectoryDAO.createGroup(allUsersGroup.id.toString, allUsersGroup.email))
 


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
