### PR TITLE
add bloop plugin and remove some transitive dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@
 configure.rb
 /config/
 
-# sbt specific
+# build specific
 .sbtopts
 .cache/
 .history/
 .lib/
+.bloop/
 dist/*
 target/
 lib_managed/

--- a/build.sbt
+++ b/build.sbt
@@ -62,3 +62,5 @@ scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito
 
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+
+bloopAggregateSourceDependencies in Global := true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,11 +62,6 @@ object Dependencies {
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
-
-    jacksonAnnotations,
-    jacksonDatabind,
-    jacksonCore,
-
     logbackClassic,
     ravenLogback,
     scalaLogging,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("com.lucidchart"      %  "sbt-scalafmt" % "1.15")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.0.0")


### PR DESCRIPTION
Ticket: no ticket

https://scalacenter.github.io/bloop/docs/
`bloop compile root` is much faster than `sbt compile`. I haven't figured out how to make tests run successfully yet since we pass in arguments, and bloop is ignoring the args. But `bloop compile root -w` alone is worth adding `bloop` I think 🤔 


you can run tests by hardcoding values in `.bloop/root/scala-2.12/test-classes/reference.conf`...but not sure what's a better way to do this yet

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

