### PR TITLE
set servcie account user

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   val workbenchUtilV   = "0.3-2771e2d"
   val workbenchModelV  = "0.12-a19203d"
-  val workbenchGoogleV = "0.16-f2a0020"
+  val workbenchGoogleV = "0.16-0245949"
   val workbenchNotificationsV = "0.1-f2a0020"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -69,7 +69,7 @@ object Boot extends App with LazyLogging {
 
         val googleDirDaos = (googleServicesConfig.adminSdkServiceAccounts match {
           case None => NonEmptyList.one(Pem(WorkbenchEmail(googleServicesConfig.serviceAccountClientId), new File(googleServicesConfig.pemFile), Option(googleServicesConfig.subEmail)))
-          case Some(accounts) => accounts.map(account => Json(account.json))
+          case Some(accounts) => accounts.map(account => Json(account.json, Option(googleServicesConfig.subEmail)))
         }).map { credentials =>
           new HttpGoogleDirectoryDAO(googleServicesConfig.appName, credentials, "google")
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -192,7 +192,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     */
   it should "update googleSubjectId when there's no existing subject for a given googleSubjectId and but there is one for email" in{
     val user = genCreateWorkbenchUserAPI.sample.get
-    dirDAO.createUser(WorkbenchUser(user.id, None, user.email))
+    dirDAO.createUser(WorkbenchUser(user.id, None, user.email)).futureValue
     service.registerUser(user).futureValue
     val res = dirDAO.loadUser(user.id).futureValue
     res shouldBe Some(WorkbenchUser(user.id, Some(user.googleSubjectId), user.email))


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-3759
need to set the service account user to make calls to google admin sdk

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
