### PR TITLE
add scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,19 @@
+style = default
+
+maxColumn = 120
+
+// Vertical alignment is pretty, but leads to bigger diffs
+align = none
+
+align.tokens = [
+  {code = "=>", owner = "Case"},
+  {code = "%", owner = "Term.ApplyInfix"},
+  {code = "%%", owner = "Term.ApplyInfix"}
+]
+
+rewrite.rules = [
+  RedundantBraces
+  RedundantParens
+  AsciiSortImports
+  PreferCurlyFors
+]

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 import Settings._
 import Testing._
 
-lazy val root = project.in(file("."))
-  .settings(rootSettings:_*)
+lazy val root = project
+  .in(file("."))
+  .settings(rootSettings: _*)
   .withTestSettings
 
 Revolver.settings
@@ -21,37 +22,38 @@ sys.env.getOrElse("JAVA_OPTS", "").split(" ").toSeq.map { opt =>
 
 // recommended scalac options by https://tpolecat.github.io/2017/04/25/scalac-flags.html
 scalacOptions ++= Seq(
-  "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-  "-encoding", "utf-8",                // Specify character encoding used by source files.
-  "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-  "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-  "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-  "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-encoding",
+  "utf-8", // Specify character encoding used by source files.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+  "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
 //  "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-  "-Xfuture",                          // Turn on future language features.
-  "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-  "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-  "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-  "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-  "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+  "-Xfuture", // Turn on future language features.
+  "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+  "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+  "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+  "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+  "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
 //  "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Xlint:option-implicit",            // Option.apply used implicit view.
-  "-Xlint:package-object-classes",     // Class or object defined in package object.
-  "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-  "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-  "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+  "-Xlint:option-implicit", // Option.apply used implicit view.
+  "-Xlint:package-object-classes", // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
 //  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
   "-Ypartial-unification",             // Enable partial unification in type constructor inference
-  "-Ywarn-dead-code",                  // Warn when dead code is identified.
-  "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Ywarn-dead-code", // Warn when dead code is identified.
+  "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+  "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
 //  "-Ywarn-numeric-widen",              // Warn when numerics are widened.
 //  "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-  "-Ywarn-unused:imports"             // Warn if an import selector is not referenced.
+  "-Ywarn-unused:imports" // Warn if an import selector is not referenced.
 //  "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
 )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -2,12 +2,12 @@ import Dependencies._
 import Merging._
 import Testing._
 import Version._
+import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport.{scalafmtOnCompile, scalafmtVersion}
 import sbt.Keys._
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
 
 object Settings {
-
   val artifactory = "https://artifactory.broadinstitute.org/artifactory/"
 
   val commonResolvers = List(
@@ -44,13 +44,15 @@ object Settings {
     scalacOptions ++= commonCompilerSettings
   )
 
+  val scalafmtSettings = List(scalafmtOnCompile := true)
+
   //the full list of settings for the root project that's ultimately the one we build into a fat JAR and run
   //coreDefaultSettings (inside commonSettings) sets the project name, which we want to override, so ordering is important.
   //thus commonSettings needs to be added first.
   val rootSettings = commonSettings ++ List(
     name := "sam",
     libraryDependencies ++= rootDependencies
-  ) ++ commonAssemblySettings ++ rootVersionSettings
+  ) ++ commonAssemblySettings ++ rootVersionSettings ++ scalafmtSettings
 
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+
+addSbtPlugin("com.lucidchart"      %  "sbt-scalafmt" % "1.15")


### PR DESCRIPTION
Ticket: no ticket
For some reason, `sbt compile` doesn't seem to format the code automatically. But with `.scalafmt.conf`, at least you can config intellij or other editors to use `scalafmt` so that we don't have to worry about format anymore

you can do `sbt scalafmt` to format all files, or you can use format one file in IJ or other editors

more configuration settings: https://scalameta.org/scalafmt/docs/configuration.html
plugin repo: https://github.com/lucidsoftware/neo-sbt-scalafmt

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
