### PR TITLE
GAWB 3720 v2 user endpoints

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1083,6 +1083,54 @@ paths:
       tags:
         - Users
 
+  /register/user/v2/self:
+    post:
+      summary: create current user in the system using login credentials
+      responses:
+        201:
+          description: 'user successfully created'
+          schema:
+            $ref: '#/definitions/UserStatus'
+        409:
+          description: user already exists
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      operationId: createUserV2
+      tags:
+        - Users
+
+  /register/user/v2/self/info:
+    get:
+      summary: gets the registration status info of the logged in user
+      responses:
+        200:
+          description: 'user exists'
+          schema:
+            $ref: '#/definitions/UserStatusInfo'
+        404:
+          description: user not found
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      operationId: getUserStatusInfo
+      tags:
+      - Users
+
+  /register/user/v2/self/diagnostics:
+    get:
+      summary: gets the various enabled statuses of the logged in user
+      responses:
+        200:
+          description: 'user exists'
+          schema:
+            $ref: '#/definitions/UserStatusDiagnostics'
+        404:
+          description: user not found
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      operationId: getUserStatusDiagnostics
+      tags:
+      - Users
+
   /status:
     get:
       summary: gets system status
@@ -1392,3 +1440,32 @@ definitions:
       enabled:
         $ref: '#/definitions/Enabled'
         description: the status of the user's account
+
+  UserStatusInfo:
+    description: ''
+    required:
+      - userInfo
+      - enabled
+    properties:
+      userInfo:
+        $ref: '#/definitions/UserInfo'
+      enabled:
+        type: Boolean
+        description: true if the user is enabled in ldap
+
+  UserStatusDiagnostics:
+    description: ''
+    required:
+      - enabled
+      - inAllUsersGroup
+      - inGoogleProxyGroup
+    properties:
+      enabled:
+        type: Boolean
+        description: true if the user is enabled in ldap
+      inAllUsersGroup:
+        type: Boolean
+        description: true if the user is in the all users group
+      inGoogleProxyGroup:
+        type: Boolean
+        description: true if the user is in their proxy group

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1444,13 +1444,18 @@ definitions:
   UserStatusInfo:
     description: ''
     required:
-      - userInfo
+      - userSubjectId
+      - userEmail
       - enabled
     properties:
-      userInfo:
-        $ref: '#/definitions/UserInfo'
+      userSubjectId:
+        type: string
+        description: user id
+      userEmail:
+        type: string
+        description: user email
       enabled:
-        type: Boolean
+        type: boolean
         description: true if the user is enabled in ldap
 
   UserStatusDiagnostics:
@@ -1461,11 +1466,11 @@ definitions:
       - inGoogleProxyGroup
     properties:
       enabled:
-        type: Boolean
+        type: boolean
         description: true if the user is enabled in ldap
       inAllUsersGroup:
-        type: Boolean
+        type: boolean
         description: true if the user is in the all users group
       inGoogleProxyGroup:
