### PR TITLE
add googleSubjectId

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val workbenchModelV  = "0.10-6800f3a"
+  val workbenchModelV  = "0.12-a19203d"
   val workbenchGoogleV = "0.16-847c3ff"
   val workbenchServiceTestV = "0.10-61981d5"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,9 +6,10 @@ object Dependencies {
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.5.0"
   val scalaTestV    = "3.0.1"
+  val scalaCheckV    = "1.14.0"
 
   val workbenchUtilV   = "0.3-f2a0020"
-  val workbenchModelV  = "0.11-f2a0020"
+  val workbenchModelV  = "0.12-a19203d"
   val workbenchGoogleV = "0.16-f2a0020"
   val workbenchNotificationsV = "0.1-f2a0020"
 
@@ -35,6 +36,7 @@ object Dependencies {
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV
   val akkaTestKit: ModuleID =       "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
+  val scalaCheck: ModuleID =        "org.scalacheck"      %%  "scalacheck"           % scalaCheckV % "test"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.0"
 
@@ -81,6 +83,7 @@ object Dependencies {
 
     scalaTest,
     mockito,
+    scalaCheck,
 
     workbenchUtil,
     workbenchModel,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.config.SwaggerConfig
 import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.service.{ManagedGroupService, ResourceService, StatusService, UserService}
-
+import SamRoutes._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -33,17 +33,6 @@ abstract class SamRoutes(val resourceService: ResourceService, val userService: 
     statusRoutes ~
     pathPrefix("register") { userRoutes } ~
     pathPrefix("api") { resourceRoutes ~ adminUserRoutes ~ extensionRoutes ~ groupRoutes }
-  }
-
-  private val myExceptionHandler = {
-    import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
-
-    ExceptionHandler {
-      case withErrorReport: WorkbenchExceptionWithErrorReport =>
-        complete(withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), withErrorReport.errorReport)
-      case e: Throwable =>
-        complete(StatusCodes.InternalServerError, ErrorReport(e))
-    }
   }
 
   // basis for logRequestResult lifted from http://stackoverflow.com/questions/32475471/how-does-one-log-akka-http-client-requests
@@ -75,3 +64,15 @@ abstract class SamRoutes(val resourceService: ResourceService, val userService: 
 
 }
 
+object SamRoutes{
+  protected[sam] val myExceptionHandler = {
+    import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+
+    ExceptionHandler {
+      case withErrorReport: WorkbenchExceptionWithErrorReport =>
+        complete(withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), withErrorReport.errorReport)
+      case e: Throwable =>
+        complete(StatusCodes.InternalServerError, ErrorReport(e))
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -1,46 +1,76 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives.{headerValueByName, onSuccess}
-import org.broadinstitute.dsde.workbench.model._
-import akka.http.scaladsl.server.Directives.headerValueByName
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.directives.OnSuccessMagnet._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, _}
+import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
+import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.service.UserService._
 
 import scala.concurrent.{ExecutionContext, Future}
-
+import scala.util.Try
 
 
 trait StandardUserInfoDirectives extends UserInfoDirectives {
   implicit val executionContext: ExecutionContext
 
-  val petSAdomain = "\\S+@\\S+\\.iam\\.gserviceaccount\\.com".r
-
-  private def isPetSA(email: WorkbenchEmail) = {
-    petSAdomain.pattern.matcher(email.value).matches
-  }
-
   def requireUserInfo: Directive1[UserInfo] = (
-    headerValueByName("OIDC_access_token") &
-      headerValueByName("OIDC_CLAIM_user_id") &
-      headerValueByName("OIDC_CLAIM_expires_in") &
-      headerValueByName("OIDC_CLAIM_email")
+    headerValueByName(accessTokenHeader) &
+      headerValueByName(googleSubjectIdHeader) &
+      headerValueByName(expiresInHeader) &
+      headerValueByName(emailHeader)
     ) tflatMap {
-    case (token, userId, expiresIn, email) => {
-      val userInfo = UserInfo(OAuth2BearerToken(token), WorkbenchUserId(userId), WorkbenchEmail(email), expiresIn.toLong)
-      onSuccess(getUserFromPetServiceAccount(userInfo).map {
-        case Some(petOwnerUser) => UserInfo(OAuth2BearerToken(token), petOwnerUser.id, petOwnerUser.email, expiresIn.toLong)
-        case None => userInfo
-      })
-    }
+    case (token, googleSubjectId, expiresIn, email) =>
+      onSuccess(Try(expiresIn.toLong).fold[Future[UserInfo]](
+        t => Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"expiresIn $expiresIn can't be converted to Long because  of $t"))),
+        l => getUserInfo(OAuth2BearerToken(token), GoogleSubjectId(googleSubjectId), WorkbenchEmail(email), l, directoryDAO)))
   }
 
-  private def getUserFromPetServiceAccount(userInfo: UserInfo):Future[Option[WorkbenchUser]] = {
-    if (isPetSA(userInfo.userEmail)) {
-      directoryDAO.getUserFromPetServiceAccount(ServiceAccountSubjectId(userInfo.userId.value))
-    } else {
-      Future.successful(None)
+  def requireCreateUser: Directive1[CreateWorkbenchUser] = (
+      headerValueByName(googleSubjectIdHeader) &
+      headerValueByName(emailHeader)
+    ) tflatMap {
+    case (googleSubjectId, email) => {
+      onSuccess(Future.successful(
+        CreateWorkbenchUser(genWorkbenchUserId(System.currentTimeMillis()), GoogleSubjectId(googleSubjectId), WorkbenchEmail(email))))
     }
   }
 }
+
+object StandardUserInfoDirectives{
+  val SAdomain = "\\S+@\\S+\\.iam\\.gserviceaccount\\.com".r
+  val accessTokenHeader = "OIDC_access_token"
+  val expiresInHeader = "OIDC_CLAIM_expires_in"
+  val emailHeader = "OIDC_CLAIM_email"
+  val googleSubjectIdHeader = "OIDC_CLAIM_user_id"
+
+  def isServiceAccount(email: WorkbenchEmail) = {
+    SAdomain.pattern.matcher(email.value).matches
+  }
+
+  def getUserInfo(token: OAuth2BearerToken, googleSubjectId: GoogleSubjectId, email: WorkbenchEmail, expiresIn: Long, directoryDAO: DirectoryDAO)(implicit ec: ExecutionContext): Future[UserInfo] = if (isServiceAccount(email)) {
+    // If it's a PET account, we treat it as its owner
+    directoryDAO.getUserFromPetServiceAccount(ServiceAccountSubjectId(googleSubjectId.value)).flatMap{
+      case Some(pet) => Future.successful(UserInfo(token, pet.id, pet.email, expiresIn.toLong))
+      case None => lookUpByGoogleSubjectId(googleSubjectId, directoryDAO).map(uid => UserInfo(token, uid, email, expiresIn))
+    }
+  } else {
+    lookUpByGoogleSubjectId(googleSubjectId, directoryDAO).map(uid => UserInfo(token, uid, email, expiresIn))
+  }
+
+  private def lookUpByGoogleSubjectId(googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO)(implicit ec: ExecutionContext): Future[WorkbenchUserId] = for{
+    subject <- directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId)
+    userInfo <- subject match{
+      case Some(uid: WorkbenchUserId) => Future.successful(uid)
+      case Some(_) => Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $googleSubjectId is not a WorkbenchUser")))
+      case None => Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"google subject Id $googleSubjectId not found in sam")))
+    }
+  }yield userInfo
+}
+
+final case class CreateWorkbenchUser(id: WorkbenchUserId, googleSubjectId: GoogleSubjectId, email: WorkbenchEmail)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.api
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.onSuccess
 import akka.http.scaladsl.server.{Directive0, Directive1, Directives}
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, UserInfo, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
@@ -16,6 +16,8 @@ trait UserInfoDirectives {
   val cloudExtensions: CloudExtensions
 
   def requireUserInfo: Directive1[UserInfo]
+
+  def requireCreateUser: Directive1[CreateWorkbenchUser]
 
   def asWorkbenchAdmin(userInfo: UserInfo): Directive0 = {
     Directives.mapInnerRoute { r =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -35,6 +35,7 @@ trait DirectoryDAO {
   def loadSubjectFromEmail(email: WorkbenchEmail): Future[Option[WorkbenchSubject]]
   def loadSubjectEmail(subject: WorkbenchSubject): Future[Option[WorkbenchEmail]]
   def loadSubjectEmails(subjects: Set[WorkbenchSubject]): Future[Set[WorkbenchEmail]]
+  def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId): Future[Option[WorkbenchSubject]]
 
   def createUser(user: WorkbenchUser): Future[WorkbenchUser]
   def loadUser(userId: WorkbenchUserId): Future[Option[WorkbenchUser]]
@@ -57,7 +58,7 @@ trait DirectoryDAO {
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): Future[Unit]
   def getAllPetServiceAccountsForUser(userId: WorkbenchUserId): Future[Seq[PetServiceAccount]]
   def updatePetServiceAccount(petServiceAccount: PetServiceAccount): Future[PetServiceAccount]
-
   def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName): Future[Option[String]]
   def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String): Future[Unit]
+  def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): Future[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -32,7 +32,8 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                 googleExtensions.getPetServiceAccountKey(WorkbenchEmail(userEmail), GoogleProject(project)) map {
                   // parse json to ensure it is json and tells akka http the right content-type
                   case Some(key) => StatusCodes.OK -> key.parseJson
-                  case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
+                  case None =>
+                    throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
                 }
               }
             }
