### PR TITLE
Serve Swagger API JSON along with YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/*
 target/
 lib_managed/
 src_managed/
+src/main/resources/swagger/api-docs.json
 project/boot/
 project/plugins/project/
 docker/stand-alone/server.crt

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -91,9 +91,12 @@ function make_jar()
     echo "building jar..."
     OPENDJ=$(bash ./docker/run-opendj.sh start jenkins | tail -n1)
     echo $OPENDJ
-    
+
     # Get the last commit hash of the model directory and set it as an environment variable
     GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
+
+    # create Swagger API JSON from YAML
+    docker run --rm -i mikefarah/yq yq r - -j < src/main/resources/swagger/api-docs.yaml > src/main/resources/swagger/api-docs.json
 
     # make jar.  cache sbt dependencies.
     set +e # Turn off error detection so that opendj has a chance to get stopped before exiting

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SwaggerRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SwaggerRoutes.scala
@@ -33,6 +33,11 @@ trait SwaggerRoutes {
           getFromResource("swagger/api-docs.yaml")
         }
       } ~
+      path("api-docs.json") {
+        get {
+          getFromResource("swagger/api-docs.json")
+        }
+      } ~
       // We have to be explicit about the paths here since we're matching at the root URL and we don't
       // want to catch all paths lest we circumvent Spray's not-found and method-not-allowed error
       // messages.


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/projects/GAWB/issues/GAWB-4013

I'd like to add support for fetching Sam Swagger API doc in JSON format.

This will be useful, for example, for calling Sam API from Google Cloud Deployment Manager. The latter can use external APIs, however we must provide a public URL to the Swagger doc in JSON format (YAML is not supported). However, currently only YAML is published in Sam (`/api-docs.yaml`).

The proposed solution is to convert YAML to JSON at build time, and include it as an additional route in Swagger UI (`/api-docs.json`).

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
