### PR TITLE
added v1 to resources, config, google, user, groups interfaces

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -157,7 +157,25 @@ paths:
       tags:
         - Admin
 
-  /api/groups:
+  /api/config/v1/resourceTypes:
+    get:
+      responses:
+        200:
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ResourceType'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      summary: Lists available resource types
+      operationId: listResourceTypes
+      tags:
+        - Config
+
+  /api/groups/v1:
     get:
       summary: Show all the groups the requesting user belongs to and their policy membership in each group
       responses:
@@ -175,7 +193,7 @@ paths:
       tags:
         - Group
 
-  /api/group/{groupName}:
+  /api/groups/v1/{groupName}:
     get:
       summary: Show email address of the group
       responses:
@@ -240,7 +258,7 @@ paths:
       tags:
         - Group
 
-  /api/group/{groupName}/requestAccess:
+  /api/groups/v1/{groupName}/requestAccess:
     post:
       summary: Request access to a managed group
       responses:
@@ -262,7 +280,7 @@ paths:
       tags:
         - Group
 
-  /api/group/{groupName}/{policyName}:
+  /api/groups/v1/{groupName}/{policyName}:
     get:
       summary: 'Get email addresses for members of the "admin" policy'
       responses:
@@ -324,7 +342,7 @@ paths:
       tags:
         - Group
 
-  /api/group/{groupName}/{policyName}/{email}:
+  /api/groups/v1/{groupName}/{policyName}/{email}:
     put:
       summary: Add email to the policy
       responses:
@@ -394,7 +412,7 @@ paths:
       tags:
         - Group
 
-  /api/google/group/{groupName}/sync:
+  /api/google/v1/group/{groupName}/sync:
     post:
       summary: Synchronize a managed-group with google group
       responses:
@@ -420,7 +438,7 @@ paths:
       tags:
         - Google
 
-  /api/google/petServiceAccount/{project}/{userEmail}:
+  /api/google/v1/petServiceAccount/{project}/{userEmail}:
     get:
       summary: gets a key for the user's pet service account, get_pet_private_key action on cloud-extension/google required
       responses:
@@ -455,7 +473,7 @@ paths:
       tags:
         - Google
 
-  /api/google/user/petServiceAccount/{project}:
+  /api/google/v1/user/petServiceAccount/{project}:
     get:
       summary: gets the pet service account for the specified user
       responses:
@@ -477,7 +495,7 @@ paths:
       tags:
         - Google
 
-  /api/google/user/petServiceAccount/{project}/key:
+  /api/google/v1/user/petServiceAccount/{project}/key:
     get:
       summary: gets a key for the user's pet service account
       responses:
@@ -497,7 +515,7 @@ paths:
       tags:
         - Google
 
-  /api/google/user/petServiceAccount/{project}/key/{keyId}:
+  /api/google/v1/user/petServiceAccount/{project}/key/{keyId}:
     delete:
       summary: removes an existing key for the user's pet service account
       responses:
@@ -522,7 +540,7 @@ paths:
       tags:
         - Google
 
-  /api/google/user/petServiceAccount/{project}/token:
+  /api/google/v1/user/petServiceAccount/{project}/token:
     post:
       summary: gets a token for the user's pet service account
       responses:
@@ -550,7 +568,7 @@ paths:
       tags:
         - Google
 
-  /api/google/user/proxyGroup/{email}:
+  /api/google/v1/user/proxyGroup/{email}:
     get:
       summary: gets the proxy group email for the specified user
       responses:
@@ -574,7 +592,7 @@ paths:
       tags:
         - Google
 
-  /api/google/resource/{resourceTypeName}/{resourceId}/{policyName}/sync:
+  /api/google/v1/resource/{resourceTypeName}/{resourceId}/{policyName}/sync:
     post:
       summary: Synchronize a policy's membership with google group. Once called all further membership changes will by automatically synchronized
       responses:
@@ -637,7 +655,7 @@ paths:
       tags:
         - Google
 
-  /api/resource/{resourceTypeName}:
+  /api/resources/v1/{resourceTypeName}:
     get:
       summary: List resources and policies for this resource for the caller
       responses:
@@ -689,7 +707,7 @@ paths:
       tags:
         - Resources
 
-  /api/resource/{resourceTypeName}/{resourceId}:
+  /api/resources/v1/{resourceTypeName}/{resourceId}:
     delete:
       summary: Delete a resource
       responses:
@@ -741,7 +759,7 @@ paths:
       tags:
         - Resources
 
-  /api/resource/{resourceTypeName}/{resourceId}/policies:
+  /api/resources/v1/{resourceTypeName}/{resourceId}/policies:
     get:
       summary: List the policies for a resource
       responses:
@@ -774,7 +792,7 @@ paths:
       tags:
         - Resources
 
-  /api/resource/{resourceTypeName}/{resourceId}/policies/{policyName}:
+  /api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}:
     get:
       summary: Gets a policy on a resource
       responses:
@@ -848,7 +866,7 @@ paths:
       tags:
         - Resources
 
-  /api/resource/{resourceTypeName}/{resourceId}/policies/{policyName}/memberEmails/{email}:
+  /api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/memberEmails/{email}:
     put:
       summary: Add a user to a policy
       responses:
@@ -929,7 +947,7 @@ paths:
         - Resources
 
 
