### PR TITLE
more Future to IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ crashlytics-build.properties
 ### Automation things
 automation/report.xml
 
+newrelic-agent-4.6.0.jar

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val workbenchGoogleV = "0.16-0245949"
   val workbenchNotificationsV = "0.1-f2a0020"
   val monocleVersion = "1.5.1-cats"
+  val newRelicVersion = "4.6.0"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
@@ -21,6 +22,7 @@ object Dependencies {
   val excludeWorkbenchGoogle =  ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.12")
 
   val catseffect: ModuleID =  "org.typelevel" %% "cats-effect" % "1.0.0" //TODO: remove this once workbenchGoogleV is upgrade
+  val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % newRelicVersion
 
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
   val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV
@@ -81,6 +83,7 @@ object Dependencies {
     catseffect,
     monocle,
     monocleMacro,
+    newRelic,
 
     scalaTest,
     mockito,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -115,7 +115,7 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
   private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: UserInfo): Route = {
     requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), userInfo.userId) {
       complete(
-        managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName).map(StatusCodes.OK -> _)
+        managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName).map(x => StatusCodes.OK -> x.toSet)
       )
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -174,7 +174,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     get {
       requireAction(resource, SamResourceActions.readPolicies, userInfo.userId) {
         complete(resourceService.listResourcePolicies(resource).map { response =>
-          StatusCodes.OK -> response
+          StatusCodes.OK -> response.toSet
         })
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -57,10 +57,10 @@ trait DirectoryDAO {
   def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId):IO[Option[WorkbenchUser]]
   def createPetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount]
   def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Option[PetServiceAccount]]
-  def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): Future[Unit]
+  def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Unit]
   def getAllPetServiceAccountsForUser(userId: WorkbenchUserId): Future[Seq[PetServiceAccount]]
   def updatePetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount]
-  def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName): Future[Option[String]]
+  def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName): IO[Option[String]]
   def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String): IO[Unit]
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -15,9 +15,9 @@ import scala.concurrent.Future
 trait DirectoryDAO {
   def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String] = None): IO[BasicWorkbenchGroup]
   def loadGroup(groupName: WorkbenchGroupName): IO[Option[BasicWorkbenchGroup]]