-        type: Boolean
+        type: boolean
         description: true if the user is in their proxy group

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUser, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
@@ -20,21 +19,56 @@ trait UserRoutes extends UserInfoDirectives {
   val userService: UserService
 
   def userRoutes: server.Route =
-    (pathPrefix("user" / "v1") | pathPrefix("user")) {
+    pathPrefix("user") {
       requireUserInfo { userInfo =>
-        pathEndOrSingleSlash {
-          post {
-            complete {
-              userService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)).map(userStatus => StatusCodes.Created -> userStatus)
-            }
-          } ~
-          get {
-            parameter("userDetailsOnly".?) { userDetailsOnly =>
+        (pathPrefix("v1") | pathEndOrSingleSlash){
+          pathEndOrSingleSlash {
+            post {
               complete {
-                userService.getUserStatus(userInfo.userId, userDetailsOnly.exists(_.equalsIgnoreCase("true"))).map { statusOption =>
-                  statusOption.map { status =>
-                    StatusCodes.OK -> Option(status)
-                  }.getOrElse(StatusCodes.NotFound -> None)
+                userService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)).map(userStatus => StatusCodes.Created -> userStatus)
+              }
+            } ~
+            get {
+              parameter("userDetailsOnly".?) { userDetailsOnly =>
+                complete {
+                  userService.getUserStatus(userInfo.userId, userDetailsOnly.exists(_.equalsIgnoreCase("true"))).map { statusOption =>
+                    statusOption.map { status =>
+                      StatusCodes.OK -> Option(status)
+                    }.getOrElse(StatusCodes.NotFound -> None)
+                  }
+                }
+              }
+            }
+          }
+        } ~
+        pathPrefix("v2") {
+          pathPrefix("self") {
+            pathEndOrSingleSlash {
+              post {
+                complete {
+                  userService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)).map(userStatus => StatusCodes.Created -> userStatus)
+                }
+              }
+            } ~
+            path("info") {
+              get {
+                complete {
+                  userService.getUserStatusInfo(userInfo.userId).map { statusOption =>
+                    statusOption.map { status =>
+                      StatusCodes.OK -> Option(status)
+                    }.getOrElse(StatusCodes.NotFound -> None)
+                  }
+                }
+              }
+            } ~
+            path("diagnostics") {
+              get {
+                complete {
+                  userService.getUserStatusDiagnostics(userInfo.userId). map { statusOption =>
+                    statusOption.map { status =>
+                      StatusCodes.OK -> Option(status)
+                    }.getOrElse(StatusCodes.NotFound -> None)
+                  }
                 }
               }
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -64,7 +64,7 @@ trait UserRoutes extends UserInfoDirectives {
             path("diagnostics") {
               get {
                 complete {
-                  userService.getUserStatusDiagnostics(userInfo.userId). map { statusOption =>
+                  userService.getUserStatusDiagnostics(userInfo.userId).map { statusOption =>
                     statusOption.map { status =>
                       StatusCodes.OK -> Option(status)
                     }.getOrElse(StatusCodes.NotFound -> None)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -29,7 +29,7 @@ object SamJsonSupport {
 
   implicit val UserStatusInfoFormat = jsonFormat3(UserStatusInfo)
 
-  implicit val userStatusDiagnosticsFormat = jsonFormat3(UserStatusDiagnostics)
+  implicit val UserStatusDiagnosticsFormat = jsonFormat3(UserStatusDiagnostics)
 
   implicit val AccessPolicyNameFormat = ValueObjectFormat(AccessPolicyName)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -27,6 +27,10 @@ object SamJsonSupport {
 
   implicit val UserStatusFormat = jsonFormat2(UserStatus)
 
+  implicit val UserStatusInfoFormat = jsonFormat2(UserStatusInfo)
+
+  implicit val userStatusDiagnosticsFormat = jsonFormat3(UserStatusDiagnostics)
+
   implicit val AccessPolicyNameFormat = ValueObjectFormat(AccessPolicyName)
 
   implicit val ResourceIdFormat = ValueObjectFormat(ResourceId)
@@ -60,6 +64,8 @@ object SamResourceActions {
 
 case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API
 case class UserStatus(userInfo: UserStatusDetails, enabled: Map[String, Boolean])
+case class UserStatusInfo(userInfo: UserStatusDetails, enabled: Boolean)
+case class UserStatusDiagnostics(enabled: Boolean, inAllUsersGroup: Boolean, inGoogleProxyGroup: Boolean)
 
 case class ResourceActionPattern(value: String, description: String, authDomainConstrainable: Boolean) {
   def matches(other: ResourceAction) = value.r.pattern.matcher(other.value).matches()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -27,7 +27,7 @@ object SamJsonSupport {
 
   implicit val UserStatusFormat = jsonFormat2(UserStatus)
 
-  implicit val UserStatusInfoFormat = jsonFormat2(UserStatusInfo)
+  implicit val UserStatusInfoFormat = jsonFormat3(UserStatusInfo)
 
   implicit val userStatusDiagnosticsFormat = jsonFormat3(UserStatusDiagnostics)
 
@@ -64,7 +64,7 @@ object SamResourceActions {
 
 case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API
 case class UserStatus(userInfo: UserStatusDetails, enabled: Map[String, Boolean])
-case class UserStatusInfo(userInfo: UserStatusDetails, enabled: Boolean)
+case class UserStatusInfo(userSubjectId: String, userEmail: String, enabled: Boolean)
 case class UserStatusDiagnostics(enabled: Boolean, inAllUsersGroup: Boolean, inGoogleProxyGroup: Boolean)
 
 case class ResourceActionPattern(value: String, description: String, authDomainConstrainable: Boolean) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -50,7 +50,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
   def getUserStatusInfo(userId: WorkbenchUserId): Future[Option[UserStatusInfo]] = {
     directoryDAO.loadUser(userId).flatMap {
       case Some(user) => directoryDAO.isEnabled(user.id).flatMap { ldapStatus =>
-        Future.successful(Option(UserStatusInfo(UserStatusDetails(user.id, user.email), ldapStatus))) }
+        Future.successful(Option(UserStatusInfo(user.id.value, user.email.value, ldapStatus))) }
       case None => Future.successful(None)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -47,6 +47,33 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     }
   }
 
+  def getUserStatusInfo(userId: WorkbenchUserId): Future[Option[UserStatusInfo]] = {
+    directoryDAO.loadUser(userId).flatMap {
+      case Some(user) => directoryDAO.isEnabled(user.id).flatMap { ldapStatus =>
+        Future.successful(Option(UserStatusInfo(UserStatusDetails(user.id, user.email), ldapStatus))) }
+      case None => Future.successful(None)
+    }
+  }
+
+  def getUserStatusDiagnostics(userId: WorkbenchUserId): Future[Option[UserStatusDiagnostics]] = {
+    directoryDAO.loadUser(userId).flatMap {
+      case Some(user) => {
+        // pulled out of for comprehension to allow concurrent execution
+        val ldapStatus = directoryDAO.isEnabled(user.id)
+        val allUsersStatus = cloudExtensions.getOrCreateAllUsersGroup(directoryDAO).flatMap { allUsersGroup =>
+          directoryDAO.isGroupMember(allUsersGroup.id, user.id) recover { case e: NameNotFoundException => false } }
+        val googleStatus = cloudExtensions.getUserStatus(user)
+
+        for {
+          ldap <- ldapStatus
+          allUsers <- allUsersStatus
+          google <- googleStatus
+        } yield Option(UserStatusDiagnostics(ldap, allUsers, google))
+      }
+      case None => Future.successful(None)
+    }
+  }
+
   def getUserStatusFromEmail(email: WorkbenchEmail): Future[Option[UserStatus]] = {
     directoryDAO.loadSubjectFromEmail(email).flatMap {
       // don't attempt to handle groups or service accounts - just users

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -51,6 +51,10 @@ class UserRoutesV2Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
   }
 
   "GET /register/user/v2/self/info" should "get the status of an enabled user" in withDefaultRoutes { samRoutes =>
+    Get("/register/user/v2/self/info") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+
     Post("/register/user/v2/self") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
       responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
@@ -63,6 +67,10 @@ class UserRoutesV2Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
   }
 
   "GET /register/user/v2/self/diagnostics" should "get the diagnostic info for an enabled user" in withDefaultRoutes { samRoutes =>
+    Get("/register/user/v2/self/diagnostics") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+
     Post("/register/user/v2/self") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
       responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -62,7 +62,7 @@ class UserRoutesV2Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
 
     Get("/register/user/v2/self/info") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true)
+      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(defaultUserId.value, defaultUserEmail.value, true)
     }
   }
 
@@ -90,7 +90,7 @@ class UserRoutesV2Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
 
     Get("/register/user/v2/self/info") ~> SARoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true)
+      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(defaultUserId.value, defaultUserEmail.value, true)
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -1,0 +1,88 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, StatusService, UserService}
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.mockito.MockitoSugar
+
+/**
+  * Created by mtalbott on 8/8/18.
+  */
+class UserRoutesV2Spec extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
+
+  val defaultUserId = WorkbenchUserId("newuser")
+  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
+  val petSAUserId = WorkbenchUserId("123")
+  val petSAEmail = WorkbenchEmail("pet-newuser@test.iam.gserviceaccount.com")
+
+  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
+    val directoryDAO = new MockDirectoryDAO()
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO)
+    testCode(samRoutes)
+  }
+
+  def withSARoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
+    val directoryDAO = new MockDirectoryDAO()
+
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, NoExtensions)
+    val SARoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, NoExtensions)
+    testCode(samRoutes, SARoutes)
+  }
+
+  "POST /register/user/v2/self" should "create user" in withDefaultRoutes { samRoutes =>
+    Post("/register/user/v2/self") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Post("/register/user/v2/self") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Conflict
+    }
+  }
+
+  "GET /register/user/v2/self/info" should "get the status of an enabled user" in withDefaultRoutes { samRoutes =>
+    Post("/register/user/v2/self") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get("/register/user/v2/self/info") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true)
+    }
+  }
+
+  "GET /register/user/v2/self/diagnostics" should "get the diagnostic info for an enabled user" in withDefaultRoutes { samRoutes =>
+    Post("/register/user/v2/self") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get("/register/user/v2/self/diagnostics") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatusDiagnostics] shouldEqual UserStatusDiagnostics(true, true, true)
+    }
+  }
+
+  "POST /register/user/v2/self" should "create a user" in withSARoutes{ (samRoutes, SARoutes) =>
+    Post("/register/user/v2/self") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Get("/register/user/v2/self/info") ~> SARoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatusInfo] shouldEqual UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true)
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, PetServiceAccountConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, LdapDirectoryDAO}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, UserStatus, UserStatusDetails}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, UserStatus, UserStatusDetails, UserStatusInfo, UserStatusDiagnostics}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -97,6 +97,32 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
     val statusNoEnabled = service.getUserStatus(defaultUserId, true).futureValue
     statusNoEnabled shouldBe Some(UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map.empty))
