### PR TITLE
add marshaller for IO

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.sam.api
+package org.broadinstitute.dsde.workbench.sam
+package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
@@ -7,7 +8,6 @@ import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
@@ -48,7 +48,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
           withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
             pathEndOrSingleSlash {
               get {
-                complete(policyEvaluatorService.listUserAccessPolicies(resourceType.name, userInfo.userId).unsafeToFuture())
+                complete(policyEvaluatorService.listUserAccessPolicies(resourceType.name, userInfo.userId))
               } ~
               post {
                 entity(as[CreateResourceRequest]) { createResourceRequest =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsBoolean
-
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/api.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/api.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.workbench.sam
+
+import akka.http.scaladsl.marshalling.Marshaller
+import cats.effect.IO
+
+import scala.concurrent.Future
+
+package object api {
+  implicit def ioMarshaller[A, B](implicit m: Marshaller[Future[A], B]): Marshaller[IO[A], B] =
+    Marshaller(implicit ec => (x => m(x.unsafeToFuture())))
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/package.scala
@@ -1,15 +1,10 @@
 package org.broadinstitute.dsde.workbench
 
-import akka.http.scaladsl.marshalling.Marshaller
-import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.ErrorReportSource
-import scala.concurrent.Future
 
 /**
   * Created by dvoet on 5/18/17.
   */
 package object sam {
   implicit val errorReportSource = ErrorReportSource("sam")
-  implicit def ioMarshaller[A, B](implicit m: Marshaller[Future[A], B]): Marshaller[IO[A], B] =
-    Marshaller(implicit ec => (x => m(x.unsafeToFuture())))
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/package.scala
@@ -1,10 +1,15 @@
 package org.broadinstitute.dsde.workbench
 
+import akka.http.scaladsl.marshalling.Marshaller
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.ErrorReportSource
+import scala.concurrent.Future
 
 /**
   * Created by dvoet on 5/18/17.
   */
 package object sam {
   implicit val errorReportSource = ErrorReportSource("sam")
+  implicit def ioMarshaller[A, B](implicit m: Marshaller[Future[A], B]): Marshaller[IO[A], B] =
+    Marshaller(implicit ec => (x => m(x.unsafeToFuture())))
 }


### PR DESCRIPTION
Ticket: no ticket
So that we don't need to `unsafeToFuture` manually all the time.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
