### PR TITLE
sync intersection group for constrainable policy when policy or auth domain is updated

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -82,7 +82,7 @@ object Boot extends App with LazyLogging {
         val googleKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, googlePubSubDAO, googleServicesConfig, petServiceAccountConfig)
         val notificationDAO = new PubSubNotificationDAO(googlePubSubDAO, googleServicesConfig.notificationTopic)
 
-        new GoogleExtensions(directoryDAO, accessPolicyDAO, googleDirectoryDAO, googlePubSubDAO, googleIamDAO, googleStorageDAO, googleProjectDAO, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, resourceTypeMap(CloudExtensions.resourceTypeName))
+        new GoogleExtensions(directoryDAO, accessPolicyDAO, googleDirectoryDAO, googlePubSubDAO, googleIamDAO, googleStorageDAO, googleProjectDAO, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, resourceTypeMap)
       case None => NoExtensions
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -45,7 +45,7 @@ trait DirectoryDAO {
   def readProxyGroup(userId: WorkbenchUserId): Future[Option[WorkbenchEmail]]
 
   def listUsersGroups(userId: WorkbenchUserId): Future[Set[WorkbenchGroupIdentity]]
-  def listFlattenedGroupUsers(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchUserId]]
+  def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]]
   def listAncestorGroups(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchGroupIdentity]]
 
   def enableIdentity(subject: WorkbenchSubject): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -228,14 +228,7 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
 
   override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]] = Future {
     ldapSearchStream(directoryConfig.baseDn, SearchScope.SUB, Filter.createANDFilter(groupIds.map(groupId =>
-      Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava))(unmarshalUserOption).collect { case Some(user) => user.id }.toSet
-  }
-
-  private def unmarshalUserOption(results: Entry): Option[WorkbenchUser] = {
-    for {
-      uid <- getAttribute(results, Attr.uid)
-      email <- getAttribute(results, Attr.email)
-    } yield WorkbenchUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email))
+      Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava))(getAttribute(_, Attr.uid)).flatten.map(WorkbenchUserId).toSet
   }
 
   override def listAncestorGroups(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchGroupIdentity]] = Future {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -226,8 +226,16 @@ class LdapDirectoryDAO(protected val ldapConnectionPool: LDAPConnectionPool, pro
     groupsOption.getOrElse(Set.empty)
   }
 
-  override def listFlattenedGroupUsers(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchUserId]] = Future {
-    ldapSearchStream(peopleOu, SearchScope.SUB, Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId)))(unmarshalUser).map(_.id).toSet
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]] = Future {
+    ldapSearchStream(directoryConfig.baseDn, SearchScope.SUB, Filter.createANDFilter(groupIds.map(groupId =>
+      Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava))(unmarshalUserOption).collect { case Some(user) => user.id }.toSet
+  }
+
+  private def unmarshalUserOption(results: Entry): Option[WorkbenchUser] = {
+    for {
+      uid <- getAttribute(results, Attr.uid)
+      email <- getAttribute(results, Attr.email)
+    } yield WorkbenchUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email))
   }
 
   override def listAncestorGroups(groupId: WorkbenchGroupIdentity): Future[Set[WorkbenchGroupIdentity]] = Future {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -5,6 +5,8 @@ import java.util.Date
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
+//import cats.effect.IO
+//import cats.implicits._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.auth.oauth2.ServiceAccountCredentials
@@ -38,7 +40,7 @@ object GoogleExtensions {
   val getPetPrivateKeyAction = ResourceAction("get_pet_private_key")
 }
 
-class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPolicyDAO, val googleDirectoryDAO: GoogleDirectoryDAO, val googlePubSubDAO: GooglePubSubDAO, val googleIamDAO: GoogleIamDAO, val googleStorageDAO: GoogleStorageDAO, val googleProjectDAO: GoogleProjectDAO, val googleKeyCache: GoogleKeyCache, val notificationDAO: NotificationDAO, val googleServicesConfig: GoogleServicesConfig, val petServiceAccountConfig: PetServiceAccountConfig, extensionResourceType: ResourceType)(implicit val system: ActorSystem, executionContext: ExecutionContext) extends LazyLogging with FutureSupport with CloudExtensions with Retry {
+class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPolicyDAO, val googleDirectoryDAO: GoogleDirectoryDAO, val googlePubSubDAO: GooglePubSubDAO, val googleIamDAO: GoogleIamDAO, val googleStorageDAO: GoogleStorageDAO, val googleProjectDAO: GoogleProjectDAO, val googleKeyCache: GoogleKeyCache, val notificationDAO: NotificationDAO, val googleServicesConfig: GoogleServicesConfig, val petServiceAccountConfig: PetServiceAccountConfig, val resourceTypes: Map[ResourceTypeName, ResourceType])(implicit val system: ActorSystem, executionContext: ExecutionContext) extends LazyLogging with FutureSupport with CloudExtensions with Retry {
 
   private val maxGroupEmailLength = 64
 
@@ -86,7 +88,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
       this
     ))
 
-
+    val extensionResourceType = resourceTypes.getOrElse(CloudExtensions.resourceTypeName, throw new Exception(s"${CloudExtensions.resourceTypeName} resource type not found"))
     val ownerGoogleSubjectId = GoogleSubjectId(googleServicesConfig.serviceAccountClientId)
     for {
       user <- directoryDAO.loadSubjectFromGoogleSubjectId(ownerGoogleSubjectId)
@@ -127,6 +129,17 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
         case (rpn: ResourceAndPolicyName, Some(_)) => rpn.toJson.compactPrint
       }
       _ <- googlePubSubDAO.publishMessages(googleServicesConfig.groupSyncTopic, messagesForIdsWithSyncDates)