-  def loadGroups(groupNames: Set[WorkbenchGroupName]): Future[Seq[BasicWorkbenchGroup]]
-  def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]]
-  def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): Future[Seq[(WorkbenchGroupName, WorkbenchEmail)]]
+  def loadGroups(groupNames: Set[WorkbenchGroupName]): IO[Stream[BasicWorkbenchGroup]]
+  def loadGroupEmail(groupName: WorkbenchGroupName): IO[Option[WorkbenchEmail]]
+  def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): IO[Stream[(WorkbenchGroupName, WorkbenchEmail)]]
   def deleteGroup(groupName: WorkbenchGroupName): Future[Unit]
 
   /**
@@ -34,8 +34,8 @@ trait DirectoryDAO {
   def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): Future[Option[WorkbenchEmail]]
 
   def loadSubjectFromEmail(email: WorkbenchEmail): IO[Option[WorkbenchSubject]]
-  def loadSubjectEmail(subject: WorkbenchSubject): Future[Option[WorkbenchEmail]]
-  def loadSubjectEmails(subjects: Set[WorkbenchSubject]): Future[Set[WorkbenchEmail]]
+  def loadSubjectEmail(subject: WorkbenchSubject): IO[Option[WorkbenchEmail]]
+  def loadSubjectEmails(subjects: Set[WorkbenchSubject]): IO[Stream[WorkbenchEmail]]
   def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId): IO[Option[WorkbenchSubject]]
 
   def createUser(user: WorkbenchUser): IO[WorkbenchUser]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -1,4 +1,5 @@
-package org.broadinstitute.dsde.workbench.sam.google
+package org.broadinstitute.dsde.workbench.sam
+package google
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
@@ -7,7 +8,7 @@ import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUser}
-import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.sam.api.ioMarshaller
 import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SecurityDirectives, UserInfoDirectives}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -197,7 +197,7 @@ class GoogleExtensions(directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPo
     for {
       _ <- withProxyEmail(userId) { googleDirectoryDAO.deleteGroup }
       _ <- forAllPets(userId) { pet => googleIamDAO.removeServiceAccount(pet.id.project, toAccountName(pet.serviceAccount.email)) }
-      _ <- forAllPets(userId) { pet => directoryDAO.deletePetServiceAccount(pet.id) }
+      _ <- forAllPets(userId) { pet => directoryDAO.deletePetServiceAccount(pet.id).unsafeToFuture() }
     } yield ()
   }
 
@@ -209,19 +209,19 @@ class GoogleExtensions(directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPo
   def createUserPetServiceAccount(user: WorkbenchUser): Future[PetServiceAccount] = createUserPetServiceAccount(user, petServiceAccountConfig.googleProject)
 
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
-  def deleteUserPetServiceAccount(userId: WorkbenchUserId): Future[Boolean] = deleteUserPetServiceAccount(userId, petServiceAccountConfig.googleProject)
+  def deleteUserPetServiceAccount(userId: WorkbenchUserId): Future[Boolean] = deleteUserPetServiceAccount(userId, petServiceAccountConfig.googleProject).unsafeToFuture() //TODO: shall we delete these deprecated methods
 
-  def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): Future[Boolean] = {
+  def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): IO[Boolean] = {
     for {
-      maybePet <- directoryDAO.loadPetServiceAccount(PetServiceAccountId(userId, project)).unsafeToFuture()
+      maybePet <- directoryDAO.loadPetServiceAccount(PetServiceAccountId(userId, project))
       deletedSomething <- maybePet match {
         case Some(pet) =>
           for {
             _ <- directoryDAO.deletePetServiceAccount(PetServiceAccountId(userId, project))
-            _ <- googleIamDAO.removeServiceAccount(project, toAccountName(pet.serviceAccount.email))
+            _ <- IO.fromFuture(IO(googleIamDAO.removeServiceAccount(project, toAccountName(pet.serviceAccount.email))))
           } yield true
 
-        case  None => Future.successful(false) // didn't find the pet, nothing to delete
+        case  None => IO.pure(false) // didn't find the pet, nothing to delete
       }
     } yield deletedSomething
   }
@@ -376,7 +376,7 @@ class GoogleExtensions(directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPo
     // disable the pet service account
       _ <- disablePetServiceAccount(petServiceAccount)
       // remove the LDAP record for the pet service account
-      _ <- directoryDAO.deletePetServiceAccount(petServiceAccount.id)
+      _ <- directoryDAO.deletePetServiceAccount(petServiceAccount.id).unsafeToFuture()
       // remove the service account itself in Google
       _ <- googleIamDAO.removeServiceAccount(petServiceAccountConfig.googleProject, toAccountName(petServiceAccount.serviceAccount.email))
     } yield ()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -458,13 +458,13 @@ class GoogleExtensions(directoryDAO: DirectoryDAO, val accessPolicyDAO: AccessPo
           case Some(members) => Future.successful(members.map(_.toLowerCase).toSet)
         }
         samMemberEmails <- Future.traverse(members) {
-          case group: WorkbenchGroupIdentity => directoryDAO.loadSubjectEmail(group)
+          case group: WorkbenchGroupIdentity => directoryDAO.loadSubjectEmail(group).unsafeToFuture()
 
           // use proxy group email instead of user's actual email
           case userSubjectId: WorkbenchUserId => getUserProxy(userSubjectId)
 
           // not sure why this next case would happen but if a petSA is in a group just use its email
-          case petSA: PetServiceAccountId => directoryDAO.loadSubjectEmail(petSA)
+          case petSA: PetServiceAccountId => directoryDAO.loadSubjectEmail(petSA).unsafeToFuture()
         }.map(_.collect { case Some(email) => email.value.toLowerCase })
 
         toAdd = samMemberEmails -- googleMemberEmails

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -24,7 +24,7 @@ trait AccessPolicyDAO {
   def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listResourceWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]]
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]]
-  def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]]
+  def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]]
   def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]]
   def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -210,8 +210,8 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     }
   } yield accessPolicies.getOrElse(Set.empty)
 
-  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUserId]] = executeLdap(
-    IO(ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(policyId)))(unmarshalUser).map(_.id).toSet)
+  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]] = executeLdap(
+    IO(ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(policyId)))(unmarshalUser).toSet)
   )
 
   private def unmarshalUser(entry: Entry): WorkbenchUser = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -185,8 +185,8 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
         )(unmarshalAccessPolicy)))
   }
 
-  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]] = cs.evalOn(ecForLdapBlockingIO)(IO(
-    ldapSearchStream(resourceDn(resource), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.policy))(unmarshalAccessPolicy).toSet
+  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = cs.evalOn(ecForLdapBlockingIO)(IO(
+    ldapSearchStream(resourceDn(resource), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.policy))(unmarshalAccessPolicy)
   ))
 
   override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -23,7 +23,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
 
   override def createResourceType(resourceTypeName: ResourceTypeName): IO[ResourceTypeName] = {
     for{
-      _ <- cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.add(resourceTypeDn(resourceTypeName),
+      _ <- executeLdap(IO(ldapConnectionPool.add(resourceTypeDn(resourceTypeName),
         new Attribute("objectclass", List("top", ObjectClass.resourceType).asJava),
         new Attribute(Attr.ou, "resources"))
       )).void.recover{
@@ -38,7 +38,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
       new Attribute(Attr.resourceType, resource.resourceTypeName.value)
     ) ++ maybeAttribute(Attr.authDomain, resource.authDomain.map(_.value))
 
-    cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.add(resourceDn(FullyQualifiedResourceId(resource.resourceTypeName, resource.resourceId)), attributes.asJava))).recoverWith{
+    executeLdap(IO(ldapConnectionPool.add(resourceDn(FullyQualifiedResourceId(resource.resourceTypeName, resource.resourceId)), attributes.asJava))).recoverWith{
       case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "A resource of this type and name already exists")))
     }.map(_ => resource)
@@ -48,7 +48,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
   override def deleteResource(resource: FullyQualifiedResourceId): IO[Unit] = IO(ldapConnectionPool.delete(resourceDn(resource)))
 
   override def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[Set[WorkbenchGroupName]] = {
-    cs.evalOn(ecForLdapBlockingIO)((IO(Option(ldapConnectionPool.getEntry(resourceDn(resource)))))).flatMap {
+    executeLdap((IO(Option(ldapConnectionPool.getEntry(resourceDn(resource)))))).flatMap {
       case None =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Resource $resource not found")))
       case Some(r) =>
@@ -67,7 +67,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
   }
 
   override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]] = for {
-    res <- cs.evalOn(ecForLdapBlockingIO)(IO(ldapSearchStream(resourcesOu, SearchScope.SUB, Filter.createEqualityFilter(Attr.authDomain, groupId.toString))(unmarshalResource)))
+    res <- executeLdap(IO(ldapSearchStream(resourcesOu, SearchScope.SUB, Filter.createEqualityFilter(Attr.authDomain, groupId.toString))(unmarshalResource)))
     r <- res.parSequence.fold(err => IO.raiseError(new WorkbenchException(err)), r => IO.pure(r.toSet))
   } yield r
 
@@ -85,7 +85,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
       maybeAttribute(Attr.uniqueMember, policy.members.map(subjectDn)) :+
       new Attribute(Attr.public, policy.public.toString)
 
-    cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.add(policyDn(
+    executeLdap(IO(ldapConnectionPool.add(policyDn(
       FullyQualifiedPolicyId(
         FullyQualifiedResourceId(policy.id.resource.resourceTypeName, policy.id.resource.resourceId), policy.id.accessPolicyName)), attributes.asJava)).map(_ => policy))
   }
@@ -95,12 +95,12 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     case _ => Option(new Attribute(attr, values.asJava))
   }
 
-  override def deletePolicy(policy: FullyQualifiedPolicyId): IO[Unit] = cs.evalOn(ecForLdapBlockingIO)(IO(
+  override def deletePolicy(policy: FullyQualifiedPolicyId): IO[Unit] = executeLdap(IO(
     ldapConnectionPool.delete(policyDn(policy))))
 
-  override def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Option[AccessPolicy]] = cs.evalOn(ecForLdapBlockingIO) {
+  override def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Option[AccessPolicy]] = executeLdap(
     IO(Option(ldapConnectionPool.getEntry(policyDn(resourceAndPolicyName))).map(unmarshalAccessPolicy))
-  }
+  )
 
   private def unmarshalAccessPolicy(entry: Entry): AccessPolicy = {
     val policyName = getAttribute(entry, Attr.policy).get
@@ -121,7 +121,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val memberMod = new Modification(ModificationType.REPLACE, Attr.uniqueMember, memberList.map(subjectDn).toArray:_*)
     val dateMod = new Modification(ModificationType.REPLACE, Attr.groupUpdatedTimestamp, formattedDate(new Date()))
 
-    cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.modify(policyDn(id), memberMod, dateMod)))
+    executeLdap(IO(ldapConnectionPool.modify(policyDn(id), memberMod, dateMod)))
   }
 
   override def overwritePolicy(newPolicy: AccessPolicy): IO[AccessPolicy] = {
@@ -133,13 +133,13 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
 
     val ridPolicyName = FullyQualifiedPolicyId(
       FullyQualifiedResourceId(newPolicy.id.resource.resourceTypeName, newPolicy.id.resource.resourceId), newPolicy.id.accessPolicyName)
-    cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.modify(policyDn(ridPolicyName), memberMod, actionMod, roleMod, dateMod, publicMod))) *> newPolicy.pure[IO]
+    executeLdap(IO(ldapConnectionPool.modify(policyDn(ridPolicyName), memberMod, actionMod, roleMod, dateMod, publicMod))) *> newPolicy.pure[IO]
   }
 
   override def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]] = {
     for{
       policyDnPattern <- IO(dnMatcher(Seq(Attr.policy, Attr.resourceId), resourceTypeDn(resourceTypeName)))
-      entry <- cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.getEntry(userDn(userId), Attr.memberOf)))
+      entry <- executeLdap(IO(ldapConnectionPool.getEntry(userDn(userId), Attr.memberOf)))
     } yield {
       val groupDns = Option(entry).flatMap(e => Option(getAttributes(e, Attr.memberOf))).getOrElse(Set.empty)
       groupDns.collect{case policyDnPattern(policyName, resourceId) => ResourceIdAndPolicyName(ResourceId(resourceId), AccessPolicyName(policyName))}
@@ -154,7 +154,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
           ).asJava)).toSeq
 
     for{
-      stream <- cs.evalOn(ecForLdapBlockingIO)(IO(ldapSearchStream(resourceTypeDn(resourceTypeName), SearchScope.ONE, filters:_*)(et => unmarshalResourceAuthDomain(et, resourceTypeName))))
+      stream <- executeLdap(IO(ldapSearchStream(resourceTypeDn(resourceTypeName), SearchScope.ONE, filters:_*)(et => unmarshalResourceAuthDomain(et, resourceTypeName))))
       res <- IO.fromEither(stream.parSequence.leftMap(s => new WorkbenchException(s)))
     } yield res.toSet
   }
@@ -174,7 +174,7 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
   )
 
   override def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = {
-    cs.evalOn(ecForLdapBlockingIO)(
+    executeLdap(
       IO(
         ldapSearchStream(
           resourceDn(resource),
@@ -185,12 +185,12 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
         )(unmarshalAccessPolicy)))
   }
 
-  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = cs.evalOn(ecForLdapBlockingIO)(IO(
+  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = executeLdap(IO(
     ldapSearchStream(resourceDn(resource), SearchScope.SUB, Filter.createEqualityFilter("objectclass", ObjectClass.policy))(unmarshalAccessPolicy)
   ))
 
   override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = for {
-    entry <- cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.getEntry(subjectDn(user), Attr.memberOf)))
+    entry <- executeLdap(IO(ldapConnectionPool.getEntry(subjectDn(user), Attr.memberOf)))
     members <- IO.pure(Option(entry).map(e => getAttributes(e, Attr.memberOf).toList))
     accessPolicies <- members.traverse{
       policyStrs =>
@@ -206,12 +206,12 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
         }
         val filters = fullyQualifiedPolicyIds.grouped(batchSize).map(
           batch => Filter.createORFilter(batch.map(r => Filter.createEqualityFilter(Attr.policy, r.accessPolicyName.value)).asJava)).toSeq
-        cs.evalOn(ecForLdapBlockingIO)(IO(ldapSearchStream(resourceDn(resource), SearchScope.SUB, filters: _*)(unmarshalAccessPolicy).toSet))
+        executeLdap(IO(ldapSearchStream(resourceDn(resource), SearchScope.SUB, filters: _*)(unmarshalAccessPolicy).toSet))
     }
   } yield accessPolicies.getOrElse(Set.empty)
 
-  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]] = cs.evalOn(ecForLdapBlockingIO)(
-    IO(ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(policyId)))(unmarshalUser).toSet)
+  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUserId]] = executeLdap(
+    IO(ldapSearchStream(peopleOu, SearchScope.ONE, Filter.createEqualityFilter(Attr.memberOf, policyDn(policyId)))(unmarshalUser).map(_.id).toSet)
   )
 
   private def unmarshalUser(entry: Entry): WorkbenchUser = {
@@ -225,9 +225,11 @@ class LdapAccessPolicyDAO(protected val ldapConnectionPool: LDAPConnectionPool, 
     val dateMod = new Modification(ModificationType.REPLACE, Attr.groupUpdatedTimestamp, formattedDate(new Date()))
     val publicMod = new Modification(ModificationType.REPLACE, Attr.public, public.toString)
 
-    cs.evalOn(ecForLdapBlockingIO)(IO(ldapConnectionPool.modify( policyDn(policyId), dateMod, publicMod)).void).recoverWith {
+    executeLdap(IO(ldapConnectionPool.modify( policyDn(policyId), dateMod, publicMod)).void).recoverWith {
       case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy does not exist")))
     }
   }
+
+  private def executeLdap[A](ioa: IO[A]): IO[A] = cs.evalOn(ecForLdapBlockingIO)(ioa)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -47,7 +47,7 @@ trait CloudExtensions {
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
   def deleteUserPetServiceAccount(userId: WorkbenchUserId): Future[Boolean]
 
-  def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): Future[Boolean]
+  def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): IO[Boolean]
 
   def getUserProxy(userEmail: WorkbenchEmail): Future[Option[WorkbenchEmail]]
 
@@ -86,7 +86,7 @@ trait NoExtensions extends CloudExtensions {
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
   override def deleteUserPetServiceAccount(userId: WorkbenchUserId): Future[Boolean] = Future.successful(true)
 
-  override def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): Future[Boolean] = Future.successful(true)
+  override def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject): IO[Boolean] = IO.pure(true)
 
   override def getUserProxy(userEmail: WorkbenchEmail): Future[Option[WorkbenchEmail]] = Future.successful(Option(userEmail))
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -322,11 +322,7 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     }
   }
 
-<<<<<<< HEAD
-  private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy): Future[AccessPolicyMembership] = {
-=======
-  private def loadAccessPolicyWithEmails(policy: AccessPolicy): IO[AccessPolicyMembership] = {
->>>>>>> more Future to IO
+  private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy): IO[AccessPolicyMembership] = {
     val users = policy.members.collect { case userId: WorkbenchUserId => userId }
     val groups = policy.members.collect { case groupName: WorkbenchGroupName => groupName }
     val policyMembers = policy.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
@@ -334,7 +330,7 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     for {
       userEmails <- directoryDAO.loadUsers(users)
       groupEmails <- directoryDAO.loadGroups(groups)
-      policyEmails <- policyMembers.toList.parTraverse(accessPolicyDAO.loadPolicy(_)).unsafeToFuture()
+      policyEmails <- policyMembers.toList.parTraverse(accessPolicyDAO.loadPolicy(_))
     } yield AccessPolicyMembership(userEmails.toSet[WorkbenchUser].map(_.email) ++ groupEmails.map(_.email) ++ policyEmails.flatMap(_.map(_.email)), policy.actions, policy.roles)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -322,34 +322,37 @@ class ResourceService(private val resourceTypes: Map[ResourceTypeName, ResourceT
     }
   }
 
+<<<<<<< HEAD
   private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy): Future[AccessPolicyMembership] = {
+=======
+  private def loadAccessPolicyWithEmails(policy: AccessPolicy): IO[AccessPolicyMembership] = {
+>>>>>>> more Future to IO
     val users = policy.members.collect { case userId: WorkbenchUserId => userId }
     val groups = policy.members.collect { case groupName: WorkbenchGroupName => groupName }
     val policyMembers = policy.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
 
     for {
-      userEmails <- directoryDAO.loadUsers(users).unsafeToFuture()
+      userEmails <- directoryDAO.loadUsers(users)
       groupEmails <- directoryDAO.loadGroups(groups)
       policyEmails <- policyMembers.toList.parTraverse(accessPolicyDAO.loadPolicy(_)).unsafeToFuture()
     } yield AccessPolicyMembership(userEmails.toSet[WorkbenchUser].map(_.email) ++ groupEmails.map(_.email) ++ policyEmails.flatMap(_.map(_.email)), policy.actions, policy.roles)
   }
 
-  def listResourcePolicies(resource: FullyQualifiedResourceId): Future[Set[AccessPolicyResponseEntry]] = {
-    accessPolicyDAO.listAccessPolicies(resource).unsafeToFuture().flatMap { policies =>
-      Future.sequence(policies.map { policy =>
+  def listResourcePolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicyResponseEntry]] = {
+    accessPolicyDAO.listAccessPolicies(resource).flatMap { policies =>
+      policies.parTraverse { policy =>
         loadAccessPolicyWithEmails(policy).map { membership =>
           AccessPolicyResponseEntry(policy.id.accessPolicyName, membership, policy.email)
         }
-      })
+      }
     }
   }
 
-  def loadResourcePolicy(policyIdentity: FullyQualifiedPolicyId): Future[Option[AccessPolicyMembership]] = {
-    accessPolicyDAO.loadPolicy(policyIdentity).unsafeToFuture().flatMap {
-      case Some(policy) => loadAccessPolicyWithEmails(policy).map(Option(_))
-      case None => Future.successful(None)
-    }
-  }
+  def loadResourcePolicy(policyIdentity: FullyQualifiedPolicyId): IO[Option[AccessPolicyMembership]] =
+    for {
+      policy <- accessPolicyDAO.loadPolicy(policyIdentity)
+      res <- policy.traverse(p => loadAccessPolicyWithEmails(p))
+    } yield res
 
   private def makeValidatablePolicies(policies: Map[AccessPolicyName, AccessPolicyMembership]): Future[Set[ValidatableAccessPolicy]] = {
     Future.traverse(policies.toList){

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicMetrics.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicMetrics.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.workbench.sam.util
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect.{IO, Timer}
+import com.newrelic.api.agent.NewRelic
+
+object NewRelicMetrics {
+  val prefix = "Custom/sam"
+
+  def time[A](name: String, io: IO[A])(implicit timer: Timer[IO]): IO[A] = for{
+    start <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+    attemptedResult <- io.attempt
+    end <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+    duration = end - start
+    _ <- attemptedResult.fold(
+      _ => IO(NewRelic.recordResponseTimeMetric(s"${prefix}/${name}/failure", duration)),
+      _ => IO(NewRelic.recordResponseTimeMetric(s"${prefix}/${name}/success", duration))
+    )
+    res <- IO.fromEither(attemptedResult)
+  } yield res
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -409,7 +409,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
       dao.loadUser(user.id).unsafeRunSync()
     }
 
-    runAndWait(dao.loadSubjectEmail(userId)) shouldEqual None
+    dao.loadSubjectEmail(userId).unsafeRunSync()shouldEqual None
   }
 
   it should "succeed if the user has been created" in {
@@ -429,7 +429,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     }
 
     assertResult(Some(user.email)) {
-      runAndWait(dao.loadSubjectEmail(userId))
+      dao.loadSubjectEmail(userId).unsafeRunSync()
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.LdapAccessPolicyDAO
@@ -147,7 +147,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
       dao.loadPetServiceAccount(petServiceAccount.id).unsafeRunSync()
     }
 
-    runAndWait(dao.deletePetServiceAccount(petServiceAccount.id))
+    dao.deletePetServiceAccount(petServiceAccount.id).unsafeRunSync()
 
     assertResult(None) {
       dao.loadPetServiceAccount(petServiceAccount.id).unsafeRunSync()
@@ -431,6 +431,36 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     assertResult(Some(user.email)) {
       dao.loadSubjectEmail(userId).unsafeRunSync()
     }
+  }
+
+  "loadSubjectFromEmail" should "be able to load subject given an email" in {
+    val user1 = Generator.genWorkbenchUser.sample.get
+    val user2 = user1.copy(id = WorkbenchUserId(user1.id.value + "2"))
+    val res = for {
+      _ <- dao.createUser(user1)
+      email1 <- dao.loadSubjectEmail(user1.id)
+      email2 <- dao.loadSubjectEmail(user2.id)
+    } yield {
+      email1 shouldEqual(Some(user1.email))
+      email2 shouldEqual(None)
+    }
+    res.unsafeRunSync()
+  }
+
+  "loadSubjectFromGoogleSubjectId" should "be able to load subject given an google subject Id" in {
+    val user = Generator.genWorkbenchUser.sample.get
+    val user1 = user.copy(googleSubjectId = Some(GoogleSubjectId(user.id.value)))
+    val user2 = user1.copy(googleSubjectId = Some(GoogleSubjectId(user.id.value + "2")))
+
+    val res = for {
+      _ <- dao.createUser(user1)
+      subject1 <- dao.loadSubjectFromGoogleSubjectId(user1.googleSubjectId.get)
+      subject2 <- dao.loadSubjectFromGoogleSubjectId(user2.googleSubjectId.get)
+    } yield {
+      subject1 shouldEqual(Some(user1.id))
+      subject2 shouldEqual(None)
+    }
+    res.unsafeRunSync()
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -187,7 +187,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     petServiceAccountsByUser.get(petServiceAccountUniqueId)
   }
 
-  override def deletePetServiceAccount(petServiceAccountUniqueId: PetServiceAccountId): Future[Unit] = Future {
+  override def deletePetServiceAccount(petServiceAccountUniqueId: PetServiceAccountId): IO[Unit] = IO {
     petServiceAccountsByUser -= petServiceAccountUniqueId
   }
 
@@ -238,11 +238,11 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     petServiceAccount
   }
 
-  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName): Future[Option[String]] = Future {
+  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName): IO[Option[String]] = {
     if (groups.contains(groupName))
-      groupAccessInstructions.get(groupName)
+      IO.pure(groupAccessInstructions.get(groupName))
     else
-      throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "group not found"))
+      IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "group not found")))
   }
 
   override def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String): IO[Unit] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -14,12 +14,14 @@ import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.Attr
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by mbemis on 6/23/17.
   */
 class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()) extends DirectoryDAO {
+  implicit val cs = IO.contextShift(ExecutionContext.global)
+
   private val groupSynchronizedDates: mutable.Map[WorkbenchGroupIdentity, Date] = new TrieMap()
   private val users: mutable.Map[WorkbenchUserId, WorkbenchUser] = new TrieMap()
   private val userAttributes: mutable.Map[WorkbenchUserId, mutable.Map[String, Any]] = new TrieMap()
@@ -46,8 +48,8 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     groups.get(groupName).map(_.asInstanceOf[BasicWorkbenchGroup])
   }
 
