### PR TITLE
Public resources

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -2,6 +2,36 @@ akka.http.server.idle-timeout = 180 s
 akka.http.server.request-timeout = 60 s
 
 resourceTypes = {
+  resource_type_admin = {
+    actionPatternObjects = {
+      read_policies = {
+        description = "view all policies and policy details for this workspace"
+      }
+      alter_policies = {
+        description = "create and delete policies for this billing-project"
+      }
+      "share_policy::.+" = {
+        description = "modify the membership of the specified policy"
+      }
+      "read_policy::.+" = {
+        description = "view the membership of the specified policy"
+      }
+      set_public = {
+        description = "set policies to public"
+      }
+      "set_public::.+" = {
+        description = "set the specified policy to public"
+      }
+    }
+
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["read_policies", "alter_policies"]
+      }
+    }
+    reuseIds = false
+  }
   workspace = {
     actionPatternObjects = {
       delete = {
@@ -326,5 +356,3 @@ resourceTypes = {
 
   }
 }
-
-schemaLock.schemaVersion = 2

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1069,6 +1069,63 @@ paths:
       tags:
         - Resources
 
+  /api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/public:
+    get:
+      summary: Get the public flag on a policy
+      responses:
+        200:
+          description: True if the policy is public, false if the policy is private
+          schema:
+            type: boolean
+        403:
+          description: You do not have permission to read this policy
+        404:
+          description: Resource type, resource, or policy do not exist
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      operationId: getPolicyPublic
+      tags:
+      - Resources
+    put:
+      summary: Set the public flag on a policy
+      responses:
+        204:
+          description: Successfully added a user to the policy
+        403:
+          description: You do not have permission to alter this policy
+        404:
+          description: Resource type does not exist, you are not a member of any policy on the resource, or user is not permitted to set the public flag on resources of this type
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      parameters:
+      - in: path
+        description: Type of resource
+        name: resourceTypeName
+        required: true
+        type: string
+      - in: path
+        description: Id of resource
+        name: resourceId
+        required: true
+        type: string
+      - in: path
+        description: Name of the policy
+        name: policyName
+        required: true
+        type: string
+      - in: body
+        description: true to make the policy public, false to make it private
+        name: public
+        required: true
+        type: boolean
+      operationId: setPolicyPublic
+      tags:
+      - Resources
+
 
   /api/resources/v1/{resourceTypeName}/{resourceId}/roles:
     get:
@@ -1443,6 +1500,9 @@ definitions:
         type: array
         items:
           type: string
+      public:
+        type: boolean
+        description: the policy is public when this is true
 
   ResourceRole:
     type: object

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -128,7 +128,7 @@ object Boot extends App with LazyLogging {
           val (sRoutes, userService, resourceService, statusService) = createSamRoutes(cloudExtention, accessPolicyDao)
 
           for{
-            _ <- resourceTypes.toList.parTraverse(rt => accessPolicyDao.createResourceType(rt.name)).handleErrorWith{
+            _ <- resourceService.initResourceTypes().handleErrorWith{
               case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)
             }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -124,15 +124,15 @@ object Boot extends App with LazyLogging {
         blockingEc =>
           implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
           val accessPolicyDao = new LdapAccessPolicyDAO(ldapConnectionPool, directoryConfig, blockingEc)
-          val cloudExtention = createCloudExt(accessPolicyDao)
-          val (sRoutes, userService, resourceService, statusService) = createSamRoutes(cloudExtention, accessPolicyDao)
+          val cloudExtension = createCloudExt(accessPolicyDao)
+          val (sRoutes, userService, resourceService, statusService) = createSamRoutes(cloudExtension, accessPolicyDao)
 
           for{
             _ <- resourceService.initResourceTypes().handleErrorWith{
               case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)
             }
 
-            _ <- IO.fromFuture(IO(cloudExtention.onBoot(SamApplication(userService, resourceService, statusService))))
+            _ <- IO.fromFuture(IO(cloudExtension.onBoot(SamApplication(userService, resourceService, statusService))))
 
             binding <- IO.fromFuture(IO(Http().bindAndHandle(sRoutes.route, "0.0.0.0", 8080))).handleErrorWith{
               case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -142,14 +142,14 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                     } ~
                     pathPrefix("public") {
                       pathEndOrSingleSlash {
-                        requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                          get {
+                        get {
+                          requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
                             complete(resourceService.isPublic(resourceAndPolicyName))
                           }
                         } ~
-                        requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                          requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType.name.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                            put {
+                        put {
+                          requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
+                            requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType.name.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
                               entity(as[Boolean]) { isPublic =>
                                 complete(resourceService.setPublic(resourceAndPolicyName, isPublic).unsafeToFuture().map(_ => StatusCodes.NoContent))
                               }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -151,7 +151,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                           requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
                             requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType.name.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
                               entity(as[Boolean]) { isPublic =>
-                                complete(resourceService.setPublic(resourceAndPolicyName, isPublic).unsafeToFuture().map(_ => StatusCodes.NoContent))
+                                complete(resourceService.setPublic(resourceAndPolicyName, isPublic).map(_ => StatusCodes.NoContent))
                               }
                             }
                           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import spray.json.DefaultJsonProtocol._
@@ -133,6 +134,24 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                               } ~
                               delete {
                                 complete(resourceService.removeSubjectFromPolicy(resourceAndPolicyName, subject).map(_ => StatusCodes.NoContent))
+                              }
+                            }
+                          }
+                        }
+                      }
+                    } ~
+                    pathPrefix("public") {
+                      pathEndOrSingleSlash {
+                        requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
+                          get {
+                            complete(resourceService.isPublic(resourceAndPolicyName))
+                          }
+                        } ~
+                        requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
+                          requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType.name.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
+                            put {
+                              entity(as[Boolean]) { isPublic =>
+                                complete(resourceService.setPublic(resourceAndPolicyName, isPublic).unsafeToFuture().map(_ => StatusCodes.NoContent))
                               }
                             }
                           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SchemaLockConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SchemaLockConfig.scala
@@ -10,10 +10,8 @@ package org.broadinstitute.dsde.workbench.sam.config
   * @param recheckTimeInterval The number of seconds to wait before retrying the lock (should be less than or equal to maxTimeToWait)
   * @param maxTimeToWait The number of seconds to wait before giving up
   * @param instanceId The id of the instance that is dealing with the lock
-  * @param schemaVersion The version of the schema, to be incremented each time the schema changes
   */
 case class SchemaLockConfig(lockSchemaOnBoot: Boolean,
                             recheckTimeInterval: Int,
                             maxTimeToWait: Int,
-                            instanceId: String,
-                            schemaVersion: Int)
+                            instanceId: String)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/package.scala
@@ -163,8 +163,7 @@ package object config {
       config.getBoolean("lockSchemaOnBoot"),
       config.getInt("recheckTimeInterval"),
       config.getInt("maxTimeToWait"),
-      config.getString("instanceId"),
-      config.getInt("schemaVersion")
+      config.getString("instanceId")
     )
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -427,9 +427,9 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
         groupOption <- groupId match {
           case basicGroupName: WorkbenchGroupName => directoryDAO.loadGroup(basicGroupName)
           case rpn: FullyQualifiedPolicyId => accessPolicyDAO.loadPolicy(rpn).unsafeToFuture().map(_.map { loadedPolicy =>
-            if (loadedPolicy.isPublic.contains(true)) {
+            if (loadedPolicy.public) {
               // include all users group when synchronizing a public policy
-              loadedPolicy.copy(members = loadedPolicy.members + allUsersGroupName)
+              AccessPolicy.members.modify(_ + allUsersGroupName)(loadedPolicy)
             } else {
               loadedPolicy
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -55,7 +55,7 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
   }
 
   override val emailDomain = googleServicesConfig.appsDomain
-  private val allUsersGroupEmail = WorkbenchEmail(s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}GROUP_${allUsersGroupName.value}@$emailDomain")
+  private[google] val allUsersGroupEmail = WorkbenchEmail(s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}GROUP_${allUsersGroupName.value}@$emailDomain")
 
   override def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO)(implicit executionContext: ExecutionContext): Future[WorkbenchGroup] = {
     val allUsersGroup = BasicWorkbenchGroup(allUsersGroupName, Set.empty, allUsersGroupEmail)
@@ -426,7 +426,14 @@ class GoogleExtensions(val directoryDAO: DirectoryDAO, val accessPolicyDAO: Acce
       for {
         groupOption <- groupId match {
           case basicGroupName: WorkbenchGroupName => directoryDAO.loadGroup(basicGroupName)
-          case rpn: FullyQualifiedPolicyId => accessPolicyDAO.loadPolicy(rpn).unsafeToFuture()
+          case rpn: FullyQualifiedPolicyId => accessPolicyDAO.loadPolicy(rpn).unsafeToFuture().map(_.map { loadedPolicy =>
+            if (loadedPolicy.isPublic.contains(true)) {
+              // include all users group when synchronizing a public policy
+              loadedPolicy.copy(members = loadedPolicy.members + allUsersGroupName)
+            } else {
+              loadedPolicy
+            }
+          })
         }
 
         group = groupOption.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.model
 
 import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
 /**
   * Created by dvoet on 5/26/17.
@@ -34,7 +34,7 @@ object SamJsonSupport {
   implicit val UserIdInfoFormat = jsonFormat3(UserIdInfo.apply)
 
   implicit val UserStatusDiagnosticsFormat = jsonFormat3(UserStatusDiagnostics.apply)
-  
+
   implicit val AccessPolicyNameFormat = ValueObjectFormat(AccessPolicyName.apply)
 
   implicit val ResourceIdFormat = ValueObjectFormat(ResourceId.apply)
@@ -45,7 +45,7 @@ object SamJsonSupport {
 
   implicit val AccessPolicyResponseEntryFormat = jsonFormat3(AccessPolicyResponseEntry.apply)
 
-  implicit val UserPolicyResponseFormat = jsonFormat4(UserPolicyResponse.apply)
+  implicit val UserPolicyResponseFormat = jsonFormat5(UserPolicyResponse.apply)
 
   implicit val PolicyIdentityFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
 
@@ -56,6 +56,15 @@ object SamJsonSupport {
   implicit val GroupSyncResponseFormat = jsonFormat2(GroupSyncResponse.apply)
 
   implicit val CreateResourceRequestFormat = jsonFormat3(CreateResourceRequest.apply)
+
+}
+
+object RootPrimitiveJsonSupport {
+  implicit val rootBooleanJsonFormat: RootJsonFormat[Boolean] = new RootJsonFormat[Boolean] {
+    import DefaultJsonProtocol.BooleanJsonFormat
+    override def write(obj: Boolean): JsValue = BooleanJsonFormat.write(obj)
+    override def read(json: JsValue): Boolean = BooleanJsonFormat.read(json)
+  }
 }
 
 object SamResourceActions {
@@ -64,9 +73,15 @@ object SamResourceActions {
   val delete = ResourceAction("delete")
   val notifyAdmins = ResourceAction("notify_admins")
   val setAccessInstructions = ResourceAction("set_access_instructions")
+  val setPublic = ResourceAction("set_public")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")
+  def setPublicPolicy(policy: AccessPolicyName) = ResourceAction(s"set_public::${policy.value}")
+}
+
+object SamResourceTypes {
+  val resourceTypeAdminName = ResourceTypeName("resource_type_admin")
 }
 
 @Lenses case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API
@@ -96,7 +111,7 @@ object SamResourceActions {
 
 @Lenses case class ResourceId(value: String) extends ValueObject
 @Lenses final case class ResourceIdAndPolicyName(resourceId: ResourceId, accessPolicyName: AccessPolicyName)
-@Lenses final case class UserPolicyResponse(resourceId: ResourceId, accessPolicyName: AccessPolicyName, authDomainGroups: Set[WorkbenchGroupName], missingAuthDomainGroups: Set[WorkbenchGroupName])
+@Lenses final case class UserPolicyResponse(resourceId: ResourceId, accessPolicyName: AccessPolicyName, authDomainGroups: Set[WorkbenchGroupName], missingAuthDomainGroups: Set[WorkbenchGroupName], public: Boolean)
 @Lenses final case class FullyQualifiedPolicyId(resource: FullyQualifiedResourceId, accessPolicyName: AccessPolicyName) extends WorkbenchGroupIdentity {
   override def toString: String = s"${accessPolicyName.value}.${resource.resourceId.value}.${resource.resourceTypeName.value}"
 }
@@ -108,7 +123,7 @@ Note that AccessPolicy IS A group, does not have a group. This makes the ldap qu
 and thus resources much easier. We tried modeling with a "has a" relationship in code but a "is a" relationship in
 ldap but it felt unnatural.
  */
-@Lenses case class AccessPolicy(id: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], email: WorkbenchEmail, roles: Set[ResourceRoleName], actions: Set[ResourceAction]) extends WorkbenchGroup
+@Lenses case class AccessPolicy(id: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], email: WorkbenchEmail, roles: Set[ResourceRoleName], actions: Set[ResourceAction], isPublic: Option[Boolean] = None) extends WorkbenchGroup
 @Lenses case class AccessPolicyMembership(memberEmails: Set[WorkbenchEmail], actions: Set[ResourceAction], roles: Set[ResourceRoleName])
 @Lenses case class AccessPolicyResponseEntry(policyName: AccessPolicyName, policy: AccessPolicyMembership, email: WorkbenchEmail)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -123,7 +123,7 @@ Note that AccessPolicy IS A group, does not have a group. This makes the ldap qu
 and thus resources much easier. We tried modeling with a "has a" relationship in code but a "is a" relationship in
 ldap but it felt unnatural.
  */
-@Lenses case class AccessPolicy(id: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], email: WorkbenchEmail, roles: Set[ResourceRoleName], actions: Set[ResourceAction], isPublic: Option[Boolean] = None) extends WorkbenchGroup
+@Lenses case class AccessPolicy(id: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], email: WorkbenchEmail, roles: Set[ResourceRoleName], actions: Set[ResourceAction], public: Boolean) extends WorkbenchGroup
 @Lenses case class AccessPolicyMembership(memberEmails: Set[WorkbenchEmail], actions: Set[ResourceAction], roles: Set[ResourceRoleName])
 @Lenses case class AccessPolicyResponseEntry(policyName: AccessPolicyName, policy: AccessPolicyMembership, email: WorkbenchEmail)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -20,9 +20,12 @@ trait AccessPolicyDAO {
   def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Option[AccessPolicy]]
   def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject]): IO[Unit]
   def overwritePolicy(newPolicy: AccessPolicy): IO[AccessPolicy]
+  def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]]
+  def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listResourceWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]]
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]]
   def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]]
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]]
   def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUserId]]
