### PR TITLE
add eventually for shouldBe in test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -9,14 +9,14 @@ import org.broadinstitute.dsde.workbench.dao.Google.googleIamDAO
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountName}
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaFutures with CleanUp {
+class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaFutures with CleanUp with Eventually {
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)))
 
   val gcsConfig = SamConfig.GCS
@@ -106,7 +106,7 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
         val petAccountEmail = Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
         assert(petAccountEmail.value.contains(userStatus.userInfo.userSubjectId))
         Sam.removePet(projectName, userStatus.userInfo)
-        googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue shouldBe None
+        eventually (googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue shouldBe None)
 
         Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
         petAccountEmail.value should not be userStatus.userInfo.userEmail


### PR DESCRIPTION
Frequently failed test SamApiSpec:
[info] SamApiSpec:
[info] Sam test utilities
[info] - should be idempotent for user registration and removal
[info] Sam
[info] - should give pets the same access as their owners *** FAILED ***
[info]   Some(ServiceAccount(115939080767864795449,b738pet-104723459812061817911@gpalloc-qa-master-2djle1k.iam.gserviceaccount.com,null)) was not equal to None (SamApiSpec.scala:109)
[info]   org.scalatest.exceptions.TestFailedException

Fix: 
Scalatest assert `shouldBe` with `eventually`.

Jenkin job `sam-fiab-test-runner` failed.
https://fc-jenkins.dsp-techops.broadinstitute.org/view/Testing/view/Pipeline%20Jobs/job/swatomation-pipeline/7214/


\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