@@ -44,7 +45,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
               get {
                 complete {
                   import spray.json._
-                  googleExtensions.getArbitraryPetServiceAccountKey(WorkbenchUser(userInfo.userId, userInfo.userEmail)).map(key => StatusCodes.OK -> key.parseJson)
+                  googleExtensions.getArbitraryPetServiceAccountKey(WorkbenchUser(userInfo.userId, None, userInfo.userEmail)).map(key => StatusCodes.OK -> key.parseJson)
                 }
               }
             }
@@ -54,7 +55,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
               post {
                 entity(as[Set[String]]) { scopes =>
                   complete {
-                    googleExtensions.getArbitraryPetServiceAccountToken(WorkbenchUser(userInfo.userId, userInfo.userEmail), scopes).map { token =>
+                    googleExtensions.getArbitraryPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail), scopes).map { token =>
                       StatusCodes.OK -> JsString(token)
                     }
                   }
@@ -68,7 +69,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                 complete {
                   import spray.json._
                   // parse json to ensure it is json and tells akka http the right content-type
-                  googleExtensions.getPetServiceAccountKey(WorkbenchUser(userInfo.userId, userInfo.userEmail), GoogleProject(project)).map(key => StatusCodes.OK -> key.parseJson)
+                  googleExtensions.getPetServiceAccountKey(WorkbenchUser(userInfo.userId, None, userInfo.userEmail), GoogleProject(project)).map(key => StatusCodes.OK -> key.parseJson)
                 }
               } ~
               path(Segment) { keyId =>
@@ -83,7 +84,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
               post {
                 entity(as[Set[String]]) { scopes =>
                   complete {
-                    googleExtensions.getPetServiceAccountToken(WorkbenchUser(userInfo.userId, userInfo.userEmail), GoogleProject(project), scopes).map { token =>
+                    googleExtensions.getPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail), GoogleProject(project), scopes).map { token =>
                       StatusCodes.OK -> JsString(token)
                     }
                   }
@@ -93,7 +94,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
             pathEnd {
               get {
                 complete {
-                  googleExtensions.createUserPetServiceAccount(WorkbenchUser(userInfo.userId, userInfo.userEmail), GoogleProject(project)).map { petSA =>
+                  googleExtensions.createUserPetServiceAccount(WorkbenchUser(userInfo.userId, None, userInfo.userEmail), GoogleProject(project)).map { petSA =>
                     StatusCodes.OK -> petSA.serviceAccount.email
                   }
                 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -133,6 +133,6 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val uid = getAttribute(entry, Attr.uid).getOrElse(throw new WorkbenchException(s"${Attr.uid} attribute missing"))
     val email = getAttribute(entry, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing"))
 
-    WorkbenchUser(WorkbenchUserId(uid), WorkbenchEmail(email))
+    WorkbenchUser(WorkbenchUserId(uid), getAttribute(entry, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -1,9 +1,14 @@
-package org.broadinstitute.dsde.workbench.sam.service
+package org.broadinstitute.dsde.workbench.sam
+package service
 
+import java.security.SecureRandom
+
+import akka.http.scaladsl.model.StatusCodes
 import javax.naming.NameNotFoundException
-
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.codec.binary.Hex
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.api.CreateWorkbenchUser
 import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 
@@ -14,18 +19,46 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExtensions)(implicit val executionContext: ExecutionContext) extends LazyLogging {
 
-  def createUser(user: WorkbenchUser): Future[UserStatus] = {
+  def createUser(user: CreateWorkbenchUser): Future[UserStatus] = {
     for {
       allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO)
-      createdUser <- directoryDAO.createUser(user)
-      _ <- directoryDAO.enableIdentity(user.id)
-      _ <- directoryDAO.addGroupMember(allUsersGroup.id, user.id)
+      createdUser <- registerUser(user)
+      _ <- directoryDAO.enableIdentity(createdUser.id)
+      _ <- directoryDAO.addGroupMember(allUsersGroup.id, createdUser.id)
       _ <- cloudExtensions.onUserCreate(createdUser)
       userStatus <- getUserStatus(createdUser.id)
     } yield {
       userStatus.getOrElse(throw new WorkbenchException("getUserStatus returned None after user was created"))
     }
   }
+
+  /**
+    * If googleSubjectId exists in ldap, return 409; else if email also exists, we lookup pre-created user record and update
+    * its googleSubjectId field; otherwise, we create a new user
+    *
+    * GoogleSubjectId    Email
+    *      no             no      ---> We've never seen this user before, create a new user
+    *      no             yes      ---> Someone invited this user previous and we have a record for this user already. We just need to update GoogleSubjetId field for this user.
+    *      yes            skip    ---> User exists. Do nothing.
+    *      yes            skip    ---> User exists. Do nothing.
+    */
+  protected[service] def registerUser(user: CreateWorkbenchUser): Future[WorkbenchUser] = for{
+    existingSubFromGoogleSubjectId <- directoryDAO.loadSubjectFromGoogleSubjectId(user.googleSubjectId)
+    user <- existingSubFromGoogleSubjectId match{
+      case Some(_) => Future.failed[WorkbenchUser](new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"user ${user} already exists")))
+      case None => for{
+        subjectFromEmail <- directoryDAO.loadSubjectFromEmail(user.email)
+        updated <- subjectFromEmail match{
+          case Some(uid : WorkbenchUserId) =>
+            directoryDAO.setGoogleSubjectId(uid, user.googleSubjectId).map(_ => WorkbenchUser(uid, Some(user.googleSubjectId), user.email))
+          case Some(sub) =>
+            //We don't support inviting a group account or pet service account
+            Future.failed[WorkbenchUser](new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"$user is not a regular user. Please use a different endpoint")))
+          case None => directoryDAO.createUser(WorkbenchUser(WorkbenchUserId(user.googleSubjectId.value), Some(user.googleSubjectId), user.email)) //For completely new users, we still use googleSubjectId as their userId
+        }
+      } yield updated
+    }
+  } yield user
 
   def getSubjectFromEmail(email: WorkbenchEmail): Future[Option[WorkbenchSubject]] = directoryDAO.loadSubjectFromEmail(email)
 
@@ -113,5 +146,28 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       _ <- cloudExtensions.onUserDelete(userId)
       deleteResult <- directoryDAO.deleteUser(userId)
     } yield deleteResult
+  }
+}
+
+object UserService{
+
+  val random = SecureRandom.getInstance("NativePRNGNonBlocking")
+
+  // Generate a 21 digits unique identifier. First char is fixed 2
+  // CurrentMillis.append(randomString)
+  private[workbench] def genRandom(currentMilli: Long): String = {
+    val currentMillisString = currentMilli.toString
+    // one hexdecimal is 4 bits, one byte can generate 2 hexdecial number, so we only need half the number of bytes, which is 8
+    // currentMilli is 13 digits, and it'll be another 200 years before it becomes 14 digits. So we're assuming currentMillis is 13 digits here
+    val bytes = new Array[Byte](4)
+    random.nextBytes(bytes)
+    val r = new String(Hex.encodeHex(bytes))
+    // since googleSubjectId starts with 1, we are replacing 1 with 2 to avoid conflicts with existing uid
+    val front = if(currentMillisString(0) == '1') currentMillisString.replaceFirst("1", "2") else currentMilli
+    front + r
+  }
+
+  def genWorkbenchUserId(currentMilli: Long): WorkbenchUserId = {
+    WorkbenchUserId(genRandom(currentMilli))
   }
 }

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -1,0 +1,66 @@
+package org.broadinstitute.dsde.workbench.sam
+
+import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.api.CreateWorkbenchUser
+import org.scalacheck._
+import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.service.UserService
+import org.broadinstitute.dsde.workbench.sam.service.UserService._
+
+object Generator {
+  val genNonPetEmail: Gen[WorkbenchEmail] = Gen.alphaStr.map(x => WorkbenchEmail(s"t$x@gmail.com"))
+  val genPetEmail: Gen[WorkbenchEmail] = Gen.alphaStr.map(x => WorkbenchEmail(s"t$x@test.iam.gserviceaccount.com"))
+  val genGoogleSubjectId: Gen[GoogleSubjectId] = Gen.const(GoogleSubjectId(UserService.genRandom(System.currentTimeMillis())))
+  val genServiceAccountSubjectId: Gen[ServiceAccountSubjectId] = genGoogleSubjectId.map(x => ServiceAccountSubjectId(x.value))
+  val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s"+x))
+
+  val genHeadersWithoutExpiresIn: Gen[List[RawHeader]] = for{
+    email <- genNonPetEmail
+    accessToken <- genOAuth2BearerToken
+  } yield List(
+    RawHeader(emailHeader, email.value),
+    RawHeader(googleSubjectIdHeader, genRandom(System.currentTimeMillis())),
+    RawHeader(accessTokenHeader, accessToken.value),
+  )
+
+  val genUserInfoHeadersWithInvalidExpiresIn: Gen[List[RawHeader]] = for{
+    ls <- genHeadersWithoutExpiresIn
+    expiresIn <- Gen.alphaStr.map(x => s"s$x")
+  } yield RawHeader(expiresInHeader, expiresIn) :: ls
+
+  val genValidUserInfoHeaders: Gen[List[RawHeader]] = for{
+     ls <- genHeadersWithoutExpiresIn
+  } yield RawHeader(expiresInHeader, (System.currentTimeMillis() + 1000).toString) :: ls
+
+  val genUserInfo = for{
+    token <- genOAuth2BearerToken
+    email <- genNonPetEmail
+    expires <- Gen.calendar.map(_.getTimeInMillis)
+  } yield UserInfo(token, genWorkbenchUserId(System.currentTimeMillis()), email, expires)
+
+  val genCreateWorkbenchUserAPI = for{
+    email <- genNonPetEmail
+    userId = genWorkbenchUserId(System.currentTimeMillis())
+  }yield CreateWorkbenchUser(userId, GoogleSubjectId(userId.value), email)
+
+  val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s$x")) //prepending `s` just so this won't be an empty string
+  val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) //prepending `s` just so this won't be an empty string
+  val genWorkbenchSubject: Gen[WorkbenchSubject] = for{
+    groupId <- genWorkbenchGroupName
+    project <- genGoogleProject
+    res <- Gen.oneOf[WorkbenchSubject](List(genWorkbenchUserId(System.currentTimeMillis()), groupId, PetServiceAccountId(genWorkbenchUserId(System.currentTimeMillis()), project)))
+  }yield res
+
+  val genBasicWorkbenchGroup = for{
+    id <- genWorkbenchGroupName
+    subject <- Gen.listOf[WorkbenchSubject](genWorkbenchSubject).map(_.toSet)
+    email <- genNonPetEmail
+  } yield BasicWorkbenchGroup(id, subject, email)
+
+  implicit val arbNonPetEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genNonPetEmail)
+  implicit val arbOAuth2BearerToken: Arbitrary[OAuth2BearerToken] = Arbitrary(genOAuth2BearerToken)
+  implicit val arbCreateWorkbenchUserAPI: Arbitrary[CreateWorkbenchUser] = Arbitrary(genCreateWorkbenchUserAPI)
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -1,12 +1,93 @@
 package org.broadinstitute.dsde.workbench.sam
 
-import scala.concurrent.{Await, Awaitable}
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.Materializer
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO}
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.api._
+import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetServiceAccountConfig, _}
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.service._
+import org.broadinstitute.dsde.workbench.sam.service.UserService._
+import org.scalatest.prop.{Configuration, PropertyChecks}
+import org.scalatest.{FlatSpec, Matchers}
+import StandardUserInfoDirectives._
+import org.scalactic.Equality
+
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Awaitable, ExecutionContext}
 
 /**
   * Created by dvoet on 6/27/17.
   */