-  override def loadGroups(groupNames: Set[WorkbenchGroupName]): Future[Seq[BasicWorkbenchGroup]] = Future {
-    groups.filterKeys(groupNames.map(_.asInstanceOf[WorkbenchGroupIdentity])).values.map(_.asInstanceOf[BasicWorkbenchGroup]).toSeq
+  override def loadGroups(groupNames: Set[WorkbenchGroupName]): IO[Stream[BasicWorkbenchGroup]] = IO {
+    groups.filterKeys(groupNames.map(_.asInstanceOf[WorkbenchGroupIdentity])).values.map(_.asInstanceOf[BasicWorkbenchGroup]).toStream
   }
 
   override def deleteGroup(groupName: WorkbenchGroupName): Future[Unit] = {
@@ -165,12 +167,10 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     enabledUsers.contains(subject)
   }
 
-  override def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] = loadGroup(groupName).unsafeToFuture().map(_.map(_.email))
+  override def loadGroupEmail(groupName: WorkbenchGroupName): IO[Option[WorkbenchEmail]] = loadGroup(groupName).map(_.map(_.email))
 
-  override def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): Future[Seq[(WorkbenchGroupName, WorkbenchEmail)]] = Future.traverse(groupNames.toSeq) { name =>
-    loadGroupEmail(name).map { y =>
-      name -> y.get
-    }
+  override def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName]): IO[Stream[(WorkbenchGroupName, WorkbenchEmail)]] = groupNames.toStream.parTraverse { name =>
+    loadGroupEmail(name).map { y => (name -> y.get)}
   }
 
   override def createPetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount] = {
@@ -202,7 +202,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     Future.successful(())
   }
 
