### PR TITLE
Persist auth domains [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -35,7 +35,7 @@ object SamJsonSupport {
 
   implicit val ResourceIdFormat = ValueObjectFormat(ResourceId)
 
-  implicit val ResourceFormat = jsonFormat2(Resource)
+  implicit val ResourceFormat = jsonFormat3(Resource)
 
   implicit val AccessPolicyMembershipFormat = jsonFormat3(AccessPolicyMembership)
 
@@ -79,7 +79,7 @@ case class ResourceRole(roleName: ResourceRoleName, actions: Set[ResourceAction]
 
 case class ResourceTypeName(value: String) extends ValueObject
 
-case class Resource(resourceTypeName: ResourceTypeName, resourceId: ResourceId)
+case class Resource(resourceTypeName: ResourceTypeName, resourceId: ResourceId, authDomain: Set[WorkbenchGroupName] = Set.empty)
 case class ResourceType(name: ResourceTypeName, actionPatterns: Set[ResourceActionPattern], roles: Set[ResourceRole], ownerRoleName: ResourceRoleName, reuseIds: Boolean = false) {
   // Ideally we'd just store this boolean in a lazy val, but this will upset the spray/akka json serializers
   // I can't imagine a scenario where we have enough action patterns that would make this def discernibly slow though

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.openam
 
-import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import org.broadinstitute.dsde.workbench.model.{WorkbenchGroupName, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.model._
 
 import scala.concurrent.Future
@@ -13,6 +13,7 @@ trait AccessPolicyDAO {
 
   def createResource(resource: Resource): Future[Resource]
   def deleteResource(resource: Resource): Future[Unit]
+  def loadResourceAuthDomain(resource: Resource): Future[Set[WorkbenchGroupName]]
 
   def createPolicy(policy: AccessPolicy): Future[AccessPolicy]
   def deletePolicy(policy: AccessPolicy): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -46,7 +46,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
   }
 
   override def loadResourceAuthDomain(resource: Resource): Future[Set[WorkbenchGroupName]] = {
-    Option(ldapConnectionPool.getEntry(resourceDn(resource)): SearchResultEntry) match {
+    Future(Option(ldapConnectionPool.getEntry(resourceDn(resource)))).flatMap {
       case None => Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$resource auth domain not found")))
       case Some(r) => Future.successful(getAttributes(r, Attr.authDomain).getOrElse(Set.empty).toSet.map(g => WorkbenchGroupName(g)))
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
@@ -40,6 +40,7 @@ object JndiSchemaDAO {
     val googleSubjectId = "googleSubjectId"
     val project = "project"
     val proxyEmail = "proxyEmail"
+    val authDomain = "authDomain"
   }
 
   object ObjectClass {
@@ -322,6 +323,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.4", Attr.action, "the actions applicable to a policy", false)
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.6", Attr.role, "the roles for the policy, if any", false)
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.7", Attr.policy, "the policy name", true, equality = Option("caseIgnoreMatch"))
+    createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.9", Attr.authDomain, "auth domain constraining resource", false)
 
     val policyAttrs = new BasicAttributes(true) // Ignore case
     policyAttrs.put("NUMERICOID", "1.3.6.1.4.1.18060.0.4.3.2.0")
@@ -369,6 +371,10 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     resourceMust.add(Attr.resourceType)
     resourceAttrs.put(resourceMust)
 
+    val resourceMay = new BasicAttribute("MAY")
+    resourceMay.add(Attr.authDomain)
+    resourceAttrs.put(resourceMay)
+
     // Add the new schema object for "fooObjectClass"
     schema.createSubcontext("ClassDefinition/" + ObjectClass.resourceType, resourceTypeAttrs)
     schema.createSubcontext("ClassDefinition/" + ObjectClass.resource, resourceAttrs)
@@ -387,6 +393,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.action) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.role) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.policy) }
+    Try { schema.destroySubcontext("AttributeDefinition/" + Attr.authDomain) }
   }
 
   private def createOrgUnit(dn: String): Future[Unit] = withContext { ctx =>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -34,6 +34,9 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     policies -- toRemove
   }
 
+  // TODO: temporarily stubbed
+  override def loadResourceAuthDomain(resource: Resource): Future[Set[WorkbenchGroupName]] = Future.successful(Set.empty)
+
   override def createPolicy(policy: AccessPolicy): Future[AccessPolicy] = Future {
     policies += policy.id -> policy
     policy
@@ -45,7 +48,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def listAccessPolicies(resourceTypeName: ResourceTypeName, user: WorkbenchUserId): Future[Set[ResourceIdAndPolicyName]] = Future {
     policies.collect {
-      case (riapn@ResourceAndPolicyName(Resource(`resourceTypeName`, _), _), accessPolicy) if accessPolicy.members.contains(user) => ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
+      case (riapn@ResourceAndPolicyName(Resource(`resourceTypeName`, _, _), _), accessPolicy) if accessPolicy.members.contains(user) => ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
     }.toSet
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -72,8 +72,9 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def listAccessPoliciesForUser(resource: Resource, user: WorkbenchUserId): Future[Set[AccessPolicy]] = Future {
     policies.collect {
-      case (riapn@ResourceAndPolicyName(`resource`, _), policy: AccessPolicy) if policy.members.contains(user) => policy
+      case (_, policy: AccessPolicy) if policy.members.contains(user) => policy
     }.toSet
+
   }
 
   override def listFlattenedPolicyMembers(resourceAndPolicyName: ResourceAndPolicyName): Future[Set[WorkbenchUserId]] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -34,7 +34,6 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     policies -- toRemove
   }
 
-  // TODO: temporarily stubbed
   override def loadResourceAuthDomain(resource: Resource): Future[Set[WorkbenchGroupName]] = Future.successful(Set.empty)
 
   override def createPolicy(policy: AccessPolicy): Future[AccessPolicy] = Future {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -263,13 +263,19 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
 
     runAndWait(constrainableService.createResourceType(managedGroupResourceType))
     val managedGroupName = "fooGroup"
+    val secondMGroupName = "barGroup"
     runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUserInfo))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(secondMGroupName), dummyUserInfo))
 
-    val authDomain = Set(WorkbenchGroupName(managedGroupName))
+    val authDomain = Set(WorkbenchGroupName(managedGroupName), WorkbenchGroupName(secondMGroupName))
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
     val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, dummyUserInfo))
