### PR TITLE
Add entity-collection resource type

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -358,4 +358,36 @@ resourceTypes = {
     reuseIds = true
 
   }
+  entity-collection = {
+    actionPatternObjects = {
+      "delete" = {
+        description = "delete this entity collection"
+      },
+      "write" = {
+        description = "create/update/delete entities in this collection"
+      },
+      "read" = {
+        description = "read entities in this collection"
+      },
+      "alter_policies" = {
+        description = "alter entity collection policies"
+      },
+      "read_policies" = {
+        description = "read entity collection policies"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "write", "read", "alter_policies", "read_policies"]
+      },
+      writer = {
+        roleActions = ["write", "read"]
+      },
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = false
+  }
 }

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -72,8 +72,8 @@ object Generator {
     email <- genNonPetEmail
   } yield BasicWorkbenchGroup(id, subject, email)
 
-  val genResourceTypeName: Gen[ResourceTypeName] = Gen.oneOf("workspace", "managed-group", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool").map(ResourceTypeName.apply)
-  val genResourceTypeNameExcludeManagedGroup: Gen[ResourceTypeName] = Gen.oneOf("workspace", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool").map(ResourceTypeName.apply)
+  val genResourceTypeName: Gen[ResourceTypeName] = Gen.oneOf("workspace", "managed-group", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool", "entity-collection").map(ResourceTypeName.apply)
+  val genResourceTypeNameExcludeManagedGroup: Gen[ResourceTypeName] = Gen.oneOf("workspace", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool", "entity-collection").map(ResourceTypeName.apply)
   val genResourceId : Gen[ResourceId] = Gen.uuid.map(x => ResourceId(x.toString))
   val genAccessPolicyName : Gen[AccessPolicyName] = Gen.oneOf("member", "admin", "admin-notifier").map(AccessPolicyName.apply) //there might be possible values
   def genAuthDomains: Gen[Set[WorkbenchGroupName]] = Gen.listOfN[ResourceId](3, genResourceId).map(x => x.map(v => WorkbenchGroupName(v.value)).toSet) //make it a list of 3 items so that unit test won't time out


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-3755

@dvoet, you'd suggested something a little more complicated to (I think) help protect FC-created entity collection resource policies from being tampered outside of FC. I've chosen here to focus on potential use outside of FC which means being more permissive (and leaves FC somewhat prone to people going behind the curtain and tinkering). Let me know if you have other opinions/suggestions.

What is my responsibility for testing this? I didn't see much for other collection types.

Also, I'm not sure who else to add to this PR. @dvoet, please nominate someone if your care or if nobody volunteers.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
