### PR TITLE
GAWB-3902: Update workbench-service-test version

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.18-6942040"
-  val workbenchServiceTestV = "0.15-6942040"
+  val workbenchServiceTestV = "0.15-6344f5d"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)


### PR DESCRIPTION
This bumps the workbench-service-test version to include [this change](https://github.com/broadinstitute/workbench-libs/commit/6344f5d25ddc62a02daf50fd9c7e2db0147cc69e), which was from [this ticket](https://broadinstitute.atlassian.net/browse/GAWB-3902).
This version is being bumped in rawls, orch, fc-ui, sam, and leo

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
