### PR TITLE
Revert "onGroupUpdate after onUserCreate (#270)"

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -27,13 +27,6 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       _ <- directoryDAO.enableIdentity(createdUser.id).unsafeToFuture()
       _ <- directoryDAO.addGroupMember(allUsersGroup.id, createdUser.id).unsafeToFuture()
       _ <- cloudExtensions.onUserCreate(createdUser)
-
-      // If user was an invite and is already a member of some groups we must tell the cloud extension now that the user
-      // is registered. This must happen after cloudExtensions.onUserCreate as that is what tells the cloud extension
-      // about the user in the first place.
-      groups <- directoryDAO.listUserDirectMemberships(createdUser.id).unsafeToFuture()
-      _ <- cloudExtensions.onGroupUpdate(groups)
-
       userStatus <- getUserStatus(createdUser.id)
       res <- userStatus.toRight(new WorkbenchException("getUserStatus returned None after user was created")).fold(Future.failed, Future.successful)
     } yield res
@@ -68,9 +61,11 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
             subjectFromEmail <- directoryDAO.loadSubjectFromEmail(user.email)
             updated <- subjectFromEmail match {
               case Some(uid: WorkbenchUserId) =>
-                directoryDAO.setGoogleSubjectId(uid, user.googleSubjectId).map { _ =>
-                  WorkbenchUser(uid, Some(user.googleSubjectId), user.email)
-                }
+                for {
+                  groups <- directoryDAO.listUserDirectMemberships(uid)
+                  _ <- directoryDAO.setGoogleSubjectId(uid, user.googleSubjectId)
+                  _ <- IO.fromFuture(IO(cloudExtensions.onGroupUpdate(groups)))
+                } yield WorkbenchUser(uid, Some(user.googleSubjectId), user.email)
 
               case Some(sub) =>
                 //We don't support inviting a group account or pet service account

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -109,7 +109,6 @@ object TestSupport extends TestSupport {
     val googleIamDAO = googIamDAO.getOrElse(new MockGoogleIamDAO())
     val policyDAO = policyAccessDAO.getOrElse(new MockAccessPolicyDAO())
     val pubSubDAO = new MockGooglePubSubDAO()
-    runAndWait(pubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val googleStorageDAO = new MockGoogleStorageDAO()
     val notificationDAO = new PubSubNotificationDAO(pubSubDAO, "foo")
     val cloudKeyCache = new GoogleKeyCache(googleIamDAO, googleStorageDAO, pubSubDAO, googleServicesConfig, petServiceAccountConfig)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -106,7 +106,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
       val mockDirectoryDAO = mock[DirectoryDAO]
       val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
       val mockGooglePubSubDAO = new MockGooglePubSubDAO
-      runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
       val ge = new GoogleExtensions(TestSupport.testDistributedLock, mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
       val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
 
@@ -270,7 +269,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockDirectoryDAO = new MockDirectoryDAO
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val ge = new GoogleExtensions(TestSupport.testDistributedLock, mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
@@ -352,10 +350,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
-    val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
 
-    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     val defaultUserId = WorkbenchUserId("newuser123")
@@ -522,7 +518,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockDirectoryDAO = new MockDirectoryDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
@@ -751,12 +746,11 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    runAndWait(mockGooglePubSubDAO.createTopic(googleServicesConfig.groupSyncTopic))
     val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val notificationDAO = new PubSubNotificationDAO(mockGooglePubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(mockGoogleIamDAO, mockGoogleStorageDAO, mockGooglePubSubDAO, googleServicesConfig, petServiceAccountConfig)
 
-    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val googleExtensions = new GoogleExtensions(TestSupport.testDistributedLock, dirDAO, null, mockGoogleDirectoryDAO, null, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val service = new UserService(dirDAO, googleExtensions)
 
     (googleExtensions, service)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -239,12 +239,10 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     dirDAO.createGroup(BasicWorkbenchGroup(expectedGroupName, Set(user.id), WorkbenchEmail("bar"))).unsafeRunSync()
     dirDAO.createGroup(BasicWorkbenchGroup(genWorkbenchGroupName.sample.get, Set(expectedGroupName), WorkbenchEmail("baz"))).unsafeRunSync()
 
-    service.createUser(user).futureValue
+    service.registerUser(user).unsafeRunSync()
 
-    verify(googleExtensions).onGroupUpdate(argThat((actual: Seq[WorkbenchGroupIdentity]) => {
-      val expected: Set[WorkbenchGroupIdentity] = Set(expectedGroupName, expectedAccessPolicyId)
-      actual.toSet.intersect(expected) equals expected
-    }))
+    // a little fancyness to ignore the order of the groups passed to onGroupUpdate
+    verify(googleExtensions).onGroupUpdate(argThat((actual: Seq[WorkbenchGroupIdentity]) => actual.toSet equals Set(expectedGroupName, expectedAccessPolicyId)))
   }
 
   "UserService inviteUser" should "create a new user" in{


### PR DESCRIPTION
This reverts commit 3aea2a64203c49cbc1104442962efc40340f44ce.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
