### PR TITLE
fix stability when large amounts of group syncing happens

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -60,6 +60,14 @@
         <appender-ref ref="Sentry" />
     </logger>
 
+    <!-- publishing messages can be too verbose logging -->
+    <logger name="org.broadinstitute.dsde.workbench.google.HttpGooglePubSubDAO" level="info" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
     <root level="warn">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -20,9 +20,9 @@ import org.broadinstitute.dsde.workbench.google.util.DistributedLock
 import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleFirestoreOpsInterpreters, HttpGoogleDirectoryDAO, HttpGoogleIamDAO, HttpGoogleProjectDAO, HttpGooglePubSubDAO, HttpGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException, WorkbenchSubject}
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardUserInfoDirectives}
-import org.broadinstitute.dsde.workbench.sam.config.{AppConfig, DirectoryConfig, GoogleConfig}
+import org.broadinstitute.dsde.workbench.sam.config.{AppConfig, GoogleConfig}
 import org.broadinstitute.dsde.workbench.sam.directory._
-import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.google._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam._
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -68,7 +68,7 @@ object Boot extends IOApp with LazyLogging {
 
         _ <- dependencies.policyEvaluatorService.initPolicy()
 
-        _ <- dependencies.cloudExtensions.onBoot(dependencies.samApplication)
+        _ <- dependencies.cloudExtensionsInitializer.onBoot(dependencies.samApplication)
 
         binding <- IO.fromFuture(IO(Http().bindAndHandle(dependencies.samRoutes.route, "0.0.0.0", 8080))).onError {
           case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)
@@ -79,8 +79,8 @@ object Boot extends IOApp with LazyLogging {
     }
   }
 