+  def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -113,7 +113,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val email = WorkbenchEmail(getAttribute(entry, Attr.email).get)
 
     AccessPolicy(
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceId), AccessPolicyName(policyName)), members, email, roles, actions)
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceId), AccessPolicyName(policyName)), members, email, roles, actions, isPublic)
   }
 
   override def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject]): IO[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -223,7 +223,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
   override def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, public: Boolean): IO[Unit] = {
     val dateMod = new Modification(ModificationType.REPLACE, Attr.groupUpdatedTimestamp, formattedDate(new Date()))
     val publicMod = new Modification(ModificationType.REPLACE, Attr.public, public.toString)
-    
+
     cs.evalOn(blockingEc)(IO(ldapConnectionPool.modify( policyDn(policyId), dateMod, publicMod)).void).recoverWith {
       case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy does not exist")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -81,7 +81,8 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     ) ++
       maybeAttribute(Attr.action, policy.actions.map(_.value)) ++
       maybeAttribute(Attr.role, policy.roles.map(_.value)) ++
-      maybeAttribute(Attr.uniqueMember, policy.members.map(subjectDn))
+      maybeAttribute(Attr.uniqueMember, policy.members.map(subjectDn)) ++
+      maybeAttribute(Attr.isPublic, policy.isPublic.map(_.toString).toSet)
 
     cs.evalOn(blockingEc)(IO(ldapConnectionPool.add(policyDn(
       FullyQualifiedPolicyId(
@@ -107,6 +108,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val members = getAttributes(entry, Attr.uniqueMember).map(dnToSubject)
     val roles = getAttributes(entry, Attr.role).map(r => ResourceRoleName(r))
     val actions = getAttributes(entry, Attr.action).map(a => ResourceAction(a))
+    val isPublic = Option(entry.getAttribute(Attr.isPublic)).map(_.getValueAsBoolean.booleanValue())
 
     val email = WorkbenchEmail(getAttribute(entry, Attr.email).get)
 
@@ -161,31 +163,49 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     } yield Resource(resourceTypeName, ResourceId(resourceId), authDomains)
   }
 
+  override def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]] = IO(
+    ldapSearchStream(resourceTypeDn(resourceTypeName), SearchScope.SUB, Filter.createANDFilter(Filter.createEqualityFilter("objectclass", ObjectClass.policy), Filter.createEqualityFilter(Attr.isPublic, "true"))) { entry =>
+      val policy = unmarshalAccessPolicy(entry)
+      ResourceIdAndPolicyName(policy.id.resource.resourceId, policy.id.accessPolicyName)
+    }
+  )
+
+  override def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = {
+    cs.evalOn(blockingEc)(
+      IO(
+        ldapSearchStream(
+          resourceDn(resource),
+          SearchScope.SUB,
+          Filter.createANDFilter(
+            Filter.createEqualityFilter("objectclass", ObjectClass.policy),
+            Filter.createEqualityFilter(Attr.isPublic, "true"))
+        )(unmarshalAccessPolicy)))
+  }
+
   override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]] = cs.evalOn(blockingEc)(IO(
     ldapSearchStream(resourceDn(resource), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.policy))(unmarshalAccessPolicy).toSet
   ))
 
