### PR TITLE
add endpoint for reading the auth domain of a resource

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -73,17 +73,20 @@ resourceTypes = {
       "catalog" = {
         description = "catalog the workspace"
       }
+      "read_auth_domain" = {
+        description = "view the auth domain of the workspace"
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::can-compute", "share_policy::can-catalog"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain"]
       }
       writer = {
-        roleActions = ["read_policy::owner", "write", "read"]
+        roleActions = ["read_policy::owner", "write", "read", "read_auth_domain"]
       }
       reader = {
-        roleActions = ["read_policy::owner", "read"]
+        roleActions = ["read_policy::owner", "read", "read_auth_domain"]
       }
       share-reader = {
         roleActions = ["share_policy::reader"]

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -840,6 +840,39 @@ paths:
       tags:
         - Resources
 
+  /api/resources/v1/{resourceTypeName}/{resourceId}/authDomain:
+    get:
+      summary: List the groups in the Auth Domain for a resource
+      responses:
+        200:
+          description: List of groups that compose the Auth Domain for this resource. Empty if an Auth Domain has not been set
+          schema:
+            type: array
+            items:
+              type: string
+        403:
+          description: You do not have permission to perform this action on the resource
+        404:
+          description: Resource type or resource does not exist or you are not a member of any policy on the resource
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      parameters:
+        - in: path
+          description: Type of resource
+          name: resourceTypeName
+          required: true
+          type: string
+        - in: path
+          description: Id of resource
+          name: resourceId
+          required: true
+          type: string
+      operationId: getAuthDomain
+      tags:
+        - Resources
+
   /api/resources/v1/{resourceTypeName}/{resourceId}/policies:
     get:
       summary: List the policies for a resource

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -117,7 +117,7 @@ paths:
         403:
           description: You do not have admin privileges
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -139,7 +139,7 @@ paths:
         403:
           description: You do not have admin privileges
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -167,7 +167,7 @@ paths:
             items:
               $ref: '#/definitions/ResourceType'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       summary: Lists available resource types
@@ -186,7 +186,7 @@ paths:
             items:
               $ref: '#/definitions/ManagedGroupMembershipEntry'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       operationId: listGroupMemberships
@@ -205,7 +205,7 @@ paths:
         404:
           description: Group could not be found or you do not have the required permissions on this group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -225,7 +225,7 @@ paths:
         409:
           description: Group already exists
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -245,7 +245,7 @@ paths:
         404:
           description: Group could not be found or you do not have the required permissions on this group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -267,7 +267,7 @@ paths:
         404:
           description: Group could not be found or you do not have the required permissions on this group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -287,7 +287,7 @@ paths:
         204:
           description: Successfully set access instructions
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -311,7 +311,7 @@ paths:
         404:
           description: Group could not be found or you do not have the required permissions on this group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -335,7 +335,7 @@ paths:
         404:
           description: Group could not be found or you do not have the required permissions on this group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -361,7 +361,7 @@ paths:
         404:
           description: Group does not exist or you are not a member of the policy for the group
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -399,7 +399,7 @@ paths:
         404:
           description: Group does not exist, policy does not exist, or subject with specified email was not found
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -432,7 +432,7 @@ paths:
         404:
           description: Group does not exist or policy does not exist
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -456,32 +456,6 @@ paths:
       tags:
         - Group
 
-  /api/google/v1/group/{groupName}/sync:
-    post:
-      summary: Synchronize a managed-group with google group
-      responses:
-        200:
-          description: Successfully synchronized group
-          schema:
-            $ref: '#/definitions/SyncReport'
-        404:
-          description: Group could not be found
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        500:
-          description: Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-      parameters:
-        - in: path
-          description: Name of group
-          name: groupName
-          required: true
-          type: string
-      operationId: syncManagedGroup
-      tags:
-        - Google
-
   /api/google/v1/petServiceAccount/{project}/{userEmail}:
     get:
       summary: gets a key for the user's pet service account, get_pet_private_key action on cloud-extension/google required
@@ -499,7 +473,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorReport'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -526,7 +500,7 @@ paths:
           schema:
             type: string
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -546,7 +520,7 @@ paths:
         200:
           description: 'json format key for a pet service account, see https://cloud.google.com/iam/docs/creating-managing-service-account-keys'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       operationId: getArbitraryPetServiceAccountKey
@@ -562,7 +536,7 @@ paths:
           schema:
             type: string
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -583,7 +557,7 @@ paths:
         200:
           description: 'json format key for a pet service account, see https://cloud.google.com/iam/docs/creating-managing-service-account-keys'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -603,7 +577,7 @@ paths:
         204:
           description: 'user pet service account'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -630,7 +604,7 @@ paths:
           schema:
             type: string
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -660,7 +634,7 @@ paths:
         404:
           description: 'user not found'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -682,7 +656,7 @@ paths:
           schema:
             $ref: '#/definitions/SyncReport'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -769,7 +743,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorReport'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -822,7 +796,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorReport'
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -855,7 +829,7 @@ paths:
         404:
           description: Resource type or resource does not exist or you are not a member of any policy on the resource
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -888,7 +862,7 @@ paths:
         404:
           description: Resource type does not exist or you are not a member of any policy on the resource
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -919,7 +893,7 @@ paths:
         404:
           description: Resource type does not exist or you are not a member of any policy on the resource or the policy does not exist
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -951,7 +925,7 @@ paths:
         404:
           description: Resource type does not exist or you are not a member of any policy on the resource
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -993,7 +967,7 @@ paths:
         404:
           description: Resource type does not exist, you are not a member of any policy on the resource, or a member was not found
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1035,7 +1009,7 @@ paths:
         404:
           description: Resource type does not exist, you are not a member of any policy on the resource, or user was not found
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1074,7 +1048,7 @@ paths:
         404:
           description: Resource type does not exist, you are not a member of any policy on the resource, or user was not found
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1115,7 +1089,7 @@ paths:
         404:
           description: Resource type, resource, or policy do not exist
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       operationId: getPolicyPublic
@@ -1131,7 +1105,7 @@ paths:
         404:
           description: Resource type does not exist, you are not a member of any policy on the resource, or user is not permitted to set the public flag on resources of this type
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1173,7 +1147,7 @@ paths:
         404:
           description: Resource type does not exist
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1200,7 +1174,7 @@ paths:
           schema:
             type: boolean
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:
@@ -1236,7 +1210,7 @@ paths:
         404:
           description: User not found
         500:
-          description: Internal Error
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/ErrorReport'
       parameters:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -85,6 +85,17 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                   }
                 }
               } ~