+      ancestorGroups <- Future.traverse(groupIdentities) { id => directoryDAO.listAncestorGroups(id) }
+      managedGroupIds = (ancestorGroups.flatten ++ groupIdentities).collect { case ResourceAndPolicyName(Resource(ResourceTypeName("managed-group"), id, _), _) => id }
+      _ <- Future.traverse(managedGroupIds)(onManagedGroupUpdate)
+    } yield ()
+  }
+
+  private def onManagedGroupUpdate(groupId: ResourceId): Future[Unit] = {
+    for {
+      resources <- accessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(groupId.value))
+      policies <- Future.traverse(resources) { resource => accessPolicyDAO.listAccessPolicies(resource).unsafeToFuture }
+      _ <- onGroupUpdate(policies.flatten.map(_.id).toList)
     } yield ()
   }
 
@@ -403,6 +416,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
         }
       )
     }
+
     if(visitedGroups.contains(groupId)) {
       Future.successful(Map.empty)
     } else {
@@ -413,6 +427,15 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
         }
 
         group = groupOption.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
+
+        members <- group match {
+          case accessPolicy: AccessPolicy => if (isConstrainable(accessPolicy.id.resource, accessPolicy)) {
+            calculateIntersectionGroup(accessPolicy.id.resource, accessPolicy)
+          } else {
+            Future.successful(accessPolicy.members)
+          }
+          case group: BasicWorkbenchGroup => Future.successful(group.members)
+        }
 
         subGroupSyncs <- Future.traverse(group.members) {
           case subGroup: WorkbenchGroupIdentity =>
@@ -427,7 +450,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
           case None => googleDirectoryDAO.createGroup(groupId.toString, group.email, Option(googleDirectoryDAO.lockedDownGroupSettings)) map (_ => Set.empty[String])
           case Some(members) => Future.successful(members.map(_.toLowerCase).toSet)
         }