-trait TestSupport {
+trait TestSupport{
   def runAndWait[T](f: Awaitable[T]): T = Await.result(f, Duration.Inf)
 }
-object TestSupport extends TestSupport
+
+trait PropertyBasedTesting extends FlatSpec with PropertyChecks with Configuration with Matchers {
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
+}
+
+object TestSupport extends TestSupport{
+  implicit val eqThrowable: Equality[Throwable] = new Equality[Throwable]{
+    override def areEqual(a: Throwable, b: Any): Boolean = b.isInstanceOf[Throwable] && a.getMessage == b.asInstanceOf[Throwable].getMessage
+  }
+  val config = ConfigFactory.load()
+  val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
+  val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
+  val configResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.map(rt => rt.name -> rt).toMap
+  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
+  def proxyEmail(workbenchUserId: WorkbenchUserId) = WorkbenchEmail(s"PROXY_$workbenchUserId@${googleServicesConfig.appsDomain}")
+  def googleSubjectIdHeaderWithId(googleSubjectId: GoogleSubjectId) = RawHeader(googleSubjectIdHeader, googleSubjectId.value)
+  def genGoogleSubjectId(): GoogleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
+
+  def genGoogleSubjectIdHeader = RawHeader(googleSubjectIdHeader, genRandom(System.currentTimeMillis()))
+  val defaultEmailHeader = RawHeader(emailHeader, defaultUserEmail.value)
+  def genDefaultEmailHeader(workbenchEmail: WorkbenchEmail) = RawHeader(emailHeader, workbenchEmail.value)
+
+  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty, googIamDAO: Option[GoogleIamDAO] = None, googleServicesConfig: GoogleServicesConfig = googleServicesConfig, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None)(implicit system: ActorSystem, executionContext: ExecutionContext) = {
+    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val googleIamDAO = googIamDAO.getOrElse(new MockGoogleIamDAO())
+    val policyDAO = new MockAccessPolicyDAO()
+    val pubSubDAO = new MockGooglePubSubDAO()
+    val googleStorageDAO = new MockGoogleStorageDAO()
+    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
+    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleExt = cloudExtensions.getOrElse(new GoogleExtensions(
+      directoryDAO,
+      policyDAO,
+      googleDirectoryDAO,
+      null,
+      googleIamDAO,
+      null,
+      null,
+      cloudKeyCache,
+      notificationDAO,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes(CloudExtensions.resourceTypeName)))
+    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
+
+    SamDependencies(mockResourceService, new UserService(directoryDAO, googleExt), new StatusService(directoryDAO, googleExt), mockManagedGroupService, directoryDAO, googleExt)
+  }
+
+  def genSamRoutes(samDependencies: SamDependencies)(implicit system: ActorSystem, executionContext: ExecutionContext, materializer: Materializer): SamRoutes = new SamRoutes(samDependencies.resourceService, samDependencies.userService, samDependencies.statusService, samDependencies.managedGroupService, null, samDependencies.directoryDAO)
+    with StandardUserInfoDirectives
+    with GoogleExtensionRoutes {
+    override val cloudExtensions: CloudExtensions = samDependencies.cloudExtensions
+    override val googleExtensions: GoogleExtensions = if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions] else null
+    val googleKeyCache = if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions])samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions].googleKeyCache else null
+  }
+}
+
+final case class SamDependencies(resourceService: ResourceService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, directoryDAO: MockDirectoryDAO, val cloudExtensions: CloudExtensions)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
@@ -6,10 +7,10 @@ import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
+import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import spray.json.DefaultJsonProtocol._
 
@@ -32,6 +33,7 @@ class ManagedGroupRoutesV1Spec extends FlatSpec with Matchers with ScalatestRout
   private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
   private val groupId = "foo"
   private val defaultNewUser = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), WorkbenchEmail("newGuy@organization.org"), 0)
+  private val defaultGoogleSubjectId = GoogleSubjectId("NewGuy")
 
   def assertGroupDoesNotExist(samRoutes: TestSamRoutes, groupId: String = groupId): Unit = {
     Get(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
@@ -60,7 +62,8 @@ class ManagedGroupRoutesV1Spec extends FlatSpec with Matchers with ScalatestRout
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
   def makeOtherUser(samRoutes: TestSamRoutes, userInfo: UserInfo = defaultNewUser) = new {
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)))
+    runAndWait(samRoutes.userService.createUser(
+      CreateWorkbenchUser(userInfo.userId, GoogleSubjectId(genRandom(System.currentTimeMillis())), userInfo.userEmail)))
     val email = userInfo.userEmail
     val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao)
   }
@@ -99,7 +102,8 @@ class ManagedGroupRoutesV1Spec extends FlatSpec with Matchers with ScalatestRout
     assertCreateGroup(samRoutes)
     assertGetGroup(samRoutes)
 
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(newGuy.userId, newGuy.userEmail)))
+    runAndWait(samRoutes.userService.createUser(
+      CreateWorkbenchUser(newGuy.userId, GoogleSubjectId(newGuy.userId.value), newGuy.userEmail)))
 
     setGroupMembers(samRoutes, Set(newGuyEmail), expectedStatus = StatusCodes.Created)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
@@ -1,4 +1,6 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
+
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives.provide
@@ -7,7 +9,7 @@ import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, Workbe
 /**
   * Created by dvoet on 6/7/17.
   */