+              pathPrefix("authDomain") {
+                pathEndOrSingleSlash {
+                  get {
+                    requireAction(resource, SamResourceActions.readAuthDomain, userInfo.userId) {
+                      complete(resourceService.loadResourceAuthDomain(resource).map { response =>
+                        StatusCodes.OK -> response
+                      })
+                    }
+                  }
+                }
+              } ~
               pathPrefix("policies") {
                 pathEndOrSingleSlash {
                   get {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -6,14 +6,15 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
+import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsBoolean
+
 import scala.concurrent.ExecutionContext
 import ImplicitConversions.ioOnSuccessMagnet
 
@@ -48,136 +49,65 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
         pathPrefix(Segment) { resourceTypeName =>
           withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
             pathEndOrSingleSlash {
-              get {
-                complete(policyEvaluatorService.listUserAccessPolicies(resourceType.name, userInfo.userId))
-              } ~
-              post {
-                entity(as[CreateResourceRequest]) { createResourceRequest =>
-                  if (resourceType.reuseIds) {
-                    throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow id reuse"))
-                  }
-                  complete(resourceService.createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, userInfo.userId).map(_ => StatusCodes.NoContent))
-                }
-              }
+              getUserPoliciesForResourceType(resourceType, userInfo) ~
+              postResource(resourceType, userInfo)
             } ~
             pathPrefix(Segment) { resourceId =>
-
               val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
 
               pathEndOrSingleSlash {
-                delete {
-                  requireAction(resource, SamResourceActions.delete, userInfo.userId) {
-                    complete(resourceService.deleteResource(FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))).map(_ => StatusCodes.NoContent))
-                  }
-                } ~
-                post {
-                  complete(resourceService.createResource(resourceType, ResourceId(resourceId), userInfo).map(_ => StatusCodes.NoContent))
-                }
+                deleteResource(resource, userInfo) ~
+                postDefaultResource(resourceType, resource, userInfo)
               } ~
               pathPrefix("action") {
                 pathPrefix(Segment) { action =>
                   pathEndOrSingleSlash {
-                    get {
-                      complete(policyEvaluatorService.hasPermission(FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId)), ResourceAction(action), userInfo.userId).map { hasPermission =>
-                        StatusCodes.OK -> JsBoolean(hasPermission)
-                      })
-                    }
+                    getActionPermissionForUser(resource, userInfo, action)
                   }
                 }
               } ~
               pathPrefix("authDomain") {
                 pathEndOrSingleSlash {
-                  get {
-                    requireAction(resource, SamResourceActions.readAuthDomain, userInfo.userId) {
-                      complete(resourceService.loadResourceAuthDomain(resource).map { response =>
-                        StatusCodes.OK -> response
-                      })
-                    }
-                  }
+                  getResourceAuthDomain(resource, userInfo)
                 }
               } ~
               pathPrefix("policies") {
                 pathEndOrSingleSlash {
-                  get {
-                    requireAction(resource, SamResourceActions.readPolicies, userInfo.userId) {
-                      complete(resourceService.listResourcePolicies(FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))).map { response =>
-                        StatusCodes.OK -> response
-                      })
-                    }
-                  }
+                  getResourcePolicies(resource, userInfo)
                 } ~