-        samMemberEmails <- Future.traverse(group.members) {
+        samMemberEmails <- Future.traverse(members) {
           case group: WorkbenchGroupIdentity => directoryDAO.loadSubjectEmail(group)
 
           // use proxy group email instead of user's actual email
@@ -447,6 +470,32 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
       } yield {
         Map(group.email -> Seq(addTrials, removeTrials).flatten) ++ subGroupSyncs.flatten
       }
+    }
+  }
+
+  private def isConstrainable(resource: Resource, accessPolicy: AccessPolicy): Boolean = {
+    resourceTypes.get(resource.resourceTypeName) match {
+      case Some(resourceType) => resourceType.actionPatterns.exists { actionPattern =>
+        actionPattern.authDomainConstrainable &&
+          (accessPolicy.actions.exists(actionPattern.matches) ||
+            accessPolicy.roles.exists { accessPolicyRole =>
+              resourceType.roles.exists {
+                case resourceTypeRole@ResourceRole(`accessPolicyRole`, _) => resourceTypeRole.actions.exists(actionPattern.matches)
+                case _ => false
+              }
+            })
+      }
+      case None =>
+        throw new Exception(s"Invalid resource type specified. ${resource.resourceTypeName} is not a recognized resource type.")
+    }
+  }
+
+  private def calculateIntersectionGroup(resource: Resource, policy: AccessPolicy): Future[Set[WorkbenchUserId]] = {
+    for {
+      groups <- accessPolicyDAO.loadResourceAuthDomain(resource).unsafeToFuture
+      members <- directoryDAO.listIntersectionGroupUsers(groups.asInstanceOf[Set[WorkbenchGroupIdentity]] + policy.id)
+    } yield {
+      members
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.openam
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.model.{WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchGroupIdentity, WorkbenchGroupName, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.model._
 
 import scala.concurrent.Future
@@ -15,6 +15,7 @@ trait AccessPolicyDAO {
   def createResource(resource: Resource): IO[Resource]
   def deleteResource(resource: Resource): IO[Unit]
   def loadResourceAuthDomain(resource: Resource): IO[Set[WorkbenchGroupName]]
+  def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): Future[Set[Resource]]
 
   def createPolicy(policy: AccessPolicy): IO[AccessPolicy]
   def deletePolicy(policy: AccessPolicy): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -247,11 +247,13 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
   private def createOrUpdatePolicy(resource: Resource, policy: ValidatableAccessPolicy): Future[AccessPolicy] = {
     val resourceAndPolicyName = ResourceAndPolicyName(resource, policy.policyName)
     val workbenchSubjects = policy.emailsToSubjects.values.flatten.toSet
+
     accessPolicyDAO.loadPolicy(resourceAndPolicyName).flatMap {
       case None => createPolicy(resourceAndPolicyName, workbenchSubjects, generateGroupEmail(), policy.roles, policy.actions)
       case Some(accessPolicy) => accessPolicyDAO.overwritePolicy(AccessPolicy(resourceAndPolicyName, workbenchSubjects, accessPolicy.email, policy.roles, policy.actions))
     } andThen {
-      case Success(policy) => fireGroupUpdateNotification(policy.id)
+      case Success(policy) =>
+        fireGroupUpdateNotification(policy.id)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -86,7 +86,7 @@ object TestSupport extends TestSupport{
       notificationDAO,
       googleServicesConfig,
       petServiceAccountConfig,
-      configResourceTypes(CloudExtensions.resourceTypeName)))
+      resourceTypes))
     val mockResourceService = new ResourceService(resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -183,44 +183,6 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  it should "list flattened group users" in {
-    val userId1 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user1 = WorkbenchUser(userId1, None, WorkbenchEmail("foo@bar.com"))
-    val userId2 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user2 = WorkbenchUser(userId2, None, WorkbenchEmail("foo@bar.com"))
-    val userId3 = WorkbenchUserId(UUID.randomUUID().toString)
-    val user3 = WorkbenchUser(userId3, None, WorkbenchEmail("foo@bar.com"))
-
-    val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
-    val group1 = BasicWorkbenchGroup(groupName1, Set(userId1), WorkbenchEmail("g1@example.com"))
-
-    val groupName2 = WorkbenchGroupName(UUID.randomUUID().toString)
-    val group2 = BasicWorkbenchGroup(groupName2, Set(userId2, groupName1), WorkbenchEmail("g2@example.com"))
-
-    val groupName3 = WorkbenchGroupName(UUID.randomUUID().toString)
-    val group3 = BasicWorkbenchGroup(groupName3, Set(userId3, groupName2), WorkbenchEmail("g3@example.com"))
-
-    runAndWait(dao.createUser(user1))
-    runAndWait(dao.createUser(user2))
-    runAndWait(dao.createUser(user3))
-    runAndWait(dao.createGroup(group1))
-    runAndWait(dao.createGroup(group2))
-    runAndWait(dao.createGroup(group3))
-
-    try {
-      assertResult(Set(userId1, userId2, userId3)) {
-        runAndWait(dao.listFlattenedGroupUsers(groupName3))
-      }
-    } finally {
-      runAndWait(dao.deleteUser(userId1))
-      runAndWait(dao.deleteUser(userId2))
-      runAndWait(dao.deleteUser(userId3))
-      runAndWait(dao.deleteGroup(groupName3))
-      runAndWait(dao.deleteGroup(groupName2))
-      runAndWait(dao.deleteGroup(groupName1))
-    }
-  }
-
   it should "list group ancestors" in {
     val groupName1 = WorkbenchGroupName(UUID.randomUUID().toString)
     val group1 = BasicWorkbenchGroup(groupName1, Set(), WorkbenchEmail("g1@example.com"))
@@ -267,10 +229,6 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     runAndWait(dao.addGroupMember(groupName1, groupName3))
 
     try {
-      assertResult(Set(userId)) {
-        runAndWait(dao.listFlattenedGroupUsers(groupName3))
-      }
-
       assertResult(Set(groupName1, groupName2, groupName3)) {
         runAndWait(dao.listUsersGroups(userId))
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -132,8 +132,8 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def listFlattenedGroupUsers(groupName: WorkbenchGroupIdentity): Future[Set[WorkbenchUserId]] = Future {
-    listGroupUsers(groupName, Set.empty)
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]] = Future {
+    groupIds.flatMap(groupId => listGroupUsers(groupId, Set.empty))
   }
 
   private def listGroupUsers(groupName: WorkbenchGroupIdentity, visitedGroups: Set[WorkbenchGroupIdentity]): Set[WorkbenchUserId] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -5,6 +5,7 @@ import java.util.{Date, GregorianCalendar, UUID}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestKit
 import com.google.api.services.groupssettings.model.Groups
 import com.typesafe.config.ConfigFactory
@@ -19,7 +20,7 @@ import org.broadinstitute.dsde.workbench.sam.api.CreateWorkbenchUser
 import org.broadinstitute.dsde.workbench.sam.config.{DirectoryConfig, GoogleServicesConfig, PetServiceAccountConfig, _}
 import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, LdapDirectoryDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, MockAccessPolicyDAO}
+import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, LdapAccessPolicyDAO, MockAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.{TestSupport, _}
@@ -28,7 +29,9 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, PrivateMethodTester}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.blockingEc
+import cats.effect.IO
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -36,7 +39,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Success, Try}
 
-class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll {
+class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
   override def beforeAll(): Unit = {
@@ -99,14 +102,14 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val removeError = "removeError@foo.bar"
 
     val testGroup = BasicWorkbenchGroup(groupName, Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail)
-    val testPolicy = AccessPolicy(ResourceAndPolicyName(Resource(ResourceTypeName("rt"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty)
+    val testPolicy = AccessPolicy(ResourceAndPolicyName(Resource(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty)
 
     Seq(testGroup, testPolicy).foreach { target =>
       val mockAccessPolicyDAO = mock[AccessPolicyDAO]
       val mockDirectoryDAO = mock[DirectoryDAO]
       val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
       val mockGooglePubSubDAO = new MockGooglePubSubDAO
-      val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+      val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
 
       target match {
         case g: BasicWorkbenchGroup =>
@@ -153,6 +156,100 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     }
   }
 
+  it should "sync the intersection group if the policy is constrainable" in {
+    // In both the policy and the auth domain, will be added to Google Group
+    val intersectionSamUserId = WorkbenchUserId("intersectionSamUser")
+    val intersectionSamUserProxyEmail = s"PROXY_intersectionSamUser@${googleServicesConfig.appsDomain}"
+
+    // In only the policy, not the auth domain, will not be synced
+    val policyOnlySamUserId = WorkbenchUserId("policyOnlySamUser")
+
+    // Currently synced with Google, but in neither the policy nor the auth domain, so will be removed from Google Group
+    val unauthorizedGoogleUserProxyEmail = s"PROXY_unauthorizedGoogleUser@${googleServicesConfig.appsDomain}"
+
+    // Currently synced with Google and in policy and auth domain, will remain in Google Group
+    val authorizedGoogleUserId = WorkbenchUserId("authorizedGoogleUser")
+    val authorizedGoogleUserProxyEmail = s"PROXY_authorizedGoogleUser@${googleServicesConfig.appsDomain}"
+
+    val addError = WorkbenchUserId("addError")
+    val addErrorProxyEmail = s"PROXY_addError@${googleServicesConfig.appsDomain}"
+
+    val removeError = "removeError@foo.bar"
+
+    val subPolicyOnlySamGroupUserId = WorkbenchUserId("policySamSubUser")
+
+    val subIntersectionSamGroupUserId = WorkbenchUserId("intersectionSamSubUser")
+    val subIntersectionSamGroupUserProxyEmail = s"PROXY_intersectionSamSubUser@${googleServicesConfig.appsDomain}"
+
+    val subAuthorizedGoogleGroupUserId = WorkbenchUserId("authorizedGoogleSubUser")
+    val subAuthorizedGoogleGroupUserProxyEmail = s"PROXY_authorizedGoogleSubUser@${googleServicesConfig.appsDomain}"
+
+    val policyOnlySamSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inSamSubGroup"), Set(subPolicyOnlySamGroupUserId), WorkbenchEmail("inSamSubGroup@example.com"))
+    val intersectionSamSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inGoogleSubGroup"), Set(subIntersectionSamGroupUserId), WorkbenchEmail("inGoogleSubGroup@example.com"))
+    val authorizedGoogleSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(subAuthorizedGoogleGroupUserId), WorkbenchEmail("inBothSubGroup@example.com"))
+
+    // Set up constrainable resource type
+    val constrainableActionPatterns = Set(ResourceActionPattern("constrainable_view", "Can be constrained by an auth domain", true))
+    val constrainableViewAction = ResourceAction("constrainable_view")
+    val constrainableResourceTypeActions = Set(constrainableViewAction)
+    val constrainableReaderRoleName = ResourceRoleName("constrainable_reader")
+    val constrainableRole = ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)
+    val constrainableResourceType = ResourceType(
+    ResourceTypeName(UUID.randomUUID().toString),
+    constrainableActionPatterns,
+    Set(ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)),
+    constrainableReaderRoleName
+    )
+    val constrainableResourceTypes = Map(constrainableResourceType.name -> constrainableResourceType)
+
+    // Set up constrained policy
+    val managedGroupId = WorkbenchGroupName("authDomainGroup")
+    val resource = Resource(constrainableResourceType.name, ResourceId("rid"), Set(managedGroupId))
+    val rpn = ResourceAndPolicyName(resource, AccessPolicyName("ap"))
+    val testPolicy = AccessPolicy(rpn, Set(policyOnlySamUserId, intersectionSamUserId, authorizedGoogleUserId, policyOnlySamSubGroup.id, intersectionSamSubGroup.id, authorizedGoogleSubGroup.id, addError), WorkbenchEmail("testPolicy@example.com"), Set(constrainableRole.roleName), constrainableRole.actions)
+
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
+    val mockDirectoryDAO = mock[DirectoryDAO]
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
+    val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, null, null, null,null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes)
+
+    when(mockAccessPolicyDAO.loadPolicy(testPolicy.id)).thenReturn(Future.successful(Option(testPolicy)))
+    when(mockAccessPolicyDAO.loadResourceAuthDomain(resource)).thenReturn(IO.pure(Set(managedGroupId)))
+
+    when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id))).thenReturn(Future.successful(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
+
+    when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(Future.successful(()))
+    when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(Future.successful(Some(new GregorianCalendar(2017, 11, 22).getTime())))
+
+    val added = Seq(WorkbenchEmail(intersectionSamUserProxyEmail), WorkbenchEmail(subIntersectionSamGroupUserProxyEmail))
+    val removed = Seq(WorkbenchEmail(unauthorizedGoogleUserProxyEmail))
+
+    // mock pre-sync google group members
+    when(mockGoogleDirectoryDAO.listGroupMembers(testPolicy.email)).thenReturn(Future.successful(Option(Seq(authorizedGoogleUserProxyEmail, unauthorizedGoogleUserProxyEmail, subAuthorizedGoogleGroupUserProxyEmail, removeError))))
+    when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
+    when(mockGoogleDirectoryDAO.removeMemberFromGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
+
+    val addException = new Exception("addError")
+    when(mockGoogleDirectoryDAO.addMemberToGroup(testPolicy.email, WorkbenchEmail(addErrorProxyEmail.toLowerCase))).thenReturn(Future.failed(addException))
+
+    val removeException = new Exception("removeError")
+    when(mockGoogleDirectoryDAO.removeMemberFromGroup(testPolicy.email, WorkbenchEmail(removeError.toLowerCase))).thenReturn(Future.failed(removeException))
+
+    val results = runAndWait(ge.synchronizeGroupMembers(testPolicy.id))
+
+    results.head._1 should equal(testPolicy.email)
+    results.head._2 should contain theSameElementsAs (
+      added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
+        removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
+        Seq(
+          SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
+          SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))))
+
+    added.foreach { email => verify(mockGoogleDirectoryDAO).addMemberToGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)) }
+    removed.foreach { email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)) }
+    verify(mockDirectoryDAO).updateSynchronizedDate(testPolicy.id)
+  }
+
   it should "break out of cycle" in {
     val groupName = WorkbenchGroupName("group1")
     val groupEmail = WorkbenchEmail("group1@example.com")
@@ -167,7 +264,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
-    val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
     //create groups
     runAndWait(mockDirectoryDAO.createGroup(topGroup))
@@ -247,7 +344,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
 
-    val googleExtensions = new GoogleExtensions(dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val googleExtensions = new GoogleExtensions(dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     val defaultUserId = WorkbenchUserId("newuser123")
@@ -305,7 +402,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val mockDirectoryDAO = mock[DirectoryDAO]
 
-    val ge = new GoogleExtensions(mockDirectoryDAO, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(mockDirectoryDAO, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
 
     when(mockDirectoryDAO.getSynchronizedDate(groupName)).thenReturn(Future.successful(None))
     runAndWait(ge.getSynchronizedDate(groupName)) shouldBe None
@@ -317,7 +414,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "throw an exception with a NotFound error report when getting sync date for group that does not exist" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(ge.getSynchronizedDate(groupName))
@@ -328,7 +425,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "return None when getting sync date for a group that has not been synced" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail(""))))
     try {
@@ -340,7 +437,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "return sync date for a group that has been synced" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org"))))
     try {
@@ -354,7 +451,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "throw an exception with a NotFound error report when getting email for group that does not exist" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(ge.getSynchronizedEmail(groupName))
@@ -365,7 +462,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "return email for a group" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), email)))
@@ -378,7 +475,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "return None if an email is found, but the group has not been synced" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), email)))
@@ -391,7 +488,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "return SyncState with email and last sync date if there is an email and the group has been synced" in {
     val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
-    val ge = new GoogleExtensions(dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
     runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), email)))
