### PR TITLE
use semephore to limit number of ldap requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ docker/stand-alone/ca-bundle.crt
 
 ## Directory-based project format:
 .idea/
+.metals/
+env.properties
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:
@@ -81,3 +83,5 @@ newrelic-agent-4.6.0.jar
 automation/report.xml
 automation/test-reports/
 automation/src/test/resources/
+
+*.jar

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -33,16 +33,15 @@ trait SecurityDirectives {
       }
     }
 
-  private def listActions(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, requestedActions: Set[ResourceAction]): IO[Set[ResourceAction]] = {
+  private def listActions(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, requestedActions: Set[ResourceAction]): IO[Set[ResourceAction]] =
     // this is optimized for the case where the user has permission since that is the usual case
     // if the first attempt shows the user does not have permission, force a second attempt
     for {
       actionsAttempt1 <- policyEvaluatorService.listUserResourceActions(resource, userId, force = false)
-      actionsAttempt2 <- if (hasAccess(requestedActions, actionsAttempt1)) IO.pure(actionsAttempt1) else policyEvaluatorService.listUserResourceActions(resource, userId, force = true)
+      actionsAttempt2 <- if (hasAccess(requestedActions, actionsAttempt1)) IO.pure(actionsAttempt1)
+      else policyEvaluatorService.listUserResourceActions(resource, userId, force = true)
     } yield actionsAttempt2
-  }
 
-  private def hasAccess(requestedActions: Set[ResourceAction], actions: Set[ResourceAction]): Boolean = {
+  private def hasAccess(requestedActions: Set[ResourceAction], actions: Set[ResourceAction]): Boolean =
     actions.intersect(requestedActions).nonEmpty
-  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRoutes.scala
@@ -30,11 +30,11 @@ trait StatusRoutes {
         }
       }
     } ~