-trait MockUserInfoDirectives extends UserInfoDirectives {
+trait MockUserInfoDirectives extends StandardUserInfoDirectives {
   val userInfo: UserInfo
   val petSAdomain = "\\S+@\\S+\\.iam\\.gserviceaccount\\.com".r
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -1,0 +1,123 @@
+package org.broadinstitute.dsde.workbench.sam
+package api
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
+import akka.http.scaladsl.server.Directives.{complete, handleExceptions}
+import akka.http.scaladsl.server.MissingHeaderRejection
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.sam.Generator._
+import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
+import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, UserService}
+import org.scalatest.concurrent.ScalaFutures
+import org.broadinstitute.dsde.workbench.sam.service.UserService._
+
+import scala.concurrent.ExecutionContext
+import TestSupport.eqThrowable
+import org.broadinstitute.dsde.workbench.sam.api.SamRoutes.myExceptionHandler
+
+class StandardUserInfoDirectivesSpec extends PropertyBasedTesting with ScalatestRouteTest with ScalaFutures{
+  def directives: StandardUserInfoDirectives = new StandardUserInfoDirectives {
+    override implicit val executionContext: ExecutionContext = null
+    override val directoryDAO: DirectoryDAO = new MockDirectoryDAO()
+    override val cloudExtensions: CloudExtensions = null
+  }
+
+  "isServiceAccount" should "be able to tell whether an email is a PET email" in {
+    forAll(genPetEmail, genNonPetEmail){
+      (petEmail: WorkbenchEmail, nonPetEmail: WorkbenchEmail) =>
+        isServiceAccount(petEmail) shouldBe(true)
+        isServiceAccount(nonPetEmail) shouldBe(false)
+    }
+  }
+
+  "getUserInfo" should "be able to get a UserInfo object for regular user" in {
+    forAll{
+      (token: OAuth2BearerToken, email: WorkbenchEmail) =>
+      val directoryDAO = new MockDirectoryDAO()
+      val googleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
+      val uid = genWorkbenchUserId(System.currentTimeMillis())
+      directoryDAO.createUser(WorkbenchUser(uid, Some(googleSubjectId), email)).futureValue
+      val res = getUserInfo(token, googleSubjectId, email, 10L, directoryDAO).futureValue
+      res should be (UserInfo(token, uid, email, 10L))
+    }
+  }
+
+  it should "be able to get a UserInfo object for service account if it is a PET" in {
+    forAll(genServiceAccountSubjectId, genGoogleSubjectId, genOAuth2BearerToken, genPetEmail){
+      (serviceSubjectId: ServiceAccountSubjectId, googleSubjectId: GoogleSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+      val directoryDAO = new MockDirectoryDAO()
+      val uid = genWorkbenchUserId(System.currentTimeMillis())
+      directoryDAO.createUser(WorkbenchUser(uid, Some(googleSubjectId), email)).futureValue
+      directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName("")))).futureValue
+      val res = getUserInfo(token, googleSubjectId, email, 10L, directoryDAO).futureValue
+      res should be (UserInfo(token, uid, email, 10L))
+    }
+  }
+
+  it should "be able to get a UserInfo object for service account if it is a not PET" in {
+    forAll(genServiceAccountSubjectId, genOAuth2BearerToken, genPetEmail){
+      (serviceSubjectId: ServiceAccountSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+      val directoryDAO = new MockDirectoryDAO()
+      val gSid = GoogleSubjectId(serviceSubjectId.value)
+      val uid = genWorkbenchUserId(System.currentTimeMillis())
+      directoryDAO.createUser(WorkbenchUser(uid, Some(gSid), email)).futureValue
+      val res = getUserInfo(token, gSid, email, 10L, directoryDAO).futureValue
+      res should be (UserInfo(token, uid, email, 10L))
+    }
+  }
+
+  it should "fail if provided googleSubjectId doesn't exist in sam" in {
+    forAll{
+      (token: OAuth2BearerToken, email: WorkbenchEmail) =>
+        val directoryDAO = new MockDirectoryDAO()
+        val googleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
+        val res = getUserInfo(token, googleSubjectId, email, 10L, directoryDAO).failed.futureValue
+        res === new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"google subject Id $googleSubjectId not found in sam")) shouldBe(true)
+    }
+  }
+
+  it should "fail if PET account is not found" in {
+    forAll(genOAuth2BearerToken, genPetEmail){
+      (token: OAuth2BearerToken, email: WorkbenchEmail) =>
+        val directoryDAO = new MockDirectoryDAO()
+        val googleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
+        val res = getUserInfo(token, googleSubjectId, email, 10L, directoryDAO).failed.futureValue
+        res === new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"google subject Id $googleSubjectId not found in sam")) shouldBe(true)
+    }
+  }
+
+  it should "fail if a regular user email is provided, but subjectId is not for a regular user" in {
+    forAll(genServiceAccountSubjectId, genOAuth2BearerToken, genNonPetEmail){
+      (serviceSubjectId: ServiceAccountSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+        val directoryDAO = new MockDirectoryDAO()
+        val gSid = GoogleSubjectId(serviceSubjectId.value)
+        val uid = genWorkbenchUserId(System.currentTimeMillis())
+        directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName("")))).futureValue
+        val res = getUserInfo(token, gSid, email, 10L, directoryDAO).failed.futureValue
+        res === new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $gSid is not a WorkbenchUser")) shouldBe(true)
+    }
+  }
+
+  "StandardUserInfoDirectives" should "fail if expiresIn is in illegal format" in {
+    forAll(genUserInfoHeadersWithInvalidExpiresIn){
+      headers: List[RawHeader] =>
+        Get("/").withHeaders(headers) ~> handleExceptions(myExceptionHandler){directives.requireUserInfo(x => complete(x.toString))}~> check {
+          val res = responseAs[String]
+          status shouldBe StatusCodes.BadRequest
+          responseAs[String].contains(s"expiresIn ${headers.find(_.name == expiresInHeader).get.value} can't be converted to Long") shouldBe(true)
+        }
+    }
+  }
+
+  it should "fail if required headers are missing" in {
+    Get("/") ~> handleExceptions(myExceptionHandler){directives.requireUserInfo(x => complete(x.toString))} ~> check {
+      rejection shouldBe MissingHeaderRejection(accessTokenHeader)
+    }
+  }
+
+  //skipping positive test for StandardUserInfoDirectives since all other routes mixes in StandardUserInfoDirectives relies on success path.
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -30,8 +30,8 @@ class TestSamRoutes(resourceService: ResourceService, userService: UserService, 
 }
 
 object TestSamRoutes {
-
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+  val defaultGoogleSubjectId = GoogleSubjectId("user1")
 
   def apply(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo)(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext) = {
     // need to make sure MockDirectoryDAO and MockAccessPolicyDAO share the same groups
@@ -44,7 +44,8 @@ object TestSamRoutes {
     val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val mockUserService = new UserService(directoryDAO, NoExtensions)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, NoExtensions, emailDomain)
-    TestSupport.runAndWait(mockUserService.createUser(WorkbenchUser(userInfo.userId, userInfo.userEmail)))
+    TestSupport.runAndWait(mockUserService.createUser(
+      CreateWorkbenchUser(userInfo.userId, defaultGoogleSubjectId, userInfo.userEmail)))
     val allUsersGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(directoryDAO))
     TestSupport.runAndWait(googleDirectoryDAO.createGroup(allUsersGroup.id.toString, allUsersGroup.email))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -1,37 +1,186 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.model.google.{ServiceAccount, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, genSamRoutes}
 import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, StatusService, UserService}
+import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, NoExtensions, StatusService, UserService}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
-
+import StandardUserInfoDirectives._
 import scala.concurrent.Future
 /**
   * Created by dvoet on 6/7/17.
   */
-class UserRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
+class UserRoutesSpec extends UserRoutesSpecHelper {
+  "POST /register/user" should "create user" in withDefaultRoutes { samRoutes =>
+    val header = TestSupport.genGoogleSubjectIdHeader
+    Post("/register/user").withHeaders(header, TestSupport.defaultEmailHeader) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      val res = responseAs[UserStatus]
+      res.userInfo.userSubjectId.value.length shouldBe 21
+      res.userInfo.userEmail shouldBe defaultUserEmail
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+    }
+
+    Post("/register/user").withHeaders(header, TestSupport.defaultEmailHeader) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Conflict
+    }
+  }
+
+  "GET /register/user" should "get the status of an enabled user" in {
+    val (user, headers, _, routes) = createTestUser()
+
+    Get("/register/user").withHeaders(headers) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  "POST /register/user" should "retrieve PET owner's user info if a PET account is provided" in {
+    val (user, _, samDep, routes) = createTestUser()
+    val petEmail = s"pet-${user.id.value}@test.iam.gserviceaccount.com"
+    val headers = List(
+      RawHeader(emailHeader, petEmail),
+      TestSupport.googleSubjectIdHeaderWithId(user.googleSubjectId.get),
+      RawHeader(accessTokenHeader, ""),
+      RawHeader(expiresInHeader, "1000")
+    )
+    //create a PET service account owned by test user
+    runAndWait(samDep.directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(user.id, null), ServiceAccount(ServiceAccountSubjectId(user.googleSubjectId.get.value), WorkbenchEmail(petEmail), null))))
+    Get("/register/user").withHeaders(headers) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  "GET /admin/user/{userSubjectId}" should "get the user status of a user (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Get(s"/api/admin/user/${user.id}").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/$defaultUserId").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "GET /admin/user/email/{email}" should "get the user status of a user by email (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Get(s"/api/admin/user/email/${user.email}").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "return 404 for an unknown user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Get(s"/api/admin/user/email/XXX${defaultUserEmail}XXX").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "return 404 for an group's email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
+    Get(s"/api/admin/user/email/fc-admins@dev.test.firecloud.org").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/email/$defaultUserEmail").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "PUT /admin/user/{userSubjectId}/(re|dis)able" should "disable and then re-enable a user (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Put(s"/api/admin/user/${user.id}/disable").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails({user.id}, user.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
+    }
+
+    Put(s"/api/admin/user/${user.id}/enable").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails({user.id}, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    }
+  }
+
+  it should "not allow a non-admin to enable or disable a user" in withAdminRoutes { (samRoutes, _) =>
+    Put(s"/api/admin/user/$defaultUserId/disable").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+
+    Put(s"/api/admin/user/$defaultUserId/enable").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "DELETE /admin/user/{userSubjectId}" should "delete a user (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Delete(s"/api/admin/user/${user.id}").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+
+    Get(s"/api/admin/user/${user.id}").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "not allow a non-admin to delete a user" in withAdminRoutes { (samRoutes, _) =>
+    Delete(s"/api/admin/user/$defaultUserId").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "DELETE /admin/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Delete(s"/api/admin/user/${user.id}/petServiceAccount/myproject").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "not allow a non-admin to delete a pet" in withAdminRoutes { (samRoutes, _) =>
+    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+}
+
+trait UserRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport{
   val defaultUserId = WorkbenchUserId("newuser")
   val defaultUserEmail = WorkbenchEmail("newuser@new.com")
+
   val adminUserId = WorkbenchUserId("adminuser")
+  val adminGoogleSubjectId = GoogleSubjectId("adminuserGoog")
   val adminUserEmail = WorkbenchEmail("adminuser@new.com")
+  val adminHeaders = List(
+    RawHeader(accessTokenHeader, ""),
+    RawHeader(googleSubjectIdHeader, adminGoogleSubjectId.value),
+    RawHeader(emailHeader, adminUserEmail.value),
+    RawHeader(expiresInHeader, "1000"),
+    TestSupport.genGoogleSubjectIdHeader,
+  )
+
   val petSAUserId = WorkbenchUserId("123")
   val petSAEmail = WorkbenchEmail("pet-newuser@test.iam.gserviceaccount.com")
 
-  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
-    val directoryDAO = new MockDirectoryDAO()
-
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO)
-    testCode(samRoutes)
-  }
 
   def setupAdminsGroup(googleDirectoryDAO: MockGoogleDirectoryDAO): Future[WorkbenchEmail] = {
     val adminGroupEmail = WorkbenchEmail("fc-admins@dev.test.firecloud.org")
@@ -39,6 +188,45 @@ class UserRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with
       _ <- googleDirectoryDAO.createGroup(WorkbenchGroupName("fc-admins"), adminGroupEmail)
       _ <- googleDirectoryDAO.addMemberToGroup(adminGroupEmail, WorkbenchEmail(adminUserEmail.value))
     } yield adminGroupEmail