-  override def loadSubjectEmail(subject: WorkbenchSubject): Future[Option[WorkbenchEmail]] = Future {
+  override def loadSubjectEmail(subject: WorkbenchSubject): IO[Option[WorkbenchEmail]] = IO {
     subject match {
       case id: WorkbenchUserId => users.get(id).map(_.email)
       case id: WorkbenchGroupIdentity => groups.get(id).map(_.email)
@@ -210,11 +210,9 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def loadSubjectEmails(subjects: Set[WorkbenchSubject]): Future[Set[WorkbenchEmail]] = {
-    Future.traverse(subjects) { subject =>
+  override def loadSubjectEmails(subjects: Set[WorkbenchSubject]): IO[Stream[WorkbenchEmail]] = subjects.toStream.parTraverse { subject =>
       loadSubjectEmail(subject).map(_.get)
     }
-  }
 
   override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]] = {
     Future.successful(groupSynchronizedDates.get(groupId))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -123,8 +123,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
       when(mockDirectoryDAO.readProxyGroup(WorkbenchUserId("inBothUser"))).thenReturn(Future.successful(Some(WorkbenchEmail(inBothUserProxyEmail))))
 
       val subGroups = Seq(inSamSubGroup, inGoogleSubGroup, inBothSubGroup)
-      subGroups.foreach { g => when(mockDirectoryDAO.loadSubjectEmail(g.id)).thenReturn(Future.successful(Option(g.email))) }
-      when(mockDirectoryDAO.loadSubjectEmail(ge.allUsersGroupName)).thenReturn(Future.successful(Option(ge.allUsersGroupEmail)))
+      subGroups.foreach { g => when(mockDirectoryDAO.loadSubjectEmail(g.id)).thenReturn(IO.pure(Option(g.email))) }
+      when(mockDirectoryDAO.loadSubjectEmail(ge.allUsersGroupName)).thenReturn(IO.pure(Option(ge.allUsersGroupEmail)))
 
       val added = Seq(inSamSubGroup.email, WorkbenchEmail(inSamUserProxyEmail)) ++ (target match {
         case _: BasicWorkbenchGroup => Seq.empty
@@ -648,7 +648,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))
-    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Set(ownerPolicy, readerPolicy)))
+    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Stream(ownerPolicy, readerPolicy)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(managedGroupRPN)))
 
