### PR TITLE
Truncate pet service account display names to 100 characters

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -463,9 +463,8 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
 
     // Display names have a max length of 100 characters
     val displayName = s"Pet Service Account for user [${user.email.value}]"
-    val trimmedDisplayName = displayName.take(100)
 
-    (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(trimmedDisplayName))
+    (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(displayName.take(100)))
   }
 
   override def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -460,9 +460,12 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
      * Subject IDs are 22 numeric characters, so "pet-${subjectId}" fulfills these requirements.
      */
     val serviceAccountName = s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}pet-${user.id.value}"
-    val displayName = s"Pet Service Account for user [${user.email.value}]"
 
-    (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(displayName))
+    // Display names have a max length of 100 characters
+    val displayName = s"Pet Service Account for user [${user.email.value}]"
+    val trimmedDisplayName = displayName.substring(0, Math.min(displayName.length, 100))
+
+    (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(trimmedDisplayName))
   }
 
   override def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -463,7 +463,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
 
     // Display names have a max length of 100 characters
     val displayName = s"Pet Service Account for user [${user.email.value}]"
-    val trimmedDisplayName = displayName.substring(0, Math.min(displayName.length, 100))
+    val trimmedDisplayName = displayName.take(100)
 
     (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(trimmedDisplayName))
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -460,10 +460,9 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
      * Subject IDs are 22 numeric characters, so "pet-${subjectId}" fulfills these requirements.
      */
     val serviceAccountName = s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}pet-${user.id.value}"
-
-    // Display names have a max length of 100 characters
     val displayName = s"Pet Service Account for user [${user.email.value}]"
 
+    // Display names have a max length of 100 characters
     (ServiceAccountName(serviceAccountName), ServiceAccountDisplayName(displayName.take(100)))
   }
 


### PR DESCRIPTION
This came from an AoU user trying to create a Leo cluster and getting a 500 error from Sam. Google is throwing this when Sam creates a pet SA for this user:
```
com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "The display_name length (111) is longer than the maximum allowed length 100.",
    "reason" : "badRequest"
  } ],
  "message" : "The display_name length (111) is longer than the maximum allowed length 100.",
  "status" : "INVALID_ARGUMENT"
}
```
The account in question is `rainforestuserffdf5b0e-c719-4757-b78d-d67e1d3eb8f9@staging.fake-research-aou.org`. Previously this resulted in a display name of 111 characters:
```
scala> val displayName = s"Pet Service Account for user [${email}]"
displayName: String = Pet Service Account for user [rainforestuserffdf5b0e-c719-4757-b78d-d67e1d3eb8f9@staging.fake-research-aou.org]

scala> displayName.size
res0: Int = 111
```
Now it is truncated to 100 characters:
```
scala> val trimmedDisplayName = displayName.take(100)
trimmedDisplayName: String = Pet Service Account for user [rainforestuserffdf5b0e-c719-4757-b78d-d67e1d3eb8f9@staging.fake-resear

scala> trimmedDisplayName.size
res4: Int = 100
```



---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