-    val resultingPolicies: Set[ResourceAndPolicyName] = runAndWait(policyDAO.listAccessPolicies(resource)).map(_.id)
-    resultingPolicies shouldEqual Set(ResourceAndPolicyName(resource, viewPolicyName))
+//    val resultingPolicies: Set[ResourceAndPolicyName] = runAndWait(policyDAO.listAccessPolicies(resource)).map(_.id)
+    val storedAuthDomain = runAndWait(constrainableService.loadResourceAuthDomain(resource))
+
+    storedAuthDomain shouldEqual authDomain
+
+//    resultingPolicies shouldEqual Set(ResourceAndPolicyName(resource, viewPolicyName))
   }
 
   it should "fail when at least 1 of the auth domain groups does not exist" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -270,12 +270,9 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     val authDomain = Set(WorkbenchGroupName(managedGroupName), WorkbenchGroupName(secondMGroupName))
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
     val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, dummyUserInfo))
-//    val resultingPolicies: Set[ResourceAndPolicyName] = runAndWait(policyDAO.listAccessPolicies(resource)).map(_.id)
     val storedAuthDomain = runAndWait(constrainableService.loadResourceAuthDomain(resource))
 
     storedAuthDomain shouldEqual authDomain
-
-//    resultingPolicies shouldEqual Set(ResourceAndPolicyName(resource, viewPolicyName))
   }
 
   it should "fail when at least 1 of the auth domain groups does not exist" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -311,6 +311,14 @@ class ResourceServiceSpec extends FlatSpec with Matchers with TestSupport with B
     }
   }
 
+  "Loading an auth domain" should "fail when the resource does not exist" in {
+    val e = intercept[WorkbenchExceptionWithErrorReport] {
+      runAndWait(constrainableService.loadResourceAuthDomain(Resource(constrainableResourceType.name, ResourceId(UUID.randomUUID().toString))))
+    }
+
+    e.getMessage should include ("not found")
+  }
+
   "Creating a resource that has 0 constrainable action patterns" should "fail when an auth domain is provided" in {
     defaultResourceType.isAuthDomainConstrainable shouldEqual false
     runAndWait(service.createResourceType(defaultResourceType))


### PR DESCRIPTION
Ticket: [GAWB-3789](https://broadinstitute.atlassian.net/browse/GAWB-3789)

Persist auth domains in Sam by storing them on the resource.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