@@ -683,7 +683,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))
-    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Set(ownerPolicy, readerPolicy)))
+    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Stream(ownerPolicy, readerPolicy)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(WorkbenchGroupName(subGroupId))))
 
@@ -719,7 +719,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))
-    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Set(ownerPolicy, readerPolicy)))
+    when(mockAccessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)).thenReturn(IO.pure(Stream(ownerPolicy, readerPolicy)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(WorkbenchGroupName(subGroupId))))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -322,7 +322,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     petSaResponse2 shouldBe petServiceAccount
 
     // delete the pet service account
-    googleExtensions.deleteUserPetServiceAccount(newUser.userInfo.userSubjectId, googleProject).futureValue shouldBe true
+    googleExtensions.deleteUserPetServiceAccount(newUser.userInfo.userSubjectId, googleProject).unsafeRunSync() shouldBe true
 
     // the user should still exist in LDAP
     dirDAO.loadUser(defaultUserId).unsafeRunSync() shouldBe Some(defaultUser)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -73,15 +73,15 @@ class LdapAccessPolicyDAOSpec extends AsyncFlatSpec with ScalaFutures with Match
       _ <- dao.deletePolicy(policy3.id)
       ls3AfterDeletePolicy3 <- dao.listAccessPolicies(policy3.id.resource)
     } yield{
-      ls1 shouldBe(Set.empty)
-      ls2 shouldBe(Set.empty)
-      ls3 shouldBe(Set.empty)
+      ls1 shouldBe(Stream.empty)
+      ls2 shouldBe(Stream.empty)
+      ls3 shouldBe(Stream.empty)
 
       lsPolicy1 should contain theSameElementsAs (Seq(policy1, policy2))
-      lsPolicy3 shouldBe(Set(policy3))
-      lsAfterDeletePolicy1 shouldBe Set(policy2)
-      lsAfterDeletePolicy2 shouldBe Set.empty
-      ls3AfterDeletePolicy3 shouldBe Set.empty
+      lsPolicy3 shouldBe(Stream(policy3))
+      lsAfterDeletePolicy1 shouldBe Stream(policy2)
+      lsAfterDeletePolicy2 shouldBe Stream.empty
+      ls3AfterDeletePolicy3 shouldBe Stream.empty
     }
 
     res.unsafeToFuture()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -74,10 +74,10 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     }
   }
 
