### PR TITLE
use ehcache for memberOf lists

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,6 +50,7 @@ object Dependencies {
   val mockito: ModuleID =         "org.mockito"    % "mockito-core" % "2.7.22"   % "test"
 
   val unboundid: ModuleID = "com.unboundid" % "unboundid-ldapsdk" % "4.0.6"
+  val ehcache: ModuleID = "org.ehcache" % "ehcache" % "3.6.2"
 
   // All of workbench-libs pull in Akka; exclude it since we provide our own Akka dependency.
   // workbench-google pulls in workbench-{util, model, metrics}; exclude them so we can control the library versions individually.
@@ -92,6 +93,7 @@ object Dependencies {
     workbenchNotifications,
     workbenchGoogleTests,
 
-    unboundid
+    unboundid,
+    ehcache
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction}
 import org.broadinstitute.dsde.workbench.sam.service.PolicyEvaluatorService
 import ImplicitConversions.ioOnSuccessMagnet
+import cats.effect.IO
 
 trait SecurityDirectives {
   def policyEvaluatorService: PolicyEvaluatorService
@@ -17,8 +18,8 @@ trait SecurityDirectives {
 
   def requireOneOfAction(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId): Directive0 =
     Directives.mapInnerRoute { innerRoute =>
-      onSuccess(policyEvaluatorService.listUserResourceActions(resource, userId)) { actions =>
-        if (actions.intersect(requestedActions).nonEmpty) innerRoute
+      onSuccess(listActions(resource, userId, requestedActions)) { actions =>
+        if (hasAccess(requestedActions, actions)) innerRoute
         else if (actions.isEmpty)
           Directives.failWith(
             new WorkbenchExceptionWithErrorReport(
@@ -31,4 +32,17 @@ trait SecurityDirectives {
             )))
       }
     }
+
+  private def listActions(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, requestedActions: Set[ResourceAction]): IO[Set[ResourceAction]] = {
+    // this is optimized for the case where the user has permission since that is the usual case
+    // if the first attempt shows the user does not have permission, force a second attempt
+    for {
+      actionsAttempt1 <- policyEvaluatorService.listUserResourceActions(resource, userId, force = false)
+      actionsAttempt2 <- if (hasAccess(requestedActions, actionsAttempt1)) IO.pure(actionsAttempt1) else policyEvaluatorService.listUserResourceActions(resource, userId, force = true)
+    } yield actionsAttempt2
+  }
+
+  private def hasAccess(requestedActions: Set[ResourceAction], actions: Set[ResourceAction]): Boolean = {
+    actions.intersect(requestedActions).nonEmpty
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -94,6 +94,10 @@ object AppConfig {
       case ex: WrongType => getActionPatternObjects(config, path)
     }
 
+  implicit val cacheConfigReader: ValueReader[CacheConfig] = ValueReader.relative { config =>
+    CacheConfig(config.getLong("maxEntries"), config.getDuration("timeToLive"))
+  }
+
   implicit val directoryConfigReader: ValueReader[DirectoryConfig] = ValueReader.relative { config =>
     DirectoryConfig(
       config.getString("url"),
@@ -101,7 +105,9 @@ object AppConfig {
       config.getString("password"),
       config.getString("baseDn"),
       config.getString("enabledUsersGroupDn"),
-      config.as[Option[Int]]("connectionPoolSize").getOrElse(20)
+      config.as[Option[Int]]("connectionPoolSize").getOrElse(20),
+      config.as[Option[CacheConfig]]("memberOfCache").getOrElse(CacheConfig(100, java.time.Duration.ofMinutes(5))),
+      config.as[Option[CacheConfig]]("resourceCache").getOrElse(CacheConfig(10000, java.time.Duration.ofHours(1)))
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -106,7 +106,7 @@ object AppConfig {
       config.getString("baseDn"),
       config.getString("enabledUsersGroupDn"),
       config.as[Option[Int]]("connectionPoolSize").getOrElse(20),
-      config.as[Option[CacheConfig]]("memberOfCache").getOrElse(CacheConfig(100, java.time.Duration.ofMinutes(5))),
+      config.as[Option[CacheConfig]]("memberOfCache").getOrElse(CacheConfig(100, java.time.Duration.ofMinutes(1))),
       config.as[Option[CacheConfig]]("resourceCache").getOrElse(CacheConfig(10000, java.time.Duration.ofHours(1)))
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
@@ -3,4 +3,14 @@ package org.broadinstitute.dsde.workbench.sam.config
 /**
   * Created by dvoet on 5/26/17.
   */
-case class DirectoryConfig(directoryUrl: String, user: String, password: String, baseDn: String, enabledUsersGroupDn: String, connectionPoolSize: Int = 20)
+case class DirectoryConfig(directoryUrl: String,
+                           user: String,
+                           password: String,
+                           baseDn: String,
+                           enabledUsersGroupDn: String,
+                           connectionPoolSize: Int = 20,
+                           memberOfCache: CacheConfig,
+                           resourceCache: CacheConfig
+                          )
+
+case class CacheConfig(maxEntries: Long, timeToLive: java.time.Duration)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -29,7 +29,7 @@ trait DirectoryDAO {
     * @return true if the subject was removed, false if it was already gone
     */
   def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): IO[Boolean]
-  def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean]
+  def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): IO[Boolean]
   def updateSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Unit]
   def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]]
   def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): Future[Option[WorkbenchEmail]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
 import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.{Attr, ObjectClass}
 import org.broadinstitute.dsde.workbench.sam.util.{LdapSupport, NewRelicMetrics}
+import org.ehcache.Cache
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,7 +23,8 @@ import scala.util.Try
 class LdapDirectoryDAO(
     protected val ldapConnectionPool: LDAPConnectionPool,
     protected val directoryConfig: DirectoryConfig,
-    protected val ecForLdapBlockingIO: ExecutionContext)(implicit executionContext: ExecutionContext, timer: Timer[IO])
+    protected val ecForLdapBlockingIO: ExecutionContext,
+    protected val memberOfCache: Cache[String, Set[String]])(implicit executionContext: ExecutionContext, timer: Timer[IO])
     extends DirectoryDAO
     with DirectorySubjectNameSupport
     with LdapSupport {
@@ -125,15 +127,13 @@ class LdapDirectoryDAO(
         case Left(regrets) => IO.raiseError(regrets)
       }
 
-  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean] = Future {
-    val isMember = for {
-      entry <- Option(ldapConnectionPool.getEntry(subjectDn(member), Attr.memberOf))
-      memberOf <- Option(entry.getAttribute(Attr.memberOf))
+  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): IO[Boolean] = {
+    for {
+      memberOf <- ldapLoadMemberOf(subjectDn(member))
     } yield {
-      val memberships = memberOf.getValues.map(_.toLowerCase).toSet //toLowerCase because the dn can have varying capitalization
+      val memberships = memberOf.map(_.toLowerCase) //toLowerCase because the dn can have varying capitalization
       memberships.contains(groupDn(groupId).toLowerCase)
     }
-    isMember.getOrElse(false)
   }
 
   override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Unit] = Future {
@@ -248,13 +248,11 @@ class LdapDirectoryDAO(
       }))
 
   private def listMemberOfGroups(dn: String): IO[Set[WorkbenchGroupIdentity]] = {
-    val groupsOptionT = for {
-      entry <- OptionT(IO(ldapConnectionPool.getEntry(dn, Attr.memberOf)).map(Option(_)))
-      memberOf <- OptionT.fromOption[IO](Option(entry.getAttributeValues(Attr.memberOf)))
+    for {
+      memberOf <- ldapLoadMemberOf(dn)
     } yield {
-      memberOf.toSet.map(dnToGroupIdentity)
+      memberOf.map(dnToGroupIdentity)
     }
-    groupsOptionT.fold(Set.empty[WorkbenchGroupIdentity])(identity)
   }
 
   override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]] = Future {
@@ -399,6 +397,4 @@ class LdapDirectoryDAO(
 
   override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit] =
     executeLdap(IO(ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.googleSubjectId, googleSubjectId.value))))
