### PR TITLE
revert akkahttp to 10.1.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val akkaV = "2.5.16"
-  val akkaHttpV = "10.1.5"
+  val akkaHttpV = "10.1.3"
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.5.0"
   val scalaTestV    = "3.0.1"


### PR DESCRIPTION
Ticket: No ticket

I tested out akka-http 10.1.3, and I'm seeing newrelic metrics on sam - dev - local, so I think we can downgrade to akka-http 10.1.3 until NR figures out a fix.

https://rpm.newrelic.com/accounts/1862859/applications/194648810/transactions#id=5b225765625472616e73616374696f6e2f416b6b61487474702f2e3f7e2f2e3f222c22225d


cc @hjfbynara  @davidbernick 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
