### PR TITLE
update swagger docs with list all resource users endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -847,6 +847,39 @@ paths:
       tags:
         - Resources
 
+  /api/resources/v1/{resourceTypeName}/{resourceId}/allUsers:
+    get:
+      summary: List all of the members of a resource
+      responses:
+        200:
+          description: List of users in all policies on this resource
+          schema:
+            type: array
+            items:
+              type: string
+        403:
+          description: You do not have permission to perform this action on the resource
+        404:
+          description: Resource type or resource does not exist or you are not a member of any policy on the resource
+        500:
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      parameters:
+      - in: path
+        description: Type of resource
+        name: resourceTypeName
+        required: true
+        type: string
+      - in: path
+        description: Id of resource
+        name: resourceId
+        required: true
+        type: string
+      operationId: getAllResourceUsers
+      tags:
+      - Resources
+
   /api/resources/v1/{resourceTypeName}/{resourceId}/policies:
     get:
       summary: List the policies for a resource


### PR DESCRIPTION
Ticket: [GAWB-3926](https://broadinstitute.atlassian.net/browse/GAWB-3926)
This should have been included with the [original PR](https://github.com/broadinstitute/sam/pull/232), but I forgot to add it so this just updates the swagger docs with details for the list all resource users endpoint that was added in the previously linked PR.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
