### PR TITLE
WIP: Dockstore Resource Type

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -264,10 +264,10 @@ resourceTypes = {
         description = "delete a tool"
       },
       "read_policies" = {
-        description = "read policies of tool"
+        description = "read tool policies"
       },
       "alter_policies" = {
-        description = "alter policies of tool"
+        description = "alter tool policies"
       },
       "write" = {
         description = "modify tool"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -258,4 +258,37 @@ resourceTypes = {
     }
     reuseIds = false
   }
+  tool = {
+    actionPatternObjects = {
+      "delete" = {
+        description = "delete a tool"
+      },
+      "read_policies" = {
+        description = "read policies of tool"
+      },
+      "alter_policies" = {
+        description = "alter policies of tool"
+      },
+      "write" = {
+        description = "modify tool"
+      },
+      "read" = {
+        description = "read tool"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "alter_policies", "write", "read"]
+      },
+      writer = {
+        roleActions = ["write", "read"]
+      },
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = true
+
+  }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -258,7 +258,7 @@ resourceTypes = {
     }
     reuseIds = false
   }
-  tool = {
+  dockstore-tool = {
     actionPatternObjects = {
       "delete" = {
         description = "delete a tool"


### PR DESCRIPTION
Add a resource type for Dockstore resources.

I went with the name `tool`, because of Dockstore implements the Tool Registry Service (TRS).  Dockstore has the concept of both tools and workflows, but just like with TRS we can distinguish the two by path, prepending `#workflow/` to the path for workflows.

In other words, the resource id for the workflow `dockstore.org/myworkflow` would be, with the escaped characters,`%23workflow%2Fdockstore.org%2Fmyworkflow`, and the resource id for the tool `dockstore.org/mytool`would be `dockstore.org%2Fmytool`.

We currently only plan to support sharing for workflows in the first iteration, but we may support tools later.

I made this a WIP; looking for feedback, with these questions in particular:

1. Is the name `tool` too generic? Do we want to call it `dockstore-tool`, `dockstore-workflow` or something like that?
2. Should we have separate resource types for Dockstore tools and workflows, or put both Dockstore types under the single SAM resource type, like I currently have it?
3. How do the roles and actions I've defined seem? I've kept it fairly simple, but I don't know if I'm missing anything.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [  ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