-
-  private def executeLdap[A](ioa: IO[A]): IO[A] = cs.evalOn(ecForLdapBlockingIO)(ioa)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -28,4 +28,6 @@ trait AccessPolicyDAO {
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]]
   def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]]
   def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit]
+
+  def evictIsMemberOfCache(subject: WorkbenchSubject): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -22,7 +22,7 @@ trait AccessPolicyDAO {
   def overwritePolicy(newPolicy: AccessPolicy): IO[AccessPolicy]
   def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]]
   def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
-  def listResourceWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]]
+  def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]]
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]]
   def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -35,21 +35,29 @@ class PolicyEvaluatorService(
   }
 
   def hasPermission(resource: FullyQualifiedResourceId, action: ResourceAction, userId: WorkbenchUserId): IO[Boolean] = {
-    def checkPermission = {
-      listUserResourceActions(resource, userId).map { _.contains(action) }
+    def checkPermission(force: Boolean) = {
+      listUserResourceActions(resource, userId, force).map { _.contains(action) }
     }
 
     // this is optimized for the case where the user has permission since that is the usual case
-    // if the first attempt shows the user does not have permission, evict the user from the cache and attempt again
+    // if the first attempt shows the user does not have permission, force a second attempt
     for {
-      attempt1 <- checkPermission
-      attempt2 <- if (attempt1) IO.pure(attempt1) else accessPolicyDAO.evictIsMemberOfCache(userId) *> checkPermission
+      attempt1 <- checkPermission(force = false)
+      attempt2 <- if (attempt1) IO.pure(attempt1) else checkPermission(force = true)
     } yield {
       attempt2
     }
   }
 
-  def listUserResourceActions(resource: FullyQualifiedResourceId, userId: WorkbenchUserId): IO[Set[ResourceAction]] = {
+  /**
+    * Lists all the actions a user has on the specified resource
+    *
+    * @param resource
+    * @param userId
+    * @param force true to ignore any caching
+    * @return
+    */
+  def listUserResourceActions(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, force: Boolean = false): IO[Set[ResourceAction]] = {
     def allActions(policy: AccessPolicy, resourceType: ResourceType): Set[ResourceAction] = {
       val roleActions = policy.roles.flatMap { role =>
         resourceType.roles.filter(_.roleName == role).flatMap(_.actions)
@@ -58,6 +66,7 @@ class PolicyEvaluatorService(
     }
 
     for {
+      _ <- if (force) accessPolicyDAO.evictIsMemberOfCache(userId) else IO.unit
       rt <- IO.fromEither[ResourceType](
         resourceTypes.get(resource.resourceTypeName).toRight(new WorkbenchException(s"missing configuration for resourceType ${resource.resourceTypeName}")))
       isConstrained = rt.isAuthDomainConstrainable

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -100,7 +100,7 @@ class PolicyEvaluatorService(
       ridAndPolicyName <- accessPolicyDAO.listAccessPolicies(resourceTypeName, userId) // List all policies of a given resourceType the user is a member of
       rids = ridAndPolicyName.map(_.resourceId)
 
-      resources <- if (isConstrained) accessPolicyDAO.listResourceWithAuthdomains(resourceTypeName, rids)
+      resources <- if (isConstrained) accessPolicyDAO.listResourcesWithAuthdomains(resourceTypeName, rids)
       else IO.pure(Set.empty)
       authDomainMap = resources.map(x => x.resourceId -> x.authDomain).toMap
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -86,7 +86,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
         for {
           googleStatus <- cloudExtensions.getUserStatus(user)
           allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO)
-          allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id) recover { case e: NameNotFoundException => false }
+          allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id).unsafeToFuture() recover { case e: NameNotFoundException => false }
           ldapStatus <- directoryDAO.isEnabled(user.id).unsafeToFuture()
         } yield {
           Option(UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> ldapStatus, "allUsersGroup" -> allUsersStatus, "google" -> googleStatus)))
@@ -112,7 +112,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
         // pulled out of for comprehension to allow concurrent execution
         val ldapStatus = directoryDAO.isEnabled(user.id).unsafeToFuture()
         val allUsersStatus = cloudExtensions.getOrCreateAllUsersGroup(directoryDAO).flatMap { allUsersGroup =>
-          directoryDAO.isGroupMember(allUsersGroup.id, user.id) recover { case e: NameNotFoundException => false }
+          directoryDAO.isGroupMember(allUsersGroup.id, user.id).unsafeToFuture() recover { case e: NameNotFoundException => false }
         }
         val googleStatus = cloudExtensions.getUserStatus(user)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -56,17 +56,29 @@ trait PropertyBasedTesting extends PropertyChecks with Configuration with Matche
 object TestSupport extends TestSupport {
   private val executor = Executors.newCachedThreadPool()
   val blockingEc = ExecutionContext.fromExecutor(executor)
-  def testCache: Cache[WorkbenchSubject, Set[String]] = {
+  def testMemberOfCache: Cache[WorkbenchSubject, Set[String]] = {
     val cacheManager = CacheManagerBuilder.newCacheManagerBuilder
       .withCache(
-        "test",
+        "test-memberof",
         CacheConfigurationBuilder
           .newCacheConfigurationBuilder(classOf[WorkbenchSubject], classOf[Set[String]], ResourcePoolsBuilder.heap(10))
           .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(java.time.Duration.ofMillis(0)))
       )
       .build
     cacheManager.init()
-    cacheManager.getCache("test", classOf[WorkbenchSubject], classOf[Set[String]])
+    cacheManager.getCache("test-memberof", classOf[WorkbenchSubject], classOf[Set[String]])
+  }
+  def testResourceCache: Cache[FullyQualifiedResourceId, Resource] = {
+    val cacheManager = CacheManagerBuilder.newCacheManagerBuilder
+      .withCache(
+        "test-resource",
+        CacheConfigurationBuilder
+          .newCacheConfigurationBuilder(classOf[FullyQualifiedResourceId], classOf[Resource], ResourcePoolsBuilder.heap(100))
+          .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(java.time.Duration.ofMillis(1000)))
+      )
+      .build
+    cacheManager.init()
+    cacheManager.getCache("test-resource", classOf[FullyQualifiedResourceId], classOf[Resource])
   }
 
   implicit val eqWorkbenchExceptionErrorReport: Eq[WorkbenchExceptionWithErrorReport] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -53,20 +53,20 @@ trait PropertyBasedTesting extends PropertyChecks with Configuration with Matche
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
 }
 
-object TestSupport extends TestSupport{
+object TestSupport extends TestSupport {
   private val executor = Executors.newCachedThreadPool()
   val blockingEc = ExecutionContext.fromExecutor(executor)
-  def testCache: Cache[String, Set[String]] = {
+  def testCache: Cache[WorkbenchSubject, Set[String]] = {
     val cacheManager = CacheManagerBuilder.newCacheManagerBuilder
       .withCache(
         "test",
         CacheConfigurationBuilder
-          .newCacheConfigurationBuilder(classOf[String], classOf[Set[String]], ResourcePoolsBuilder.heap(10))
+          .newCacheConfigurationBuilder(classOf[WorkbenchSubject], classOf[Set[String]], ResourcePoolsBuilder.heap(10))
           .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(java.time.Duration.ofMillis(0)))
       )
       .build
     cacheManager.init()
-    cacheManager.getCache("test", classOf[String], classOf[Set[String]])
+    cacheManager.getCache("test", classOf[WorkbenchSubject], classOf[Set[String]])
   }
 
   implicit val eqWorkbenchExceptionErrorReport: Eq[WorkbenchExceptionWithErrorReport] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+  val dao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {
@@ -306,7 +306,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     dao.createGroup(group1).unsafeRunSync()
     dao.createGroup(group2).unsafeRunSync()
 
-    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
 
     val typeName1 = ResourceTypeName(UUID.randomUUID().toString)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -83,7 +83,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     true
   }
 
-  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): Future[Boolean] = Future {
+  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): IO[Boolean] = IO {
     groups.getOrElse(groupId, BasicWorkbenchGroup(null, Set.empty, WorkbenchEmail("g1@example.com"))).members.contains(member)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -338,7 +338,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   private def initPetTest: (DirectoryDAO, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchUserId, WorkbenchEmail, WorkbenchEmail, CreateWorkbenchUser) = {
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
@@ -417,7 +417,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "throw an exception with a NotFound error report when getting sync date for group that does not exist" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
@@ -428,7 +428,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return None when getting sync date for a group that has not been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail(""))).unsafeRunSync()
@@ -440,7 +440,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return sync date for a group that has been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org"))).unsafeRunSync()
@@ -454,7 +454,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "throw an exception with a NotFound error report when getting email for group that does not exist" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
@@ -465,7 +465,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return email for a group" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -478,7 +478,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return None if an email is found, but the group has not been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -491,7 +491,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return SyncState with email and last sync date if there is an email and the group has been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -729,7 +729,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
     implicit val patienceConfig = PatienceConfig(1 second)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
@@ -869,8 +869,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupResourceType = realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
-    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
     val schemaDAO = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDAO.clearDatabase())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -338,7 +338,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   private def initPetTest: (DirectoryDAO, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchUserId, WorkbenchEmail, WorkbenchEmail, CreateWorkbenchUser) = {
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
@@ -417,7 +417,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "throw an exception with a NotFound error report when getting sync date for group that does not exist" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
@@ -428,7 +428,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return None when getting sync date for a group that has not been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail(""))).unsafeRunSync()
@@ -440,7 +440,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return sync date for a group that has been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org"))).unsafeRunSync()
@@ -454,7 +454,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "throw an exception with a NotFound error report when getting email for group that does not exist" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
@@ -465,7 +465,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return email for a group" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -478,7 +478,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return None if an email is found, but the group has not been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -491,7 +491,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "return SyncState with email and last sync date if there is an email and the group has been synced" in {
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -729,7 +729,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   private def setupGoogleKeyCacheTests: (GoogleExtensions, UserService) = {
     implicit val patienceConfig = PatienceConfig(1 second)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDao.clearDatabase())
@@ -869,8 +869,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupResourceType = realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
-    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+    val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
     val schemaDAO = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
     runAndWait(schemaDAO.clearDatabase())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -140,8 +140,8 @@ object LdapAccessPolicyDAOSpec{
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc)
-  val dirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc)
+  val dao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+  val dirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   // before() doesn't seem to work well with AsyncFlatSpec

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -120,7 +120,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     }.toSet
   }
 
