### PR TITLE
add unit test for loadSubjectFromEmail

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -44,7 +44,8 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
           }
         } ~ path("accessInstructions") {
           put {
-            entity(as[ManagedGroupAccessInstructions]) { accessInstructions => handleSetAccessInstructions(managedGroup, accessInstructions, userInfo)
+            entity(as[ManagedGroupAccessInstructions]) { accessInstructions =>
+              handleSetAccessInstructions(managedGroup, accessInstructions, userInfo)
             }
           } ~ get {
             handleGetAccessInstructions(managedGroup)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -153,7 +153,8 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   def getResourceAuthDomain(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route =
     get {
       requireAction(resource, SamResourceActions.readAuthDomain, userInfo.userId) {
-        complete(resourceService.loadResourceAuthDomain(resource).map { response => StatusCodes.OK -> response
+        complete(resourceService.loadResourceAuthDomain(resource).map { response =>
+          StatusCodes.OK -> response
         })
       }
     }
@@ -161,7 +162,8 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   def getResourcePolicies(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route =
     get {
       requireAction(resource, SamResourceActions.readPolicies, userInfo.userId) {
-        complete(resourceService.listResourcePolicies(resource).map { response => StatusCodes.OK -> response.toSet
+        complete(resourceService.listResourcePolicies(resource).map { response =>
+          StatusCodes.OK -> response.toSet
         })
       }
     }
@@ -229,14 +231,16 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
 
   def getUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route =
     get {
-      complete(resourceService.listUserResourceRoles(resource, userInfo).map { roles => StatusCodes.OK -> roles
+      complete(resourceService.listUserResourceRoles(resource, userInfo).map { roles =>
+        StatusCodes.OK -> roles
       })
     }
 
   def getAllResourceUsers(resource: FullyQualifiedResourceId, userInfo: UserInfo): server.Route =
     get {
       requireAction(resource, SamResourceActions.readPolicies, userInfo.userId) {
-        complete(resourceService.listAllFlattenedResourceUsers(resource).map { allUsers => StatusCodes.OK -> allUsers
+        complete(resourceService.listAllFlattenedResourceUsers(resource).map { allUsers =>
+          StatusCodes.OK -> allUsers
         })
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -435,6 +435,20 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
 
   "loadSubjectFromEmail" should "be able to load subject given an email" in {
     val user1 = Generator.genWorkbenchUser.sample.get
+    val user2 = user1.copy(email = WorkbenchEmail(user1.email.value + "2"))
+    val res = for {
+      _ <- dao.createUser(user1)
+      subject1 <- dao.loadSubjectFromEmail(user1.email)
+      subject2 <- dao.loadSubjectFromEmail(user2.email)
+    } yield {
+      subject1 shouldEqual(Some(user1.id))
+      subject2 shouldEqual(None)
+    }
+    res.unsafeRunSync()
+  }
+
+  "loadSubjectEmail" should "be able to load subject given an email" in {
+    val user1 = Generator.genWorkbenchUser.sample.get
     val user2 = user1.copy(id = WorkbenchUserId(user1.id.value + "2"))
     val res = for {
       _ <- dao.createUser(user1)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -447,7 +447,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     res.unsafeRunSync()
   }
 
-  "loadSubjectEmail" should "be able to load subject given an email" in {
+  "loadSubjectEmail" should "be able to load a subject's email" in {
     val user1 = Generator.genWorkbenchUser.sample.get
     val user2 = user1.copy(id = WorkbenchUserId(user1.id.value + "2"))
     val res = for {


### PR DESCRIPTION
In previous PR, I meant to add unit test for `loadSubjectFromEmail`, but realize I was calling `loadSubjectEmail` in the test instead. This PR adds the intended test for `loadSubjectFromEmail`

Diff involving the other 2 files is from `sbt scalafmt` (probably was reverted when merging conflicts during lock PR)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
