### PR TITLE
policy sync automation tests

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val workbenchModelV  = "0.12-8bf4279-SNAP"
+  val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.16-847c3ff"
-  val workbenchServiceTestV = "0.13-dc0998e"
+  val workbenchServiceTestV = "0.15-7e86fba"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val workbenchModelV  = "0.12-fe70cc3-SNAP"
+  val workbenchModelV  = "0.12-8bf4279-SNAP"
   val workbenchGoogleV = "0.16-847c3ff"
   val workbenchServiceTestV = "0.13-dc0998e"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val workbenchModelV  = "0.12-d8462bf-SNAP"
+  val workbenchModelV  = "0.12-fe70cc3-SNAP"
   val workbenchGoogleV = "0.16-847c3ff"
   val workbenchServiceTestV = "0.13-dc0998e"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val workbenchModelV  = "0.12-db13bb0"
+  val workbenchModelV  = "0.12-d8462bf-SNAP"
   val workbenchGoogleV = "0.16-847c3ff"
   val workbenchServiceTestV = "0.13-dc0998e"
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -516,7 +516,7 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
       // create default resource                               POST /api/resources/v1/{resourceTypeName}/{resourceId} // alternatively, just use the other resource creation endpoint
       // set resource/specific policy to be public             PUT  /api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/public
       // synchronize that policy or resource with google       POST /api/google/v1/resource/{resourceTypeName}/{resourceId}/{policyName}/sync
-      // check that google knows about the all users group... honestly not sure what this will look like... just the group's email? probably
+      // check that google knows about the all users group... honestly not sure what this will look like... just the group's email? can figure out based on test failure
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -17,12 +17,11 @@ import spray.json.JsBoolean
 
 import scala.concurrent.ExecutionContext
 import ImplicitConversions.ioOnSuccessMagnet
-import com.typesafe.scalalogging.LazyLogging
 
 /**
   * Created by mbemis on 5/22/17.
   */
-trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives with LazyLogging {
+trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives {
   implicit val executionContext: ExecutionContext
   val resourceService: ResourceService
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -131,7 +131,6 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   def postResource(resourceType: ResourceType, userInfo: UserInfo): server.Route = {
     post {
       entity(as[CreateResourceRequest]) { createResourceRequest =>
-        logger.info(s"From Sam, CREATE RESOURCE REQUEST: $createResourceRequest")
         if (resourceType.reuseIds) {
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow id reuse"))
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -17,11 +17,12 @@ import spray.json.JsBoolean
 
 import scala.concurrent.ExecutionContext
 import ImplicitConversions.ioOnSuccessMagnet
+import com.typesafe.scalalogging.LazyLogging
 
 /**
   * Created by mbemis on 5/22/17.
   */
-trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives {
+trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives with LazyLogging {
   implicit val executionContext: ExecutionContext
   val resourceService: ResourceService
 
@@ -130,6 +131,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   def postResource(resourceType: ResourceType, userInfo: UserInfo): server.Route = {
     post {
       entity(as[CreateResourceRequest]) { createResourceRequest =>
+        logger.info(s"From Sam, CREATE RESOURCE REQUEST: $createResourceRequest")
         if (resourceType.reuseIds) {
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow id reuse"))
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
@@ -14,7 +14,7 @@ trait ValueObject {
 case class ValueObjectFormat[T <: ValueObject](create: String => T) extends RootJsonFormat[T] {
   def read(obj: JsValue): T = obj match {
     case JsString(value) => create(value)
-    case _ => throw new DeserializationException("could not deserialize user object")
+    case _ => throw new DeserializationException(s"could not deserialize value object: $obj")
   }
 
   def write(obj: T): JsValue = JsString(obj.value)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
@@ -14,7 +14,7 @@ trait ValueObject {
 case class ValueObjectFormat[T <: ValueObject](create: String => T) extends RootJsonFormat[T] {
   def read(obj: JsValue): T = obj match {
     case JsString(value) => create(value)
-    case _ => throw new DeserializationException(s"could not deserialize value object: $obj")
+    case _ => throw new DeserializationException(s"could not deserialize value object $obj")
   }
 
   def write(obj: T): JsValue = JsString(obj.value)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -22,7 +22,7 @@ class PolicyEvaluatorService(
       Set.empty,
       WorkbenchEmail(s"dummy@$emailDomain"),
       Set.empty,
-      Set(SamResourceActions.setPublicPolicy(policyName)),
+      Set(SamResourceActions.setPublicPolicy(ManagedGroupService.adminNotifierPolicyName)),
       true
     )).void.recoverWith{
       case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>


### PR DESCRIPTION
Ticket: [GAWB-3963](https://broadinstitute.atlassian.net/browse/GAWB-3963)
automation tests
1. Test that the intersection group is synced in Google for policies constrained by an auth domain
2. Test that the all users group is synced in google for public policies

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
