### PR TITLE
Introduced MockitoSafety to allow mockito mocks to be test instance values

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -21,7 +21,8 @@ import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, MockAccess
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.scalatest.prop.{Configuration, PropertyChecks}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest, Suite}
+import org.scalatest.mockito.MockitoSugar
 import StandardUserInfoDirectives._
 import cats.kernel.Eq
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -106,3 +107,11 @@ object TestSupport extends TestSupport{
 }
 
 final case class SamDependencies(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, directoryDAO: MockDirectoryDAO, policyDao: AccessPolicyDAO, val cloudExtensions: CloudExtensions)
+
+/**
+  * Convenience mash-up of MockitoSugar and OneInstancePerTest. Mockito mocks are stateful and
+  * therefore must not be shared between tests. Using OneInstancePerTest creates test case isolation
+  * whice allowing mocks to be instance variables as opposed to the extra ceremony of fixture
+  * factory functions.
+  */
+trait MockitoSafety extends MockitoSugar with OneInstancePerTest { self: Suite => }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, NoExtensions, StatusService, UserService}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.Future
@@ -165,7 +164,7 @@ class UserRoutesSpec extends UserRoutesSpecHelper {
   }
 }
 
-trait UserRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport{
+trait UserRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSafety with TestSupport{
   val defaultUserId = WorkbenchUserId("newuser")
   val defaultUserEmail = WorkbenchEmail("newuser@new.com")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -19,7 +19,6 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -235,7 +234,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
   }
 }
 
-trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
+trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSafety {
   val defaultUserId = genWorkbenchUserId(System.currentTimeMillis())
   val defaultUserEmail = genNonPetEmail.sample.get
   /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -28,7 +28,6 @@ import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, PrivateMethodTester}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.blockingEc
 import cats.effect.IO
@@ -39,7 +38,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Success, Try}
 
-class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
+class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSafety with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, Wor
 import org.broadinstitute.dsde.workbench.sam.{TestSupport, _}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
 
@@ -18,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import spray.json._
 
-class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with BeforeAndAfterAll with Eventually {
+class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSafety with BeforeAndAfterAll with Eventually {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{MockitoSafety, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.config._
 import org.broadinstitute.dsde.workbench.sam.directory.LdapDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
@@ -19,7 +19,6 @@ import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.mockito.Mockito.{verify, when}
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -27,7 +26,7 @@ import scala.concurrent.Future
 /**
   * Created by gpolumbo on 2/21/2018
   */
-class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSugar
+class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSafety
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures with OptionValues {
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 import TestSupport.eqWorkbenchExceptionErrorReport
 import cats.kernel.Eq
@@ -33,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * Created by rtitle on 10/6/17.
   */
-class UserServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSugar
+class UserServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSafety
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
 
   override implicit val patienceConfig = PatienceConfig(timeout = scaled(5.seconds))


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-3432

This may or may not be a solution for GAWB-3432. I didn't read the details of the ticket... it was just mentioned as a "flaky test" ticket and this PR helps with flaky test behavior I was experiencing. The flakiness may or not be the same so someone with more knowledge should check before closing the ticket.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