-  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Set[AccessPolicy]] = IO {
+  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = IO {
     policies.collect {
       case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) => policy
-    }.toSet
+    }.toStream
   }
 
   override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = IO {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -95,7 +95,7 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     runAndWait(mock.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUserInfo)) shouldEqual intendedResource
 
     val expectedGroups = Set(ResourceIdAndPolicyName(ResourceId(groupName), ManagedGroupService.adminPolicyName))
-    runAndWait(jndi.managedGroupService.listGroups(dummyUserInfo.userId)).map(ripn => ResourceIdAndPolicyName(ripn.groupName, ripn.role)) shouldEqual expectedGroups
-    runAndWait(mock.managedGroupService.listGroups(dummyUserInfo.userId)).map(ripn => ResourceIdAndPolicyName(ripn.groupName, ripn.role)) shouldEqual expectedGroups
+    jndi.managedGroupService.listGroups(dummyUserInfo.userId).unsafeRunSync().map(ripn => ResourceIdAndPolicyName(ripn.groupName, ripn.role)) shouldEqual expectedGroups
+    mock.managedGroupService.listGroups(dummyUserInfo.userId).unsafeRunSync().map(ripn => ResourceIdAndPolicyName(ripn.groupName, ripn.role)) shouldEqual expectedGroups
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -429,7 +429,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
         requester.googleSubjectId.map(id => WorkbenchUserId(id.value)).getOrElse(fail("no requester google subject id"))
       ))
 