-  /api/resource/{resourceTypeName}/{resourceId}/roles:
+  /api/resources/v1/{resourceTypeName}/{resourceId}/roles:
     get:
       summary: Query for the list of roles that the requesting user has on the resource
       responses:
@@ -960,7 +978,7 @@ paths:
       tags:
         - Resources
 
-  /api/resource/{resourceTypeName}/{resourceId}/action/{action}:
+  /api/resources/v1/{resourceTypeName}/{resourceId}/action/{action}:
     get:
       summary: Query if requesting user may perform the action
       responses:
@@ -992,25 +1010,7 @@ paths:
       tags:
         - Resources
 
-  /api/resourceTypes:
-    get:
-      responses:
-        200:
-          description: Success
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/ResourceType'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-      summary: Lists available resource types
-      operationId: listResourceTypes
-      tags:
-        - Resources
-
-  /register/user:
+  /register/user/v1:
     get:
       summary: gets the registration status of the logged in user
       responses:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -25,51 +25,55 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
   val managedGroupService: ManagedGroupService
 
   def groupRoutes: server.Route = requireUserInfo { userInfo =>
-    pathPrefix("group" / Segment) { groupId =>
-      val managedGroup = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupId))
-
-      pathEndOrSingleSlash {
-        get {
-          handleGetGroup(managedGroup)
-        } ~
-        post {
-          handleCreateGroup(managedGroup, userInfo)
-        } ~
-        delete {
-          handleDeleteGroup(managedGroup, userInfo)
-        }
-      } ~
-      pathPrefix("requestAccess") {
-        post {
-          handleRequestAccess(managedGroup, userInfo)
-        }
-      } ~
-      pathPrefix(Segment) { policyName =>
-        val accessPolicyName = ManagedGroupService.getPolicyName(policyName)
+    (pathPrefix("groups" / "v1") | pathPrefix("group")) {
+      pathPrefix(Segment) { groupId =>
+        val managedGroup = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupId))
 
         pathEndOrSingleSlash {
           get {
-            handleListEmails(managedGroup, accessPolicyName, userInfo)
+            handleGetGroup(managedGroup)
           } ~
-          put {
-            handleOverwriteEmails(managedGroup, accessPolicyName, userInfo)
-          }
-        } ~
-        pathPrefix(Segment) { email =>
-          pathEndOrSingleSlash {
-            put {
-              handleAddEmailToPolicy(managedGroup, accessPolicyName, email, userInfo)
+            post {
+              handleCreateGroup(managedGroup, userInfo)
             } ~
             delete {
-              handleDeleteEmailFromPolicy(managedGroup, accessPolicyName, email, userInfo)
+              handleDeleteGroup(managedGroup, userInfo)
+            }
+        } ~
+        pathPrefix("requestAccess") {
+          post {
+            handleRequestAccess(managedGroup, userInfo)
+          }
+        } ~
+        pathPrefix(Segment) { policyName =>
+          val accessPolicyName = ManagedGroupService.getPolicyName(policyName)
+
+          pathEndOrSingleSlash {
+            get {
+              handleListEmails(managedGroup, accessPolicyName, userInfo)
+            } ~
+              put {
+                handleOverwriteEmails(managedGroup, accessPolicyName, userInfo)
+              }
+          } ~
+          pathPrefix(Segment) { email =>
+            pathEndOrSingleSlash {
+              put {
+                handleAddEmailToPolicy(managedGroup, accessPolicyName, email, userInfo)
+              } ~
+              delete {
+                handleDeleteEmailFromPolicy(managedGroup, accessPolicyName, email, userInfo)
+              }
             }
           }
         }
       }
     } ~
-    path("groups") {
-      get {
-        handleListGroups(userInfo)
+    (pathPrefix("groups" / "v1") | pathPrefix("groups")) {
+      pathEndOrSingleSlash {
+        get {
+          handleListGroups(userInfo)
+        }
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -30,7 +30,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   }
 
   def resourceRoutes: server.Route =
-    pathPrefix("resourceTypes") {
+    (pathPrefix("config" / "v1" / "resourceTypes") | pathPrefix("resourceTypes")) {
       requireUserInfo { userInfo =>
         pathEndOrSingleSlash {
           get {
@@ -41,7 +41,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
         }
       }
     } ~
-    pathPrefix("resource") {
+    (pathPrefix("resources" / "v1") | pathPrefix("resource")) {
       requireUserInfo { userInfo =>
         pathPrefix(Segment) { resourceTypeName =>
           withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -41,7 +41,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
         }
       }
     } ~
-    pathPrefix("google") {
+    (pathPrefix("google" / "v1") | pathPrefix("google")) {
       requireUserInfo { userInfo =>
         path("petServiceAccount" / Segment / Segment ) { (project, userEmail) =>
           get {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -1,0 +1,624 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import spray.json.DefaultJsonProtocol._
+
+/**
+  * Created by gpolumbo on 2/26/2017.
+  */
+class ManagedGroupRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
+
+  private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
+  private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+  private val resourceActions = Set(ResourceAction("delete"), ResourceAction("notify_admins")) union policyActions
+  private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
+  private val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
+  private val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
+  private val defaultAdminNotifierRole = ResourceRole(ManagedGroupService.adminNotifierRoleName, Set(ResourceAction("notify_admins")))
+  private val defaultRoles = Set(defaultOwnerRole, defaultMemberRole, defaultAdminNotifierRole)
+  private val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+  private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
+  private val groupId = "foo"
+  private val defaultNewUser = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), WorkbenchEmail("newGuy@organization.org"), 0)
+
+  def assertGroupDoesNotExist(samRoutes: TestSamRoutes, groupId: String = groupId) {
+    Get(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  def assertCreateGroup(samRoutes: TestSamRoutes, groupId: String = groupId): Unit = {
+    Post(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
+
+  def assertGetGroup(samRoutes: TestSamRoutes, groupId: String = groupId) = {
+    Get(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
+      val expectedResource = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupId))
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  def assertDeleteGroup(samRoutes: TestSamRoutes, groupId: String = groupId) = {
+    Delete(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
+  def makeOtherUser(samRoutes: TestSamRoutes, userInfo: UserInfo = defaultNewUser) = new {
+    runAndWait(samRoutes.userService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)))
+    val email = userInfo.userEmail
+    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao)
+  }
+
+  def setGroupMembers(samRoutes: TestSamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {
+    Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
+      status shouldEqual expectedStatus
+    }
+  }
+
+  def withUserNotInGroup[T](defaultRoutes: TestSamRoutes)(body: TestSamRoutes => T): T = {
+    assertCreateGroup(defaultRoutes)
+    assertGetGroup(defaultRoutes)
+
+    val theDude = UserInfo(OAuth2BearerToken("tokenDude"), WorkbenchUserId("ElDudarino"), WorkbenchEmail("ElDudarino@example.com"), 0)
+    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.mockDirectoryDao)
+
+    body(dudesRoutes)
+  }
+
+  "GET /api/groups/v1/{groupName}" should "respond with 200 if the requesting user is in the admin policy for the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+  }
+
+  it should "respond with 200 if the requesting user is in the member policy for the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+
+    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
+    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+
+    runAndWait(samRoutes.userService.createUser(WorkbenchUser(newGuy.userId, newGuy.userEmail)))
+
+    setGroupMembers(samRoutes, Set(newGuyEmail), expectedStatus = StatusCodes.Created)
+
+    assertGetGroup(newGuyRoutes)
+  }
+
+  it should "respond with 404 if the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertGroupDoesNotExist(samRoutes)
+  }
+
+  it should "respond with 200 if the group exists but the user is not in the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
+    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+
+
+    Get(s"/api/groups/v1/$groupId") ~> newGuyRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  "POST /api/groups/v1/{groupName}" should "respond 201 if the group did not already exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertGroupDoesNotExist(samRoutes)
+    assertCreateGroup(samRoutes)
+  }
+
+  it should "fail with a 409 if the group already exists" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+    Post(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Conflict
+    }
+  }
+
+  it should "fail with a 400 if the group name contains invalid characters" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+
+    val badGroupName = "bad$name"
+    Post(s"/api/groups/v1/$badGroupName") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "fail with a 400 if the group name contains 64 or more characters" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+
+    val badGroupName = "X" * 61
+    Post(s"/api/groups/v1/$badGroupName") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  "DELETE /api/groups/v1/{groupName}" should "should respond with 204 when the group is successfully deleted" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+    assertDeleteGroup(samRoutes)
+    assertGroupDoesNotExist(samRoutes)
+  }
+
+  it should "fail with 404 if the authenticated user is not in the owner policy for the group" in {
+    val defaultRoutes = TestSamRoutes(resourceTypes)
+    withUserNotInGroup(defaultRoutes){ nonMemberRoutes =>
+    assertGetGroup(nonMemberRoutes)
+    Delete(s"/api/groups/v1/$groupId") ~> nonMemberRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+    assertGetGroup(nonMemberRoutes)
+    assertGetGroup(defaultRoutes)}
+  }
+
+  "GET /api/groups/v1/{groupName}/member" should "succeed with 200 when the group exists and the requesting user is in the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    Get(s"/api/groups/v1/$groupId/member") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] shouldEqual "[]"
+    }
+  }
+
+  it should "fail with 404 when the requesting user is a 'member' but not an 'admin'" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
+
+    Get(s"/api/groups/v1/$groupId/member") ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "fail with 404 when the requesting user is not in the group" in {
+    withUserNotInGroup( TestSamRoutes(resourceTypes)
+    ) { nonMemberRoutes =>
+
+    Get(s"/api/groups/v1/$groupId/members") ~> nonMemberRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound}
+    }
+  }
+
+  it should "fail with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+
+    Get(s"/api/groups/v1/$groupId/member") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "GET /api/groups/v1/{groupName}/{policyName}" should "fail with 404 if policy name is not in [member, admin]" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    Get(s"/api/groups/v1/$groupId/blah") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+      responseAs[String] should include ("must be one of")
+    }
+  }
+
+  "PUT /api/groups/v1/{groupName}/member" should "fail with 400 when updating the 'member' policy of the group with a user who has not been created yet" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
+    val members = Set(newGuyEmail)
+
+    Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include (newGuyEmail.toString())
+    }
+  }
+
+  it should "succeed with 201 after successfully updating the 'member' policy of the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
+  }
+
+  it should "fail with 404 when the requesting user is not in the admin policy for the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+    setGroupMembers(newGuy.routes, Set(newGuy.email), expectedStatus = StatusCodes.NotFound)
+  }
+
+  it should "fail with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.NotFound)
+  }
+
+  it should "fail with 500 when any of the email addresses being added are invalid" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuyEmail = WorkbenchEmail("I'm not an email address but I should be")
+
+    val members = Set(newGuyEmail)
+    Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include (newGuyEmail.toString())
+    }
+  }
+
+  "GET /api/groups/v1/{groupName}/admin" should "succeed with 200 when the group exists and the requesting user is in the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+
+    Get(s"/api/groups/v1/$groupId/admin") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] should include (TestSamRoutes.defaultUserInfo.userEmail.value)
+    }
+  }
+
+  it should "fail with 404 when the requesting user is a 'member' but not an 'admin'" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
+
+    Get(s"/api/groups/v1/$groupId/admin") ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "fail with 404 when the requesting user is not in the group" in {
+    withUserNotInGroup( TestSamRoutes(resourceTypes)
+    ) { nonMemberRoutes =>
+
+    Get(s"/api/groups/v1/$groupId/admin") ~> nonMemberRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound}
+    }
+  }
+
+  it should "fail with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    Get(s"/api/groups/v1/$groupId/admin") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "PUT /api/groups/v1/{groupName}/admin" should "fail with 400 when updating the 'admin' policy of the group with a user who has not been created yet" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
+    val members = Set(newGuyEmail)
+
+    Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include (newGuyEmail.toString())
+    }
+  }
+
+  it should "succeed with 201 after successfully updating the 'admin' policy of the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    val members = Set(newGuy.email)
+    Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
+
+  it should "fail with 404 when the requesting user is not in the admin policy for the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+    val members = Set(newGuy.email)
+    Put(s"/api/groups/v1/$groupId/admin", members) ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "fail with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
+    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+
+
+    val members = Set(newGuyEmail)
+    Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "fail with 500 when any of the email addresses being added are invalid" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuyEmail = WorkbenchEmail("An Invalid email address")
+
+    val members = Set(newGuyEmail)
+    Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include (newGuyEmail.toString())
+    }
+  }
+
+  "PUT /api/groups/v1/{groupName}/{policyName}/{email}" should "respond with 204 and add the email address to the specified group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    Put(s"/api/groups/v1/$groupId/admin/${newGuy.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "respond with 204 when the email address is already in the group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val defaultUserInfo = samRoutes.userInfo
+    Put(s"/api/groups/v1/$groupId/admin/${defaultUserInfo.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "respond with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    Put(s"/api/groups/v1/$groupId/admin/${newGuy.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "respond with 400 when the email address is invalid" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val notAnEmail = "NotAnEmailAddress"
+
+    Put(s"/api/groups/v1/$groupId/admin/$notAnEmail") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "respond with 404 when the policy is invalid" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    Put(s"/api/groups/v1/$groupId/xmen/${newGuy.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "respond with 404 when the requesting user does not have any permissions in the group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    Put(s"/api/groups/v1/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  // TODO: In order to be able to delete the subject, they need to exist in opendj.  Is this what we want?
+  "DELETE /api/groups/v1/{groupName}/{policyName}/{email}" should "respond with 204 and remove the email address from the specified group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    Delete(s"/api/groups/v1/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  // TODO:  I think this should just work and give back a 204
+  // TODO: well i changed something and now it returns a 204 so maybe this TODO above is complete? Must investigate...
+  it should "respond with 404 when the email address was already not present in the group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    Delete(s"/api/groups/v1/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "respond with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+
+    Delete(s"/api/groups/v1/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "respond with 404 when the policy is invalid" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    Delete(s"/api/groups/v1/$groupId/people/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "respond with 404 when the requesting user does not have permissions to edit the group and policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+
+    Delete(s"/api/groups/v1/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "GET /api/groups/v1" should "respond with 200 and a list of managed groups the authenticated user belongs to" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    val groupNames = Set("foo", "bar", "baz")
+
+    groupNames.foreach(assertCreateGroup(samRoutes, _))
+
+    Get("/api/groups/v1") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val res = responseAs[String]
+      groupNames.foreach(res should include (_))
+      res should include ("admin")
+      res shouldNot include ("member")
+    }
+  }
+
+  it should "respond with 200 and an empty list if the user is not a member of any managed groups" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+
+    Get("/api/groups/v1") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] shouldEqual "[]"
+    }
+  }
+
+  "GET /api/groups/v1/{groupName}/admin-notifier" should "succeed with 200 when the group exists and the requesting user is a group admin" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    assertCreateGroup(samRoutes)
+    assertGetGroup(samRoutes)
+
+    Get(s"/api/groups/v1/$groupId/admin-notifier") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  it should "fail with 404 when the requesting user is a 'member' but not an 'admin'" in {
+    val samRoutes: TestSamRoutes = TestSamRoutes(resourceTypes)
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
+
+    Get(s"/api/groups/v1/$groupId/admin-notifier") ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "fail with 404 when the requesting user is not in the group" in {
+    withUserNotInGroup(TestSamRoutes(resourceTypes)) { nonMemberRoutes =>
+      Get(s"/api/groups/v1/$groupId/admin-notifier") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+  }
+
+  it should "fail with 404 when the group does not exist" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+
+    Get(s"/api/groups/v1/$groupId/admin") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "PUT /api/groups/v1/{groupName}/admin-notifier" should "succeed with 201 after successfully updating the 'admin-notifier' policy" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+
+    Put(s"/api/groups/v1/$groupId/admin-notifier", Set(newGuy.email)) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
+
+  it should "fail with 404 when the requesting user is not in the admin policy for the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    assertCreateGroup(samRoutes)
+
+    val newGuy = makeOtherUser(samRoutes)
+    Put(s"/api/groups/v1/$groupId/admin-notifier", Set(newGuy.email)) ~> newGuy.routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
@@ -1,0 +1,684 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.service._
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import spray.json.DefaultJsonProtocol._
+import spray.json.{JsBoolean, JsValue}
+
+/**
+  * Created by dvoet on 6/7/17.
+  */
+class ResourceRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
+
+  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+
+  private object SamResourceActionPatterns {
+    val readPolicies = ResourceActionPattern("read_policies", "", false)
+    val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+    val delete = ResourceActionPattern("delete", "", false)
+
+    val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+    val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
+  }
+
+  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo) = {
+    val accessPolicyDAO = new MockAccessPolicyDAO()
+    val directoryDAO = new MockDirectoryDAO()
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
+    val mockUserService = new UserService(directoryDAO, NoExtensions)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
+
+    mockUserService.createUser(WorkbenchUser(defaultUserInfo.userId, defaultUserInfo.userEmail))
+
+    new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO)
+  }
+
+  "GET /api/resources/v1/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+
+    Get("/api/resources/v1/foo/bar/action") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+      responseAs[ErrorReport].message shouldEqual "resource type foo not found"
+    }
+  }
+
+  "GET /api/config/v1/resourceTypes" should "200 when listing all resource types" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+
+    Get("/api/config/v1/resourceTypes") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  "POST /api/resources/v1/{resourceType}" should "204 create resource" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))))
+    Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    Get(s"/api/resources/v1/${resourceType.name}/foo/action/run") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[JsValue] shouldEqual JsBoolean(true)
+    }
+  }
+
+  it should "400 when resource type allows id reuse" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))))
+    Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  "POST /api/resources/v1/{resourceType}/{resourceId}" should "204 create resource" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    Get(s"/api/resources/v1/${resourceType.name}/foo/action/run") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[JsValue] shouldEqual JsBoolean(true)
+    }
+
+  }
+
+  "GET /api/resources/v1/{resourceType}/{resourceId}/roles" should "200 on list resource roles" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    Get(s"/api/resources/v1/${resourceType.name}/foo/roles") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Set[String]]
+    }
+  }
+
+  it should "404 on list resource roles when resource type doesnt exist" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Get(s"/api/resources/v1/doesntexist/foo/roles") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "GET /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}" should "200 on existing policy of a resource with read_policies" in {
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val resourceId = ResourceId("foo")
+    val policyName = AccessPolicyName("bar")
+    createUserResourcePolicy(members, resourceType, samRoutes, resourceId, policyName)
+
+    Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[AccessPolicyMembership] shouldEqual members
+    }
+  }
+
+  private def responsePayloadClue(str: String): String = s" -> Here is the response payload: $str"
+
+  private def createUserResourcePolicy(members: AccessPolicyMembership, resourceType: ResourceType, samRoutes: TestSamRoutes, resourceId: ResourceId, policyName: AccessPolicyName): Unit = {
+    val user = WorkbenchUser(samRoutes.userInfo.userId, samRoutes.userInfo.userEmail)
+    findOrCreateUser(user, samRoutes.userService)
+
+    Post(s"/api/resources/v1/${resourceType.name}/${resourceId.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent withClue responsePayloadClue(responseAs[String])
+    }
+
+
+    Put(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created withClue responsePayloadClue(responseAs[String])
+    }
+  }
+
+  private def findOrCreateUser(user: WorkbenchUser, userService: UserService): UserStatus = {
+    runAndWait(userService.getUserStatus(user.id)) match {
+      case Some(userStatus) => userStatus
+      case None => runAndWait(userService.createUser(user))
+    }
+  }
+
+  it should "200 on existing policy of a resource with read_policy" in {
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val policyName = AccessPolicyName("bar")
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicy(policyName)))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val resourceId = ResourceId("foo")
+    createUserResourcePolicy(members, resourceType, samRoutes, resourceId, policyName)
+
+    Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[AccessPolicyMembership] shouldEqual members
+    }
+  }
+
+  it should "404 on non existing policy of a resource" in {
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val resourceId = ResourceId("foo")
+    val policyName = AccessPolicyName("bar")
+    createUserResourcePolicy(members, resourceType, samRoutes, resourceId, policyName)
+
+    Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}_dne") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "403 on existing policy of a resource without read policies" in {
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    val resourceId = ResourceId("foo")
+    val policyName = AccessPolicyName("bar")
+    createUserResourcePolicy(members, resourceType, samRoutes, resourceId, policyName)
+
+    Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "PUT /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}" should "201 on a new policy being created for a resource" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    val members = AccessPolicyMembership(Set(testUser.email), Set(ResourceAction("can_compute")), Set.empty)
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
+
+  it should "201 on a policy being updated" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    val members = AccessPolicyMembership(Set(testUser.email), Set(ResourceAction("can_compute")), Set.empty)
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    val members2 = AccessPolicyMembership(Set(testUser.email), Set(ResourceAction("can_compute")), Set(ResourceRoleName("owner")))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members2) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
+
+  it should "400 on a policy being created with invalid actions" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    val fakeActions = Set(ResourceAction("fake_action1"), ResourceAction("other_fake_action"))
+    val members = AccessPolicyMembership(Set(testUser.email), fakeActions, Set.empty)
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      fakeActions foreach { action => responseAs[String] should include(action.value) }
+      responseAs[String] should include ("invalid action")
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "400 on a policy being created with invalid roles" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    val fakeRoles = Set(ResourceRoleName("fakerole"), ResourceRoleName("otherfakerole"))
+    val members = AccessPolicyMembership(Set(testUser.email), Set(ResourceAction("can_compute")), fakeRoles)
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      fakeRoles foreach { role => responseAs[String] should include (role.value) }
+      responseAs[String] should include ("invalid role")
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "400 on a policy being created with invalid member emails" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    val badEmail = WorkbenchEmail("null@bar.baz")
+    val nonExistingMembers = AccessPolicyMembership(Set(badEmail), Set(ResourceAction("can_compute")), Set(ResourceRoleName("owner")))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", nonExistingMembers) ~> samRoutes.route ~> check {
+      responseAs[String] shouldNot include (testUser.email.value)
+      responseAs[String] should include (badEmail.value)
+      responseAs[String] should include ("invalid member email")
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "403 when creating a policy on a resource when the user doesn't have alter_policies permission (but can see the resource)" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val members = AccessPolicyMembership(Set(WorkbenchEmail("me@me.me")), Set(ResourceAction("can_compute")), Set.empty)
+
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 when creating a policy on a resource type that doesnt exist" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+    val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
+
+    //Create a resource of a type that doesn't exist
+    Put(s"/api/resources/v1/fakeresourcetype/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0))
+    val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
+
+    //Create a resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //As a different user who isn't on any policy, try to overwrite a policy
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> otherUserSamRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "GET /api/resources/v1/{resourceType}/{resourceId}/policies" should "200 when listing policies for a resource and user has read_policies permission" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    //Create a resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //Read the policies
+    Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  it should "403 when listing policies for a resource and user lacks read_policies permission (but can see the resource)" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    //Create a resource that doesn't have the read_policies action on any roles
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //Try to read the policies
+    Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 when listing policies for a resource type that doesnt exist" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+
+    //List policies for a bogus resource type
+    Get(s"/api/resources/v1/fakeresourcetype/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 when listing policies for a resource when user can't see the resource" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0))
+
+    //Create the resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //As a different user, try to read the policies
+    Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> otherUserSamRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "DELETE /api/resources/v1/{resourceType}/{resourceId}" should "204 when deleting a resource and the user has permission to do so" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    //Create the resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //Read the policies to make sure the resource exists)
+    Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    //Delete the resource
+    Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "403 when deleting a resource and the user has permission to see the resource but not delete" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    //Create the resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //Read the policies to make sure the resource exists)
+    Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    //Delete the resource
+    Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 when deleting a resource of a type that doesn't exist" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+
+    //Delete the resource
+    Delete(s"/api/resources/v1/INVALID_RESOURCE_TYPE/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 when deleting a resource that exists but can't be seen by the user" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    runAndWait(samRoutes.resourceService.createResourceType(resourceType))
+    runAndWait(samRoutes.userService.createUser(WorkbenchUser(WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"))))
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0)))
+
+    //Verify resource exists by checking for conflict on recreate
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Conflict
+    }
+
+    //Delete the resource
+    Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "GET /api/resources/v1/{resourceType}" should "200" in {
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+
+    //Create a resource
+    Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    //Read the policies
+    Get(s"/api/resources/v1/${resourceType.name}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  "PUT /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 adding a member" in {
+    // happy case
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "204 adding a member with can share" in {
+    // happy case
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
+      ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "400 adding unknown subject" in {
+    // differs from happy case in that we don't create user
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    //runAndWait(samRoutes.userService.createUser(testUser))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "403 adding without permission" in {
+    // differs from happy case in that owner role does not have alter_policies
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 adding without any access" in {
+    // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
+
+    runAndWait(samRoutes.userService.createUser(WorkbenchUser(testUser.userId, testUser.userEmail)))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser))
+
+    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "DELETE /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 deleting a member" in {
+    // happy case
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+
+    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "204 deleting a member with can share" in {
+    // happy case
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+
+    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "400 deleting unknown subject" in {
+    // differs from happy case in that we don't create user
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    //runAndWait(samRoutes.userService.createUser(testUser))
+
+    //runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+
+    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
+  it should "403 removing without permission" in {
+    // differs from happy case in that owner role does not have alter_policies
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = WorkbenchUser(WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo))
+
+    runAndWait(samRoutes.userService.createUser(testUser))
+
+    runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+
+    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 removing without any access" in {
+    // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
+    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
+
+    runAndWait(samRoutes.userService.createUser(WorkbenchUser(testUser.userId, testUser.userEmail)))
+
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser))
+
+    runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.userId))
+
+    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.userEmail}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+}
+

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -1,0 +1,218 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, NoExtensions, StatusService, UserService}
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.mockito.MockitoSugar
+
+import scala.concurrent.Future
+
+/**
+  * Created by dvoet on 6/7/17.
+  */
+class UserRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
+  val defaultUserId = WorkbenchUserId("newuser")
+  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
+  val adminUserId = WorkbenchUserId("adminuser")
+  val adminUserEmail = WorkbenchEmail("adminuser@new.com")
+  val petSAUserId = WorkbenchUserId("123")
+  val petSAEmail = WorkbenchEmail("pet-newuser@test.iam.gserviceaccount.com")
+
+  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
+    val directoryDAO = new MockDirectoryDAO()
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO)
+    testCode(samRoutes)
+  }
+
+  def setupAdminsGroup(googleDirectoryDAO: MockGoogleDirectoryDAO): Future[WorkbenchEmail] = {
+    val adminGroupEmail = WorkbenchEmail("fc-admins@dev.test.firecloud.org")
+    for {
+      _ <- googleDirectoryDAO.createGroup(WorkbenchGroupName("fc-admins"), adminGroupEmail)
+      _ <- googleDirectoryDAO.addMemberToGroup(adminGroupEmail, WorkbenchEmail(adminUserEmail.value))
+    } yield adminGroupEmail
+  }
+
+  def withAdminRoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+
+    val adminGroupEmail = runAndWait(setupAdminsGroup(googleDirectoryDAO))
+
+    val cloudExtensions = new NoExtensions {
+      override def isWorkbenchAdmin(memberEmail: WorkbenchEmail): Future[Boolean] = googleDirectoryDAO.isGroupMember(adminGroupEmail, memberEmail)
+    }
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, cloudExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, cloudExtensions)
+    val adminRoutes = new TestSamRoutes(null, new UserService(directoryDAO, cloudExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), adminUserId, adminUserEmail, 0), directoryDAO, cloudExtensions)
+    testCode(samRoutes, adminRoutes)
+  }
+
+  def withSARoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
+    val directoryDAO = new MockDirectoryDAO()
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, NoExtensions)
+    val SARoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, NoExtensions)
+    testCode(samRoutes, SARoutes)
+  }
+
+  "POST /register/user/v1/" should "create user" in withDefaultRoutes { samRoutes =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Conflict
+    }
+  }
+
+  "GET /register/user/v1/" should "get the status of an enabled user" in withDefaultRoutes { samRoutes =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+
+  "POST /register/user/v1/" should "create a user" in withSARoutes{ (samRoutes, SARoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get("/register/user/v1/") ~> SARoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  "GET /admin/user/{userSubjectId}" should "get the user status of a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "GET /admin/user/email/{email}" should "get the user status of a user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get(s"/api/admin/user/email/$defaultUserEmail") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "return 404 for an unknown user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Get(s"/api/admin/user/email/XXX${defaultUserEmail}XXX") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "return 404 for an group's email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Get(s"/api/admin/user/email/fc-admins@dev.test.firecloud.org") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/email/$defaultUserEmail") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "PUT /admin/user/{userSubjectId}/(re|dis)able" should "disable and then re-enable a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Put(s"/api/admin/user/$defaultUserId/disable") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Put(s"/api/admin/user/$defaultUserId/enable") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "not allow a non-admin to enable or disable a user" in withAdminRoutes { (samRoutes, _) =>
+    Put(s"/api/admin/user/$defaultUserId/disable") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+
+    Put(s"/api/admin/user/$defaultUserId/enable") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "DELETE /admin/user/{userSubjectId}" should "delete a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Delete(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "not allow a non-admin to delete a user" in withAdminRoutes { (samRoutes, _) =>
+    Delete(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "DELETE /admin/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "not allow a non-admin to delete a pet" in withAdminRoutes { (samRoutes, _) =>
+    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -1,0 +1,430 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
+import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetServiceAccountConfig, _}
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.service._
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.Future
+
+/**
+  * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
+  */
+class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
+  val defaultUserId = WorkbenchUserId("newuser123")
+  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
+/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
+  val defaultUserProxyEmail = WorkbenchEmail(s"newuser_$defaultUserId@${googleServicesConfig.appsDomain}")
+*/
+  val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
+/**/
+
+  lazy val config = ConfigFactory.load()
+  lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
+  lazy val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
+
+  val configResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.map(rt => rt.name -> rt).toMap
+
+  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, null, googleDirectoryDAO, null, googleIamDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, googleExt), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+    }
+    testCode(samRoutes)
+  }
+
+  "GET /api/google/v1/user/petServiceAccount" should "get or create a pet service account for a user" in withDefaultRoutes { samRoutes =>
+    // create a user
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    // create a pet service account
+    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+    }
+
+    // same result a second time
+    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+    }
+  }
+
+  "GET /api/google/v1/user/proxyGroup/{email}" should "return a user's proxy group" in withDefaultRoutes { samRoutes =>
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    // create a user
+    Post("/register/user/v1") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get(s"/api/google/v1/user/proxyGroup/$defaultUserEmail") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response shouldBe defaultUserProxyEmail
+    }
+  }
+
+  it should "return a user's proxy group from a pet service account" in withDefaultRoutes { samRoutes =>
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    // create a user
+    Post("/register/user/v1") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    val petEmail = Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value
+    }
+
+    Get(s"/api/google/v1/user/proxyGroup/$petEmail") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response shouldBe defaultUserProxyEmail
+    }
+  }
+
+  private object SamResourceActionPatterns {
+    val readPolicies = ResourceActionPattern("read_policies", "", false)
+    val alterPolicies = ResourceActionPattern("alter_policies", "", false)
+    val delete = ResourceActionPattern("delete", "", false)
+
+    val sharePolicy = ResourceActionPattern("share_policy::.+", "", false)
+    val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
+  }
+
+  private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+  private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+
+  "POST /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
+    val resourceTypes = Map(resourceType.name -> resourceType)
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user123"), WorkbenchEmail("user1@example.com"), 0)
+/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
+    val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
+*/
+    val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_user123@${googleServicesConfig.appsDomain}")
+/**/
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val mockUserService = new UserService(directoryDAO, googleExt)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    //create user
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    import spray.json.DefaultJsonProtocol._
+    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Seq[AccessPolicyResponseEntry]].find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
+    }
+
+    import GoogleModelJsonSupport._
+    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", defaultUserProxyEmail.value.toLowerCase, None)))) {
+        responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
+      }
+    }
+  }
+
+  "GET /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "200 with sync date" in {
+    val resourceTypes = Map(resourceType.name -> resourceType)
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = new MockGoogleIamDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val mockUserService = new UserService(directoryDAO, googleExt)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    //create user
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+      assertResult("") {
+        responseAs[String]
+      }
+    }
+
+    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+      assertResult("") {
+        responseAs[String]
+      }
+    }
+
+    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    import spray.json.DefaultJsonProtocol._
+    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[Seq[AccessPolicyResponseEntry]]
+      response.find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
+    }
+
+    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] should not be empty
+    }
+  }
+
+  "GET /api/google/v1/user/petServiceAccount/{project}/key" should "200 with a new key" in {
+    val resourceTypes = Map(resourceType.name -> resourceType)
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val mockUserService = new UserService(directoryDAO, googleExt)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    //create user
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account
+    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+    }
+
+    // create a pet service account key
+    Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[String]
+      response shouldEqual(expectedJson)
+    }
+  }
+
+  "DELETE /api/google/v1/user/petServiceAccount/{project}/key/{keyId}" should "204 when deleting a key" in {
+    val resourceTypes = Map(resourceType.name -> resourceType)
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val mockUserService = new UserService(directoryDAO, googleExt)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    //create user
+    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account
+    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+    }
+
+    // create a pet service account key
+    Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[String]
+      response shouldEqual(expectedJson)
+    }
+
+    // create a pet service account key
+    Delete("/api/google/v1/user/petServiceAccount/myproject/key/123") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  private def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
+    val googleIamDAO = mock[GoogleIamDAO]
+    val expectedJson = """{"json":"yes I am"}"""
+    when(googleIamDAO.findServiceAccount(any[GoogleProject], any[ServiceAccountName])).thenReturn(Future.successful(None))
+    when(googleIamDAO.createServiceAccount(any[GoogleProject], any[ServiceAccountName], any[ServiceAccountDisplayName])).thenReturn(Future.successful(ServiceAccount(ServiceAccountSubjectId("12312341234"), WorkbenchEmail("pet@myproject.iam.gserviceaccount.com"), ServiceAccountDisplayName(""))))
+    when(googleIamDAO.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(ServiceAccountKey(ServiceAccountKeyId("foo"), ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(expectedJson).encode), None, None)))
+    when(googleIamDAO.removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])).thenReturn(Future.successful(()))
+    when(googleIamDAO.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(Seq.empty))
+    (googleIamDAO, expectedJson)
+  }
+
+  private def setupPetSATest: (UserInfo, TestSamRoutes with GoogleExtensionRoutes, String) = {
+    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val googleStorageDAO = new MockGoogleStorageDAO
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, cloudKeyCache, notificationDAO, googleServicesConfig.copy(serviceAccountClientEmail = defaultUserInfo.userEmail, serviceAccountClientId = defaultUserInfo.userId.value), petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+
+    val emailDomain = "example.com"
+    val mockResourceService = new ResourceService(configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val userService = new UserService(directoryDAO, googleExt)
+    val statusService = new StatusService(directoryDAO, NoExtensions)
+    val managedGroupService = new ManagedGroupService(mockResourceService, configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
+    val samRoutes = new TestSamRoutes(mockResourceService, userService, statusService, managedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
+      val googleExtensions = googleExt
+      val googleKeyCache = cloudKeyCache
+    }
+
+    runAndWait(googleExt.onBoot(SamApplication(userService, mockResourceService, statusService)))
+    (defaultUserInfo, samRoutes, expectedJson)
+  }
+
+  "GET /api/google/v1/petServiceAccount/{project}/{userEmail}" should "200 with a key" in {
+    val (defaultUserInfo, samRoutes, expectedJson) = setupPetSATest
+
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account key
+    Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[String]
+      response shouldEqual(expectedJson)
+    }
+  }
+
+  it should "404 when user does not exist" in {
+    val (defaultUserInfo, samRoutes, _) = setupPetSATest
+
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account key
+    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "403 when caller does not have action" in {
+    val (_, samRoutes, _) = setupPetSATest
+
+    // create a pet service account key
+    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+}


### PR DESCRIPTION
new api structure:
/api/config/v1/resourceTypes
/api/google/v1/...
/api/groups/v1/...
/api/resources/v1/...
/register/user/v1/...

note that I did not version admin end points or the status end point

The new *V1* specs are copies of the existing specs with V1 inserted. Any additions to the V1 apis should be tests in the V1 files. When we retire the unversioned apis we can delete the unversioned specs.

Swagger includes only versioned apis.

Last, there is a fair amount of whitespace changes so it is probably worth looking at file compares ignoring whitespace.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