+  }
+
+  def setUpAdminTest(): (WorkbenchUser, SamRoutes) = {
+    val googDirectoryDAO = new MockGoogleDirectoryDAO()
+    val adminGroupEmail = runAndWait(setupAdminsGroup(googDirectoryDAO))
+    val cloudExtensions = new NoExtensions {
+      override def isWorkbenchAdmin(memberEmail: WorkbenchEmail): Future[Boolean] = googDirectoryDAO.isGroupMember(adminGroupEmail, memberEmail)
+    }
+    val (user, _, _, routes) = createTestUser(cloudExtensions = Some(cloudExtensions), googleDirectoryDAO = Some(googDirectoryDAO))
+    Post("/register/user/v1/").withHeaders(adminHeaders) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+    (user, routes)
+  }
+
+  def createTestUser(googSubjectId: Option[GoogleSubjectId] = None, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None): (WorkbenchUser, List[RawHeader], SamDependencies, SamRoutes) = {
+    val googleSubjectId = googSubjectId.map(_.value).getOrElse(genRandom(System.currentTimeMillis()))
+    val googleSubjectheader = RawHeader(googleSubjectIdHeader, googleSubjectId)
+    val emHeader = RawHeader(emailHeader, defaultUserEmail.value)
+
+    val samDependencies = genSamDependencies(cloudExtensions = cloudExtensions, googleDirectoryDAO = googleDirectoryDAO)
+    val routes = genSamRoutes(samDependencies)
+
+    // create a user
+    val user = Post("/register/user/v1/").withHeaders(googleSubjectheader, emHeader) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      val res = responseAs[UserStatus]
+      res.userInfo.userEmail shouldBe defaultUserEmail
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+
+      WorkbenchUser(res.userInfo.userSubjectId, Some(GoogleSubjectId(googleSubjectId)), res.userInfo.userEmail)
+    }
+    val headers = List(
+      RawHeader(emailHeader, user.email.value),
+      TestSupport.googleSubjectIdHeaderWithId(user.googleSubjectId.get),
+      RawHeader(accessTokenHeader, ""),
+      RawHeader(expiresInHeader, "1000")
+    )
+    (user, headers, samDependencies, routes)
   }
 
   def withAdminRoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
@@ -56,160 +244,10 @@ class UserRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with
     testCode(samRoutes, adminRoutes)
   }
 
-  def withSARoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
+  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
     val directoryDAO = new MockDirectoryDAO()
 
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, NoExtensions)
-    val SARoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, NoExtensions)
-    testCode(samRoutes, SARoutes)
-  }
-
-  "POST /register/user" should "create user" in withDefaultRoutes { samRoutes =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Conflict
-    }
-  }
-
-  "GET /register/user" should "get the status of an enabled user" in withDefaultRoutes { samRoutes =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-  }
-
-
-  "POST /register/user" should "create a user" in withSARoutes{ (samRoutes, SARoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get("/register/user") ~> SARoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-  }
-
-  "GET /admin/user/{userSubjectId}" should "get the user status of a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-  }
-
-  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
-    Get(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  "GET /admin/user/email/{email}" should "get the user status of a user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get(s"/api/admin/user/email/$defaultUserEmail") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-  }
-
-  it should "return 404 for an unknown user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Get(s"/api/admin/user/email/XXX${defaultUserEmail}XXX") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
-  }
-
-  it should "return 404 for an group's email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Get(s"/api/admin/user/email/fc-admins@dev.test.firecloud.org") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
-  }
-
-  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
-    Get(s"/api/admin/user/email/$defaultUserEmail") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  "PUT /admin/user/{userSubjectId}/(re|dis)able" should "disable and then re-enable a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Put(s"/api/admin/user/$defaultUserId/disable") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Put(s"/api/admin/user/$defaultUserId/enable") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-  }
-
-  it should "not allow a non-admin to enable or disable a user" in withAdminRoutes { (samRoutes, _) =>
-    Put(s"/api/admin/user/$defaultUserId/disable") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-
-    Put(s"/api/admin/user/$defaultUserId/enable") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  "DELETE /admin/user/{userSubjectId}" should "delete a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Delete(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-    }
-
-    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
-  }
-
-  it should "not allow a non-admin to delete a user" in withAdminRoutes { (samRoutes, _) =>
-    Delete(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  "DELETE /admin/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
-    }
-  }
-
-  it should "not allow a non-admin to delete a pet" in withAdminRoutes { (samRoutes, _) =>
-    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
+    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO)
+    testCode(samRoutes)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -1,62 +1,21 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
-import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
+import org.broadinstitute.dsde.workbench.model.google.{ServiceAccount, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.model.{PetServiceAccount, PetServiceAccountId, UserInfo, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, StatusService, UserService}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
-
-import scala.concurrent.Future
+import StandardUserInfoDirectives._
 
 /**
   * Created by dvoet on 6/7/17.
   */
-class UserRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
-  val defaultUserId = WorkbenchUserId("newuser")
-  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
-  val adminUserId = WorkbenchUserId("adminuser")
-  val adminUserEmail = WorkbenchEmail("adminuser@new.com")
-  val petSAUserId = WorkbenchUserId("123")
-  val petSAEmail = WorkbenchEmail("pet-newuser@test.iam.gserviceaccount.com")
-
-  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
-    val directoryDAO = new MockDirectoryDAO()
-
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, NoExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO)
-    testCode(samRoutes)
-  }
-
-  def setupAdminsGroup(googleDirectoryDAO: MockGoogleDirectoryDAO): Future[WorkbenchEmail] = {
-    val adminGroupEmail = WorkbenchEmail("fc-admins@dev.test.firecloud.org")
-    for {
-      _ <- googleDirectoryDAO.createGroup(WorkbenchGroupName("fc-admins"), adminGroupEmail)
-      _ <- googleDirectoryDAO.addMemberToGroup(adminGroupEmail, WorkbenchEmail(adminUserEmail.value))
-    } yield adminGroupEmail
-  }
-
-  def withAdminRoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-
-    val adminGroupEmail = runAndWait(setupAdminsGroup(googleDirectoryDAO))
-
-    val cloudExtensions = new NoExtensions {
-      override def isWorkbenchAdmin(memberEmail: WorkbenchEmail): Future[Boolean] = googleDirectoryDAO.isGroupMember(adminGroupEmail, memberEmail)
-    }
-
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, cloudExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, cloudExtensions)
-    val adminRoutes = new TestSamRoutes(null, new UserService(directoryDAO, cloudExtensions), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), adminUserId, adminUserEmail, 0), directoryDAO, cloudExtensions)
-    testCode(samRoutes, adminRoutes)
-  }
-
+class UserRoutesV1Spec extends UserRoutesSpecHelper{
   def withSARoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
     val directoryDAO = new MockDirectoryDAO()
 
@@ -65,156 +24,146 @@ class UserRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest wi
     testCode(samRoutes, SARoutes)
   }
 
-  "POST /register/user/v1/" should "create user" in withDefaultRoutes { samRoutes =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+  "POST /register/user/v1/" should "create user" in withDefaultRoutes{samRoutes =>
+    val header = List(TestSupport.genGoogleSubjectIdHeader, TestSupport.defaultEmailHeader)
+    Post("/register/user/v1/").withHeaders(header) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      val res = responseAs[UserStatus]
+      res.userInfo.userSubjectId.value.length shouldBe 21
+      res.userInfo.userEmail shouldBe defaultUserEmail
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
     }
 
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
+    Post("/register/user/v1/").withHeaders(header) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Conflict
     }
   }
 
-  "GET /register/user/v1/" should "get the status of an enabled user" in withDefaultRoutes { samRoutes =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+  "GET /register/user/v1/" should "get the status of an enabled user" in {
+    val (user, headers, samDep, routes) = createTestUser()
+    val googleSubjectIdHeader = TestSupport.googleSubjectIdHeaderWithId(user.googleSubjectId.get)
+
+    Get("/register/user/v1/").withHeaders(headers) ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
 
-    Get("/register/user/v1/") ~> samRoutes.route ~> check {
+    Get("/register/user/v1?userDetailsOnly=true").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get("/register/user/v1?userDetailsOnly=true") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map.empty)
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map.empty)
     }
   }
 
-
-  "POST /register/user/v1/" should "create a user" in withSARoutes{ (samRoutes, SARoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get("/register/user/v1/") ~> SARoutes.route ~> check {
+  "POST /register/user/v1/" should "retrieve PET owner's user info if a PET account is provided" in {
+    val (user, _, samDep, routes) = createTestUser()
+    val petEmail = s"pet-${user.id.value}@test.iam.gserviceaccount.com"
+    val headers = List(
+      RawHeader(emailHeader, petEmail),
+      TestSupport.googleSubjectIdHeaderWithId(user.googleSubjectId.get),
+      RawHeader(accessTokenHeader, ""),
+      RawHeader(expiresInHeader, "1000")
+    )
+    //create a PET service account owned by test user
+    runAndWait(samDep.directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(user.id, null), ServiceAccount(ServiceAccountSubjectId(user.googleSubjectId.get.value), WorkbenchEmail(petEmail), null))))
+    Get("/register/user/v1").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
   }
 
-  "GET /admin/user/{userSubjectId}" should "get the user status of a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+  "GET /admin/user/{userSubjectId}" should "get the user status of a user (as an admin)" in {
+    val (user, getRoutes) = setUpAdminTest()
+    Get(s"/api/admin/user/${user.id}").withHeaders(adminHeaders) ~> getRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
   }
 
