### PR TITLE
update service-test to adopt billing scope change

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.18-6942040"
-  val workbenchServiceTestV = "0.16-7e37072-SNAP"
+  val workbenchServiceTestV = "0.16-fda9bcd"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchModelV  = "0.13-7e86fba"
   val workbenchGoogleV = "0.18-6942040"
-  val workbenchServiceTestV = "0.15-6344f5d"
+  val workbenchServiceTestV = "0.16-7e37072-SNAP"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)


### PR DESCRIPTION
Ticket: DataBiosphere/firecloud-app#109
adopts service-test changes from broadinstitute/workbench-libs#194

afaict Sam is oblivious to the functional change in serviceTest 0.15->0.16. Tests passed on a snapshot version of serviceTest 0.16; this PR updates the dependency to the official published  hash.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
