### PR TITLE
GAWB-3947: update serviceTest version to get bugfixes [risk: low]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.12-db13bb0"
   val workbenchGoogleV = "0.16-847c3ff"
-  val workbenchServiceTestV = "0.13-db13bb0"
+  val workbenchServiceTestV = "0.13-dc0998e"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)


### PR DESCRIPTION
Ticket: GAWB-3947

update serviceTest version in automation, to pick up this bugfix from workbench-libs:

> bugfix: BillingFixtures.claimGPAllocProject now uses the proper OAuth scopes in the case where GPAlloc did not return a project and therefore the calling test needs to create one on the fly.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