-  private[sam] def createLdapConnectionPool(directoryConfig: DirectoryConfig): cats.effect.Resource[IO, LDAPConnectionPool] = {
-    val dirURI = new URI(directoryConfig.directoryUrl)
+  private[sam] def createLdapConnectionPool(directoryUrl: String, user: String, password: String, connectionPoolSize: Int): cats.effect.Resource[IO, LDAPConnectionPool] = {
+    val dirURI = new URI(directoryUrl)
     val (socketFactory, defaultPort) = dirURI.getScheme.toLowerCase match {
       case "ldaps" => (SSLContext.getDefault.getSocketFactory, 636)
       case "ldap" => (SocketFactory.getDefault, 389)
@@ -90,8 +90,8 @@ object Boot extends IOApp with LazyLogging {
     cats.effect.Resource.make(
       IO {
         val connectionPool = new LDAPConnectionPool(
-          new LDAPConnection(socketFactory, dirURI.getHost, port, directoryConfig.user, directoryConfig.password),
-          directoryConfig.connectionPoolSize, directoryConfig.connectionPoolSize
+          new LDAPConnection(socketFactory, dirURI.getHost, port, user, password),
+          connectionPoolSize, connectionPoolSize
         )
         connectionPool.setCreateIfNecessary(false)
         connectionPool.setMaxWaitTimeMillis(30000)
@@ -142,12 +142,20 @@ object Boot extends IOApp with LazyLogging {
   private[sam] def createAppDependencies(
       appConfig: AppConfig)(implicit actorSystem: ActorSystem, actorMaterializer: ActorMaterializer): cats.effect.Resource[IO, AppDependencies] =
     for {
-      ldapConnectionPool <- createLdapConnectionPool(appConfig.directoryConfig)
+      ldapConnectionPool <- createLdapConnectionPool(appConfig.directoryConfig.directoryUrl, appConfig.directoryConfig.user, appConfig.directoryConfig.password, appConfig.directoryConfig.connectionPoolSize)
       memberOfCache <- createMemberOfCache("memberof", appConfig.directoryConfig.memberOfCache.maxEntries, appConfig.directoryConfig.memberOfCache.timeToLive)
       resourceCache <- createResourceCache("resource", appConfig.directoryConfig.resourceCache.maxEntries, appConfig.directoryConfig.resourceCache.timeToLive)
       ldapExecutionContext <- ExecutionContexts.fixedThreadPool[IO](appConfig.directoryConfig.connectionPoolSize)
       accessPolicyDao = new LdapAccessPolicyDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache, resourceCache)
       directoryDAO = new LdapDirectoryDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache)
+
+      // This special set of objects are for operations that happen in the background, i.e. not in the immediate service
+      // of an api call. They are meant to partition resources so that background processes can't crowd our api calls.
+      backgroundLdapConnectionPool <- createLdapConnectionPool(appConfig.directoryConfig.directoryUrl, appConfig.directoryConfig.user, appConfig.directoryConfig.password, appConfig.directoryConfig.backgroundConnectionPoolSize)
+      backgroundLdapExecutionContext <- ExecutionContexts.fixedThreadPool[IO](appConfig.directoryConfig.backgroundConnectionPoolSize)
+      backgroundAccessPolicyDao = new LdapAccessPolicyDAO(backgroundLdapConnectionPool, appConfig.directoryConfig, backgroundLdapExecutionContext, memberOfCache, resourceCache)
+      backgroundDirectoryDAO = new LdapDirectoryDAO(backgroundLdapConnectionPool, appConfig.directoryConfig, backgroundLdapExecutionContext, memberOfCache)
+
       appDependencies <- appConfig.googleConfig match {
         case Some(config) =>
           for {
@@ -160,9 +168,11 @@ object Boot extends IOApp with LazyLogging {
               DistributedLock[IO](s"sam-${config.googleServicesConfig.resourceNamePrefix.getOrElse("local")}", appConfig.distributedLockConfig, ioFireStore)
             val resourceTypeMap = appConfig.resourceTypes.map(rt => rt.name -> rt).toMap
             val cloudExtension = createGoogleCloudExt(accessPolicyDao, directoryDAO, config, resourceTypeMap, lock)
-            createAppDepenciesWithSamRoutes(appConfig, cloudExtension, accessPolicyDao, directoryDAO)
+            val googleGroupSynchronizer = new GoogleGroupSynchronizer(backgroundDirectoryDAO, backgroundAccessPolicyDao, cloudExtension.googleDirectoryDAO, cloudExtension, resourceTypeMap)
+            val cloudExtensionsInitializer = new GoogleExtensionsInitializer(cloudExtension, googleGroupSynchronizer)
+            createAppDepenciesWithSamRoutes(appConfig, cloudExtensionsInitializer, accessPolicyDao, directoryDAO)
           }
-        case None => cats.effect.Resource.pure[IO, AppDependencies](createAppDepenciesWithSamRoutes(appConfig, NoExtensions, accessPolicyDao, directoryDAO))
+        case None => cats.effect.Resource.pure[IO, AppDependencies](createAppDepenciesWithSamRoutes(appConfig, NoExtensionsInitializer, accessPolicyDao, directoryDAO))
       }
     } yield appDependencies
 
@@ -232,30 +242,31 @@ object Boot extends IOApp with LazyLogging {
 
   private[sam] def createAppDepenciesWithSamRoutes(
       config: AppConfig,
-      cloudExtensions: CloudExtensions,
+      cloudExtensionsInitializer: CloudExtensionsInitializer,
       accessPolicyDAO: AccessPolicyDAO,
       directoryDAO: DirectoryDAO)(implicit actorSystem: ActorSystem, actorMaterializer: ActorMaterializer): AppDependencies = {
     val resourceTypeMap = config.resourceTypes.map(rt => rt.name -> rt).toMap
     val policyEvaluatorService = PolicyEvaluatorService(config.emailDomain, resourceTypeMap, accessPolicyDAO)
-    val resourceService = new ResourceService(resourceTypeMap, policyEvaluatorService, accessPolicyDAO, directoryDAO, cloudExtensions, config.emailDomain)
-    val userService = new UserService(directoryDAO, cloudExtensions)
-    val statusService = new StatusService(directoryDAO, cloudExtensions, 10 seconds)
+    val resourceService = new ResourceService(resourceTypeMap, policyEvaluatorService, accessPolicyDAO, directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.emailDomain)
+    val userService = new UserService(directoryDAO, cloudExtensionsInitializer.cloudExtensions)
+    val statusService = new StatusService(directoryDAO, cloudExtensionsInitializer.cloudExtensions, 10 seconds)
     val managedGroupService =
-      new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, accessPolicyDAO, directoryDAO, cloudExtensions, config.emailDomain)
+      new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, accessPolicyDAO, directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.emailDomain)
     val samApplication = SamApplication(userService, resourceService, statusService)
 
-    cloudExtensions match {
-      case googleExt: GoogleExtensions =>
+    cloudExtensionsInitializer match {
+      case GoogleExtensionsInitializer(googleExt, synchronizer) =>
         val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, directoryDAO, policyEvaluatorService)
         with StandardUserInfoDirectives with GoogleExtensionRoutes {
           val googleExtensions = googleExt
           val cloudExtensions = googleExt
+          val googleGroupSynchronizer = synchronizer
         }
-        AppDependencies(routes, samApplication, googleExt, directoryDAO, accessPolicyDAO, policyEvaluatorService)
+        AppDependencies(routes, samApplication, cloudExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
       case _ =>
         val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, directoryDAO, policyEvaluatorService)
         with StandardUserInfoDirectives with NoExtensionRoutes
-        AppDependencies(routes, samApplication, NoExtensions, directoryDAO, accessPolicyDAO, policyEvaluatorService)
+        AppDependencies(routes, samApplication, NoExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
     }
   }
 }
@@ -263,7 +274,7 @@ object Boot extends IOApp with LazyLogging {
 final case class AppDependencies(
     samRoutes: SamRoutes,
     samApplication: SamApplication,
-    cloudExtensions: CloudExtensions,
+    cloudExtensionsInitializer: CloudExtensionsInitializer,
     directoryDAO: DirectoryDAO,
     accessPolicyDAO: AccessPolicyDAO,
     policyEvaluatorService: PolicyEvaluatorService)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -145,9 +145,9 @@ object Boot extends IOApp with LazyLogging {
       ldapConnectionPool <- createLdapConnectionPool(appConfig.directoryConfig)
       memberOfCache <- createMemberOfCache("memberof", appConfig.directoryConfig.memberOfCache.maxEntries, appConfig.directoryConfig.memberOfCache.timeToLive)
       resourceCache <- createResourceCache("resource", appConfig.directoryConfig.resourceCache.maxEntries, appConfig.directoryConfig.resourceCache.timeToLive)
-      blockingEc <- ExecutionContexts.cachedThreadPool[IO]
-      accessPolicyDao = new LdapAccessPolicyDAO(ldapConnectionPool, appConfig.directoryConfig, blockingEc, memberOfCache, resourceCache)
-      directoryDAO = new LdapDirectoryDAO(ldapConnectionPool, appConfig.directoryConfig, blockingEc, memberOfCache)
+      ldapExecutionContext <- ExecutionContexts.fixedThreadPool[IO](appConfig.directoryConfig.connectionPoolSize)
+      accessPolicyDao = new LdapAccessPolicyDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache, resourceCache)
+      directoryDAO = new LdapDirectoryDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache)
       appDependencies <- appConfig.googleConfig match {
         case Some(config) =>
           for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -155,8 +155,7 @@ object Boot extends IOApp with LazyLogging {
       // of an api call. They are meant to partition resources so that background processes can't crowd our api calls.
       backgroundLdapConnectionPool <- createLdapConnectionPool(appConfig.directoryConfig.directoryUrl, appConfig.directoryConfig.user, appConfig.directoryConfig.password, appConfig.directoryConfig.backgroundConnectionPoolSize, "background")
       backgroundLdapExecutionContext <- ExecutionContexts.fixedThreadPool[IO](appConfig.directoryConfig.backgroundConnectionPoolSize)
-      backgroundContextShift = IOContextShift(backgroundLdapExecutionContext)
-      backgroundAccessPolicyDao = new LdapAccessPolicyDAO(backgroundLdapConnectionPool, appConfig.directoryConfig, backgroundLdapExecutionContext, memberOfCache, resourceCache)(backgroundContextShift)
+      backgroundAccessPolicyDao = new LdapAccessPolicyDAO(backgroundLdapConnectionPool, appConfig.directoryConfig, backgroundLdapExecutionContext, memberOfCache, resourceCache)(IOContextShift(backgroundLdapExecutionContext))
       backgroundDirectoryDAO = new LdapDirectoryDAO(backgroundLdapConnectionPool, appConfig.directoryConfig, backgroundLdapExecutionContext, memberOfCache)(backgroundLdapExecutionContext, implicitly[Timer[IO]])
 
       appDependencies <- appConfig.googleConfig match {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -278,6 +278,6 @@ object SamLdapConnectionPostProcessor extends PostConnectProcessor with LazyLogg
 object SamLdapConnectionDisconnectHandler extends DisconnectHandler with LazyLogging {
   override def handleDisconnect(
       connection: LDAPConnection, host: String, port: Int, disconnectType: DisconnectType, message: String, cause: Throwable): Unit = {
-    logger.info(s"handleDisconnect -- ${connection.getConnectionID}", cause)
+    logger.info(s"handleDisconnect -- ${connection.getConnectionID}, $disconnectType, $message", cause)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -105,7 +105,8 @@ object AppConfig {
       config.getString("password"),
       config.getString("baseDn"),
       config.getString("enabledUsersGroupDn"),
-      config.as[Option[Int]]("connectionPoolSize").getOrElse(20),
+      config.as[Option[Int]]("connectionPoolSize").getOrElse(15),
+      config.as[Option[Int]]("backgroundDonnectionPoolSize").getOrElse(5),
       config.as[Option[CacheConfig]]("memberOfCache").getOrElse(CacheConfig(100, java.time.Duration.ofMinutes(1))),
       config.as[Option[CacheConfig]]("resourceCache").getOrElse(CacheConfig(10000, java.time.Duration.ofHours(1)))
     )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -106,7 +106,7 @@ object AppConfig {
       config.getString("baseDn"),
       config.getString("enabledUsersGroupDn"),
       config.as[Option[Int]]("connectionPoolSize").getOrElse(15),
-      config.as[Option[Int]]("backgroundDonnectionPoolSize").getOrElse(5),
+      config.as[Option[Int]]("backgroundConnectionPoolSize").getOrElse(5),
       config.as[Option[CacheConfig]]("memberOfCache").getOrElse(CacheConfig(100, java.time.Duration.ofMinutes(1))),
       config.as[Option[CacheConfig]]("resourceCache").getOrElse(CacheConfig(10000, java.time.Duration.ofHours(1)))
     )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
@@ -8,7 +8,8 @@ case class DirectoryConfig(directoryUrl: String,
                            password: String,
                            baseDn: String,
                            enabledUsersGroupDn: String,
-                           connectionPoolSize: Int = 20,
+                           connectionPoolSize: Int = 15,
+                           backgroundConnectionPoolSize: Int = 5,
                            memberOfCache: CacheConfig,
                            resourceCache: CacheConfig
                           )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -49,7 +49,7 @@ trait DirectoryDAO {
   def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]]
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]
   def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]]
-  def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
+  def listParentGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
 
   def enableIdentity(subject: WorkbenchSubject): IO[Unit]
   def disableIdentity(subject: WorkbenchSubject): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -48,7 +48,7 @@ trait DirectoryDAO {
 
   def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]]
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]
-  def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]]
+  def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]]
   def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
 
   def enableIdentity(subject: WorkbenchSubject): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -31,8 +31,8 @@ trait DirectoryDAO {
   def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject): IO[Boolean]
   def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject): IO[Boolean]
   def updateSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Unit]