@@ -415,7 +512,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(mockGoogleIamDAO, mockGoogleStorageDAO, mockGooglePubSubDAO, googleServicesConfig, petServiceAccountConfig)
 
-    val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val ge = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
 
     val app = SamApplication(new UserService(mockDirectoryDAO, ge), new ResourceService(configResourceTypes, mockAccessPolicyDAO, mockDirectoryDAO, ge, "example.com"), null)
     val resourceAndPolicyName = ResourceAndPolicyName(Resource(CloudExtensions.resourceTypeName, GoogleExtensions.resourceId), AccessPolicyName("owner"))
@@ -444,7 +541,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val username = "foo"
 
     val config = googleServicesConfig.copy(appsDomain = appsDomain)
-    val googleExtensions = new GoogleExtensions(null, null, null, null, null, null, null, null, null, config, null, null )
+    val googleExtensions = new GoogleExtensions(null, null, null, null, null, null, null, null, null, config, null, configResourceTypes)
 
     val user = WorkbenchUser(WorkbenchUserId(subjectId), None, WorkbenchEmail(s"$username@test.org"))
 
@@ -461,7 +558,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "truncate username if proxy group email would otherwise be too long" in {
     val config = googleServicesConfig.copy(appsDomain = "test.cloudfire.org")
-    val googleExtensions = new GoogleExtensions(null, null, null, null, null, null, null, null, null, config, null, null)
+    val googleExtensions = new GoogleExtensions(null, null, null, null, null, null, null, null, null, config, null, configResourceTypes)
 
     val user = WorkbenchUser(WorkbenchUserId("0123456789"), None, WorkbenchEmail("foo-bar-baz-qux-quux-corge-grault-garply@test.org"))
 
@@ -486,7 +583,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val mockDirectoryDAO = mock[DirectoryDAO]
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
-    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, null, mockGoogleDirectoryDAO, null, null, null, null, null, null, googleServicesConfig, null, null)
+    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, null, mockGoogleDirectoryDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val allUsersGroup = BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
     val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