-                  pathPrefix(Segment) { policyName =>
-                    val resourceAndPolicyName =
-                      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId)), AccessPolicyName(policyName))
+                pathPrefix(Segment) { policyName =>
+                  val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
+
+                  pathEndOrSingleSlash {
+                    getPolicy(policyId, userInfo) ~
+                    putPolicyOverwrite(resourceType, policyId, userInfo)
+                  } ~
+                  pathPrefix("memberEmails") {
                     pathEndOrSingleSlash {
-                      get {
-                        requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                          complete(resourceService.loadResourcePolicy(resourceAndPolicyName).map {
-                            case Some(response) => StatusCodes.OK -> response
-                            case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found"))
-                          })
-                        }
-                      } ~
-                      put {
-                        requireAction(resource, SamResourceActions.alterPolicies, userInfo.userId) {
-                          entity(as[AccessPolicyMembership]) { membershipUpdate =>
-                            complete(resourceService.overwritePolicy(resourceType, AccessPolicyName(policyName), FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId)), membershipUpdate).map(_ => StatusCodes.Created))
-                          }
-                        }
-                      }
+                      putPolicyMembershipOverwrite(resourceType, policyId, userInfo)
                     } ~
-                    pathPrefix("memberEmails") {
-                      pathEndOrSingleSlash {
-                        put {
-                          requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(AccessPolicyName(policyName))), userInfo.userId) {
-                            entity(as[Set[WorkbenchEmail]]) { membersList =>
-                              complete(resourceService.overwritePolicyMembers(resourceType, AccessPolicyName(policyName), FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId)), membersList).map(_ => StatusCodes.NoContent))
-                            }
-                          }
-                        }
-                      } ~
-                      pathPrefix(Segment) { email =>
-                        withSubject(WorkbenchEmail(email)) { subject =>
-                          pathEndOrSingleSlash {
-                            requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                              put {
-                                complete(resourceService.addSubjectToPolicy(resourceAndPolicyName, subject).map(_ => StatusCodes.NoContent))
-                              } ~
-                              delete {
-                                complete(resourceService.removeSubjectFromPolicy(resourceAndPolicyName, subject).map(_ => StatusCodes.NoContent))
-                              }
-                            }
-                          }
-                        }
-                      }
-                    } ~
-                    pathPrefix("public") {
-                      pathEndOrSingleSlash {
-                        get {
-                          requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                            complete(resourceService.isPublic(resourceAndPolicyName))
-                          }
-                        } ~
-                        put {
-                          requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                            requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType.name.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(resourceAndPolicyName.accessPolicyName)), userInfo.userId) {
-                              entity(as[Boolean]) { isPublic =>
-                                complete(resourceService.setPublic(resourceAndPolicyName, isPublic).map(_ => StatusCodes.NoContent))
-                              }
-                            }
+                    pathPrefix(Segment) { email =>
+                      withSubject(WorkbenchEmail(email)) { subject =>
+                        pathEndOrSingleSlash {
+                          requireOneOfAction(resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId) {
+                            putUserInPolicy(policyId, subject) ~
+                            deleteUserFromPolicy(policyId, subject)
                           }
                         }
                       }
                     }
+                  } ~
+                  pathPrefix("public") {
+                    pathEndOrSingleSlash {
+                      getPublicFlag(policyId, userInfo) ~
+                      putPublicFlag(policyId, userInfo)
+                    }
                   }
+                }
               } ~
               pathPrefix("roles") {
                 pathEndOrSingleSlash {
-                  get {
-                    complete(resourceService.listUserResourceRoles(FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId)), userInfo).map { roles =>
-                      StatusCodes.OK -> roles
-                    })
-                  }
+                  getUserResourceRoles(resource, userInfo)
                 }
               }
             }
@@ -185,4 +115,134 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
         }
       }
     }