-  override def listAccessPoliciesForUser(
-      resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = for {
-      entry <- cs.evalOn(blockingEc)(IO(ldapConnectionPool.getEntry(subjectDn(user), Attr.memberOf)))
-      members <- IO.pure(Option(entry).map(e => getAttributes(e, Attr.memberOf).toList))
-      accessPolicies <- members.traverse{
-        policyStrs =>
-          val fullyQualifiedPolicyIds = policyStrs.mapFilter{
-            str =>
-              for{
-                subject <- Either.catchNonFatal(dnToSubject(str)).toOption
-                fullyQualifiedPolicyId <- subject match {
-                  case sub: FullyQualifiedPolicyId if sub.resource.resourceId == resource.resourceId && sub.resource.resourceTypeName == resource.resourceTypeName => Some(sub)
-                  case _ => None
-                }
-              } yield fullyQualifiedPolicyId
-          }
-          val filters = fullyQualifiedPolicyIds.grouped(batchSize).map(
-            batch => Filter.createORFilter(batch.map(r => Filter.createEqualityFilter(Attr.policy, r.accessPolicyName.value)).asJava)).toSeq
-          cs.evalOn(blockingEc)(IO(ldapSearchStream(resourceDn(resource), SearchScope.SUB, filters: _*)(unmarshalAccessPolicy).toSet))
-      }
-    } yield accessPolicies.getOrElse(Set.empty)
+  override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = for {
+    entry <- cs.evalOn(blockingEc)(IO(ldapConnectionPool.getEntry(subjectDn(user), Attr.memberOf)))
+    members <- IO.pure(Option(entry).map(e => getAttributes(e, Attr.memberOf).toList))
+    accessPolicies <- members.traverse{
+      policyStrs =>
+        val fullyQualifiedPolicyIds = policyStrs.mapFilter{
+          str =>
+            for{
+              subject <- Either.catchNonFatal(dnToSubject(str)).toOption
+              fullyQualifiedPolicyId <- subject match {
+                case sub: FullyQualifiedPolicyId if sub.resource.resourceId == resource.resourceId && sub.resource.resourceTypeName == resource.resourceTypeName => Some(sub)
+                case _ => None
+              }
+            } yield fullyQualifiedPolicyId
+        }
+        val filters = fullyQualifiedPolicyIds.grouped(batchSize).map(
+          batch => Filter.createORFilter(batch.map(r => Filter.createEqualityFilter(Attr.policy, r.accessPolicyName.value)).asJava)).toSeq
+        cs.evalOn(blockingEc)(IO(ldapSearchStream(resourceDn(resource), SearchScope.SUB, filters: _*)(unmarshalAccessPolicy).toSet))
+    }
+  } yield accessPolicies.getOrElse(Set.empty)
 
   override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUserId]] = cs.evalOn(blockingEc)(
     IO(ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(policyId)))(unmarshalUser).map(_.id).toSet)