+  }
+
+  it should "get user status info" in {
+    // user doesn't exist yet
+    service.getUserStatus(defaultUserId).futureValue shouldBe None
+
+    // create a user
+    val newUser = service.createUser(defaultUser).futureValue
+    newUser shouldBe UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+
+    // get user status info (id, email, ldap)
+    val info = service.getUserStatusInfo(defaultUserId).futureValue
+    info shouldBe Some(UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true))
+  }
+
+  it should "get user status diagnostics" in {
+    // user doesn't exist yet
+    service.getUserStatus(defaultUserId).futureValue shouldBe None
+
+    // create a user
+    val newUser = service.createUser(defaultUser).futureValue
+    newUser shouldBe UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+
+    // get user status diagnostics (ldap, usersGroups, googleGroups
+    val diagnostics = service.getUserStatusDiagnostics(defaultUserId).futureValue
+    diagnostics shouldBe Some(UserStatusDiagnostics(true, true, true))
   }
 
   it should "enable/disable user" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -101,7 +101,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
   it should "get user status info" in {
     // user doesn't exist yet
-    service.getUserStatus(defaultUserId).futureValue shouldBe None
+    service.getUserStatusInfo(defaultUserId).futureValue shouldBe None
 
     // create a user
     val newUser = service.createUser(defaultUser).futureValue
@@ -114,7 +114,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
   it should "get user status diagnostics" in {
     // user doesn't exist yet
-    service.getUserStatus(defaultUserId).futureValue shouldBe None
+    service.getUserStatusDiagnostics(defaultUserId).futureValue shouldBe None
 
     // create a user
     val newUser = service.createUser(defaultUser).futureValue
@@ -126,6 +126,10 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
   }
 
   it should "enable/disable user" in {
+    // user doesn't exist yet
+    service.enableUser(defaultUserId, userInfo).futureValue shouldBe None
+    service.disableUser(defaultUserId, userInfo).futureValue shouldBe None
+
     // create a user
     val newUser = service.createUser(defaultUser).futureValue
     newUser shouldBe UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -109,7 +109,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
     // get user status info (id, email, ldap)
     val info = service.getUserStatusInfo(defaultUserId).futureValue
-    info shouldBe Some(UserStatusInfo(UserStatusDetails(defaultUserId, defaultUserEmail), true))
+    info shouldBe Some(UserStatusInfo(defaultUserId.value, defaultUserEmail.value, true))
   }
 
   it should "get user status diagnostics" in {


### PR DESCRIPTION
Create v2 of userStatus interface which separates diagnostic info from normal status info. Help cut down on expensive Google queries which are often unneeded. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
