### PR TITLE
performance optimization

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1059,6 +1059,12 @@ paths:
           description: user not found
           schema:
             $ref: '#/definitions/ErrorReport'
+      parameters:
+        - in: query
+          description: when set to true does not check the various enabled status of the user
+          name: userDetailsOnly
+          required: false
+          type: string
       operationId: getUserStatus
       tags:
         - Users

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -29,11 +29,13 @@ trait UserRoutes extends UserInfoDirectives {
             }
           } ~
           get {
-            complete {
-              userService.getUserStatus(userInfo.userId).map { statusOption =>
-                statusOption.map { status =>
-                  StatusCodes.OK -> Option(status)
-                }.getOrElse(StatusCodes.NotFound -> None)
+            parameter("userDetailsOnly".?) { userDetailsOnly =>
+              complete {
+                userService.getUserStatus(userInfo.userId, userDetailsOnly.exists(_.equalsIgnoreCase("true"))).map { statusOption =>
+                  statusOption.map { status =>
+                    StatusCodes.OK -> Option(status)
+                  }.getOrElse(StatusCodes.NotFound -> None)
+                }
               }
             }
           }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -88,6 +88,11 @@ class UserRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
       status shouldEqual StatusCodes.OK
       responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
+
+    Get("/register/user/v1?userDetailsOnly=true") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map.empty)
+    }
   }
 
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -90,6 +90,9 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     // user should exist now
     val status = service.getUserStatus(defaultUserId).futureValue
     status shouldBe Some(UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)))
+
+    val statusNoEnabled = service.getUserStatus(defaultUserId, true).futureValue
+    statusNoEnabled shouldBe Some(UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map.empty))
   }
 
   it should "enable/disable user" in {


### PR DESCRIPTION
New Relic showed that the user status call is a top consumer and a lot of time is spend querying google. This enables a switch to turn that off if we don't need the info.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