@@ -510,11 +607,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 */
   }
 
-
   it should "do Googley stuff onGroupDelete" in {
     val mockDirectoryDAO = mock[DirectoryDAO]
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
-    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, null, mockGoogleDirectoryDAO, null, null, null, null, null, null, googleServicesConfig, null, null)
+    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, null, mockGoogleDirectoryDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val testPolicy = BasicWorkbenchGroup(WorkbenchGroupName("blahblahblah"), Set.empty, WorkbenchEmail(s"blahblahblah@test.firecloud.org"))
 
@@ -523,6 +619,70 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     googleExtensions.onGroupDelete(testPolicy.email)
 
     verify(mockGoogleDirectoryDAO).deleteGroup(testPolicy.email)
+  }
+
+  "onGroupUpdate" should "trigger updates to constrained policies if updating a managed group" in {
+    val mockDirectoryDAO = mock[DirectoryDAO]
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
+    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO]
+    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+
+    val managedGroupId = "managedGroupId"
+
+    val managedGroupRPN = ResourceAndPolicyName(Resource(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), AccessPolicyName("managedGroup"))
+    val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
+    val ownerRPN = ResourceAndPolicyName(resource, AccessPolicyName("owner"))
+    val readerRPN = ResourceAndPolicyName(resource, AccessPolicyName("reader"))
+    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty)
+    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty)
+
+    // mock responses for onGroupUpdate
+    when(mockDirectoryDAO.listAncestorGroups(any[ResourceAndPolicyName])).thenReturn(Future.successful(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.getSynchronizedDate(any[ResourceAndPolicyName])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
+    when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
+
+    // mock responses for onManagedGroupUpdate
+    when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(Future.successful(Set(resource)))
+    when(mockAccessPolicyDAO.listAccessPolicies(resource)).thenReturn(IO.pure(Set(ownerPolicy, readerPolicy)))
+
+    runAndWait(googleExtensions.onGroupUpdate(Seq(managedGroupRPN)))
+
+    // once when updating the managed group, and once when updating the policies it constrains
+    verify(mockGooglePubSubDAO, times(2)).publishMessages(any[String], any[Seq[String]])
+  }
+
+  it should "trigger updates to constrained policies when updating a group that is a part of a managed group" in {
+    val mockDirectoryDAO = mock[DirectoryDAO]
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
+    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO]
+    val googleExtensions = new GoogleExtensions(mockDirectoryDAO, mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+
+    val managedGroupId = "managedGroupId"
+    val subGroupId = "subGroupId"
+    val managedGroupRPN = ResourceAndPolicyName(Resource(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), AccessPolicyName("managedGroup"))
+
+    val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
+    val ownerRPN = ResourceAndPolicyName(resource, AccessPolicyName("owner"))
+    val readerRPN = ResourceAndPolicyName(resource, AccessPolicyName("reader"))
+    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty)
+    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty)
+
+    // mock responses for onGroupUpdate
+    when(mockDirectoryDAO.listAncestorGroups(any[ResourceAndPolicyName])).thenReturn(Future.successful(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.getSynchronizedDate(any[ResourceAndPolicyName])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
+    when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
+
+    // mock ancestor call to establish subgroup relationship to managed group
+    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId))).thenReturn(Future.successful(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+
+    // mock responses for onManagedGroupUpdate
+    when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(Future.successful(Set(resource)))
+    when(mockAccessPolicyDAO.listAccessPolicies(resource)).thenReturn(IO.pure(Set(ownerPolicy, readerPolicy)))
+
+    runAndWait(googleExtensions.onGroupUpdate(Seq(WorkbenchGroupName(subGroupId))))
+
+    // once when updating the subgroup, and once when updating the policies constrained by the managed group
+    verify(mockGooglePubSubDAO, times(2)).publishMessages(any[String], any[Seq[String]])
   }
 
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
@@ -541,7 +701,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(mockGoogleIamDAO, mockGoogleStorageDAO, mockGooglePubSubDAO, googleServicesConfig, petServiceAccountConfig)
 
-    val googleExtensions = new GoogleExtensions(dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes(CloudExtensions.resourceTypeName))
+    val googleExtensions = new GoogleExtensions(dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     (googleExtensions, service)
@@ -652,5 +812,274 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     })
 
     assert(firstKey != secondKey)