-    pathPrefix("version") {
-      pathEndOrSingleSlash {
-        get {
-          complete((StatusCodes.OK, BuildTimeVersion.versionJson))
+      pathPrefix("version") {
+        pathEndOrSingleSlash {
+          get {
+            complete((StatusCodes.OK, BuildTimeVersion.versionJson))
+          }
         }
       }
-    }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DirectoryConfig.scala
@@ -3,15 +3,15 @@ package org.broadinstitute.dsde.workbench.sam.config
 /**
   * Created by dvoet on 5/26/17.
   */
-case class DirectoryConfig(directoryUrl: String,
-                           user: String,
-                           password: String,
-                           baseDn: String,
-                           enabledUsersGroupDn: String,
-                           connectionPoolSize: Int = 15,
-                           backgroundConnectionPoolSize: Int = 5,
-                           memberOfCache: CacheConfig,
-                           resourceCache: CacheConfig
-                          )
+final case class DirectoryConfig(
+    directoryUrl: String,
+    user: String,
+    password: String,
+    baseDn: String,
+    enabledUsersGroupDn: String,
+    connectionPoolSize: Int = 15,
+    backgroundConnectionPoolSize: Int = 5,
+    memberOfCache: CacheConfig,
+    resourceCache: CacheConfig)
 
-case class CacheConfig(maxEntries: Long, timeToLive: java.time.Duration)
+final case class CacheConfig(maxEntries: Long, timeToLive: java.time.Duration)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -3,6 +3,7 @@ import java.util.Date
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.data.OptionT
+import cats.effect.concurrent.Semaphore
 import cats.effect.{IO, Timer}
 import cats.implicits._
 import com.unboundid.ldap.sdk._
@@ -21,6 +22,7 @@ import scala.util.Try
 
 // use ExecutionContexts.blockingThreadPool for blockingEc
 class LdapDirectoryDAO(
+    protected val semaphore: Semaphore[IO],
     protected val ldapConnectionPool: LDAPConnectionPool,
     protected val directoryConfig: DirectoryConfig,
     protected val ecForLdapBlockingIO: ExecutionContext,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -14,7 +14,15 @@ import com.google.rpc.Code
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.util.{DistributedLock, LockPath}
-import org.broadinstitute.dsde.workbench.google.{CollectionName, Document, GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{
+  CollectionName,
+  Document,
+  GoogleDirectoryDAO,
+  GoogleIamDAO,
+  GoogleProjectDAO,
+  GooglePubSubDAO,
+  GoogleStorageDAO
+}
 import org.broadinstitute.dsde.workbench.model.Notifications.Notification
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchGroupNameFormat
 import org.broadinstitute.dsde.workbench.model._
@@ -235,7 +243,8 @@ class GoogleExtensions(
     googleDirectoryDAO.deleteGroup(groupEmail)
 
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
-  def createUserPetServiceAccount(user: WorkbenchUser): Future[PetServiceAccount] = createUserPetServiceAccount(user, petServiceAccountConfig.googleProject).unsafeToFuture()
+  def createUserPetServiceAccount(user: WorkbenchUser): Future[PetServiceAccount] =
+    createUserPetServiceAccount(user, petServiceAccountConfig.googleProject).unsafeToFuture()
 
   @deprecated("Use new two-argument version of this function", "Sam Phase 3")
   def deleteUserPetServiceAccount(userId: WorkbenchUserId): Future[Boolean] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -35,7 +35,14 @@ object GoogleGroupSyncMonitorSupervisor {
       workerCount: Int,
       groupSynchronizer: GoogleGroupSynchronizer): Props =
     Props(
-      new GoogleGroupSyncMonitorSupervisor(pollInterval, pollIntervalJitter, pubSubDao, pubSubTopicName, pubSubSubscriptionName, workerCount, groupSynchronizer))
+      new GoogleGroupSyncMonitorSupervisor(
+        pollInterval,
+        pollIntervalJitter,
+        pubSubDao,
+        pubSubTopicName,
+        pubSubSubscriptionName,
+        workerCount,
+        groupSynchronizer))
 }
 
 class GoogleGroupSyncMonitorSupervisor(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -14,15 +14,17 @@ import org.broadinstitute.dsde.workbench.util.FutureSupport
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
-                              accessPolicyDAO: AccessPolicyDAO,
-                              googleDirectoryDAO: GoogleDirectoryDAO,
-                              googleExtensions: GoogleExtensions,
-                              resourceTypes: Map[ResourceTypeName, ResourceType])(implicit executionContext: ExecutionContext)
-  extends LazyLogging with FutureSupport {
+class GoogleGroupSynchronizer(
+    directoryDAO: DirectoryDAO,
+    accessPolicyDAO: AccessPolicyDAO,
+    googleDirectoryDAO: GoogleDirectoryDAO,
+    googleExtensions: GoogleExtensions,
+    resourceTypes: Map[ResourceTypeName, ResourceType])(implicit executionContext: ExecutionContext)
+    extends LazyLogging
+    with FutureSupport {
   def synchronizeGroupMembers(
-                               groupId: WorkbenchGroupIdentity,
-                               visitedGroups: Set[WorkbenchGroupIdentity] = Set.empty[WorkbenchGroupIdentity]): Future[Map[WorkbenchEmail, Seq[SyncReportItem]]] = {
+      groupId: WorkbenchGroupIdentity,
+      visitedGroups: Set[WorkbenchGroupIdentity] = Set.empty[WorkbenchGroupIdentity]): Future[Map[WorkbenchEmail, Seq[SyncReportItem]]] = {
     def toSyncReportItem(operation: String, email: String, result: Try[Unit]) =
       SyncReportItem(
         operation,
@@ -113,13 +115,13 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
       case Some(resourceType) =>
         resourceType.actionPatterns.exists { actionPattern =>
           actionPattern.authDomainConstrainable &&
-            (accessPolicy.actions.exists(actionPattern.matches) ||
-              accessPolicy.roles.exists { accessPolicyRole =>
-                resourceType.roles.exists {
-                  case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _) => resourceTypeRole.actions.exists(actionPattern.matches)
-                  case _ => false
-                }
-              })
+          (accessPolicy.actions.exists(actionPattern.matches) ||
+          accessPolicy.roles.exists { accessPolicyRole =>
+            resourceType.roles.exists {
+              case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _) => resourceTypeRole.actions.exists(actionPattern.matches)
+              case _ => false
+            }
+          })
         }
       case None =>
         throw new WorkbenchException(s"Invalid resource type specified. ${resource.resourceTypeName} is not a recognized resource type.")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -4,6 +4,7 @@ package openam
 import java.util.Date
 
 import akka.http.scaladsl.model.StatusCodes
+import cats.effect.concurrent.Semaphore
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.unboundid.ldap.sdk._
@@ -21,6 +22,7 @@ import scala.concurrent.ExecutionContext
 
 // use ExecutionContexts.blockingThreadPool for blockingEc
 class LdapAccessPolicyDAO(
+    protected val semaphore: Semaphore[IO],
     protected val ldapConnectionPool: LDAPConnectionPool,
     protected val directoryConfig: DirectoryConfig,
     protected val ecForLdapBlockingIO: ExecutionContext,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -35,9 +35,8 @@ class PolicyEvaluatorService(
   }
 
   def hasPermission(resource: FullyQualifiedResourceId, action: ResourceAction, userId: WorkbenchUserId): IO[Boolean] = {
-    def checkPermission(force: Boolean) = {
+    def checkPermission(force: Boolean) =
       listUserResourceActions(resource, userId, force).map { _.contains(action) }
-    }
 
     // this is optimized for the case where the user has permission since that is the usual case
     // if the first attempt shows the user does not have permission, force a second attempt

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.Materializer
 import cats.effect.IO
+import cats.effect.concurrent.Semaphore
 import cats.kernel.Eq
 import com.google.cloud.firestore.{DocumentSnapshot, Firestore, Transaction}
 import com.typesafe.config.ConfigFactory
@@ -47,6 +48,7 @@ trait TestSupport{
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
   implicit val timer = IO.timer(scala.concurrent.ExecutionContext.global)
   implicit val eqWorkbenchException: Eq[WorkbenchException] = (x: WorkbenchException, y: WorkbenchException) => x.getMessage == y.getMessage
+  val semaphore = Semaphore[IO](15).unsafeRunSync()
 }
 
 trait PropertyBasedTesting extends PropertyChecks with Configuration with Matchers {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -27,7 +27,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
   override lazy val directoryConfig: DirectoryConfig = TestSupport.directoryConfig
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+  val dao = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   override protected def beforeAll(): Unit = {
@@ -311,7 +311,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     dao.createGroup(group1).unsafeRunSync()
     dao.createGroup(group2).unsafeRunSync()
 
-    val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+    val policyDAO = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
 
     val typeName1 = ResourceTypeName(UUID.randomUUID().toString)
 
@@ -485,7 +485,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
   "cache" should "return existing item" in {
     val cache: Cache[WorkbenchSubject, Set[String]] = createMemberOfCache("test-memberof-1")
 
-    val testDao = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, cache)
+    val testDao = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, blockingEc, cache)
 
     val workbenchSubject = WorkbenchUserId("snarglepup")
     val group = WorkbenchGroupName("testgroup")
@@ -499,7 +499,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
   it should "retain non-existing item" in {
     val cache: Cache[WorkbenchSubject, Set[String]] = createMemberOfCache("test-memberof-2")
 
-    val testDao = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, cache)
+    val testDao = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, blockingEc, cache)
 
     val workbenchSubject = WorkbenchUserId("snarglepup")
     val group = WorkbenchGroupName("testgroup")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -57,8 +57,8 @@ class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport wi
     val shared = sharedFixtures
     val dirURI = new URI(directoryConfig.directoryUrl)
     val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-    val ldapPolicyDao = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
-    val ldapDirDao = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+    val ldapPolicyDao = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+    val ldapDirDao = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(ldapDirDao))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, ldapPolicyDao)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -35,8 +35,8 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+  val dirDAO = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val resourceId = ResourceId("myNewGroup")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -22,8 +22,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
   val connectionPool = new LDAPConnectionPool(
     new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password),
     directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+  val dirDAO = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -35,8 +35,8 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
-  val policyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+  val dirDAO = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache)
+  val policyDAO = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -47,7 +47,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
   lazy val petServiceAccountConfig = TestSupport.appConfig.googleConfig.get.petServiceAccountConfig
   lazy val dirURI = new URI(directoryConfig.directoryUrl)
   lazy val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)
-  lazy val dirDAO = new LdapDirectoryDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
+  lazy val dirDAO = new LdapDirectoryDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache)
   lazy val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)
 
   var service: UserService = _
@@ -227,7 +227,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
     dirDAO.createUser(WorkbenchUser(user.id, None, user.email)).unsafeRunSync()
 
-    val accessPolicyDAO = new LdapAccessPolicyDAO(connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
+    val accessPolicyDAO = new LdapAccessPolicyDAO(semaphore, connectionPool, directoryConfig, TestSupport.blockingEc, TestSupport.testMemberOfCache, TestSupport.testResourceCache)
     val createPolicy = for {
       _ <- accessPolicyDAO.createResourceType(expectedAccessPolicyId.resource.resourceTypeName)
       _ <- accessPolicyDAO.createResource(Resource(expectedAccessPolicyId.resource.resourceTypeName, expectedAccessPolicyId.resource.resourceId, Set.empty))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupportSpec.scala
@@ -1,0 +1,48 @@
+package org.broadinstitute.dsde.workbench.sam.util
+import java.util.concurrent.Executors
+
+import cats.effect.IO
+import cats.effect.concurrent.Semaphore
+import cats.implicits._
+import com.unboundid.ldap.sdk.LDAPConnectionPool
+import org.broadinstitute.dsde.workbench.model.WorkbenchSubject
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.TestSupport._
+import org.broadinstitute.dsde.workbench.sam.config.{CacheConfig, DirectoryConfig}
+import org.ehcache.Cache
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class LdapSupportSpec extends AsyncFlatSpec with Matchers with TestSupport {
+  val cacheConfig = CacheConfig(1, java.time.Duration.ofMinutes(10L))
+  val config = DirectoryConfig("url", "user", "password", "baseDN", "true", 1, 2, cacheConfig, cacheConfig)
+
+  "LdapSupport executeLdap" should "be able to limit number of executions" in {
+    val ioa = IO.sleep(1 seconds)
+    val fakeLdapSupport = new FakeLdapSupport(config)
+    val executeBoth = (fakeLdapSupport.executeLdap(ioa), fakeLdapSupport.executeLdap(ioa)).parTupled
+    val executeThree = (fakeLdapSupport.executeLdap(ioa), fakeLdapSupport.executeLdap(ioa), fakeLdapSupport.executeLdap(ioa)).parTupled
+    val result = for {
+      start <- timer.clock.monotonic(MILLISECONDS)
+      _ <- executeBoth
+      end <- timer.clock.monotonic(MILLISECONDS)
+      start3 <- timer.clock.monotonic(MILLISECONDS)
+      _ <- executeThree
+      end3 <- timer.clock.monotonic(MILLISECONDS)
+    } yield {
+      (end - start) should be <= (2 seconds).toMillis //two ioas can run in paralell
+      (end3 - start3) should be >= (2 seconds).toMillis //when 3 ios try to run at the same time, the third one will have to wait until one of ioas finish
+    }
+    result.unsafeToFuture()
+  }
+}
+
+//
+class FakeLdapSupport(val directoryConfig: DirectoryConfig) extends LdapSupport with TestSupport {
+  override protected val ldapConnectionPool: LDAPConnectionPool = null
+  override protected val ecForLdapBlockingIO: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
+  override val semaphore: Semaphore[IO] = Semaphore[IO](2).unsafeRunSync()
+  override protected val memberOfCache: Cache[WorkbenchSubject, Set[String]] = testMemberOfCache
+}


### PR DESCRIPTION
Ticket: No ticket

* Main change https://github.com/broadinstitute/sam/pull/264/files#diff-4b4d0d53ffe86d27c3dafbead02fb4d8R88
* I think it's easy to get deadlock with fixedThreadPool when running blockingIO.
It seems better to use `unbounded` pool and semaphore to limit number of queries (see [this link](https://typelevel.org/cats-effect/concurrency/basics.html#unbounded)). [Semaphore](https://typelevel.org/cats-effect/concurrency/semaphore.html) will semantically block(there's no actual thread being blocked) when there's no more "permits" available.
* We don't need to use blocking thread pool for `ContextShift` since it's only used for shifting, which should be the global one. The blocking IOs are all run on the first argument of `evalOn`.
* I'm not convinced `backgroundLdapConnectionPool` is necessary since both classes are connecting to same opendj, which has a fixed number of available connections. Allocating fixed number of connections to background tasks seem a bit wasteful too when there's no background tasks running and these connections could've been used for normal IOs. Curious to hear more on this though. (I didn't remove all background pool related code since I'm completely sure yet either)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