@@ -196,5 +216,18 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val email = getAttribute(entry, Attr.email).getOrElse(throw new WorkbenchException(s"${Attr.email} attribute missing"))
 
     WorkbenchUser(WorkbenchUserId(uid), getAttribute(entry, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email))
+  }
+
+  override def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit] = {
+    cs.evalOn(blockingEc)(
+        IO(
+          ldapConnectionPool.modify(
+            policyDn(policyId),
+            new Modification(ModificationType.REPLACE, Attr.isPublic, isPublic.toString))).void)
+      .recoverWith {
+        case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
+          IO.raiseError(
+            new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy does not exist")))
+      }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
@@ -48,7 +48,7 @@ object JndiSchemaDAO {
     val project = "project"
     val proxyEmail = "proxyEmail"
     val authDomain = "authDomain"
-    val isPublic = "isPublic"
+    val public = "public"
   }
 
   object ObjectClass {
@@ -332,7 +332,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.6", Attr.role, "the roles for the policy, if any", false)
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.7", Attr.policy, "the policy name", true, equality = Option("caseIgnoreMatch"))
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.9", Attr.authDomain, "auth domain constraining resource", false)
-    createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.10", Attr.isPublic, "boolean attribute marking a policy as public", false, syntax = Option("1.3.6.1.4.1.1466.115.121.1.7"), equality = Option("booleanMatch"))
+    createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.10", Attr.public, "boolean attribute marking a policy as public", false, syntax = Option("1.3.6.1.4.1.1466.115.121.1.7"), equality = Option("booleanMatch"))
 
     val policyAttrs = new BasicAttributes(true) // Ignore case
     policyAttrs.put("NUMERICOID", "1.3.6.1.4.1.18060.0.4.3.2.0")
@@ -352,7 +352,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     val policyMay = new BasicAttribute("MAY")
     policyMay.add(Attr.action)
     policyMay.add(Attr.role)
-    policyMay.add(Attr.isPublic)
+    policyMay.add(Attr.public)
     policyAttrs.put(policyMay)
 
     val resourceTypeAttrs = new BasicAttributes(true) // Ignore case
@@ -404,7 +404,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.role) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.policy) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.authDomain) }
-    Try { schema.destroySubcontext("AttributeDefinition/" + Attr.isPublic) }
+    Try { schema.destroySubcontext("AttributeDefinition/" + Attr.public) }
   }
 
   private def createOrgUnit(dn: String): Future[Unit] = withContext { ctx =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
@@ -18,6 +18,12 @@ import scala.util.{Failure, Success, Try}
   * Created by mbemis on 10/3/17.
   */
 object JndiSchemaDAO {
+  /**
+    * This is the version of the schema reflected by this code. Update this when adding code that updates the schema.
+    * If schemaVersion is not updated your changes may not be applied.
+    */
+  val schemaVersion = 3
+
   object Attr {
     val resourceId = "resourceId"
     val objectClass = "objectclass"
@@ -42,6 +48,7 @@ object JndiSchemaDAO {
     val project = "project"
     val proxyEmail = "proxyEmail"
     val authDomain = "authDomain"
+    val isPublic = "isPublic"
   }
 
   object ObjectClass {
@@ -62,7 +69,7 @@ object SchemaStatus {
   case object Ignore extends SchemaStatus
 }
 
-class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLockConfig: SchemaLockConfig)(implicit executionContext: ExecutionContext) extends JndiSupport with DirectorySubjectNameSupport with LazyLogging {
+class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLockConfig: SchemaLockConfig, val schemaVersion: Int = JndiSchemaDAO.schemaVersion)(implicit executionContext: ExecutionContext) extends JndiSupport with DirectorySubjectNameSupport with LazyLogging {
 
   def init(): Future[Unit] = {
     if(schemaLockConfig.lockSchemaOnBoot) { initWithSchemaLock() }
@@ -106,13 +113,13 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     val myAttrs = new BasicAttributes(true)
     myAttrs.put("completed", true.toString)
 
-    logger.info(s"Schema successfully updated to version [${schemaLockConfig.schemaVersion}]")
+    logger.info(s"Schema successfully updated to version [${schemaVersion}]")
 
-    ctx.modifyAttributes(schemaLockDn(schemaLockConfig.schemaVersion), DirContext.REPLACE_ATTRIBUTE, myAttrs)
+    ctx.modifyAttributes(schemaLockDn(schemaVersion), DirContext.REPLACE_ATTRIBUTE, myAttrs)
   }
 
   def readSchemaStatus(): Future[SchemaStatus] = withContext { ctx =>
-    val attributes = Try { ctx.getAttributes(schemaLockDn(schemaLockConfig.schemaVersion)) }
+    val attributes = Try { ctx.getAttributes(schemaLockDn(schemaVersion)) }
 
     attributes match {
       case Success(attrs) =>
@@ -163,14 +170,14 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
         val oc = new BasicAttribute("objectclass")
         Seq("top", "schemaVersion").foreach(oc.add)
         myAttrs.put(oc)
-        myAttrs.put("schemaVersion", schemaLockConfig.schemaVersion.toString)
+        myAttrs.put("schemaVersion", schemaVersion.toString)
         myAttrs.put("completed", false.toString)
         myAttrs.put("instanceId", schemaLockConfig.instanceId)
 
         myAttrs
       }
     }
-    ctx.bind(schemaLockDn(schemaLockConfig.schemaVersion), resourceContext)
+    ctx.bind(schemaLockDn(schemaVersion), resourceContext)
   }
   } match {
     case Failure(e: NameAlreadyBoundException) =>
@@ -325,6 +332,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.6", Attr.role, "the roles for the policy, if any", false)
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.7", Attr.policy, "the policy name", true, equality = Option("caseIgnoreMatch"))
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.9", Attr.authDomain, "auth domain constraining resource", false)
+    createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.10", Attr.isPublic, "boolean attribute marking a policy as public", false, syntax = Option("1.3.6.1.4.1.1466.115.121.1.7"), equality = Option("booleanMatch"))
 
     val policyAttrs = new BasicAttributes(true) // Ignore case
     policyAttrs.put("NUMERICOID", "1.3.6.1.4.1.18060.0.4.3.2.0")
@@ -344,6 +352,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     val policyMay = new BasicAttribute("MAY")
     policyMay.add(Attr.action)
     policyMay.add(Attr.role)
+    policyMay.add(Attr.isPublic)
     policyAttrs.put(policyMay)
 
     val resourceTypeAttrs = new BasicAttributes(true) // Ignore case
@@ -395,6 +404,7 @@ class JndiSchemaDAO(protected val directoryConfig: DirectoryConfig, val schemaLo
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.role) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.policy) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.authDomain) }
+    Try { schema.destroySubcontext("AttributeDefinition/" + Attr.isPublic) }
   }
 
   private def createOrgUnit(dn: String): Future[Unit] = withContext { ctx =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -40,7 +40,7 @@ class ManagedGroupService(private val resourceService: ResourceService, private 
     val workbenchGroupName = WorkbenchGroupName(resource.resourceId.value)
     val groupMembers: Set[WorkbenchSubject] = componentPolicies.collect {
       // collect only member and admin policies
-      case AccessPolicy(id @ FullyQualifiedPolicyId(_, ManagedGroupService.memberPolicyName | ManagedGroupService.adminPolicyName), _, _, _, _) => id
+      case AccessPolicy(id @ FullyQualifiedPolicyId(_, ManagedGroupService.memberPolicyName | ManagedGroupService.adminPolicyName), _, _, _, _, _) => id
     }
     directoryDAO.createGroup(BasicWorkbenchGroup(workbenchGroupName, groupMembers, email), accessInstructionsOpt)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -189,16 +189,9 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
   }
 
   def listUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo): Future[Set[ResourceRoleName]] = {
-    listResourceAccessPoliciesForUser(resource, userInfo).map { matchingPolicies =>
+    policyEvaluatorService.listResourceAccessPoliciesForUser(resource, userInfo.userId).map { matchingPolicies =>
       matchingPolicies.flatMap(_.roles)
     }.unsafeToFuture()
-  }
-
-  private def listResourceAccessPoliciesForUser(resource: FullyQualifiedResourceId, userInfo: UserInfo): IO[Set[AccessPolicy]] = {
-    for {
-      policies <- accessPolicyDAO.listAccessPoliciesForUser(resource, userInfo.userId)
-      publicPolicies <- accessPolicyDAO.listPublicAccessPolicies(resource)
-    } yield policies ++ publicPolicies
   }
 
   /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -364,9 +364,9 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
   private def generateGroupEmail() = WorkbenchEmail(s"policy-${UUID.randomUUID}@$emailDomain")
 
   def isPublic(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Boolean] = {
-    accessPolicyDAO.loadPolicy(resourceAndPolicyName).map {
-      case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found"))
-      case Some(accessPolicy) => accessPolicy.public
+    accessPolicyDAO.loadPolicy(resourceAndPolicyName).flatMap {
+      case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found")))
+      case Some(accessPolicy) => IO.pure(accessPolicy.public)
     }
   }
 

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -103,7 +103,7 @@ object Generator {
     email <- genNonPetEmail
     roles <- Gen.listOf(genRoleName).map(_.toSet)
     actions <- Gen.listOf(genResourceAction).map(_.toSet)
-  } yield AccessPolicy(id, members, email, roles, actions)
+  } yield AccessPolicy(id, members, email, roles, actions, public = false)
 
   implicit val arbNonPetEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genNonPetEmail)
   implicit val arbOAuth2BearerToken: Arbitrary[OAuth2BearerToken] = Arbitrary(genOAuth2BearerToken)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -315,7 +315,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
     val resource = Resource(typeName1, ResourceId("resource"), Set.empty)
     val policy1 = AccessPolicy(
-      FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("role1-a")), Set(userId), WorkbenchEmail("p1@example.com"), Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")))
+      FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("role1-a")), Set(userId), WorkbenchEmail("p1@example.com"), Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")), public = false)
 
     policyDAO.createResourceType(typeName1).unsafeRunSync()
     policyDAO.createResource(resource).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -104,7 +104,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val testGroup = BasicWorkbenchGroup(groupName, Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail)
     val testPolicy = AccessPolicy(
       model.FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty)