-  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
-    Get(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
+  it should "not allow a non-admin with userId to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/$defaultUserId").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
-  "GET /admin/user/email/{email}" should "get the user status of a user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
+  "GET /admin/user/email/{email}" should "get the user status of a user by email (as an admin)" in {
+    val (user, getRoutes) = setUpAdminTest()
 
-    Get(s"/api/admin/user/email/$defaultUserEmail") ~> adminRoutes.route ~> check {
+    Get(s"/api/admin/user/email/${user.email}").withHeaders(adminHeaders) ~> getRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
   }
 
   it should "return 404 for an unknown user by email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Get(s"/api/admin/user/email/XXX${defaultUserEmail}XXX") ~> adminRoutes.route ~> check {
+    Get(s"/api/admin/user/email/XXX${defaultUserEmail}XXX").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "return 404 for an group's email (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Get(s"/api/admin/user/email/fc-admins@dev.test.firecloud.org") ~> adminRoutes.route ~> check {
+    Get(s"/api/admin/user/email/fc-admins@dev.test.firecloud.org").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
-  it should "not allow a non-admin to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
-    Get(s"/api/admin/user/email/$defaultUserEmail") ~> samRoutes.route ~> check {
+  it should "not allow a non-admin with user email to get the status of another user" in withAdminRoutes { (samRoutes, _) =>
+    Get(s"/api/admin/user/email/$defaultUserEmail").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
-  "PUT /admin/user/{userSubjectId}/(re|dis)able" should "disable and then re-enable a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+  "PUT /admin/user/{userSubjectId}/(re|dis)able" should "disable and then re-enable a user (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
+
+    Put(s"/api/admin/user/${user.id}/disable").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
     }
 
-    Put(s"/api/admin/user/$defaultUserId/disable") ~> adminRoutes.route ~> check {
+    Put(s"/api/admin/user/${user.id}/enable").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Put(s"/api/admin/user/$defaultUserId/enable") ~> adminRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
   }
 
   it should "not allow a non-admin to enable or disable a user" in withAdminRoutes { (samRoutes, _) =>
-    Put(s"/api/admin/user/$defaultUserId/disable") ~> samRoutes.route ~> check {
+    Put(s"/api/admin/user/$defaultUserId/disable").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
 
-    Put(s"/api/admin/user/$defaultUserId/enable") ~> samRoutes.route ~> check {
+    Put(s"/api/admin/user/$defaultUserId/enable").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
-  "DELETE /admin/user/{userSubjectId}" should "delete a user (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
+  "DELETE /admin/user/{userSubjectId}" should "delete a user (as an admin)" in {
+    val (user, adminRoutes) = setUpAdminTest()
 
-    Delete(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+    Delete(s"/api/admin/user/${user.id}").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    Get(s"/api/admin/user/$defaultUserId") ~> adminRoutes.route ~> check {
+    Get(s"/api/admin/user/${user.id}").withHeaders(adminHeaders)~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "not allow a non-admin to delete a user" in withAdminRoutes { (samRoutes, _) =>
-    Delete(s"/api/admin/user/$defaultUserId") ~> samRoutes.route ~> check {
+    Delete(s"/api/admin/user/$defaultUserId").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   "DELETE /admin/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in withAdminRoutes { (samRoutes, adminRoutes) =>
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
+    val (user, adminRoutes) = setUpAdminTest()
 
-    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> adminRoutes.route ~> check {
+    Delete(s"/api/admin/user/${user.id}/petServiceAccount/myproject").withHeaders(adminHeaders) ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "not allow a non-admin to delete a pet" in withAdminRoutes { (samRoutes, _) =>
-    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Delete(s"/api/admin/user/$defaultUserId/petServiceAccount/myproject").withHeaders(adminHeaders) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -70,7 +70,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "create, read, delete users" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     assertResult(None) {
       runAndWait(dao.loadUser(user.id))
@@ -93,7 +93,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "add and read proxy group email" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     assertResult(user) {
       runAndWait(dao.createUser(user))
@@ -112,7 +112,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "create, read, delete pet service accounts" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
     val serviceAccountUniqueId = ServiceAccountSubjectId(UUID.randomUUID().toString)
     val serviceAccount = ServiceAccount(serviceAccountUniqueId, WorkbenchEmail("foo@bar.com"), ServiceAccountDisplayName(""))
     val project = GoogleProject("testproject")
@@ -164,7 +164,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "list groups" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(userId), WorkbenchEmail("g1@example.com"))
@@ -189,11 +189,11 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "list flattened group users" in {
     val userId1 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user1 = WorkbenchUser(userId1, WorkbenchEmail("foo@bar.com"))
+    val user1 = WorkbenchUser(userId1, None, WorkbenchEmail("foo@bar.com"))
     val userId2 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user2 = WorkbenchUser(userId2, WorkbenchEmail("foo@bar.com"))
+    val user2 = WorkbenchUser(userId2, None, WorkbenchEmail("foo@bar.com"))
     val userId3 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user3 = WorkbenchUser(userId3, WorkbenchEmail("foo@bar.com"))
+    val user3 = WorkbenchUser(userId3, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(userId1), WorkbenchEmail("g1@example.com"))
@@ -252,7 +252,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "handle circular groups" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(userId), WorkbenchEmail("g1@example.com"))
@@ -293,7 +293,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "add/remove groups" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set.empty, WorkbenchEmail("g1@example.com"))
@@ -340,7 +340,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "handle different kinds of groups" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(userId), WorkbenchEmail("g1@example.com"))
@@ -369,7 +369,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "be case insensitive when checking for group membership" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(userId), WorkbenchEmail("g1@example.com"))
@@ -382,7 +382,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "get pet for user" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     runAndWait(dao.createUser(user))
 
@@ -447,7 +447,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   "JndiDirectoryDao loadSubjectEmail" should "fail if the user has not been created" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     assertResult(None) {
       runAndWait(dao.loadUser(user.id))
@@ -458,7 +458,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   it should "succeed if the user has been created" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, WorkbenchEmail("foo@bar.com"))
+    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
 
     assertResult(None) {
       runAndWait(dao.loadUser(user.id))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -1,140 +1,80 @@
-package org.broadinstitute.dsde.workbench.sam.google
+package org.broadinstitute.dsde.workbench.sam
+package google
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
-import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetServiceAccountConfig, _}
-import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.Generator._
+import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, genSamRoutes, _}
+import org.broadinstitute.dsde.workbench.sam.api.SamRoutes
+import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, _}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
+import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
+import org.broadinstitute.dsde.workbench.sam.service.UserService._
+import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
 /**
   * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
-class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
-  val defaultUserId = WorkbenchUserId("newuser123")
-  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-  val defaultUserProxyEmail = WorkbenchEmail(s"newuser_$defaultUserId@${googleServicesConfig.appsDomain}")
-*/
-  val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
-/**/
+class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
 
-  lazy val config = ConfigFactory.load()
-  lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
-  lazy val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
-
-  val configResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.map(rt => rt.name -> rt).toMap
-
-  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, null, googleDirectoryDAO, null, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
-
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, googleExt), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-    }
-    testCode(samRoutes)
-  }
-
-  "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user" in withDefaultRoutes { samRoutes =>
-    // create a user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
+  "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user" in {
+    val (user, headers, _, routes) = createTestUser()
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // same result a second time
-    Get("/api/google/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
   }
 
-  "GET /api/google/user/proxyGroup/{email}" should "return a user's proxy group" in withDefaultRoutes { samRoutes =>
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+  "GET /api/google/user/proxyGroup/{email}" should "return a user's proxy group" in {
+    val (user, headers, _, routes) = createTestUser()
 
-    // create a user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get(s"/api/google/user/proxyGroup/$defaultUserEmail") ~> samRoutes.route ~> check {
+    Get(s"/api/google/user/proxyGroup/${user.email}").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response shouldBe defaultUserProxyEmail
+      response shouldBe TestSupport.proxyEmail(user.id)
     }
   }
 
-  it should "return a user's proxy group from a pet service account" in withDefaultRoutes { samRoutes =>
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+  it should "return a user's proxy group from a pet service account" in {
+    val (user, headers, _, routes) = createTestUser()
 
-    // create a user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
 
-    val petEmail = Get("/api/google/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    val petEmail = Get("/api/google/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
       response.value
     }
 
-    Get(s"/api/google/user/proxyGroup/$petEmail") ~> samRoutes.route ~> check {
+    Get(s"/api/google/user/proxyGroup/$petEmail").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response shouldBe defaultUserProxyEmail
+      response shouldBe TestSupport.proxyEmail(user.id)
     }
   }
 
@@ -151,52 +91,28 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
   private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
 
   "POST /api/google/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
+///* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
+//    val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
+//*/
+//    val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_user123@${googleServicesConfig.appsDomain}")
+///**/
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user123"), WorkbenchEmail("user1@example.com"), 0)
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
-*/
-    val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_user123@${googleServicesConfig.appsDomain}")
-/**/
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (user, headers, _, routes) = createTestUser(resourceTypes)
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+    Post(s"/api/resource/${resourceType.name}/foo").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
     import spray.json.DefaultJsonProtocol._
-    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Seq[AccessPolicyResponseEntry]].find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
     }
 
     import GoogleModelJsonSupport._
-    Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", defaultUserProxyEmail.value.toLowerCase, None)))) {
+      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", TestSupport.proxyEmail(user.id).value.toLowerCase, None)))) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }
@@ -204,53 +120,29 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
 
   "GET /api/google/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "200 with sync date and policy email" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (user, headers, samDep, routes) = createTestUser(resourceTypes)
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+    Post(s"/api/resource/${resourceType.name}/foo").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
       assertResult("") {
         responseAs[String]
       }
     }
 
-    Get(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Get(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
       assertResult("") {
         responseAs[String]
       }
     }
 
-    Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    runAndWait(directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com"))))
+    samDep.directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com"))).futureValue
 
-    Get(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Get(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[String] should not be empty
     }
@@ -258,41 +150,19 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
 
   "GET /api/google/user/petServiceAccount/{project}/key" should "200 with a new key" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
+    val (user, headers, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
-    Get("/api/google/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject/key").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
@@ -301,53 +171,115 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
 
   "DELETE /api/google/user/petServiceAccount/{project}/key/{keyId}" should "204 when deleting a key" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
+    val (user, headers, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
-    Get("/api/google/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+    Get("/api/google/user/petServiceAccount/myproject/key").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
     }
 
     // create a pet service account key
-    Delete("/api/google/user/petServiceAccount/myproject/key/123") ~> samRoutes.route ~> check {
+    Delete("/api/google/user/petServiceAccount/myproject/key/123").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
-  private def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
+  "GET /api/google/petServiceAccount/{project}/{userEmail}" should "200 with a key" in {
+    val (defaultUserInfo, samRoutes, expectedJson, headers) = setupPetSATest()
+
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members).withHeaders(headers) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account key
+    Get(s"/api/google/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}").withHeaders(headers) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[String]
+      response shouldEqual(expectedJson)
+    }
+  }
+
+  it should "404 when user does not exist" in {
+    val (defaultUserInfo, samRoutes, _, headers) = setupPetSATest()
+
+    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members).withHeaders(headers) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+
+    // create a pet service account key
+    Get(s"/api/google/petServiceAccount/myproject/I-do-not-exist@foo.bar").withHeaders(headers) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "403 when caller does not have action" in {
+    val (_, samRoutes, _, headers) = setupPetSATest()
+
+    // create a pet service account key
+    Get(s"/api/google/petServiceAccount/myproject/I-do-not-exist@foo.bar").withHeaders(headers) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+}
+
+trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
+  val defaultUserId = genWorkbenchUserId(System.currentTimeMillis())
+  val defaultUserEmail = genNonPetEmail.sample.get
+  /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
+    val defaultUserProxyEmail = WorkbenchEmail(s"newuser_$defaultUserId@${googleServicesConfig.appsDomain}")
+  */
+  val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
+  /**/
+
+  val configResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.map(rt => rt.name -> rt).toMap
+
+  def createTestUser(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty[ResourceTypeName, ResourceType],
+                             googIamDAO: Option[GoogleIamDAO] = None,
+                             googleServicesConfig: GoogleServicesConfig = TestSupport.googleServicesConfig,
+                             googSubjectId: Option[GoogleSubjectId] = None,
+                             email: Option[WorkbenchEmail] = None
+                    ): (WorkbenchUser, List[RawHeader], SamDependencies, SamRoutes) = {
+    val em = email.getOrElse(defaultUserEmail)
+    val googleSubjectId = googSubjectId.map(_.value).getOrElse(genRandom(System.currentTimeMillis()))
+    val googHeader = RawHeader(googleSubjectIdHeader, googleSubjectId)
+    val emailRawHeader = RawHeader(emailHeader, em.value)
+
+    val samDependencies = genSamDependencies(resourceTypes, googIamDAO, googleServicesConfig)
+    val createRoutes = genSamRoutes(samDependencies)
+
+    // create a user
+    val user = Post("/register/user/v1/").withHeaders(googHeader, emailRawHeader) ~> createRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+      val res = responseAs[UserStatus]
+      res.userInfo.userEmail shouldBe em
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+
+      WorkbenchUser(res.userInfo.userSubjectId, Some(GoogleSubjectId(googleSubjectId)), res.userInfo.userEmail)
+    }
+
+    val headers = List(
+      RawHeader(emailHeader, user.email.value),
+      RawHeader(googleSubjectIdHeader, googleSubjectId),
+      RawHeader(accessTokenHeader, ""),
+      RawHeader(expiresInHeader, "1000")
+    )
+    (user, headers, samDependencies, createRoutes)
+  }
+
+  def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
     val googleIamDAO = mock[GoogleIamDAO]
     val expectedJson = """{"json":"yes I am"}"""
     when(googleIamDAO.findServiceAccount(any[GoogleProject], any[ServiceAccountName])).thenReturn(Future.successful(None))
@@ -358,68 +290,20 @@ class GoogleExtensionRoutesSpec extends FlatSpec with Matchers with ScalatestRou
     (googleIamDAO, expectedJson)
   }
 
-  private def setupPetSATest: (UserInfo, TestSamRoutes with GoogleExtensionRoutes, String) = {
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig.copy(serviceAccountClientEmail = defaultUserInfo.userEmail, serviceAccountClientId = defaultUserInfo.userId.value), petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+  def setupPetSATest(): (UserInfo, SamRoutes, String, List[RawHeader]) = {
+    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val googleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
+    val email = genNonPetEmail.sample.get
+    val (user, headers, samDeps, routes) = createTestUser(
+      configResourceTypes,
+      Some(googleIamDAO),
+      TestSupport.googleServicesConfig.copy(serviceAccountClientEmail = email, serviceAccountClientId = googleSubjectId.value),
+      Some(googleSubjectId),
+      Some(email)
+    )
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val userService = new UserService(directoryDAO, googleExt)
-    val statusService = new StatusService(directoryDAO, NoExtensions)
-    val managedGroupService = new ManagedGroupService(mockResourceService, configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, userService, statusService, managedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    runAndWait(googleExt.onBoot(SamApplication(userService, mockResourceService, statusService)))
-    (defaultUserInfo, samRoutes, expectedJson)
-  }
-
-  "GET /api/google/petServiceAccount/{project}/{userEmail}" should "200 with a key" in {
-    val (defaultUserInfo, samRoutes, expectedJson) = setupPetSATest
-
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
-    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    // create a pet service account key
-    Get(s"/api/google/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[String]
-      response shouldEqual(expectedJson)
-    }
-  }
-
-  it should "404 when user does not exist" in {
-    val (defaultUserInfo, samRoutes, _) = setupPetSATest
-
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
-    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    // create a pet service account key
-    Get(s"/api/google/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
-    }
-  }
-
-  it should "403 when caller does not have action" in {
-    val (_, samRoutes, _) = setupPetSATest
-
-    // create a pet service account key
-    Get(s"/api/google/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
+    val userInfo = UserInfo(genOAuth2BearerToken.sample.get, user.id, email, 0)
+    runAndWait(samDeps.cloudExtensions.asInstanceOf[GoogleExtensions].onBoot(SamApplication(samDeps.userService, samDeps.resourceService, samDeps.statusService)))
+    (userInfo.copy(userId = user.id), routes, expectedJson, headers)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -1,140 +1,61 @@
-package org.broadinstitute.dsde.workbench.sam.google
+package org.broadinstitute.dsde.workbench.sam
+package google
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import com.typesafe.config.ConfigFactory
-import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
-import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleDirectoryDAO, MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
-import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetServiceAccountConfig, _}
-import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
-
-import scala.concurrent.Future
+import org.scalatest.concurrent.ScalaFutures
 
 /**
   * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
-class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
-  val defaultUserId = WorkbenchUserId("newuser123")
-  val defaultUserEmail = WorkbenchEmail("newuser@new.com")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-  val defaultUserProxyEmail = WorkbenchEmail(s"newuser_$defaultUserId@${googleServicesConfig.appsDomain}")
-*/
-  val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
-/**/
-
-  lazy val config = ConfigFactory.load()
-  lazy val petServiceAccountConfig = config.as[PetServiceAccountConfig]("petServiceAccount")
-  lazy val googleServicesConfig = config.as[GoogleServicesConfig]("googleServices")
-
-  val configResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.map(rt => rt.name -> rt).toMap
-
-  def withDefaultRoutes[T](testCode: TestSamRoutes => T): T = {
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, null, googleDirectoryDAO, null, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
-
-    val samRoutes = new TestSamRoutes(null, new UserService(directoryDAO, googleExt), new StatusService(directoryDAO, NoExtensions), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-    }
-    testCode(samRoutes)
-  }
-
-  "GET /api/google/v1/user/petServiceAccount" should "get or create a pet service account for a user" in withDefaultRoutes { samRoutes =>
-    // create a user
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
+class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
+  "GET /api/google/v1/user/petServiceAccount" should "get or create a pet service account for a user" in {
+    val (user, headers, _, routes) = createTestUser()
 
     // create a pet service account
-    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // same result a second time
-    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
   }
 
-  "GET /api/google/v1/user/proxyGroup/{email}" should "return a user's proxy group" in withDefaultRoutes { samRoutes =>
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
-
-    // create a user
-    Post("/register/user/v1") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    Get(s"/api/google/v1/user/proxyGroup/$defaultUserEmail") ~> samRoutes.route ~> check {
+  "GET /api/google/v1/user/proxyGroup/{email}" should "return a user's proxy group" in {
+    val (user, headers, _, routes) = createTestUser()
+    Get(s"/api/google/v1/user/proxyGroup/$defaultUserEmail").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response shouldBe defaultUserProxyEmail
+      response shouldBe WorkbenchEmail(s"PROXY_${user.id}@${googleServicesConfig.appsDomain}")
     }
   }
 
-  it should "return a user's proxy group from a pet service account" in withDefaultRoutes { samRoutes =>
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, null, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+  it should "return a user's proxy group from a pet service account" in {
+    val (user, headers, _, routes) = createTestUser()
 
-    // create a user
-    Post("/register/user/v1") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-    }
-
-    val petEmail = Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    val petEmail = Get("/api/google/v1/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
       response.value
     }
 
-    Get(s"/api/google/v1/user/proxyGroup/$petEmail") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/user/proxyGroup/$petEmail").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response shouldBe defaultUserProxyEmail
+      response shouldBe WorkbenchEmail(s"PROXY_${user.id.value}@${googleServicesConfig.appsDomain}")
     }
   }
 
@@ -152,51 +73,29 @@ class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestR
 
   "POST /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user123"), WorkbenchEmail("user1@example.com"), 0)
+//    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user123"), WorkbenchEmail("user1@example.com"), 0)
 /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
     val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
 */
-    val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_user123@${googleServicesConfig.appsDomain}")
 /**/
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
+    val (user, headers, _, routes) = createTestUser(resourceTypes)
 
-    //create user
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+    Post(s"/api/resource/${resourceType.name}/foo").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
     import spray.json.DefaultJsonProtocol._
-    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
+    val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Seq[AccessPolicyResponseEntry]].find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
     }
 
     import GoogleModelJsonSupport._
-    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", defaultUserProxyEmail.value.toLowerCase, None)))) {
+      val proxyEmail = WorkbenchEmail(s"PROXY_${user.id}@${googleServicesConfig.appsDomain}")
+      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", proxyEmail.value.toLowerCase, None)))) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }
@@ -204,53 +103,29 @@ class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestR
 
   "GET /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "200 with sync date and policy email" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val googleIamDAO = new MockGoogleIamDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (user, headers, samDep, routes) = createTestUser(resourceTypes)
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
-
-    Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
+    Post(s"/api/resource/${resourceType.name}/foo").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
       assertResult("") {
         responseAs[String]
       }
     }
 
-    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
       assertResult("") {
         responseAs[String]
       }
     }
 
-    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    runAndWait(directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com"))))
+    samDep.directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com"))).futureValue
 
-    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[String] should not be empty
     }
@@ -258,142 +133,62 @@ class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestR
 
   "GET /api/google/v1/user/petServiceAccount/{project}/key" should "200 with a new key" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
+    val (user, headers, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
-    Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject/key").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
     }
   }
 
+
   "DELETE /api/google/v1/user/petServiceAccount/{project}/key/{keyId}" should "204 when deleting a key" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO()
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
 
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val mockUserService = new UserService(directoryDAO, googleExt)
-    val mockStatusService = new StatusService(directoryDAO, NoExtensions)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    //create user
-    Post("/register/user/v1/") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Created
-    }
+    val (user, headers, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/v1/user/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response.value should endWith (s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
-    Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> samRoutes.route ~> check {
+    Get("/api/google/v1/user/petServiceAccount/myproject/key").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
     }
 
     // create a pet service account key
-    Delete("/api/google/v1/user/petServiceAccount/myproject/key/123") ~> samRoutes.route ~> check {
+    Delete("/api/google/v1/user/petServiceAccount/myproject/key/123").withHeaders(headers) ~> routes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
-  private def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
-    val googleIamDAO = mock[GoogleIamDAO]
-    val expectedJson = """{"json":"yes I am"}"""
-    when(googleIamDAO.findServiceAccount(any[GoogleProject], any[ServiceAccountName])).thenReturn(Future.successful(None))
-    when(googleIamDAO.createServiceAccount(any[GoogleProject], any[ServiceAccountName], any[ServiceAccountDisplayName])).thenReturn(Future.successful(ServiceAccount(ServiceAccountSubjectId("12312341234"), WorkbenchEmail("pet@myproject.iam.gserviceaccount.com"), ServiceAccountDisplayName(""))))
-    when(googleIamDAO.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(ServiceAccountKey(ServiceAccountKeyId("foo"), ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(expectedJson).encode), None, None)))
-    when(googleIamDAO.removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])).thenReturn(Future.successful(()))
-    when(googleIamDAO.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(Seq.empty))
-    (googleIamDAO, expectedJson)
-  }
-
-  private def setupPetSATest: (UserInfo, TestSamRoutes with GoogleExtensionRoutes, String) = {
-    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-    val googleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val directoryDAO = new MockDirectoryDAO()
-    val (googleIamDAO: GoogleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
-    val googleStorageDAO = new MockGoogleStorageDAO
-    val policyDAO = new MockAccessPolicyDAO()
-    val pubSubDAO = new MockGooglePubSubDAO()
-    val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = new GoogleExtensions(directoryDAO, policyDAO, googleDirectoryDAO, pubSubDAO, googleIamDAO, googleStorageDAO, null, cloudKeyCache, notificationDAO, googleServicesConfig.copy(serviceAccountClientEmail = defaultUserInfo.userEmail, serviceAccountClientId = defaultUserInfo.userId.value), petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
-
-    val emailDomain = "example.com"
-    val mockResourceService = new ResourceService(configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val userService = new UserService(directoryDAO, googleExt)
-    val statusService = new StatusService(directoryDAO, NoExtensions)
-    val managedGroupService = new ManagedGroupService(mockResourceService, configResourceTypes, policyDAO, directoryDAO, googleExt, emailDomain)
-    val samRoutes = new TestSamRoutes(mockResourceService, userService, statusService, managedGroupService, UserInfo(OAuth2BearerToken(""), defaultUserInfo.userId, defaultUserInfo.userEmail, 0), directoryDAO) with GoogleExtensionRoutes {
-      val googleExtensions = googleExt
-      val googleKeyCache = cloudKeyCache
-    }
-
-    runAndWait(googleExt.onBoot(SamApplication(userService, mockResourceService, statusService)))
-    (defaultUserInfo, samRoutes, expectedJson)
-  }
-
   "GET /api/google/v1/petServiceAccount/{project}/{userEmail}" should "200 with a key" in {
-    val (defaultUserInfo, samRoutes, expectedJson) = setupPetSATest
+    val (defaultUserInfo, samRoutes, expectedJson, headers) = setupPetSATest()
 
     val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
-    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members).withHeaders(headers) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
 
     // create a pet service account key
-    Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}").withHeaders(headers) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
@@ -401,24 +196,24 @@ class GoogleExtensionRoutesV1Spec extends FlatSpec with Matchers with ScalatestR
   }
 
   it should "404 when user does not exist" in {
-    val (defaultUserInfo, samRoutes, _) = setupPetSATest
+    val (defaultUserInfo, samRoutes, _, headers) = setupPetSATest()
 
     val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty)
-    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
+    Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members).withHeaders(headers) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
 
     // create a pet service account key
-    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar").withHeaders(headers) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "403 when caller does not have action" in {
-    val (_, samRoutes, _) = setupPetSATest
+    val (_, samRoutes, _, headers) = setupPetSATest()
 
     // create a pet service account key
-    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar").withHeaders(headers) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -8,6 +8,7 @@ import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.api.CreateWorkbenchUser
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, SchemaLockConfig}
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -84,7 +85,7 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     val jndi = jndiServicesFixture
     val mock = mockServicesFixture
 
-    val dummyUser = WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)
+    val dummyUser = CreateWorkbenchUser(dummyUserInfo.userId, GoogleSubjectId(dummyUserInfo.userId.value), dummyUserInfo.userEmail)
     runAndWait(jndi.userService.createUser(dummyUser))
     runAndWait(mock.userService.createUser(dummyUser))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.sam.service
+package org.broadinstitute.dsde.workbench.sam
+package service
 
 import java.net.URI
 import java.util.UUID
@@ -80,7 +81,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   before {
     runAndWait(schemaDao.clearDatabase())
     runAndWait(schemaDao.createOrgUnits())
-    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, dummyUserInfo.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
   }
 
   def toEmail(resourceType: String, resourceName: String, policyName: String) = {
@@ -170,7 +171,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
   it should "list the user's actions for a resource with nested groups" in {
     val resourceName1 = ResourceId("resource1")
 
-    val user = runAndWait(dirDAO.createUser(WorkbenchUser(WorkbenchUserId("asdfawefawea"), WorkbenchEmail("asdfawefawea@foo.bar"))))
+    val user = runAndWait(dirDAO.createUser(WorkbenchUser(WorkbenchUserId("asdfawefawea"), None, WorkbenchEmail("asdfawefawea@foo.bar"))))
     val group = BasicWorkbenchGroup(WorkbenchGroupName("g"), Set(user.id), WorkbenchEmail("foo@bar.com"))
     runAndWait(dirDAO.createGroup(group))
 
@@ -293,7 +294,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     runAndWait(constrainableService.createResourceType(constrainableResourceType))
 
     val bender = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("Bender"), WorkbenchEmail("bender@planex.com"), 0)
-    runAndWait(dirDAO.createUser(WorkbenchUser(bender.userId, bender.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(bender.userId, None, bender.userEmail)))
 
     runAndWait(constrainableService.createResourceType(managedGroupResourceType))
     val managedGroupName1 = "firstGroup"
@@ -571,7 +572,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val policyName = AccessPolicyName(defaultResourceType.ownerRoleName.value)
     val otherUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("otheruserid"), WorkbenchEmail("otheruser@company.com"), 0)
 
-    runAndWait(dirDAO.createUser(WorkbenchUser(otherUserInfo.userId, otherUserInfo.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(otherUserInfo.userId, None, otherUserInfo.userEmail)))
 
     runAndWait(service.createResourceType(defaultResourceType))
     runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo))


### PR DESCRIPTION
This should be merged after https://github.com/broadinstitute/sam/pull/198

Things changed:
* There's some refactoring in involved spec files. With the change, https://github.com/broadinstitute/sam/blob/develop/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala#L15 will be used in tests instead of a mocking object. 
* https://broadinstitute.atlassian.net/wiki/spaces/~952052303/pages/622624856/sam+Support+invite+feature 

TODO: 
- [x] add more unit tests for new code
- [x] once https://github.com/broadinstitute/workbench-libs/pull/157 is released, update sha in dependency
- [x] clean up generators in tests if people are okay with adding scalacheck
- [x] remove CreateWorkbenchUserAPI from workbench-lib