### PR TITLE
isGroupMember shouldn't care about case of full dn

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -105,7 +105,8 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
       entry <- Option(ldapConnectionPool.getEntry(subjectDn(member), Attr.memberOf))
       memberOf <- Option(entry.getAttribute(Attr.memberOf))
     } yield {
-      memberOf.getValues.contains(groupDn(groupId))
+      val memberships = memberOf.getValues.toSet.map(dnToGroupIdentity)
+      memberships.contains(groupId)
     }
     isMember.getOrElse(false)
   }


### PR DESCRIPTION
with this change, isGroupMember will only look at the actual group name instead of the full dn, which can have differing cases due to inconsistencies in past code/migrations.

specific bug described:

dev broke because we'd be looking for membership in `cn=All_Users,ou=groups,dc=dsde-dev,dc=broadinstitute,dc=org`, but the user was in `cn=All_Users,ou=Groups,dc=dsde-dev,dc=broadinstitute,dc=org`. doing string comparison, they're not the same, thus user was seen as not fully activated.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