+        FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty, isPublic = Some(true))
 
     Seq(testGroup, testPolicy).foreach { target =>
       val mockAccessPolicyDAO = mock[AccessPolicyDAO]

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -104,7 +104,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val testGroup = BasicWorkbenchGroup(groupName, Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail)
     val testPolicy = AccessPolicy(
       model.FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty, isPublic = Some(true))
+        FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty, public = true)
 
     Seq(testGroup, testPolicy).foreach { target =>
       val mockAccessPolicyDAO = mock[AccessPolicyDAO]
@@ -215,7 +215,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupId = WorkbenchGroupName("authDomainGroup")
     val resource = Resource(constrainableResourceType.name, ResourceId("rid"), Set(managedGroupId))
     val rpn = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("ap"))
-    val testPolicy = AccessPolicy(rpn, Set(policyOnlySamUserId, intersectionSamUserId, authorizedGoogleUserId, policyOnlySamSubGroup.id, intersectionSamSubGroup.id, authorizedGoogleSubGroup.id, addError), WorkbenchEmail("testPolicy@example.com"), Set(constrainableRole.roleName), constrainableRole.actions)
+    val testPolicy = AccessPolicy(rpn, Set(policyOnlySamUserId, intersectionSamUserId, authorizedGoogleUserId, policyOnlySamSubGroup.id, intersectionSamSubGroup.id, authorizedGoogleSubGroup.id, addError), WorkbenchEmail("testPolicy@example.com"), Set(constrainableRole.roleName), constrainableRole.actions, public = false)
 
     val mockAccessPolicyDAO = mock[AccessPolicyDAO]
     val mockDirectoryDAO = mock[DirectoryDAO]
