### PR TITLE
onGroupUpdate after onUserCreate

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -109,6 +109,7 @@ object TestSupport extends TestSupport {
     val googleIamDAO = googIamDAO.getOrElse(new MockGoogleIamDAO())
     val policyDAO = policyAccessDAO.getOrElse(new MockAccessPolicyDAO())
     val pubSubDAO = new MockGooglePubSubDAO()
+    runAndWait(pubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val googleStorageDAO = new MockGoogleStorageDAO()
     val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
     val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -106,6 +106,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
       val mockDirectoryDAO = mock[DirectoryDAO]
       val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
       val mockGooglePubSubDAO = new MockGooglePubSubDAO
+      runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
       val ge = new GoogleExtensions(TestSupport.testDistributedLock, mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
       val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
 
@@ -269,6 +270,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockDirectoryDAO = new MockDirectoryDAO
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
+    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
@@ -350,8 +352,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
+    val mockGooglePubSubDAO = new MockGooglePubSubDAO
+    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
 
-    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     val defaultUserId = WorkbenchUserId("newuser123")
@@ -518,6 +522,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockDirectoryDAO = new MockDirectoryDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
+    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
@@ -746,11 +751,12 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
+    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(mockGoogleIamDAO, mockGoogleStorageDAO, mockGooglePubSubDAO, googleServicesConfig, petServiceAccountConfig)
 
-    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     (googleExtensions, service)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -239,10 +239,12 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     dirDAO.createGroup(BasicWorkbenchGroup(expectedGroupName, Set(user.id), WorkbenchEmail("bar"))).unsafeRunSync()
     dirDAO.createGroup(BasicWorkbenchGroup(genWorkbenchGroupName.sample.get, Set(expectedGroupName), WorkbenchEmail("baz"))).unsafeRunSync()
 
-    service.registerUser(user).unsafeRunSync()
+    service.createUser(user).futureValue
 
-    // a little fancyness to ignore the order of the groups passed to onGroupUpdate
-    verify(googleExtensions).onGroupUpdate(argThat((actual: Seq[WorkbenchGroupIdentity]) => actual.toSet equals Set(expectedGroupName, expectedAccessPolicyId)))
+    verify(googleExtensions).onGroupUpdate(argThat((actual: Seq[WorkbenchGroupIdentity]) => {
+      val expected: Set[WorkbenchGroupIdentity] = Set(expectedGroupName, expectedAccessPolicyId)
+      actual.toSet.intersect(expected) equals expected
+    }))
   }
 
   "UserService inviteUser" should "create a new user" in{


### PR DESCRIPTION
For invites being converted to real users, we were syncing their groups before creating their proxy group creating a weird state in google. Once upon a time google returned an error in this situation which would have caused a retry and eventually be OK, but no longer.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