-    testManagedGroupService.requestAccess(resourceId, requester.id).futureValue
+    testManagedGroupService.requestAccess(resourceId, requester.id).unsafeRunSync()
 
     verify(mockCloudExtension).fireAndForgetNotifications(expectedNotificationMessages)
   }
@@ -438,7 +438,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     assertMakeGroup(groupId = resourceId.value)
     managedGroupService.setAccessInstructions(resourceId, "instructions").unsafeRunSync()
     val error = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(managedGroupService.requestAccess(resourceId, dummyUserInfo.userId))
+      managedGroupService.requestAccess(resourceId, dummyUserInfo.userId).unsafeRunSync()
     }
     error.errorReport.statusCode should be(Some(StatusCodes.BadRequest))
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -373,18 +373,18 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     val instructions = "Test Instructions"
 
     managedGroupService.setAccessInstructions(managedGroup.resourceId, instructions).unsafeRunSync()
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)).getOrElse(None) shouldEqual instructions
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync().getOrElse(None) shouldEqual instructions
   }
 
   it should "return None when access instructions have not been set" in {
     val managedGroup = assertMakeGroup()
 
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)) shouldEqual None
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync() shouldEqual None
   }
 
   it should "throw an exception if the group is not found" in {
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(managedGroupService.getAccessInstructions(ResourceId("Nonexistent Group")))
+      managedGroupService.getAccessInstructions(ResourceId("Nonexistent Group")).unsafeRunSync()
     }
     exception.getMessage should include ("not found")
   }