@@ -643,8 +643,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
-    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty)
-    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty)
+    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty, public = false)
+    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
     when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
@@ -675,8 +675,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
-    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty)
-    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty)
+    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty, public = false)
+    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
     when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
@@ -710,8 +710,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
-    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty)
-    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty)
+    val ownerPolicy = AccessPolicy(ownerRPN, Set.empty, WorkbenchEmail("owner@example.com"), Set.empty, Set.empty, public = false)
+    val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
     when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -39,11 +39,11 @@ class LdapAccessPolicyDAOSpec extends AsyncFlatSpec with ScalaFutures with Match
     val resource3 = Resource(typeName2, ResourceId("resource"), Set.empty)
 
     val policy1 = AccessPolicy(
-      FullyQualifiedPolicyId(resource1.fullyQualifiedId, AccessPolicyName("role1-a")), policy1Group.members, policy1Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")))
+      FullyQualifiedPolicyId(resource1.fullyQualifiedId, AccessPolicyName("role1-a")), policy1Group.members, policy1Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")), public = false)
     val policy2 = AccessPolicy(
-      FullyQualifiedPolicyId(resource2.fullyQualifiedId, AccessPolicyName("role1-b")), policy2Group.members, policy2Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action3"), ResourceAction("action4")))
+      FullyQualifiedPolicyId(resource2.fullyQualifiedId, AccessPolicyName("role1-b")), policy2Group.members, policy2Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action3"), ResourceAction("action4")), public = false)
     val policy3 = AccessPolicy(
-      FullyQualifiedPolicyId(resource3.fullyQualifiedId, AccessPolicyName("role1-a")), policy3Group.members, policy3Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")))
+      FullyQualifiedPolicyId(resource3.fullyQualifiedId, AccessPolicyName("role1-a")), policy3Group.members, policy3Group.email, Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")), public = false)
 
 
     val res = for{

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -95,7 +95,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
     maybePolicy match {
       case Some((_, policy: AccessPolicy)) =>
-        val newPolicy = policy.copy(isPublic = Option(isPublic))
+        val newPolicy = policy.copy(public = isPublic)
         IO(policies.put(resourceAndPolicyName, newPolicy))
       case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy does not exist")))
     }
@@ -104,7 +104,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
   override def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]] = {
     IO.pure(
       policies.collect {
-        case (_, policy: AccessPolicy) if policy.isPublic.contains(true) => ResourceIdAndPolicyName(policy.id.resource.resourceId, policy.id.accessPolicyName)
+        case (_, policy: AccessPolicy) if policy.public => ResourceIdAndPolicyName(policy.id.resource.resourceId, policy.id.accessPolicyName)
       }.toStream
     )
   }
@@ -119,7 +119,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
   override def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = {
     IO.pure(
       policies.collect {
-        case (_, policy: AccessPolicy) if policy.isPublic.contains(true) => policy
+        case (_, policy: AccessPolicy) if policy.public => policy
       }.toStream
     )
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -76,13 +76,13 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]] = IO {
     policies.collect {
-      case (riapn @ FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) => policy
+      case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) => policy
     }.toSet
   }
 
   override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = IO {
     policies.collect {
-      case (_, policy: AccessPolicy) if policy.members.contains(user) => policy
+      case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) if policy.members.contains(user) => policy
     }.toSet
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
@@ -42,8 +42,7 @@ class JndiSchemaDAOSpec extends FlatSpec with Matchers with TestSupport with Bef
   }
 
   it should "not update the schema when trying to apply an out-of-date version" taggedAs SchemaInit in {
-    val schemaLockConfigChanged = schemaLockConfig.copy(schemaVersion = schemaLockConfig.schemaVersion - 1)
-    val schemaDaoOlder = new JndiSchemaDAO(directoryConfig, schemaLockConfigChanged)
+    val schemaDaoOlder = new JndiSchemaDAO(directoryConfig, schemaLockConfig, JndiSchemaDAO.schemaVersion-1)
 
     //First check to make sure that the schema can be applied
     Await.result(schemaDaoOlder.readSchemaStatus(), Duration.Inf) shouldEqual Proceed

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -218,7 +218,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
       _ <- IO.fromFuture(IO(constrainableService.createPolicy(policy.id, policy.members + user.userId, policy.roles, policy.actions)))
       r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, user.userId)
     } yield {
-      val expected = Set(UserPolicyResponse(resource.resourceId, policy.id.accessPolicyName, resource.authDomain, resource.authDomain))
+      val expected = Set(UserPolicyResponse(resource.resourceId, policy.id.accessPolicyName, resource.authDomain, resource.authDomain, false))
       r shouldBe(expected)
     }
 