-  def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]]
-  def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): Future[Option[WorkbenchEmail]]
+  def getSynchronizedDate(groupId: WorkbenchGroupIdentity): IO[Option[Date]]
+  def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): IO[Option[WorkbenchEmail]]
 
   def loadSubjectFromEmail(email: WorkbenchEmail): IO[Option[WorkbenchSubject]]
   def loadSubjectEmail(subject: WorkbenchSubject): IO[Option[WorkbenchEmail]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -49,7 +49,7 @@ trait DirectoryDAO {
   def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]]
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]
   def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]]
-  def listParentGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
+  def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
 
   def enableIdentity(subject: WorkbenchSubject): IO[Unit]
   def disableIdentity(subject: WorkbenchSubject): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -255,23 +255,23 @@ class LdapDirectoryDAO(
     }
   }
 
-  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = IO {
-    ldapSearchStream(
-      directoryConfig.baseDn,
-      SearchScope.SUB,
-      Filter.createANDFilter(groupIds.map(groupId => Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava)
-    )(getAttribute(_, Attr.uid)).flatten.map(WorkbenchUserId).toSet
-  }
-
-//  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = {
-//    for {
-//      flatMembers <- groupIds.toList.traverse { groupId =>
-//        listFlattenedMembers(groupId)
-//      }
-//    } yield {
-//      flatMembers.reduce(_ intersect _)
-//    }
+//  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = IO {
+//    ldapSearchStream(
+//      directoryConfig.baseDn,
+//      SearchScope.SUB,
+//      Filter.createANDFilter(groupIds.map(groupId => Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava)
+//    )(getAttribute(_, Attr.uid)).flatten.map(WorkbenchUserId).toSet
 //  }
+
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = {
+    for {
+      flatMembers <- groupIds.toList.traverse { groupId =>
+        listFlattenedMembers(groupId)
+      }
+    } yield {
+      flatMembers.reduce(_ intersect _)
+    }
+  }
 
   def listFlattenedMembers(groupId: WorkbenchGroupIdentity, visitedGroupIds: Set[WorkbenchGroupIdentity] = Set.empty): IO[Set[WorkbenchUserId]] = {
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -255,15 +255,23 @@ class LdapDirectoryDAO(
     }
   }
 
-  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = {
-    for {
-      flatMembers <- groupIds.toList.traverse { groupId =>
-        listFlattenedMembers(groupId)
-      }
-    } yield {
-      flatMembers.reduce(_ intersect _)
-    }
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = IO {
+    ldapSearchStream(
+      directoryConfig.baseDn,
+      SearchScope.SUB,
+      Filter.createANDFilter(groupIds.map(groupId => Filter.createEqualityFilter(Attr.memberOf, groupDn(groupId))).asJava)
+    )(getAttribute(_, Attr.uid)).flatten.map(WorkbenchUserId).toSet
   }
+
+//  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = {
+//    for {
+//      flatMembers <- groupIds.toList.traverse { groupId =>
+//        listFlattenedMembers(groupId)
+//      }
+//    } yield {
+//      flatMembers.reduce(_ intersect _)
+//    }
+//  }
 
   def listFlattenedMembers(groupId: WorkbenchGroupIdentity, visitedGroupIds: Set[WorkbenchGroupIdentity] = Set.empty): IO[Set[WorkbenchUserId]] = {
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -90,8 +90,8 @@ class LdapDirectoryDAO(
 
   override def deleteGroup(groupName: WorkbenchGroupName): IO[Unit] =
     for {
-      ancestors <- listAncestorGroups(groupName)
-      res <- if (ancestors.nonEmpty) {
+      parents <- listParentGroups(groupName)
+      res <- if (parents.nonEmpty) {
         IO.raiseError(
           new WorkbenchExceptionWithErrorReport(
             ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group")))
@@ -291,7 +291,9 @@ class LdapDirectoryDAO(
     )
   }
 
-  override def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = listMemberOfGroups(groupId)
+  override def listParentGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = {
+    executeLdap(IO(ldapSearchStream(directoryConfig.baseDn, SearchScope.SUB, Filter.createEqualityFilter(Attr.uniqueMember, groupDn(groupId)))(e => dnToGroupIdentity(e.getDN)).toSet))
+  }
 
   override def enableIdentity(subject: WorkbenchSubject): IO[Unit] =
     executeLdap(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -140,20 +140,20 @@ class LdapDirectoryDAO(
     ldapConnectionPool.modify(groupDn(groupId), new Modification(ModificationType.REPLACE, Attr.groupSynchronizedTimestamp, formattedDate(new Date())))
   }
 
-  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]] = Future {
-    Option(ldapConnectionPool.getEntry(groupDn(groupId), Attr.groupSynchronizedTimestamp))
+  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): IO[Option[Date]] = {
+    executeLdap(IO(Option(ldapConnectionPool.getEntry(groupDn(groupId), Attr.groupSynchronizedTimestamp))
       .map { entry =>
         Option(entry.getAttributeValue(Attr.groupSynchronizedTimestamp)).map(parseDate)
       }
-      .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
+      .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))))
   }
 
-  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): Future[Option[WorkbenchEmail]] = Future {
-    Option(ldapConnectionPool.getEntry(groupDn(groupId), Attr.email))
+  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): IO[Option[WorkbenchEmail]] = {
+    executeLdap(IO(Option(ldapConnectionPool.getEntry(groupDn(groupId), Attr.email))
       .map { entry =>
         Option(entry.getAttributeValue(Attr.email)).map(WorkbenchEmail)
       }
-      .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
+      .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))))
   }
 
   override def loadSubjectFromEmail(email: WorkbenchEmail): IO[Option[WorkbenchSubject]] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -21,6 +21,7 @@ import scala.concurrent.ExecutionContext
 trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with SecurityDirectives {
   implicit val executionContext: ExecutionContext
   val googleExtensions: GoogleExtensions
+  val googleGroupSynchronizer: GoogleGroupSynchronizer
 
   override def extensionRoutes: server.Route =
     (pathPrefix("google" / "v1") | pathPrefix("google")) {
@@ -138,7 +139,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                 post {
                   complete {
                     import GoogleModelJsonSupport._
-                    googleExtensions.synchronizeGroupMembers(policyId).map { syncReport =>
+                    googleGroupSynchronizer.synchronizeGroupMembers(policyId).map { syncReport =>
                       StatusCodes.OK -> syncReport
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -153,13 +153,13 @@ class GoogleExtensions(
         case (rpn: FullyQualifiedPolicyId, Some(_)) => rpn.toJson.compactPrint
       }
       _ <- googlePubSubDAO.publishMessages(googleServicesConfig.groupSyncTopic, messagesForIdsWithSyncDates)
-      parentGroups <- Future.traverse(groupIdentities) { id =>
-        directoryDAO.listParentGroups(id).unsafeToFuture()
+      ancestorGroups <- Future.traverse(groupIdentities) { id =>
+        directoryDAO.listAncestorGroups(id).unsafeToFuture()
       }
-      managedGroupIds = (parentGroups.flatten ++ groupIdentities).filterNot(visitedGroups.contains).collect {
+      managedGroupIds = (ancestorGroups.flatten ++ groupIdentities).filterNot(visitedGroups.contains).collect {
         case FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, id), _) => id
       }
-      _ <- Future.traverse(managedGroupIds)(id => onManagedGroupUpdate(id, visitedGroups ++ groupIdentities ++ parentGroups.flatten))
+      _ <- Future.traverse(managedGroupIds)(id => onManagedGroupUpdate(id, visitedGroups ++ groupIdentities ++ ancestorGroups.flatten))
     } yield ()
 
   private def onManagedGroupUpdate(groupId: ResourceId, visitedGroups: Seq[WorkbenchGroupIdentity]): Future[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -14,15 +14,7 @@ import com.google.rpc.Code
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.util.{DistributedLock, LockPath}
-import org.broadinstitute.dsde.workbench.google.{
-  CollectionName,
-  Document,
-  GoogleDirectoryDAO,
-  GoogleIamDAO,
-  GoogleProjectDAO,
-  GooglePubSubDAO,
-  GoogleStorageDAO
-}
+import org.broadinstitute.dsde.workbench.google.{CollectionName, Document, GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.Notifications.Notification
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchGroupNameFormat
 import org.broadinstitute.dsde.workbench.model._
@@ -35,7 +27,7 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.AccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
-import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, SamApplication}
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, ManagedGroupService, SamApplication}
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, SubsystemStatus, Subsystems}
 import org.broadinstitute.dsde.workbench.util.{FutureSupport, Retry}
 import spray.json._
@@ -177,7 +169,7 @@ class GoogleExtensions(
         directoryDAO.listAncestorGroups(id).unsafeToFuture()
       }
       managedGroupIds = (ancestorGroups.flatten ++ groupIdentities).filterNot(visitedGroups.contains).collect {
-        case FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("managed-group"), id), _) => id
+        case FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, id), _) => id
       }
       _ <- Future.traverse(managedGroupIds)(id => onManagedGroupUpdate(id, visitedGroups ++ groupIdentities ++ ancestorGroups.flatten))
     } yield ()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -33,9 +33,9 @@ object GoogleGroupSyncMonitorSupervisor {
       pubSubTopicName: String,
       pubSubSubscriptionName: String,
       workerCount: Int,
-      googleExtensions: GoogleExtensions): Props =
+      groupSynchronizer: GoogleGroupSynchronizer): Props =
     Props(
-      new GoogleGroupSyncMonitorSupervisor(pollInterval, pollIntervalJitter, pubSubDao, pubSubTopicName, pubSubSubscriptionName, workerCount, googleExtensions))
+      new GoogleGroupSyncMonitorSupervisor(pollInterval, pollIntervalJitter, pubSubDao, pubSubTopicName, pubSubSubscriptionName, workerCount, groupSynchronizer))
 }
 
 class GoogleGroupSyncMonitorSupervisor(
@@ -45,7 +45,7 @@ class GoogleGroupSyncMonitorSupervisor(
     pubSubTopicName: String,
     pubSubSubscriptionName: String,
     workerCount: Int,
-    googleExtensions: GoogleExtensions)
+    groupSynchronizer: GoogleGroupSynchronizer)
     extends Actor
     with LazyLogging {
   import GoogleGroupSyncMonitorSupervisor._
@@ -67,7 +67,7 @@ class GoogleGroupSyncMonitorSupervisor(
 
   def startOne(): Unit = {
     logger.info("starting GoogleGroupSyncMonitorActor")
-    actorOf(GoogleGroupSyncMonitor.props(pollInterval, pollIntervalJitter, pubSubDao, pubSubSubscriptionName, googleExtensions))
+    actorOf(GoogleGroupSyncMonitor.props(pollInterval, pollIntervalJitter, pubSubDao, pubSubSubscriptionName, groupSynchronizer))
   }
 
   override val supervisorStrategy =
@@ -94,8 +94,8 @@ object GoogleGroupSyncMonitor {
       pollIntervalJitter: FiniteDuration,
       pubSubDao: GooglePubSubDAO,
       pubSubSubscriptionName: String,
-      googleExtensions: GoogleExtensions): Props =
-    Props(new GoogleGroupSyncMonitorActor(pollInterval, pollIntervalJitter, pubSubDao, pubSubSubscriptionName, googleExtensions))
+      groupSynchronizer: GoogleGroupSynchronizer): Props =
+    Props(new GoogleGroupSyncMonitorActor(pollInterval, pollIntervalJitter, pubSubDao, pubSubSubscriptionName, groupSynchronizer))
 }
 
 class GoogleGroupSyncMonitorActor(
@@ -103,7 +103,7 @@ class GoogleGroupSyncMonitorActor(
     pollIntervalJitter: FiniteDuration,
     pubSubDao: GooglePubSubDAO,
     pubSubSubscriptionName: String,
-    googleExtensions: GoogleExtensions)
+    googleExtensions: GoogleGroupSynchronizer)
     extends Actor
     with LazyLogging
     with FutureSupport {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -103,7 +103,7 @@ class GoogleGroupSyncMonitorActor(
     pollIntervalJitter: FiniteDuration,
     pubSubDao: GooglePubSubDAO,
     pubSubSubscriptionName: String,
-    googleExtensions: GoogleGroupSynchronizer)
+    groupSynchronizer: GoogleGroupSynchronizer)
     extends Actor
     with LazyLogging
     with FutureSupport {
@@ -129,7 +129,7 @@ class GoogleGroupSyncMonitorActor(
       logger.debug(s"received sync message: $message")
       val groupId: WorkbenchGroupIdentity = parseMessage(message)
 
-      googleExtensions
+      groupSynchronizer
         .synchronizeGroupMembers(groupId)
         .toTry
         .map(sr => sr.fold(t => FailToSynchronize(t, message.ackId), x => ReportMessage(x, message.ackId))) pipeTo self

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -1,0 +1,136 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.openam.AccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.util.FutureSupport
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
+                              accessPolicyDAO: AccessPolicyDAO,
+                              googleDirectoryDAO: GoogleDirectoryDAO,
+                              googleExtensions: GoogleExtensions,
+                              resourceTypes: Map[ResourceTypeName, ResourceType])(implicit executionContext: ExecutionContext)
+  extends LazyLogging with FutureSupport {
+  def synchronizeGroupMembers(
+                               groupId: WorkbenchGroupIdentity,
+                               visitedGroups: Set[WorkbenchGroupIdentity] = Set.empty[WorkbenchGroupIdentity]): Future[Map[WorkbenchEmail, Seq[SyncReportItem]]] = {
+    def toSyncReportItem(operation: String, email: String, result: Try[Unit]) =
+      SyncReportItem(
+        operation,
+        email,
+        result match {
+          case Success(_) => None
+          case Failure(t) => Option(ErrorReport(t))
+        }
+      )
+
+    if (visitedGroups.contains(groupId)) {
+      Future.successful(Map.empty)
+    } else {
+      for {
+        groupOption <- groupId match {
+          case basicGroupName: WorkbenchGroupName => directoryDAO.loadGroup(basicGroupName).unsafeToFuture()
+          case rpn: FullyQualifiedPolicyId =>
+            accessPolicyDAO
+              .loadPolicy(rpn)
+              .unsafeToFuture()
+              .map(_.map { loadedPolicy =>
+                if (loadedPolicy.public) {
+                  // include all users group when synchronizing a public policy
+                  AccessPolicy.members.modify(_ + googleExtensions.allUsersGroupName)(loadedPolicy)
+                } else {
+                  loadedPolicy
+                }
+              })
+        }
+
+        group = groupOption.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
+
+        members <- (group match {
+          case accessPolicy: AccessPolicy =>
+            if (isConstrainable(accessPolicy.id.resource, accessPolicy)) {
+              calculateIntersectionGroup(accessPolicy.id.resource, accessPolicy)
+            } else {
+              IO.pure(accessPolicy.members)
+            }
+          case group: BasicWorkbenchGroup => IO.pure(group.members)
+        }).unsafeToFuture()
+
+        subGroupSyncs <- Future.traverse(group.members) {
+          case subGroup: WorkbenchGroupIdentity =>
+            directoryDAO.getSynchronizedDate(subGroup).flatMap {
+              case None => synchronizeGroupMembers(subGroup, visitedGroups + groupId)
+              case _ => Future.successful(Map.empty[WorkbenchEmail, Seq[SyncReportItem]])
+            }
+          case _ => Future.successful(Map.empty[WorkbenchEmail, Seq[SyncReportItem]])
+        }
+
+        googleMemberEmails <- googleDirectoryDAO.listGroupMembers(group.email) flatMap {
+          case None =>
+            googleDirectoryDAO.createGroup(groupId.toString, group.email, Option(googleDirectoryDAO.lockedDownGroupSettings)) map (_ => Set.empty[String])
+          case Some(members) => Future.successful(members.map(_.toLowerCase).toSet)
+        }
+        samMemberEmails <- Future
+          .traverse(members) {
+            case group: WorkbenchGroupIdentity => directoryDAO.loadSubjectEmail(group).unsafeToFuture()
+
+            // use proxy group email instead of user's actual email
+            case userSubjectId: WorkbenchUserId => googleExtensions.getUserProxy(userSubjectId)
+
+            // not sure why this next case would happen but if a petSA is in a group just use its email
+            case petSA: PetServiceAccountId => directoryDAO.loadSubjectEmail(petSA).unsafeToFuture()
+          }
+          .map(_.collect { case Some(email) => email.value.toLowerCase })
+
+        toAdd = samMemberEmails -- googleMemberEmails
+        toRemove = googleMemberEmails -- samMemberEmails
+
+        addTrials <- Future.traverse(toAdd) { addEmail =>
+          googleDirectoryDAO.addMemberToGroup(group.email, WorkbenchEmail(addEmail)).toTry.map(toSyncReportItem("added", addEmail, _))
+        }
+        removeTrials <- Future.traverse(toRemove) { removeEmail =>
+          googleDirectoryDAO.removeMemberFromGroup(group.email, WorkbenchEmail(removeEmail)).toTry.map(toSyncReportItem("removed", removeEmail, _))
+        }
+
+        _ <- directoryDAO.updateSynchronizedDate(groupId)
+      } yield {
+        Map(group.email -> Seq(addTrials, removeTrials).flatten) ++ subGroupSyncs.flatten
+      }
+    }
+  }
+
+  private[google] def isConstrainable(resource: FullyQualifiedResourceId, accessPolicy: AccessPolicy): Boolean =
+    resourceTypes.get(resource.resourceTypeName) match {
+      case Some(resourceType) =>
+        resourceType.actionPatterns.exists { actionPattern =>
+          actionPattern.authDomainConstrainable &&
+            (accessPolicy.actions.exists(actionPattern.matches) ||
+              accessPolicy.roles.exists { accessPolicyRole =>
+                resourceType.roles.exists {
+                  case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _) => resourceTypeRole.actions.exists(actionPattern.matches)
+                  case _ => false
+                }
+              })
+        }
+      case None =>
+        throw new WorkbenchException(s"Invalid resource type specified. ${resource.resourceTypeName} is not a recognized resource type.")
+    }
+
+  private[google] def calculateIntersectionGroup(resource: FullyQualifiedResourceId, policy: AccessPolicy): IO[Set[WorkbenchUserId]] =
+    for {
+      groups <- accessPolicyDAO.loadResourceAuthDomain(resource)
+      members <- directoryDAO.listIntersectionGroupUsers(groups.asInstanceOf[Set[WorkbenchGroupIdentity]] + policy.id)
+    } yield {
+      members
+    }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -67,7 +67,7 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
 
         subGroupSyncs <- Future.traverse(group.members) {
           case subGroup: WorkbenchGroupIdentity =>
-            directoryDAO.getSynchronizedDate(subGroup).flatMap {
+            directoryDAO.getSynchronizedDate(subGroup).unsafeToFuture().flatMap {
               case None => synchronizeGroupMembers(subGroup, visitedGroups + groupId)
               case _ => Future.successful(Map.empty[WorkbenchEmail, Seq[SyncReportItem]])
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -364,13 +364,13 @@ class ResourceService(
     }
 
   def addSubjectToPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject): Future[Unit] =
-    directoryDAO.addGroupMember(policyIdentity, subject).unsafeToFuture().map(_ => ()) flatMap {
-      _ => fireGroupUpdateNotification(policyIdentity)
+    directoryDAO.addGroupMember(policyIdentity, subject).unsafeToFuture().map(_ => ()) andThen {
+      case Success(_) => fireGroupUpdateNotification(policyIdentity)
     }
 
   def removeSubjectFromPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject): Future[Unit] =
-    directoryDAO.removeGroupMember(policyIdentity, subject).void.unsafeToFuture() flatMap {
-      _ => fireGroupUpdateNotification(policyIdentity)
+    directoryDAO.removeGroupMember(policyIdentity, subject).void.unsafeToFuture() andThen {
+      case Success(_) => fireGroupUpdateNotification(policyIdentity)
     }
 
   private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy): IO[AccessPolicyMembership] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -364,13 +364,13 @@ class ResourceService(
     }
 
   def addSubjectToPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject): Future[Unit] =
-    directoryDAO.addGroupMember(policyIdentity, subject).unsafeToFuture().map(_ => ()) andThen {
-      case Success(_) => fireGroupUpdateNotification(policyIdentity)
+    directoryDAO.addGroupMember(policyIdentity, subject).unsafeToFuture().map(_ => ()) flatMap {
+      _ => fireGroupUpdateNotification(policyIdentity)
     }
 
   def removeSubjectFromPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject): Future[Unit] =
-    directoryDAO.removeGroupMember(policyIdentity, subject).void.unsafeToFuture() andThen {
-      case Success(_) => fireGroupUpdateNotification(policyIdentity)
+    directoryDAO.removeGroupMember(policyIdentity, subject).void.unsafeToFuture() flatMap {
+      _ => fireGroupUpdateNotification(policyIdentity)
     }
 
   private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy): IO[AccessPolicyMembership] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
 import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
-import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, MockAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -138,6 +138,11 @@ object TestSupport extends TestSupport {
     with GoogleExtensionRoutes {
       override val cloudExtensions: CloudExtensions = samDependencies.cloudExtensions
       override val googleExtensions: GoogleExtensions = if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions] else null
+      override val googleGroupSynchronizer: GoogleGroupSynchronizer = {
+        if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) {
+          new GoogleGroupSynchronizer(googleExtensions.directoryDAO, googleExtensions.accessPolicyDAO, googleExtensions.googleDirectoryDAO, googleExtensions, googleExtensions.resourceTypes)(executionContext)
+        } else null
+      }
       val googleKeyCache = if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions])samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions].googleKeyCache else null
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -203,8 +203,8 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     dao.createGroup(group3).unsafeRunSync()
 
     try {
-      assertResult(Set(groupName2, groupName3)) {
-        dao.listAncestorGroups(groupName1).unsafeRunSync()
+      assertResult(Set(groupName2)) {
+        dao.listParentGroups(groupName1).unsafeRunSync()
       }
     } finally {
       dao.deleteGroup(groupName3).unsafeRunSync()
@@ -238,8 +238,8 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
         dao.listUsersGroups(userId).unsafeRunSync()
       }
 
-      assertResult(Set(groupName1, groupName2, groupName3)) {
-        dao.listAncestorGroups(groupName3).unsafeRunSync()
+      assertResult(Set(groupName1)) {
+        dao.listParentGroups(groupName3).unsafeRunSync()
       }
     } finally {
       runAndWait(dao.deleteUser(userId))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -203,8 +203,8 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     dao.createGroup(group3).unsafeRunSync()
 
     try {
-      assertResult(Set(groupName2)) {
-        dao.listParentGroups(groupName1).unsafeRunSync()
+      assertResult(Set(groupName2, groupName3)) {
+        dao.listAncestorGroups(groupName1).unsafeRunSync()
       }
     } finally {
       dao.deleteGroup(groupName3).unsafeRunSync()
@@ -238,8 +238,8 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
         dao.listUsersGroups(userId).unsafeRunSync()
       }
 
-      assertResult(Set(groupName1)) {
-        dao.listParentGroups(groupName3).unsafeRunSync()
+      assertResult(Set(groupName1, groupName2, groupName3)) {
+        dao.listAncestorGroups(groupName3).unsafeRunSync()
       }
     } finally {
       runAndWait(dao.deleteUser(userId))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -53,7 +53,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
   }
 
   override def deleteGroup(groupName: WorkbenchGroupName): IO[Unit] = {
-    listParentGroups(groupName).map { ancestors =>
+    listAncestorGroups(groupName).map { ancestors =>
       if (ancestors.nonEmpty)
         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group"))
       else
@@ -153,7 +153,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def listParentGroups(groupName: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = IO {
+  override def listAncestorGroups(groupName: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = IO {
     listSubjectsGroups(groupName, Set.empty).map(_.id)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -53,7 +53,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
   }
 
   override def deleteGroup(groupName: WorkbenchGroupName): IO[Unit] = {
-    listAncestorGroups(groupName).map { ancestors =>
+    listParentGroups(groupName).map { ancestors =>
       if (ancestors.nonEmpty)
         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group"))
       else
@@ -153,7 +153,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def listAncestorGroups(groupName: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = IO {
+  override def listParentGroups(groupName: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = IO {
     listSubjectsGroups(groupName, Set.empty).map(_.id)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -135,7 +135,7 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
     }
   }
 
-  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): Future[Set[WorkbenchUserId]] = Future {
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = IO {
     groupIds.flatMap(groupId => listGroupUsers(groupId, Set.empty))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -214,12 +214,12 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
       loadSubjectEmail(subject).map(_.get)
     }
 
-  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): Future[Option[Date]] = {
-    Future.successful(groupSynchronizedDates.get(groupId))
+  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity): IO[Option[Date]] = {
+    IO.pure(groupSynchronizedDates.get(groupId))
   }
 
-  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): Future[Option[WorkbenchEmail]] = {
-    Future.successful(groups.get(WorkbenchGroupName(groupId.toString)).map(_.email))
+  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity): IO[Option[WorkbenchEmail]] = {
+    IO.pure(groups.get(WorkbenchGroupName(groupId.toString)).map(_.email))
   }
 
   override def getUserFromPetServiceAccount(petSAId: ServiceAccountSubjectId): IO[Option[WorkbenchUser]] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -649,7 +649,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
@@ -681,12 +681,12 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish subgroup relationship to managed group
-    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))
@@ -716,13 +716,13 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish nested group structure for owner policy and subgroup in managed group
-    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
-    when(mockDirectoryDAO.listAncestorGroups(ownerRPN)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listParentGroups(ownerRPN)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -220,7 +220,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     when(mockAccessPolicyDAO.loadPolicy(testPolicy.id)).thenReturn(IO.pure(Option(testPolicy)))
     when(mockAccessPolicyDAO.loadResourceAuthDomain(resource.fullyQualifiedId)).thenReturn(IO.pure(Set(managedGroupId)))
 
-    when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id))).thenReturn(Future.successful(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
+    when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id))).thenReturn(IO.pure(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
 
     when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(Future.successful(()))
     when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(Future.successful(Some(new GregorianCalendar(2017, 11, 22).getTime())))
@@ -923,8 +923,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), Set.empty, Set.empty)))
 
-    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
-    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy))
+    val calculateIntersectionGroup = PrivateMethod[IO[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = (ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy)).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothUser.userId)
   }
 
@@ -964,8 +964,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     // Access policy that intersection group will be calculated for
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicySubGroup.email, inBothSubGroup.email), Set.empty, Set.empty)))
 