-  override def listResourceWithAuthdomains(
+  override def listResourcesWithAuthdomains(
       resourceTypeName: ResourceTypeName,
       resourceId: Set[ResourceId])
     : IO[Set[Resource]] = IO.pure(Set.empty)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -132,4 +132,6 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
       }.toStream
     )
   }
+
+  override def evictIsMemberOfCache(subject: WorkbenchSubject): IO[Unit] = IO.unit
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -57,8 +57,8 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     val shared = sharedFixtures
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
-    val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+    val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(ldapDirDao))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, ldapPolicyDao)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -57,8 +57,8 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     val shared = sharedFixtures
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
-    val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(ldapDirDao))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, ldapPolicyDao)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -35,8 +35,8 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val resourceId = ResourceId("myNewGroup")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -35,8 +35,8 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val resourceId = ResourceId("myNewGroup")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -22,8 +22,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
   val connectionPool = new LDAPConnectionPool(
     new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password),
     directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -22,8 +22,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
   val connectionPool = new LDAPConnectionPool(
     new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password),
     directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -35,8 +35,8 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -35,8 +35,8 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc)
+  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
+  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -47,7 +47,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
   lazy val petServiceAccountConfig = TestSupport.appConfig.googleConfig.get.petServiceAccountConfig
   lazy val dirURI = new URI(directoryConfig.directoryUrl)
   lazy val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  lazy val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+  lazy val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
   lazy val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   var service: UserService = _