@@ -274,9 +274,9 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
       r <- service.policyEvaluatorService.listUserAccessPolicies(defaultResourceType.name, dummyUserInfo.userId).unsafeToFuture()
     } yield {
       assertResult(Set(
-        UserPolicyResponse(resource1.resourceId, AccessPolicyName(defaultResourceType.ownerRoleName.value), Set.empty, Set.empty),
-        UserPolicyResponse(resource2.resourceId, AccessPolicyName(defaultResourceType.ownerRoleName.value), Set.empty, Set.empty),
-        UserPolicyResponse(resource1.resourceId, AccessPolicyName("in-it"), Set.empty, Set.empty)))(r)
+        UserPolicyResponse(resource1.resourceId, AccessPolicyName(defaultResourceType.ownerRoleName.value), Set.empty, Set.empty, false),
+        UserPolicyResponse(resource2.resourceId, AccessPolicyName(defaultResourceType.ownerRoleName.value), Set.empty, Set.empty, false),
+        UserPolicyResponse(resource1.resourceId, AccessPolicyName("in-it"), Set.empty, Set.empty, false)))(r)
     }
   }
 
@@ -295,7 +295,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
       _ <- IO.fromFuture(IO(constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, dummyUserInfo.userId)))
       r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUserInfo.userId)
     } yield {
-      val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, Set.empty, Set.empty))
+      val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, Set.empty, Set.empty, false))
       r shouldBe(expected)
     }
 
