### PR TITLE
GAWB-3999:  Fail billing project creation if gpalloc runs out of billing projects

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.18-6942040"
-  val workbenchServiceTestV = "0.15-7bc56cf-SNAP"
+  val workbenchServiceTestV = "0.15-40f9df6"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.18-6942040"
-  val workbenchServiceTestV = "0.15-6344f5d"
+  val workbenchServiceTestV = "0.15-7bc56cf-SNAP"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)


### PR DESCRIPTION
Goes with this ticket: https://broadinstitute.atlassian.net/browse/GAWB-3999
Workbench-libs service-test changes: broadinstitute/workbench-libs#191
gpalloc has had its min available projects bumped from 5 to 25 to compensate for this change.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
