### PR TITLE
remove group from cloud first

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -77,8 +77,9 @@ class ManagedGroupService(private val resourceService: ResourceService, private 
 
   def deleteManagedGroup(groupId: ResourceId): Future[Unit] = {
     for {
-      _ <- directoryDAO.deleteGroup(WorkbenchGroupName(groupId.value))
+      // remove from cloud extensions first so a failure there does not leave ldap in a bad state
       _ <- cloudExtensions.onGroupDelete(WorkbenchEmail(constructEmail(groupId.value)))
+      _ <- directoryDAO.deleteGroup(WorkbenchGroupName(groupId.value))
       _ <- resourceService.deleteResource(Resource(managedGroupType.name, groupId))
     } yield ()
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -77,10 +77,12 @@ class ManagedGroupService(private val resourceService: ResourceService, private 
 
   def deleteManagedGroup(groupId: ResourceId): Future[Unit] = {
     for {
-      // remove from cloud extensions first so a failure there does not leave ldap in a bad state
+      // order is important here, we want to make sure we do all the cloudExtensions calls before we touch ldap
+      // so failures there do not leave ldap in a bad state
+      // resourceService.deleteResource also does cloudExtensions.onGroupDelete first thing
       _ <- cloudExtensions.onGroupDelete(WorkbenchEmail(constructEmail(groupId.value)))
-      _ <- directoryDAO.deleteGroup(WorkbenchGroupName(groupId.value))
       _ <- resourceService.deleteResource(Resource(managedGroupType.name, groupId))
+      _ <- directoryDAO.deleteGroup(WorkbenchGroupName(groupId.value))
     } yield ()
   }
 


### PR DESCRIPTION
I have seen test failures in cleanup where we attempt to remove a managed group but sam gets a failure in google land (412 precondition failed in this case). But the code removes the group from ldap first so when the test code retries there is the error that the group does not exist.

This PR fixes that by removing the group from google first. If it fails and the group remains in google then ldap still thinks the group exists. If it fails but the group actually got deleted in google (I have seen that), removing the group from google again on retry is tolerant.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
