### PR TITLE
GAWB-3987  opendj container cleanup

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -96,11 +96,13 @@ function make_jar()
     GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
 
     # make jar.  cache sbt dependencies.
+    set +e # Turn off error detection so that opendj has a chance to get stopped before exiting
     docker run --rm --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/init_schema.sh /working
     docker restart $OPENDJ
     sleep 40
     docker run --rm --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/install.sh /working
     EXIT_CODE=$?
+    set -e # Turn error detection back on for the rest of the script
 
     bash ./docker/run-opendj.sh stop jenkins $OPENDJ
 


### PR DESCRIPTION
Ticket: [GAWB-3987](https://broadinstitute.atlassian.net/browse/GAWB-3987)
The logic for making the jar depends on the fact that the script will NOT immediately exit when a command returns a non-zero value.  However, at the top of the script, `set -e` is called which will ensure that the script fails immediately when a non-zero value is returned.  Updated the script to turn off error detection (`set +e`) around the commands for which we need to cleanup if they return a non-zero value.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