-    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
-    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy))
+    val calculateIntersectionGroup = PrivateMethod[IO[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = (ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy)).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothSubGroupUser.userId)
   }
 
@@ -982,8 +982,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), Set.empty, Set.empty)))
 
-    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
-    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy))
+    val calculateIntersectionGroup = PrivateMethod[IO[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = (ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy)).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothUser.userId, inPolicyUser.userId)
   }
 
@@ -1004,8 +1004,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.userEmail), Set.empty, Set.empty)))
 
-    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
-    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy))
+    val calculateIntersectionGroup = PrivateMethod[IO[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = (ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy)).unsafeRunSync()
     intersectionGroup shouldEqual Set.empty
   }
 
@@ -1023,8 +1023,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, Set.empty, Set.empty)))
 
-    val calculateIntersectionGroup = PrivateMethod[Future[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
-    val intersectionGroup = runAndWait(ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy))
+    val calculateIntersectionGroup = PrivateMethod[IO[Set[WorkbenchUserId]]]('calculateIntersectionGroup)
+    val intersectionGroup = (ge invokePrivate calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy)).unsafeRunSync()
     intersectionGroup shouldEqual Set.empty
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -649,7 +649,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
@@ -681,12 +681,12 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish subgroup relationship to managed group
-    when(mockDirectoryDAO.listParentGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))
@@ -716,13 +716,13 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val readerPolicy = AccessPolicy(readerRPN, Set.empty, WorkbenchEmail("reader@example.com"), Set.empty, Set.empty, public = false)
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listParentGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId])).thenReturn(Future.successful(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGooglePubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish nested group structure for owner policy and subgroup in managed group
-    when(mockDirectoryDAO.listParentGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
-    when(mockDirectoryDAO.listParentGroups(ownerRPN)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId))).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(ownerRPN)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
     when(mockAccessPolicyDAO.listResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId))).thenReturn(IO.pure(Set(resource)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -33,7 +33,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
   "GoogleGroupSyncMonitor" should "handle sync message" in {
     implicit val patienceConfig = PatienceConfig(timeout = 1 second)
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleExtensions = mock[GoogleExtensions]
+    val mockGoogleExtensions = mock[GoogleGroupSynchronizer]
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")
@@ -65,7 +65,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
   it should "handle missing target group" in {
     implicit val patienceConfig = PatienceConfig(timeout = 1 second)
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleExtensions = mock[GoogleExtensions]
+    val mockGoogleExtensions = mock[GoogleGroupSynchronizer]
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")


### PR DESCRIPTION
Let me tell you a story. Once upon a time integration tests ran on alpha. The sun was out and everyone was happy until the big bad whitelist sync tests came to town. They huffed and they puffed and they blew sam and opendj down. 

First we looked at opendj to see why it was unhappy. The ldap audit logs showed a bunch of slow queries using the isMemberOf attribute to figure out intersection groups. That only happens during google group synching! And there are a lot of calls all involving the TCGA group. Who is calling google group syncing? Hey tests, why are you syncing the whitelist 3 time in quick succession (according to Kibana logs)!?! That is not so great, but still sam and opendj should be able to stand up to that load.

First theory: isMemberOf queries are not that bad when the volume is small. When there are too many it is too cpu intensive and everything slows down. Solution rewrite the queries to do our own recursive lookups since individually they are pretty fast.

Test again: BOOM! no dice. Plus now the out of memory (OOM) killer likes to stomp on sam every now and then. The isMemberOf queries are gone now but now there are BIND requests in the ldap audit logs that are taking as long as 2+ minutes! Why are there so many BIND requests. Those are for authenticating new ldap connections. But we have a ldap connection pool why would we have too many connections?

Next theory: Something is up with our connection pool. After reading the docs a bit, turns out our connection pool has a "create if necessary" feature where if it runs out of connections it will create new one, and it is on by default, how thoughtful. Fortunately there are settings to turn that off and set how long to wait for a connection. OK, turn it off, set the timeout to 30s.

Test again: BOOM! no dice: the OOM killer is having a field day in sam. Opendj seems ok though without any queries above a few hundred ms.

Next theory: sam has too much memory for the VM. Let's try trimming the heap size. Still have problems with 1.5g (down from 2g) and 1g. Hmmmm... what the hell is sam doing!?! Let's look at a thread dump... holy crap why are there >1k threads!?! At rest sam has about 70 threads, when sync starts >1k are added, that would add some non-heap memory pressure! This smells like our ldap execution context which has an unbounded thread pool size.

Next theory: change our unbounded thread pool to a fixed thread pool with the same size as our ldap connection pool.

Test again: now we have a few dice but not all of them. Sam and opendj seem stable as in they are doing things and the things they do are moving along pretty fast. But sam is generally unresponsive to other queries (especially other sync requests) when the sync is being processed in the background. A peak at the thread dump shows that all of threads on sam are busy doing sync stuff leaving no resources for other requests.

Next theory: we need a way to let the background stuff run without crowding everything else out. Let's create a background context, thread pool, ldap pool and run all the background stuff there leaving the main context, etc. for servicing api calls.

Test again: still some problems... the main thread pool is still full of junk but it seems weird. [try a bunch of things, bang head on table, more trying, more banging]. On a whim convert the onGroupUpdate code from Future to IO. Eureka! I am not 100% certain why that works but the code still seems to have the same functionality so I'll take it. 

But the tests still fail on alpha but they cruise along, no timeouts... god damn caching! Now I need to figure that out but that is another story.

new config settings: https://github.com/broadinstitute/firecloud-develop/pull/1474
wait for caching to clear: https://github.com/broadinstitute/firecloud-orchestration/pull/697

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