@@ -227,7 +227,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
     dirDAO.createUser(WorkbenchUser(user.id, None, user.email)).unsafeRunSync()
 
-    val accessPolicyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
+    val accessPolicyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
     val createPolicy = for {
       _ <- accessPolicyDAO.createResourceType(expectedAccessPolicyId.resource.resourceTypeName)
       _ <- accessPolicyDAO.createResource(Resource(expectedAccessPolicyId.resource.resourceTypeName, expectedAccessPolicyId.resource.resourceId, Set.empty))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -47,7 +47,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
   lazy val petServiceAccountConfig = TestSupport.appConfig.googleConfig.get.petServiceAccountConfig
   lazy val dirURI = new URI(directoryConfig.directoryUrl)
   lazy val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  lazy val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+  lazy val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
   lazy val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   var service: UserService = _
@@ -227,7 +227,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
     dirDAO.createUser(WorkbenchUser(user.id, None, user.email)).unsafeRunSync()
 
-    val accessPolicyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
+    val accessPolicyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testCache)
     val createPolicy = for {
       _ <- accessPolicyDAO.createResourceType(expectedAccessPolicyId.resource.resourceTypeName)
       _ <- accessPolicyDAO.createResource(Resource(expectedAccessPolicyId.resource.resourceTypeName, expectedAccessPolicyId.resource.resourceId, Set.empty))


### PR DESCRIPTION
This PR adds 2 caches to sam:
- memberOf cache: for each user cache the results of the query that lists which groups the user is a member of. This call is particularly hard on opendj because it is a computed result and it produces a lot of data. Caching this means that when users are added or removed from groups it can take up to the cache expiry for the change to take effect.
- resource cache: cache the results when we load a resource (specifically auth domains). A single one of these calls is not a big deal but in the course of listing resource policies we need to load hundreds or thousands of resources. And they never change.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
