### PR TITLE
Unboundid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - SBT_OPTS=-Xmx3g sbt clean -Denv.type=test -Ddirectory.url=ldap://localhost:3389 -Ddirectory.password=testtesttest "test-only -- -n org.broadinstitute.tags.SchemaInit"
   - docker restart opendj
   - sleep 40
-  - SBT_OPTS=-Xmx3g sbt coverage -Denv.type=test -Ddirectory.url=ldap://localhost:3389 -Ddirectory.password=testtesttest "test-only -- -l org.broadinstitute.tags.SchemaInit"
+  - SBT_OPTS=-Xmx3g sbt coverage -Denv.type=test -Ddirectory.url=ldap://localhost:3389 -Ddirectory.password=testtesttest "test-only -- -l org.broadinstitute.tags.SchemaInit" coverageReport
 
 after_success:
   - SBT_OPTS=-Xmx3g sbt coveralls

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,6 +43,8 @@ object Dependencies {
   val scalaTest: ModuleID =       "org.scalatest" %% "scalatest"    % scalaTestV % "test"
   val mockito: ModuleID =         "org.mockito"    % "mockito-core" % "2.7.22"   % "test"
 
+  val unboundid: ModuleID = "com.unboundid" % "unboundid-ldapsdk" % "4.0.6"
+
   // All of workbench-libs pull in Akka; exclude it since we provide our own Akka dependency.
   // workbench-google pulls in workbench-{util, model, metrics}; exclude them so we can control the library versions individually.
   val workbenchUtil: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-util"   % workbenchUtilV
@@ -84,6 +86,8 @@ object Dependencies {
     workbenchModel,
     workbenchGoogle,
     workbenchNotifications,
-    workbenchGoogleTests
+    workbenchGoogleTests,
+
+    unboundid
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -1,16 +1,21 @@
 package org.broadinstitute.dsde.workbench.sam
 
 import java.io.File
+import java.net.URI
+import javax.net.SocketFactory
+import javax.net.ssl.SSLContext
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
+import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
+import com.unboundid.util.ssl.{SSLUtil, TrustStoreTrustManager}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.Pem
-import org.broadinstitute.dsde.workbench.google.{HttpGoogleProjectDAO, HttpGoogleDirectoryDAO, HttpGoogleIamDAO, HttpGooglePubSubDAO, HttpGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{HttpGoogleDirectoryDAO, HttpGoogleIamDAO, HttpGoogleProjectDAO, HttpGooglePubSubDAO, HttpGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.sam.config._
@@ -40,8 +45,16 @@ object Boot extends App with LazyLogging {
     implicit val materializer = ActorMaterializer()
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val accessPolicyDAO = new JndiAccessPolicyDAO(directoryConfig)
-    val directoryDAO = new JndiDirectoryDAO(directoryConfig)
+    val dirURI = new URI(directoryConfig.directoryUrl)
+    val socketFactory = dirURI.getScheme.toLowerCase match {
+      case "ldaps" => SSLContext.getDefault.getSocketFactory
+      case "ldap" => SocketFactory.getDefault
+      case unsupported => throw new WorkbenchException(s"unsupported directory url scheme: $unsupported")
+    }
+    val ldapConnectionPool = new LDAPConnectionPool(new LDAPConnection(socketFactory, dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+
+    val accessPolicyDAO = new LdapAccessPolicyDAO(ldapConnectionPool, directoryConfig)
+    val directoryDAO = new LdapDirectoryDAO(ldapConnectionPool, directoryConfig)
     val schemaDAO = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     val resourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.toSet

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
@@ -3,5 +3,5 @@ package org.broadinstitute.dsde.workbench.sam.config
 /**
   * Created by dvoet on 5/26/17.
   */
-case class DirectoryConfig(directoryUrl: String, user: String, password: String, baseDn: String, enabledUsersGroupDn: String)
+case class DirectoryConfig(directoryUrl: String, user: String, password: String, baseDn: String, enabledUsersGroupDn: String, connectionPoolSize: Int = 20)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
@@ -88,7 +88,8 @@ package object config {
       config.getString("user"),
       config.getString("password"),
       config.getString("baseDn"),
-      config.getString("enabledUsersGroupDn")
+      config.getString("enabledUsersGroupDn"),
+      config.as[Option[Int]]("connectionPoolSize").getOrElse(20)
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -19,8 +19,14 @@ trait DirectoryDAO {
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): Future[Seq[(WorkbenchGroupName, WorkbenchEmail)]]
   def deleteGroup(groupName: WorkbenchGroupName): Future[Unit]
 
-  def addGroupMember(groupId: WorkbenchGroupIdentity, addMember: WorkbenchSubject): Future[Unit]
-  def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): Future[Unit]
+  /**
+    * @return true if the subject was added, false if it was already there
+    */
+  def addGroupMember(groupId: WorkbenchGroupIdentity, addMember: WorkbenchSubject): Future[Boolean]
+  /**
+    * @return true if the subject was removed, false if it was already gone
+    */
+  def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): Future[Boolean]
   def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean]
   def updateSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Unit]
   def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectorySubjectNameSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectorySubjectNameSupport.scala
@@ -81,6 +81,7 @@ trait DirectorySubjectNameSupport {
     }
   }
 
-  protected def formattedDate(date: Date) = new SimpleDateFormat("yyyyMMddHHmmss.SSSZ").format(date)
-  protected def parseDate(date: String) = new SimpleDateFormat("yyyyMMddHHmmss.SSSZ").parse(date)
+  protected val dateFormat = "yyyyMMddHHmmss.SSSZ"
+  protected def formattedDate(date: Date) = new SimpleDateFormat(dateFormat).format(date)
+  protected def parseDate(date: String) = new SimpleDateFormat(dateFormat).parse(date)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -228,6 +228,7 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
           new Attribute("objectclass", Seq("top", "groupofnames").asJava),
           new Attribute(Attr.member, subjectDn(subject))
         )
+      case ldape: LDAPException if ldape.getResultCode == ResultCode.ATTRIBUTE_OR_VALUE_EXISTS =>
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -1,0 +1,309 @@
+package org.broadinstitute.dsde.workbench.sam.directory
+import java.util.Date
+
+import akka.http.scaladsl.model.StatusCodes
+import com.unboundid.ldap.sdk._
+import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.{ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.{Attr, ObjectClass}
+import org.broadinstitute.dsde.workbench.sam.util.LdapSupport
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, protected val directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext) extends DirectoryDAO with DirectorySubjectNameSupport with LdapSupport {
+
+  override def createGroup(group: BasicWorkbenchGroup): Future[BasicWorkbenchGroup] = Future {
+    val membersAttribute = if (group.members.isEmpty) None else Option(new Attribute(Attr.uniqueMember, group.members.map(subject => subjectDn(subject)).asJava))
+    val attributes = Seq(
+      new Attribute("objectclass", "top", "workbenchGroup"),
+      new Attribute(Attr.email, group.email.value),
+      new Attribute(Attr.groupUpdatedTimestamp, formattedDate(new Date()))
+    ) ++ membersAttribute
+
+    ldapConnectionPool.add(groupDn(group.id), attributes.asJava)
+
+    group
+  }.recover {
+    case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>
+      throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group name ${group.id.value} already exists"))
+  }
+
+  override def loadGroup(groupName: WorkbenchGroupName): Future[Option[BasicWorkbenchGroup]] = Future {
+    Option(ldapConnectionPool.getEntry(groupDn(groupName))) map { results =>
+      unmarshalGroup(results)
+    }
+  }
+
+  private def unmarshalGroup(results: Entry) = {
+    val cn = getAttribute(results, Attr.cn).getOrElse(throw new WorkbenchException(s"${Attr.cn} attribute missing: ${results.getDN}"))
+    val email = getAttribute(results, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing: ${results.getDN}"))
+    val memberDns = getAttributes(results, Attr.uniqueMember).getOrElse(Set.empty).toSet
+
+    BasicWorkbenchGroup(WorkbenchGroupName(cn), memberDns.map(dnToSubject), WorkbenchEmail(email))
+  }
+
+  override def loadGroups(groupNames: Set[WorkbenchGroupName]): Future[Seq[BasicWorkbenchGroup]] = Future {
+    val filters = groupNames.grouped(batchSize).map(batch => Filter.createORFilter(batch.map(g => Filter.createEqualityFilter(Attr.cn, g.value)).asJava)).toSeq
+    ldapSearchStream(groupsOu, SearchScope.BASE, filters:_*)(unmarshalGroup)
+  }
+
+  override def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] = Future {
+    Option(ldapConnectionPool.getEntry(groupDn(groupName), Attr.email)) map { results =>
+      WorkbenchEmail(getAttribute(results, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing: ${results.getDN}")))
+    }
+  }
+
+  override def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): Future[Seq[(WorkbenchGroupName, WorkbenchEmail)]] = loadGroups(groupNames).map(_.map(g => g.id -> g.email))
+
+  override def deleteGroup(groupName: WorkbenchGroupName): Future[Unit] = {
+    listAncestorGroups(groupName).map { ancestors =>
+      if (ancestors.nonEmpty) {
+        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group"))
+      } else {
+        ldapConnectionPool.delete(groupDn(groupName))
+      }
+    }
+  }
+
+  override def addGroupMember(groupId: WorkbenchGroupIdentity, addMember: WorkbenchSubject): Future[Unit] = Future {
+    ldapConnectionPool.modify(groupDn(groupId),
+      new Modification(ModificationType.ADD, Attr.uniqueMember, subjectDn(addMember)),
+      groupUpdatedModification
+    )
+  }
+
+  private def groupUpdatedModification = {
+    new Modification(ModificationType.REPLACE, Attr.groupUpdatedTimestamp, formattedDate(new Date()))
+  }
+
+  override def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): Future[Unit] = Future {
+    ldapConnectionPool.modify(groupDn(groupId),
+      new Modification(ModificationType.DELETE, Attr.uniqueMember, subjectDn(removeMember)),
+      groupUpdatedModification
+    )
+  }
+
+  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean] = Future {
+    val isMember = for {
+      entry <- Option(ldapConnectionPool.getEntry(subjectDn(member), Attr.memberOf))
+      memberOf <- Option(entry.getAttribute(Attr.memberOf))
+    } yield {
+      memberOf.getValues.contains(groupDn(groupId))
+    }
+    isMember.getOrElse(false)
+  }
+
+  override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Unit] = Future {
+    ldapConnectionPool.modify(groupDn(groupId), new Modification(ModificationType.REPLACE, Attr.groupSynchronizedTimestamp, formattedDate(new Date())))
+  }
+
+  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]] = Future {
+    Option(ldapConnectionPool.getEntry(groupDn(groupId), Attr.groupSynchronizedTimestamp)).map { entry =>
+      Option(entry.getAttributeValue(Attr.groupSynchronizedTimestamp)).map(parseDate)
+    }.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
+  }
+
+  override def loadSubjectFromEmail(email: WorkbenchEmail): Future[Option[WorkbenchSubject]] = Future {
+    ldapConnectionPool.search(directoryConfig.baseDn, SearchScope.SUB, Filter.createEqualityFilter(Attr.email, email.value)).getSearchEntries.asScala match {
+      case Seq() => None
+      case Seq(subject) => Option(dnToSubject(subject.getDN))
+      case subjects => throw new WorkbenchException(s"Database error: email $email refers to too many subjects: ${subjects.map(_.getDN)}")
+    }
+  }
+
+  override def loadSubjectEmail(subject: WorkbenchSubject): Future[Option[WorkbenchEmail]] = Future {
+    Option(ldapConnectionPool.getEntry(subjectDn(subject), Attr.email)).flatMap { entry =>
+      Option(entry.getAttributeValue(Attr.email)).map(WorkbenchEmail)
+    }
+  }
+
+  override def loadSubjectEmails(subjects: Set[WorkbenchSubject]): Future[Set[WorkbenchEmail]] = {
+    val users = loadUsers(subjects collect { case userId: WorkbenchUserId => userId })
+    val groups = loadGroups(subjects collect { case groupName: WorkbenchGroupName => groupName })
+    for {
+      userEmails <- users.map(_.map(_.email))
+      groupEmails <- groups.map(_.map(_.email))
+    } yield (userEmails ++ groupEmails).toSet
+  }
+
+  override def createUser(user: WorkbenchUser): Future[WorkbenchUser] = Future {
+    ldapConnectionPool.add(userDn(user.id),
+      new Attribute(Attr.email, user.email.value),
+      new Attribute(Attr.sn, user.id.value),
+      new Attribute(Attr.cn, user.id.value),
+      new Attribute(Attr.uid, user.id.value),
+      new Attribute("objectclass", Seq("top", "workbenchPerson").asJava)
+    )
+
+    user
+  }.recover {
+    case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>
+      throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"identity with id ${user.id} already exists"))
+  }
+
+  override def loadUser(userId: WorkbenchUserId): Future[Option[WorkbenchUser]] = Future {
+    loadUserInternal(userId)
+  }
+
+  private def loadUserInternal(userId: WorkbenchUserId) = {
+    Option(ldapConnectionPool.getEntry(userDn(userId))) map { results =>
+      unmarshalUser(results)
+    }
+  }
+
+  private def unmarshalUser(results: Entry): WorkbenchUser = {
+    val uid = getAttribute(results, Attr.uid).getOrElse(throw new WorkbenchException(s"${Attr.uid} attribute missing"))
+    val email = getAttribute(results, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing"))
+
+    WorkbenchUser(WorkbenchUserId(uid), WorkbenchEmail(email))
+  }
+
+  override def loadUsers(userIds: Set[WorkbenchUserId]): Future[Seq[WorkbenchUser]] = Future {
+    val filters = userIds.grouped(batchSize).map(batch => Filter.createORFilter(batch.map(g => Filter.createEqualityFilter(Attr.uid, g.value)).asJava)).toSeq
+    ldapSearchStream(peopleOu, SearchScope.BASE, filters:_*)(unmarshalUser)
+  }
+
+  override def deleteUser(userId: WorkbenchUserId): Future[Unit] = Future {
+    ldapConnectionPool.delete(userDn(userId))
+  }
+
+  override def addProxyGroup(userId: WorkbenchUserId, proxyEmail: WorkbenchEmail): Future[Unit] = Future {
+    ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.proxyEmail, proxyEmail.value))
+  }
+
+  override def readProxyGroup(userId: WorkbenchUserId): Future[Option[WorkbenchEmail]] = Future {
+    for {
+      entry <- Option(ldapConnectionPool.getEntry(userDn(userId), Attr.proxyEmail))
+      email <- Option(entry.getAttributeValue(Attr.proxyEmail))
+    } yield {
+      WorkbenchEmail(email)
+    }
+  }
+
+  override def listUsersGroups(userId: WorkbenchUserId): Future[Set[WorkbenchGroupIdentity]] = Future {
+    listMemberOfGroups(userDn(userId))
+  }
+
+  private def listMemberOfGroups(dn: String) = {
+    val groupsOption = for {
+      entry <- Option(ldapConnectionPool.getEntry(dn, Attr.memberOf))
+      memberOf <- Option(entry.getAttributeValues(Attr.memberOf))
+    } yield {
+      memberOf.toSet.map(dnToGroupIdentity)
+    }
+    groupsOption.getOrElse(Set.empty)
+  }
+
+  override def listFlattenedGroupUsers(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchUserId]] = Future {
+    ldapSearchStream(peopleOu, SearchScope.SUB, Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId)))(unmarshalUser).map(_.id).toSet
+  }
+
+  override def listAncestorGroups(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchGroupIdentity]] = Future {
+    listMemberOfGroups(groupDn(groupId))
+  }
+
+  override def enableIdentity(subject: WorkbenchSubject): Future[Unit] = Future {
+    try {
+      ldapConnectionPool.modify(directoryConfig.enabledUsersGroupDn, new Modification(ModificationType.ADD, Attr.member, subjectDn(subject)))
+    } catch {
+      case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
+        ldapConnectionPool.add(directoryConfig.enabledUsersGroupDn,
+          new Attribute("objectclass", Seq("top", "groupofnames").asJava),
+          new Attribute(Attr.member, subjectDn(subject))
+        )
+    }
+  }
+
+  override def disableIdentity(subject: WorkbenchSubject): Future[Unit] = Future {
+    try {
+      ldapConnectionPool.modify(directoryConfig.enabledUsersGroupDn, new Modification(ModificationType.DELETE, Attr.member, subjectDn(subject)))
+    } catch {
+      case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_ATTRIBUTE =>
+    }
+  }
+
+  override def isEnabled(subject: WorkbenchSubject): Future[Boolean] = Future {
+    val result = for {
+      entry <- Option(ldapConnectionPool.getEntry(directoryConfig.enabledUsersGroupDn, Attr.member))
+      members <- Option(entry.getAttributeValues(Attr.member))
+    } yield {
+      members.contains(subjectDn(subject))
+    }
+    result.getOrElse(false)
+  }
+
+  override def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId): Future[Option[WorkbenchUser]] = Future {
+    val matchingUsers = ldapSearchStream(peopleOu, SearchScope.SUBORDINATE_SUBTREE, Filter.createEqualityFilter(Attr.uid, petSA.value)) { entry =>
+      dnToSubject(entry.getDN)
+    }.collect {
+      case pet: PetServiceAccountId => pet.userId
+    }.toSet
+
+    if (matchingUsers.size > 1) {
+      throw new WorkbenchException(s"id $petSA refers to too many subjects: $matchingUsers")
+    } else {
+      matchingUsers.headOption.flatMap(loadUserInternal)
+    }
+  }
+
+  override def createPetServiceAccount(petServiceAccount: PetServiceAccount): Future[PetServiceAccount] = Future {
+    val attributes = createPetServiceAccountAttributes(petServiceAccount) ++
+      Seq(new Attribute("objectclass", Seq("top", ObjectClass.petServiceAccount).asJava), new Attribute(Attr.project, petServiceAccount.id.project.value))
+
+    ldapConnectionPool.add(petDn(petServiceAccount.id), attributes:_*)
+    petServiceAccount
+  }.recover {
+    case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>
+      throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"identity with id ${petServiceAccount.id} already exists"))
+  }
+
+  private def createPetServiceAccountAttributes(petServiceAccount: PetServiceAccount) = {
+    val attributes = Seq(
+      new Attribute(Attr.email, petServiceAccount.serviceAccount.email.value),
+      new Attribute(Attr.sn, petServiceAccount.serviceAccount.subjectId.value),
+      new Attribute(Attr.cn, petServiceAccount.serviceAccount.subjectId.value),
+      new Attribute(Attr.uid, petServiceAccount.serviceAccount.subjectId.value)
+    )
+
+
+    val displayNameAttribute = if (!petServiceAccount.serviceAccount.displayName.value.isEmpty) {
+      Option(new Attribute(Attr.givenName, petServiceAccount.serviceAccount.displayName.value))
+    } else {
+      None
+    }
+
+    attributes ++ displayNameAttribute
+  }
+
+  override def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId): Future[Option[PetServiceAccount]] = Future {
+    Option(ldapConnectionPool.getEntry(petDn(petServiceAccountId))).map(unmarshalPetServiceAccount)
+  }
+
+  private def unmarshalPetServiceAccount(entry: Entry): PetServiceAccount = {
+    val uid = getAttribute(entry, Attr.uid).getOrElse(throw new WorkbenchException(s"${Attr.uid} attribute missing"))
+    val email = getAttribute(entry, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing"))
+    val displayName = getAttribute(entry, Attr.givenName).getOrElse("")
+
+    PetServiceAccount(dnToSubject(entry.getDN).asInstanceOf[PetServiceAccountId], ServiceAccount(ServiceAccountSubjectId(uid), WorkbenchEmail(email), ServiceAccountDisplayName(displayName)))
+  }
+
+  override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): Future[Unit] = Future {
+    ldapConnectionPool.delete(petDn(petServiceAccountId))
+  }
+
+  override def getAllPetServiceAccountsForUser(userId: WorkbenchUserId): Future[Seq[PetServiceAccount]] = Future {
+    ldapSearchStream(userDn(userId), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.petServiceAccount))(unmarshalPetServiceAccount)
+  }
+
+  override def updatePetServiceAccount(petServiceAccount: PetServiceAccount): Future[PetServiceAccount] = Future {
+    val modifications = createPetServiceAccountAttributes(petServiceAccount).map { attribute =>
+      new Modification(ModificationType.REPLACE, attribute.getName, attribute.getRawValues)
+    }
+    ldapConnectionPool.modify(petDn(petServiceAccount.id), modifications.asJava)
+    petServiceAccount
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -48,7 +48,7 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
 
   override def loadGroups(groupNames: Set[WorkbenchGroupName]): Future[Seq[BasicWorkbenchGroup]] = Future {
     val filters = groupNames.grouped(batchSize).map(batch => Filter.createORFilter(batch.map(g => Filter.createEqualityFilter(Attr.cn, g.value)).asJava)).toSeq
-    ldapSearchStream(groupsOu, SearchScope.BASE, filters:_*)(unmarshalGroup)
+    ldapSearchStream(groupsOu, SearchScope.SUB, filters:_*)(unmarshalGroup)
   }
 
   override def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] = Future {
@@ -164,7 +164,7 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
 
   override def loadUsers(userIds: Set[WorkbenchUserId]): Future[Seq[WorkbenchUser]] = Future {
     val filters = userIds.grouped(batchSize).map(batch => Filter.createORFilter(batch.map(g => Filter.createEqualityFilter(Attr.uid, g.value)).asJava)).toSeq
-    ldapSearchStream(peopleOu, SearchScope.BASE, filters:_*)(unmarshalUser)
+    ldapSearchStream(peopleOu, SearchScope.ONE, filters:_*)(unmarshalUser)
   }
 
   override def deleteUser(userId: WorkbenchUserId): Future[Unit] = Future {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -1,0 +1,138 @@
+package org.broadinstitute.dsde.workbench.sam.openam
+
+import java.util.Date
+
+import akka.http.scaladsl.model.StatusCodes
+import com.unboundid.ldap.sdk._
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
+import org.broadinstitute.dsde.workbench.sam.directory.DirectorySubjectNameSupport
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.{Attr, ObjectClass}
+import org.broadinstitute.dsde.workbench.sam.util.LdapSupport
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, protected val directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext) extends AccessPolicyDAO with DirectorySubjectNameSupport with LdapSupport {
+  override def createResourceType(resourceTypeName: ResourceTypeName): Future[ResourceTypeName] = Future {
+    ldapConnectionPool.add(resourceTypeDn(resourceTypeName),
+      new Attribute("objectclass", Seq("top", ObjectClass.resourceType).asJava),
+      new Attribute(Attr.ou, "resources")
+    )
+    resourceTypeName
+  }.recover {
+    case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS => resourceTypeName
+  }
+
+  override def createResource(resource: Resource): Future[Resource] = Future {
+    ldapConnectionPool.add(resourceDn(resource),
+      new Attribute("objectclass", Seq("top", ObjectClass.resource).asJava),
+      new Attribute(Attr.resourceType, resource.resourceTypeName.value)
+    )
+    resource
+  }.recover {
+    case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>
+      throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "A resource of this type and name already exists"))
+  }
+
+  // TODO: Method is not tested.  To test properly, we'll probably need a loadResource or getResource method
+  override def deleteResource(resource: Resource): Future[Unit] = Future {
+    ldapConnectionPool.delete(resourceDn(resource))
+  }
+
+  override def createPolicy(policy: AccessPolicy): Future[AccessPolicy] = Future {
+    val attributes = Seq(
+      new Attribute("objectclass", "top", ObjectClass.policy),
+      new Attribute(Attr.cn, policy.id.accessPolicyName.value),
+      new Attribute(Attr.email, policy.email.value),
+      new Attribute(Attr.resourceType, policy.id.resource.resourceTypeName.value),
+      new Attribute(Attr.resourceId, policy.id.resource.resourceId.value),
+      new Attribute(Attr.groupUpdatedTimestamp, formattedDate(new Date()))
+    ) ++
+      maybeAttribute(Attr.action, policy.actions.map(_.value)) ++
+      maybeAttribute(Attr.role, policy.roles.map(_.value)) ++
+      maybeAttribute(Attr.uniqueMember, policy.members.map(subjectDn))
+
+    ldapConnectionPool.add(policyDn(policy.id), attributes.asJava)
+    policy
+  }
+
+  private def maybeAttribute(attr: String, values: Set[String]): Option[Attribute] = values.toSeq match {
+    case Seq() => None
+    case _ => Option(new Attribute(attr, values.asJava))
+  }
+
+  override def deletePolicy(policy: AccessPolicy): Future[Unit] = Future {
+    ldapConnectionPool.delete(policyDn(policy.id))
+  }
+
+  override def loadPolicy(resourceAndPolicyName: ResourceAndPolicyName): Future[Option[AccessPolicy]] = Future {
+    Option(ldapConnectionPool.getEntry(policyDn(resourceAndPolicyName))).map(unmarshalAccessPolicy)
+  }
+
+  private def unmarshalAccessPolicy(entry: Entry): AccessPolicy = {
+    val policyName = getAttribute(entry, Attr.policy).get
+    val resourceTypeName = ResourceTypeName(getAttribute(entry, Attr.resourceType).get)
+    val resourceId = ResourceId(getAttribute(entry, Attr.resourceId).get)
+    val resource = Resource(resourceTypeName, resourceId)
+    val members = getAttributes(entry, Attr.uniqueMember).getOrElse(Set.empty).toSet.map(dnToSubject)
+    val roles = getAttributes(entry, Attr.role).getOrElse(Set.empty).toSet.map(r => ResourceRoleName(r))
+    val actions = getAttributes(entry, Attr.action).getOrElse(Set.empty).toSet.map(a => ResourceAction(a))
+
+    val email = WorkbenchEmail(getAttribute(entry, Attr.email).get)
+
+    AccessPolicy(ResourceAndPolicyName(resource, AccessPolicyName(policyName)), members, email, roles, actions)
+  }
+
+  override def overwritePolicy(newPolicy: AccessPolicy): Future[AccessPolicy] = Future {
+    val memberMod = new Modification(ModificationType.REPLACE, Attr.uniqueMember, newPolicy.members.map(subjectDn).toArray:_*)
+    val actionMod = new Modification(ModificationType.REPLACE, Attr.action, newPolicy.actions.map(_.value).toArray:_*)
+    val roleMod = new Modification(ModificationType.REPLACE, Attr.role, newPolicy.roles.map(_.value).toArray:_*)
+    val dateMod = new Modification(ModificationType.REPLACE, Attr.groupUpdatedTimestamp, formattedDate(new Date()))
+
+    ldapConnectionPool.modify(policyDn(newPolicy.id), memberMod, actionMod, roleMod, dateMod)
+
+    newPolicy
+  }
+
+  override def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): Future[Set[ResourceIdAndPolicyName]] = Future {
+    val entry = ldapConnectionPool.getEntry(userDn(userId), Attr.memberOf)
+    val groupDns = getAttributes(entry, Attr.memberOf).getOrElse(Set.empty).toSet
+
+    val policyDnPattern = dnMatcher(Seq(Attr.policy, Attr.resourceId), resourceTypeDn(resourceTypeName))
+
+    groupDns.collect {
+      case policyDnPattern(policyName, resourceId) => ResourceIdAndPolicyName(ResourceId(resourceId), AccessPolicyName(policyName))
+    }
+  }
+
+  override def listAccessPolicies(resource: Resource): Future[Set[AccessPolicy]] = Future {
+    ldapSearchStream(resourceDn(resource), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.policy))(unmarshalAccessPolicy).toSet
+  }
+
+  override def listAccessPoliciesForUser(resource: Resource, user: WorkbenchUserId): Future[Set[AccessPolicy]] = Future {
+    val result = for {
+      entry <- Option(ldapConnectionPool.getEntry(subjectDn(user), Attr.memberOf))
+      memberOfDns <- getAttributes(entry, Attr.memberOf)
+    } yield {
+      val memberOfSubjects = memberOfDns.map(dnToSubject).toSet
+      memberOfSubjects.collect {
+        case ripn@ResourceAndPolicyName(`resource`, _) => unmarshalAccessPolicy(ldapConnectionPool.getEntry(subjectDn(ripn)))
+      }
+    }
+    result.getOrElse(Set.empty)
+  }
+
+  override def listFlattenedPolicyMembers(resourceAndPolicyName: ResourceAndPolicyName): Future[Set[WorkbenchUserId]] = Future {
+    ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(resourceAndPolicyName)))(unmarshalUser).map(_.id).toSet
+  }
+
+  private def unmarshalUser(entry: Entry): WorkbenchUser = {
+    val uid = getAttribute(entry, Attr.uid).getOrElse(throw new WorkbenchException(s"${Attr.uid} attribute missing"))
+    val email = getAttribute(entry, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing"))
+
+    WorkbenchUser(WorkbenchUserId(uid), WorkbenchEmail(email))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
@@ -58,20 +58,6 @@ trait JndiSupport {
     t.get
   }
 
-  /**
-    * Constructs a regular expression to extract the leading attribute values of a dn. Example: to extract
-    * policy namd an resource id from the dn policy=foo,resourceId=bar,resourceType=splat,ou=resources,dc=x,dc=u,dc=com
-    * matchAttributeNames would be Seq("policy", "resourceId") and baseDn would be "resourceType=splat,ou=resources,dc=x,dc=u,dc=com".
-    *
-    * @param matchAttributeNames names of attributes in the leading part of the dn that should match and extract values
-    * @param baseDn the trailing part of the dn that should match but we don't care to extract values
-    * @return pattern with capture groups for each member of matchAttributeNames
-    */
-  protected def dnMatcher(matchAttributeNames: Seq[String], baseDn: String): Regex = {
-    val partStrings = matchAttributeNames.map { attrName => s"$attrName=([^,]+)" }
-    partStrings.mkString("(?i)", ",", s",$baseDn").r
-  }
-
   import scala.language.implicitConversions
   /**
     * Use this implicit conversion class and following call to extractResultsAndClose
@@ -94,9 +80,6 @@ trait JndiSupport {
       }
     }
   }
-
-  protected def formattedDate(date: Date) = new SimpleDateFormat("yyyyMMddHHmmss.SSSZ").format(date)
-  protected def parseDate(date: String) = new SimpleDateFormat("yyyyMMddHHmmss.SSSZ").parse(date)
 }
 
 /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.util.matching.Regex
 
+@deprecated(message = "use LdapSupport instead")
 trait JndiSupport {
   private val batchSize = 1000
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/JndiSupport.scala
@@ -23,7 +23,7 @@ trait JndiSupport {
     env.put(Context.SECURITY_CREDENTIALS, password)
 
     // enable connection pooling
-    env.put("com.sun.jndi.ldap.connect.pool", "true")
+//    env.put("com.sun.jndi.ldap.connect.pool", "true")
 
     new InitialDirContext(env)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -13,7 +13,7 @@ trait LdapSupport {
     *
     * This function makes use of Unboundid's asynchronous and buffered loading of search results. That's why it
     * returns a Stream. The LDAPEntrySource used internally limits the number of items pulled back from ldap
-    * to avoid memory overrun and the user of Stream passes that behavior up to the caller. If the results are
+    * to avoid memory overrun and the use of Stream passes that behavior up to the caller. If the results are
     * possibly large try not to read them all in to memory (e.g. by calling toSet).
     *
     * @param baseDn dn to start the search

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.workbench.sam.util
+
+import com.unboundid.ldap.sdk._
+
+trait LdapSupport {
+  protected val ldapConnectionPool: LDAPConnectionPool
+  protected val batchSize = 1000
+
+  protected def ldapSearchStream[T](baseDn: String, searchScope: SearchScope, filters: Filter*)(unmarshaller: Entry => T): Stream[T] = {
+    filters.flatMap { filter =>
+      val search = new SearchRequest(baseDn, searchScope, filter)
+      val entrySource = new LDAPEntrySource(ldapConnectionPool.getConnection, search, true)
+      ldapEntrySourceStream(entrySource)(unmarshaller)
+    }.toStream
+  }
+
+  protected def ldapEntrySourceStream[T](entrySource: LDAPEntrySource)(unmarshaller: Entry => T): Stream[T] = {
+    Option(entrySource.nextEntry) match {
+      case None => Stream.empty
+      case Some(next) => Stream.cons(unmarshaller(next), ldapEntrySourceStream(entrySource)(unmarshaller))
+    }
+  }
+
+  protected def getAttribute(results: Entry, key: String): Option[String] = {
+    Option(results.getAttribute(key)).map(_.getValue)
+  }
+
+  protected def getAttributes(results: Entry, key: String): Option[TraversableOnce[String]] = {
+    Option(results.getAttribute(key)).map(_.getValues)
+  }
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -8,6 +8,22 @@ trait LdapSupport {
   protected val ldapConnectionPool: LDAPConnectionPool
   protected val batchSize = 1000
 
+  /**
+    * Call this to perform an ldap search.
+    *
+    * This function makes use of Unboundid's asynchronous and buffered loading of search results. That's why it
+    * returns a Stream. The LDAPEntrySource used internally limits the number of items pulled back from ldap
+    * to avoid memory overrun and the user of Stream passes that behavior up to the caller. If the results are
+    * possibly large try not to read them all in to memory (e.g. by calling toSet).
+    *
+    * @param baseDn dn to start the search
+    * @param searchScope depth of search
+    * @param filters Can accept more than one filter to perform serially for example in the case of batched queries.
+    *                The matches for all filters are returned (logical OR). 0 filters, 0 results.
+    * @param unmarshaller transforms each matched Entry to the object of your choice
+    * @tparam T
+    * @return
+    */
   protected def ldapSearchStream[T](baseDn: String, searchScope: SearchScope, filters: Filter*)(unmarshaller: Entry => T): Stream[T] = {
     filters.flatMap { filter =>
       val search = new SearchRequest(baseDn, searchScope, filter)
@@ -16,10 +32,18 @@ trait LdapSupport {
     }.toStream
   }
 
+  // this is the magic recursive stream generator
   private def ldapEntrySourceStream[T](entrySource: LDAPEntrySource)(unmarshaller: Entry => T): Stream[T] = {
     Try(Option(entrySource.nextEntry)) match {
-      case Success(None) => Stream.empty
-      case Success(Some(next)) => Stream.cons(unmarshaller(next), ldapEntrySourceStream(entrySource)(unmarshaller))
+      case Success(None) =>
+        // reached the last element, Stream.empty terminates the stream
+        Stream.empty
+
+      case Success(Some(next)) =>
+        // next element exists, return a Stream starting with unmarshalled next followed by the rest of the stream
+        // (streams are smart and lazily evaluate the second parameter)
+        Stream.cons(unmarshaller(next), ldapEntrySourceStream(entrySource)(unmarshaller))
+
       case Failure(ldape: EntrySourceException) if ldape.getCause.isInstanceOf[LDAPException] &&
         ldape.getCause.asInstanceOf[LDAPException].getResultCode == ResultCode.NO_SUCH_OBJECT => Stream.empty // the base dn does not exist, treat as empty search
       case Failure(regrets) => throw regrets
@@ -33,6 +57,4 @@ trait LdapSupport {
   protected def getAttributes(results: Entry, key: String): Option[TraversableOnce[String]] = {
     Option(results.getAttribute(key)).map(_.getValues)
   }
-
-
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -6,6 +6,7 @@ directory {
   baseDn="dc=dsde-dev,dc=broadinstitute,dc=org"
   baseDn = ${?DIRECTORY_BASEDN}
   enabledUsersGroupDn = "cn=enabled-users,ou=groups,dc=dsde-dev,dc=broadinstitute,dc=org"
+  connectionPoolSize = 5
 }
 
 googleServices {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -22,12 +22,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 /**
   * Created by dvoet on 5/30/17.
   */
-class JndiDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
   val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dirURI = new URI(directoryConfig.directoryUrl)
-  val dao = new LdapDirectoryDAO(new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), 5), directoryConfig)
-//  val dao = new JndiDirectoryDAO(directoryConfig)
+  val dao = new LdapDirectoryDAO(new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize), directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -41,7 +41,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
   }
 
 
-  "JndiGroupDirectoryDAO" should "create, read, delete groups" in {
+  "LdapGroupDirectoryDAO" should "create, read, delete groups" in {
     val groupName = WorkbenchGroupName(UUID.randomUUID().toString)
     val group = BasicWorkbenchGroup(groupName, Set.empty, WorkbenchEmail("john@doe.org"))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAcc
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.openam.JndiAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.openam.LdapAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 
@@ -26,7 +26,8 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
   val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dirURI = new URI(directoryConfig.directoryUrl)
-  val dao = new LdapDirectoryDAO(new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize), directoryConfig)
+  val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+  val dao = new LdapDirectoryDAO(connectionPool, directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {
@@ -352,7 +353,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     runAndWait(dao.createGroup(group1))
     runAndWait(dao.createGroup(group2))
 
-    val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
+    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig)
 
     val typeName1 = ResourceTypeName(UUID.randomUUID().toString)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -54,7 +54,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def addGroupMember(groupName: WorkbenchGroupIdentity, addMember: WorkbenchSubject): Future[Unit] = Future {
+  override def addGroupMember(groupName: WorkbenchGroupIdentity, addMember: WorkbenchSubject): Future[Boolean] = Future {
     val group = groups(groupName)
     val updatedGroup = group match {
       case g: BasicWorkbenchGroup => g.copy(members = group.members + addMember)
@@ -62,9 +62,10 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
       case _ => throw new WorkbenchException(s"unknown group implementation: $group")
     }
     groups += groupName -> updatedGroup
+    true
   }
 
-  override def removeGroupMember(groupName: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): Future[Unit] = Future {
+  override def removeGroupMember(groupName: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): Future[Boolean] = Future {
     val group = groups(groupName)
     val updatedGroup = group match {
       case g: BasicWorkbenchGroup => g.copy(members = group.members - removeMember)
@@ -72,6 +73,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
       case _ => throw new WorkbenchException(s"unknown group implementation: $group")
     }
     groups += groupName -> updatedGroup
+    true
   }
 
   override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean] = Future {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -1,21 +1,22 @@
 package org.broadinstitute.dsde.workbench.sam.google
 
+import java.net.URI
 import java.util.{Date, UUID}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
+import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchExceptionWithErrorReport, _}
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, GoogleServicesConfig, PetServiceAccountConfig}
 import org.broadinstitute.dsde.workbench.sam.{TestSupport, _}
-import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, JndiDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, LdapDirectoryDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, MockAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import org.scalatest.mockito.MockitoSugar
@@ -48,6 +49,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   lazy val config = ConfigFactory.load()
   lazy val directoryConfig = config.as[DirectoryConfig]("directory")
+  lazy val dirURI = new URI(directoryConfig.directoryUrl)
+  lazy val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
   lazy val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
   lazy val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
@@ -181,7 +184,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   "GoogleExtension" should "get a pet service account for a user" in {
-    val (dirDAO: JndiDirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
+    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
 
     // create a user
     val newUser = service.createUser(defaultUser).futureValue
@@ -229,8 +232,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   }
 
-  private def initPetTest: (JndiDirectoryDAO, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchUserId, WorkbenchEmail, WorkbenchEmail, WorkbenchUser) = {
-    val dirDAO = new JndiDirectoryDAO(directoryConfig)
+  private def initPetTest: (DirectoryDAO, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchUserId, WorkbenchEmail, WorkbenchEmail, WorkbenchUser) = {
+    val dirURI = new URI(directoryConfig.directoryUrl)
+    val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
@@ -255,7 +260,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "attach existing service account to pet" in {
-    val (dirDAO: JndiDirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
+    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
     val googleProject = GoogleProject("testproject")
 
     val (saName, saDisplayName) = googleExtensions.toPetSAFromUser(defaultUser)
@@ -272,7 +277,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "recreate service account when missing for pet" in {
-    val (dirDAO: JndiDirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
+    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserId: WorkbenchUserId, defaultUserEmail: WorkbenchEmail, defaultUserProxyEmail: WorkbenchEmail, defaultUser: WorkbenchUser) = initPetTest
 
     // create a user
     val newUser = service.createUser(defaultUser).futureValue
@@ -307,7 +312,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "throw an exception with a NotFound error report when getting sync date for group that does not exist" in {
-    val dirDAO = new JndiDirectoryDAO(directoryConfig)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, "local", configResourceTypes(CloudExtensions.resourceTypeName))
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
@@ -318,7 +323,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return None when getting sync date for a group that has not been synced" in {
-    val dirDAO = new JndiDirectoryDAO(directoryConfig)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, "local", configResourceTypes(CloudExtensions.resourceTypeName))
     val groupName = WorkbenchGroupName("group-sync")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail(""))))
@@ -330,7 +335,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return sync date for a group that has been synced" in {
-    val dirDAO = new JndiDirectoryDAO(directoryConfig)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val ge = new GoogleExtensions(dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, "local", configResourceTypes(CloudExtensions.resourceTypeName))
     val groupName = WorkbenchGroupName("group-sync")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org"))))
@@ -465,7 +470,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
     implicit val patienceConfig = PatienceConfig(1 second)
-    val dirDAO = new JndiDirectoryDAO(directoryConfig)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/JndiAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/JndiAccessPolicyDAOSpec.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.sam.openam
 
+import java.net.URI
 import java.util.UUID
 
 import com.typesafe.config.ConfigFactory
+import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import net.ceedubs.ficus.Ficus._
@@ -20,8 +22,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class JndiAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
   val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
-  val dao = new JndiAccessPolicyDAO(directoryConfig)
-  val dirDao = new JndiDirectoryDAO(directoryConfig)
+  val dirURI = new URI(directoryConfig.directoryUrl)
+  private val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), 5)
+  val dao = new LdapAccessPolicyDAO(connectionPool, directoryConfig)
+  val dirDao = new LdapDirectoryDAO(connectionPool, directoryConfig)
+//  val dao = new JndiAccessPolicyDAO(directoryConfig)
+//  val dirDao = new JndiDirectoryDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -42,7 +42,7 @@ class LdapAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     WorkbenchEmail(s"policy-$resourceType-$resourceId-$policyName@dev.test.firecloud.org")
   }
 
-  "JndiAccessPolicyDAO" should "create, list, delete policies" in {
+  "LdapAccessPolicyDAO" should "create, list, delete policies" in {
     val typeName1 = ResourceTypeName(UUID.randomUUID().toString)
     val typeName2 = ResourceTypeName(UUID.randomUUID().toString)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -19,15 +19,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 /**
   * Created by dvoet on 6/26/17.
   */
-class JndiAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+class LdapAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = ConfigFactory.load().as[DirectoryConfig]("directory")
   val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
   val dirURI = new URI(directoryConfig.directoryUrl)
-  private val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), 5)
+  private val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
   val dao = new LdapAccessPolicyDAO(connectionPool, directoryConfig)
   val dirDao = new LdapDirectoryDAO(connectionPool, directoryConfig)
-//  val dao = new JndiAccessPolicyDAO(directoryConfig)
-//  val dirDao = new JndiDirectoryDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -56,15 +56,15 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
 
   def jndiServicesFixture = new {
     val shared = sharedFixtures
-    val jndiPolicyDao = new JndiAccessPolicyDAO(directoryConfig)
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig)
     val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig)
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(ldapDirDao))
 
-    val resourceService = new ResourceService(shared.resourceTypes, jndiPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
+    val resourceService = new ResourceService(shared.resourceTypes, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
     val userService = new UserService(ldapDirDao, NoExtensions)
-    val managedGroupService = new ManagedGroupService(resourceService, shared.resourceTypes, jndiPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
+    val managedGroupService = new ManagedGroupService(resourceService, shared.resourceTypes, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
     shared.resourceTypes foreach {case (_, resourceType) => runAndWait(resourceService.createResourceType(resourceType)) }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -273,13 +273,9 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
     val managedGroup = assertMakeGroup()
 
-    try {
-      runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(adminUser.email)
-      runAndWait(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, ManagedGroupService.adminPolicyName, adminUser.id))
-      runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(adminUser.email)
-    } catch {
-      case t: LDAPException => println(t.getResultCode)
-    }
+    runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(adminUser.email)
+    runAndWait(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, ManagedGroupService.adminPolicyName, adminUser.id))
+    runAndWait(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName)) shouldEqual Set(adminUser.email)
   }
 
   // TODO: Is this right?  ResourceService.overwriteResource fails with invalid emails, should addSubjectToPolicy fail too?

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -1,14 +1,16 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
+import java.net.URI
 import java.util.UUID
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
+import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.directory.LdapDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.JndiAccessPolicyDAO
@@ -30,7 +32,9 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   private val config = ConfigFactory.load()
   val directoryConfig = config.as[DirectoryConfig]("directory")
   val schemaLockConfig = ConfigFactory.load().as[SchemaLockConfig]("schemaLock")
-  val dirDAO = new JndiDirectoryDAO(directoryConfig)
+  val dirURI = new URI(directoryConfig.directoryUrl)
+  val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1,15 +1,17 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
+import java.net.URI
 import java.util.UUID
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
+import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig, _}
-import org.broadinstitute.dsde.workbench.sam.directory.JndiDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.directory.LdapDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, JndiAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -24,7 +26,9 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   val config = ConfigFactory.load()
   val directoryConfig = config.as[DirectoryConfig]("directory")
   val schemaLockConfig = config.as[SchemaLockConfig]("schemaLock")
-  val dirDAO = new JndiDirectoryDAO(directoryConfig)
+  val dirURI = new URI(directoryConfig.directoryUrl)
+  val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
   val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig, _}
 import org.broadinstitute.dsde.workbench.sam.directory.LdapDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, JndiAccessPolicyDAO}
+import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, LdapAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 
@@ -29,7 +29,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
   val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-  val policyDAO = new JndiAccessPolicyDAO(directoryConfig)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)


### PR DESCRIPTION
implemented new version of directory and access policy daos using unboundid. I did not touch the schema dao, it still uses jndi. But I did turn off the jndi connection pool (schema dao is the only one to use it now and it just runs at the beginning)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