+  }
+
+  /**
+    * Function to initialize the necessary state for the tests related to private functions isConstrainable and calculateIntersectionGroup
+    * In addition to the values it returns, this function creates the 'constrainableResourceType' and the 'managedGroupResourceType' in
+    * the ResourceService and clears the database
+    */
+  private def initPrivateTest: (DirectoryDAO, GoogleExtensions, ResourceService, ManagedGroupService, ResourceType, ResourceRole) = {
+    //Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.
+    val realResourceTypes = config.as[Map[String, ResourceType]]("resourceTypes").values.toSet
+    val realResourceTypeMap = realResourceTypes.map(rt => rt.name -> rt).toMap
+    val managedGroupResourceType = realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+
+    val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig)
+    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc)
+    val schemaDAO = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
+
+    runAndWait(schemaDAO.clearDatabase())
+    runAndWait(schemaDAO.init())
+    runAndWait(schemaDAO.createOrgUnits())
+
+    val constrainableActionPatterns = Set(ResourceActionPattern("constrainable_view", "Can be constrained by an auth domain", true))
+
+    val constrainableViewAction = ResourceAction("constrainable_view")
+    val constrainableResourceTypeActions = Set(constrainableViewAction)
+    val constrainableReaderRoleName = ResourceRoleName("constrainable_reader")
+    val constrainableRole = ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)
+    val constrainableResourceType = ResourceType(
+      ResourceTypeName(UUID.randomUUID().toString),
+      constrainableActionPatterns,
+      Set(ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)),
+      constrainableReaderRoleName
+    )
+    val constrainableResourceTypes = Map(constrainableResourceType.name -> constrainableResourceType, managedGroupResourceType.name -> managedGroupResourceType)
+
+    val emailDomain = "example.com"
+
+    val googleExtensions = new GoogleExtensions(dirDAO, policyDAO, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes)
+    val constrainableService = new ResourceService(constrainableResourceTypes, policyDAO, dirDAO, NoExtensions, emailDomain)
+    val managedGroupService = new ManagedGroupService(constrainableService, constrainableResourceTypes, policyDAO, dirDAO, NoExtensions, emailDomain)
+
+    constrainableService.createResourceType(constrainableResourceType).unsafeRunSync
+    constrainableService.createResourceType(managedGroupResourceType).unsafeRunSync
+
+    (dirDAO, googleExtensions, constrainableService, managedGroupService, constrainableResourceType, constrainableRole)
+  }
+
+  "calculateIntersectionGroup" should "find the intersection of the resource auth domain and the policy" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val inAuthDomainUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inAuthDomain"), WorkbenchEmail("inAuthDomain@example.com"), 0)
+    val inPolicyUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
+    val inBothUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inBoth"), WorkbenchEmail("inBoth@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inAuthDomainUser.userId, Some(TestSupport.genGoogleSubjectId()), inAuthDomainUser.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(inPolicyUser.userId, Some(TestSupport.genGoogleSubjectId()), inPolicyUser.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(inBothUser.userId, Some(TestSupport.genGoogleSubjectId()), inBothUser.userEmail)))
+
+    val managedGroupId = "fooGroup"
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), inAuthDomainUser))
+    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inBothUser.userId))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), constrainableRole.actions, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), inBothUser))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), Set.empty, Set.empty)))
+
+    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource, accessPolicy))
+    intersectionGroup shouldEqual Set(inBothUser.userId)
+  }
+
+  it should "handle nested group structures for policies and auth domains" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    // User in owner policy of both auth domain and resource to be used during creation of the managed group and resource
+    val superAdminOwner = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("authDomainOwner"), WorkbenchEmail("authDomainOwner@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(superAdminOwner.userId, Some(TestSupport.genGoogleSubjectId()), superAdminOwner.userEmail)))
+
+    // User in subgroup within auth domain; will not be in intersection group
+    val inAuthDomainSubGroupUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inAuthDomain"), WorkbenchEmail("inAuthDomain@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inAuthDomainSubGroupUser.userId, Some(TestSupport.genGoogleSubjectId()), inAuthDomainSubGroupUser.userEmail)))
+
+    // User in subgroup within policy; will not be in intersection group
+    val inPolicySubGroupUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inPolicySubGroupUser.userId, Some(TestSupport.genGoogleSubjectId()), inPolicySubGroupUser.userEmail)))
+
+    // User in subgroup within both policy and auth domain; will be in intersection group
+    val inBothSubGroupUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inBoth"), WorkbenchEmail("inBoth@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inBothSubGroupUser.userId, Some(TestSupport.genGoogleSubjectId()), inBothSubGroupUser.userEmail)))
+
+    // Create subgroups as groups in ldap
+    val inAuthDomainSubGroup = runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inAuthDomainSubGroup"), Set(inAuthDomainSubGroupUser.userId), WorkbenchEmail("imAuthDomain@subGroup.com"))))
+    val inPolicySubGroup = runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inPolicySubGroup"), Set(inPolicySubGroupUser.userId), WorkbenchEmail("inPolicy@subGroup.com"))))
+    val inBothSubGroup = runAndWait(dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(inBothSubGroupUser.userId), WorkbenchEmail("inBoth@subGroup.com"))))
+
+    // Create managed group to act as auth domain and add appropriate subgroups
+    val managedGroupId = "fooGroup"
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), superAdminOwner))
+    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inAuthDomainSubGroup.id))
+    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inBothSubGroup.id))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(superAdminOwner.userEmail), Set.empty, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), superAdminOwner))
+
+    // Access policy that intersection group will be calculated for
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set(inPolicySubGroup.email, inBothSubGroup.email), Set.empty, Set.empty)))
+
+    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource, accessPolicy))
+    intersectionGroup shouldEqual Set(inBothSubGroupUser.userId)
+  }
+
+  it should "return the policy members if there is no auth domain set" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val inPolicyUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
+    val inBothUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inBoth"), WorkbenchEmail("inBoth@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inPolicyUser.userId, Some(TestSupport.genGoogleSubjectId()), inPolicyUser.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(inBothUser.userId, Some(TestSupport.genGoogleSubjectId()), inBothUser.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), constrainableRole.actions, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, inBothUser))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), Set.empty, Set.empty)))
+
+    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource, accessPolicy))
+    intersectionGroup shouldEqual Set(inBothUser.userId, inPolicyUser.userId)
+  }
+
+  it should "return an empty set if none of the policy members are in the auth domain" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val inAuthDomainUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inAuthDomain"), WorkbenchEmail("inAuthDomain@example.com"), 0)
+    val inPolicyUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
+
+    runAndWait(dirDAO.createUser(WorkbenchUser(inAuthDomainUser.userId, Some(TestSupport.genGoogleSubjectId()), inAuthDomainUser.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(inPolicyUser.userId, Some(TestSupport.genGoogleSubjectId()), inPolicyUser.userEmail)))
+
+    val managedGroupId = "fooGroup"
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), inAuthDomainUser))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.userEmail), constrainableRole.actions, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), inAuthDomainUser))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set(inPolicyUser.userEmail), Set.empty, Set.empty)))
+
+    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource, accessPolicy))
+    intersectionGroup shouldEqual Set.empty
+  }
+
+  it should "return an empty set if both the auth domain and the policy are empty" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val inPolicyUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
+    val inBothUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inBoth"), WorkbenchEmail("inBoth@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(inPolicyUser.userId, Some(TestSupport.genGoogleSubjectId()), inPolicyUser.userEmail)))
+    runAndWait(dirDAO.createUser(WorkbenchUser(inBothUser.userId, Some(TestSupport.genGoogleSubjectId()), inBothUser.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.userEmail), constrainableRole.actions, Set(constrainableRole.roleName)),
+      AccessPolicyName("emptyPolicy") -> AccessPolicyMembership(Set.empty, Set.empty, Set.empty))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, inBothUser))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, Set.empty, Set.empty)))
+
+    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource, accessPolicy))
+    intersectionGroup shouldEqual Set.empty
+  }
+
+  "isConstrainable" should "return true when the policy has constrainable actions and roles" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userId"), WorkbenchEmail("userId@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, dummyUserInfo))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, constrainableRole.actions, Set(constrainableRole.roleName))))
+
+    val isConstrainable = PrivateMethod[Boolean]('isConstrainable)
+    val constrained = ge invokePrivate isConstrainable(resource, accessPolicy)
+    constrained shouldEqual true
+  }
+
+  it should "return true when the policy has a constrainable role, but no constrainable actions" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userId"), WorkbenchEmail("userId@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, dummyUserInfo))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, Set.empty, Set(constrainableRole.roleName))))
+
+    val isConstrainable = PrivateMethod[Boolean]('isConstrainable)
+    val constrained = ge invokePrivate isConstrainable(resource, accessPolicy)
+    constrained shouldEqual true
+  }
+
+  it should "return true when the policy has a constrainable action, but no constrainable roles" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userId"), WorkbenchEmail("userId@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, dummyUserInfo))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, constrainableRole.actions, Set.empty)))
+
+    val isConstrainable = PrivateMethod[Boolean]('isConstrainable)
+    val constrained = ge invokePrivate isConstrainable(resource, accessPolicy)
+    constrained shouldEqual true
+  }
+
+  it should "return false when the policy is not constrainable" in {
+    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole) = initPrivateTest
+
+    val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userId"), WorkbenchEmail("userId@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
+
+    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(constrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, dummyUserInfo))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, Set.empty, Set.empty)))
+
+    val isConstrainable = PrivateMethod[Boolean]('isConstrainable)
+    val constrained = ge invokePrivate isConstrainable(resource, accessPolicy)
+    constrained shouldEqual false
+  }
+
+  it should "return false when the resource type is not constrainable" in {
+    val (dirDAO: DirectoryDAO, _, constrainableService: ResourceService, _, _, _) = initPrivateTest
+
+    val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userId"), WorkbenchEmail("userId@example.com"), 0)
+    runAndWait(dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, Some(TestSupport.genGoogleSubjectId()), dummyUserInfo.userEmail)))
+
+    val nonConstrainableActionPatterns = Set(ResourceActionPattern("nonConstrainable_view", "Cannot be constrained by an auth domain", false))
+
+    val nonConstrainableViewAction = ResourceAction("nonConstrainable_view")
+    val nonConstrainableResourceTypeActions = Set(nonConstrainableViewAction)
+    val nonConstrainableReaderRoleName = ResourceRoleName("nonConstrainable_reader")
+    val nonConstrainableRole = ResourceRole(nonConstrainableReaderRoleName, nonConstrainableResourceTypeActions)
+    val nonConstrainableResourceType = ResourceType(
+      ResourceTypeName(UUID.randomUUID().toString),
+      nonConstrainableActionPatterns,
+      Set(ResourceRole(nonConstrainableReaderRoleName, nonConstrainableResourceTypeActions)),
+      nonConstrainableReaderRoleName
+    )
+
+    val nonConstrainableResourceTypes = Map(nonConstrainableResourceType.name -> nonConstrainableResourceType)
+
+    val ge = new GoogleExtensions(dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, nonConstrainableResourceTypes)
+
+    constrainableService.createResourceType(nonConstrainableResourceType).unsafeRunSync
+
+    val accessPolicyMap = Map(AccessPolicyName(nonConstrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), nonConstrainableRole.actions, Set(nonConstrainableRole.roleName)))
+    val resource = runAndWait(constrainableService.createResource(nonConstrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, dummyUserInfo))
+
+    val accessPolicy = runAndWait(constrainableService.overwritePolicy(nonConstrainableResourceType, AccessPolicyName("ap"), resource, AccessPolicyMembership(Set.empty, Set.empty, Set.empty)))
+
+    val isConstrainable = PrivateMethod[Boolean]('isConstrainable)
+    val constrained = ge invokePrivate isConstrainable(resource, accessPolicy)
+    constrained shouldEqual false
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -88,6 +88,23 @@ class LdapAccessPolicyDAOSpec extends AsyncFlatSpec with ScalaFutures with Match
     res.unsafeToFuture()
   }
 