@@ -393,9 +393,9 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     val managedGroup = assertMakeGroup()
     val instructions = "Test Instructions"
 
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)) shouldEqual None
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync() shouldEqual None
     managedGroupService.setAccessInstructions(managedGroup.resourceId, instructions).unsafeRunSync()
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)).getOrElse(None) shouldEqual instructions
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync().getOrElse(None) shouldEqual instructions
   }
 
   it should "modify the current access instructions" in {
@@ -404,11 +404,11 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     val instructions = "Test Instructions"
     val managedGroup = runAndWait(managedGroupService.createManagedGroup(ResourceId(resourceId.value), dummyUserInfo, Option(instructions)))
 
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)).getOrElse(None) shouldEqual instructions
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync().getOrElse(None) shouldEqual instructions
 
     val newInstructions = "Much better instructions"
     managedGroupService.setAccessInstructions(managedGroup.resourceId, newInstructions).unsafeRunSync()
-    runAndWait(managedGroupService.getAccessInstructions(managedGroup.resourceId)).getOrElse(None) shouldEqual newInstructions
+    managedGroupService.getAccessInstructions(managedGroup.resourceId).unsafeRunSync().getOrElse(None) shouldEqual newInstructions
   }
 
   "ManagedGroupService requestAccess" should "send notifications" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
 import akka.actor.ActorSystem
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, MockDirectoryDAO}
@@ -48,7 +49,7 @@ class StatusServiceSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
 
   private def failingOpenDJ = {
     val service = new StatusService(new MockDirectoryDAO {
-      override def loadGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] = Future.failed(new WorkbenchException("bad opendj"))
+      override def loadGroupEmail(groupName: WorkbenchGroupName): IO[Option[WorkbenchEmail]] = IO.raiseError(new WorkbenchException("bad opendj"))
     }, NoExtensions)
     service
   }


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-3961
* Main file changed is `LdapDirectoryDao`. Unfortunately I forgot to disable scalafmt when switched to this branch working on that file. So diff on this file will be bigger than it should be. Check out https://github.com/broadinstitute/sam/pull/244/files#diff-508e3512e77b252b9224194610088e44L18 for real changes
* while working on this, I notice `/google/petServiceAccount/Segment/Segment` in newrelic response time increased a lot compared what it was before. So I added some metrics around the related ldap call (I inserted metrics in 2 calls. One was for my local testing, but I figured it's nice to have it there anyway, so didn't remove it). It's probably better to have metrics while we're refactoring this code.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