+
+  def getUserPoliciesForResourceType(resourceType: ResourceType, userInfo: UserInfo): server.Route = {
+    get {
+      complete(policyEvaluatorService.listUserAccessPolicies(resourceType.name, userInfo.userId))
+    }
+  }
+
+  def postResource(resourceType: ResourceType, userInfo: UserInfo): server.Route = {
+    post {
+      entity(as[CreateResourceRequest]) { createResourceRequest =>
+        if (resourceType.reuseIds) {
+          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow id reuse"))
+        }
+        complete(resourceService.createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, userInfo.userId).map(_ => StatusCodes.NoContent))
+      }
+    }
+  }
+
+  def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route = {
+    delete {
+      requireAction(resource, SamResourceActions.delete, userInfo.userId) {
+        complete(resourceService.deleteResource(resource).map(_ => StatusCodes.NoContent))
+      }
+    }
+  }
+
+  def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route = {
+    post {
+      complete(resourceService.createResource(resourceType, resource.resourceId, userInfo).map(_ => StatusCodes.NoContent))
+    }
+  }
+
+  def getActionPermissionForUser(resource: FullyQualifiedResourceId, userInfo: UserInfo, action: String): server.Route = {
+    get {
+      complete(policyEvaluatorService.hasPermission(resource, ResourceAction(action), userInfo.userId).map { hasPermission =>
+        StatusCodes.OK -> JsBoolean(hasPermission)
+      })
+    }
+  }
+
+  def getResourceAuthDomain(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route = {
+    get {
+      requireAction(resource, SamResourceActions.readAuthDomain, userInfo.userId) {
+        complete(resourceService.loadResourceAuthDomain(resource).map { response =>
+          StatusCodes.OK -> response
+        })
+      }
+    }
+  }
+
+  def getResourcePolicies(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route = {
+    get {
+      requireAction(resource, SamResourceActions.readPolicies, userInfo.userId) {
+        complete(resourceService.listResourcePolicies(resource).map { response =>
+          StatusCodes.OK -> response
+        })
+      }
+    }
+  }
+
+  def getPolicy(policyId: FullyQualifiedPolicyId, userInfo: UserInfo): server.Route = {
+    get {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.userId) {
+        complete(resourceService.loadResourcePolicy(policyId).map {
+          case Some(response) => StatusCodes.OK -> response
+          case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found"))
+        })
+      }
+    }
+  }
+
+  def putPolicyOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: UserInfo): server.Route = {
+    put {
+      requireAction(policyId.resource, SamResourceActions.alterPolicies, userInfo.userId) {
+        entity(as[AccessPolicyMembership]) { membershipUpdate =>
+          complete(resourceService.overwritePolicy(resourceType, policyId.accessPolicyName, policyId.resource, membershipUpdate).map(_ => StatusCodes.Created))
+        }
+      }
+    }
+  }
+
+  def putPolicyMembershipOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: UserInfo): server.Route = {
+    put {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId) {
+        entity(as[Set[WorkbenchEmail]]) { membersList =>
+          complete(resourceService.overwritePolicyMembers(resourceType, policyId.accessPolicyName, policyId.resource, membersList).map(_ => StatusCodes.NoContent))
+        }
+      }
+    }
+  }
+
+  def putUserInPolicy(policyId: FullyQualifiedPolicyId, subject: WorkbenchSubject): server.Route = {
+    put {
+      complete(resourceService.addSubjectToPolicy(policyId, subject).map(_ => StatusCodes.NoContent))
+    }
+  }
+
+  def deleteUserFromPolicy(policyId: FullyQualifiedPolicyId, subject: WorkbenchSubject): server.Route = {
+    delete {
+      complete(resourceService.removeSubjectFromPolicy(policyId, subject).map(_ => StatusCodes.NoContent))
+    }
+  }
+
+  def getPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: UserInfo): server.Route = {
+    get {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.userId) {
+        complete(resourceService.isPublic(policyId))
+      }
+    }
+  }
+
+  def putPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: UserInfo): server.Route = {
+    put {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId) {
+        requireOneOfAction(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(policyId.resource.resourceTypeName.value)), Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(policyId.accessPolicyName)), userInfo.userId) {
+          entity(as[Boolean]) { isPublic =>
+            complete(resourceService.setPublic(policyId, isPublic).map(_ => StatusCodes.NoContent))
+          }
+        }
+      }
+    }
+  }
+
+  def getUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route = {
+    get {
+      complete(resourceService.listUserResourceRoles(resource, userInfo).map { roles =>
+        StatusCodes.OK -> roles
+      })
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -74,6 +74,7 @@ object SamResourceActions {
   val notifyAdmins = ResourceAction("notify_admins")
   val setAccessInstructions = ResourceAction("set_access_instructions")
   val setPublic = ResourceAction("set_public")
+  val readAuthDomain = ResourceAction("read_auth_domain")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -36,7 +36,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
   }
 
   override def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[Set[WorkbenchGroupName]] = IO.fromEither(resources.get(resource)
-    .toRight(new Exception(s"no resource $resource found in mock policy dao $resources")).map(_.authDomain))
+    .toRight(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"no resource $resource found in mock policy dao $resources"))).map(_.authDomain))
 
   override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]] = IO.pure(Set.empty)
 


### PR DESCRIPTION
Ticket: [GAWB-3925](https://broadinstitute.atlassian.net/browse/GAWB-3925)
- this endpoint takes in a resource and returns the auth domain of that resource

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