@@ -316,7 +316,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
       _ <- IO.fromFuture(IO(constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, dummyUserInfo.userId)))
       r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUserInfo.userId)
     } yield {
-      val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, resource.authDomain, Set.empty))
+      val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, resource.authDomain, Set.empty, false))
       r shouldBe(expected)
     }
 
@@ -340,7 +340,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
       _ <- IO.fromFuture(IO(constrainableService.createPolicy(policy.id, policy.members + user.userId, policy.roles, policy.actions)))
       r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, user.userId)
     } yield {
-      val expected = Set(UserPolicyResponse(resource.resourceId, policy.id.accessPolicyName, resource.authDomain, resource.authDomain))
+      val expected = Set(UserPolicyResponse(resource.resourceId, policy.id.accessPolicyName, resource.authDomain, resource.authDomain, false))
       r shouldBe(expected)
     }
 


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-3796
This PR introduces a flag on a policy that declares it public. When public is set to true all users may perform the roles/actions listed by the policy. This means that list resources, list actions, has permission all recognize public policies. Further, when a public policy is synched to google the all users group is place in the google group.

Security: There is a new resource type: resource_type_admin. When sam starts it automatically creates a resource of type resource_type_admin for every other resource type. This controls at the type level who can set resources to public. For example, we want only comms to be able to make workspaces public but we probably want anybody to be able to make methods public.

In order to make a policy public, a user must have either the set_public or set_public::[policy_name] action on the resource_type_admin resource for the given type *and* have either alter_policies or share::[policy_name] on the give resource.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