+  it should "list the resources constrained by the given managed group" in {
+    val authDomain = WorkbenchGroupName("authDomain")
+    val resourceTypeName = ResourceTypeName(UUID.randomUUID().toString)
+    val resource1 = Resource(resourceTypeName, ResourceId("rid1"), Set(authDomain))
+    val resource2 = Resource(resourceTypeName, ResourceId("rid2"), Set(authDomain))
+
+    val res = for {
+      _ <- dao.createResourceType(resourceTypeName)
+      _ <- dao.createResource(resource1)
+      _ <- dao.createResource(resource2)
+      resources <- IO.fromFuture(IO(dao.listResourcesConstrainedByGroup(authDomain)))
+    } yield {
+      resources should contain theSameElementsAs Set(resource1, resource2)
+    }
+    res.unsafeToFuture
+  }
+
   "LdapAccessPolicyDAO listUserPolicyResponse" should "return UserPolicyResponse" in {
     val policy = genPolicy.sample.get
     val res = for{

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -35,6 +35,8 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def loadResourceAuthDomain(resource: Resource): IO[Set[WorkbenchGroupName]] = IO.pure(Set.empty)
 
+  override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): Future[Set[Resource]] = Future.successful(Set.empty)
+
   override def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = IO {
     policies += policy.id -> policy
     policy


### PR DESCRIPTION
Ticket: [GAWB-3570](https://broadinstitute.atlassian.net/browse/GAWB-3570), [GAWB-3574](https://broadinstitute.atlassian.net/browse/GAWB-3574)
- When policies are updated or created, Sam now looks to see if they are constrainable by checking if any of the policy's actions are constrainable. If the policy is constrainable, then the intersection of the policy's members and the resource's auth domain is calculated and synced with Google
- When managed groups are updated or created, Sam now checks whether there are any policies that are constrained by it and updates those policies
---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
