### PR TITLE
create proxy groups for invites

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -191,7 +191,7 @@ trait UserRoutes extends UserInfoDirectives {
               path(Segment) { inviteeEmail =>
                 complete {
                   userService
-                    .inviteUser(InviteUser(genWorkbenchUserId(System.currentTimeMillis()), WorkbenchEmail(inviteeEmail)))
+                    .inviteUser(InviteUser(genWorkbenchUserId(System.currentTimeMillis()), WorkbenchEmail(inviteeEmail.trim)))
                     .map(userStatus => StatusCodes.Created -> userStatus)
                 }
               }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -157,7 +157,7 @@ class GoogleExtensions(
         directoryDAO.listAncestorGroups(id)
       }
       managedGroupIds = (ancestorGroups.flatten ++ groupIdentities).filterNot(visitedGroups.contains).collect {
-        case FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, id), _) => id
+        case FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, id), ManagedGroupService.adminPolicyName | ManagedGroupService.memberPolicyName) => id
       }
       _ <- managedGroupIds.traverse(id => onManagedGroupUpdate(id, visitedGroups ++ groupIdentities ++ ancestorGroups.flatten))
     } yield ()
@@ -177,7 +177,6 @@ class GoogleExtensions(
       _ <- googleDirectoryDAO.createGroup(user.email.value, proxyEmail, Option(googleDirectoryDAO.lockedDownGroupSettings)) recover {
         case e: GoogleJsonResponseException if e.getDetails.getCode == StatusCodes.Conflict.intValue => ()
       }
-      _ <- googleDirectoryDAO.addMemberToGroup(proxyEmail, WorkbenchEmail(user.email.value))
       allUsersGroup <- getOrCreateAllUsersGroup(directoryDAO)
       _ <- googleDirectoryDAO.addMemberToGroup(allUsersGroup.email, proxyEmail)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -216,10 +216,10 @@ object UserService {
   def genWorkbenchUserId(currentMilli: Long): WorkbenchUserId =
     WorkbenchUserId(genRandom(currentMilli))
 
-  def validateEmailAddress(email: WorkbenchEmail) = {
+  def validateEmailAddress(email: WorkbenchEmail): IO[Unit] = {
     email.value match {
       case UserService.emailRegex() => IO.unit
-      case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "invalid email address")))
+      case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"invalid email address [${email.value}]")))
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
 
 /**
   * Created by dvoet on 7/14/17.
@@ -24,19 +25,19 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     for {
       allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO)
       createdUser <- registerUser(user).unsafeToFuture()
-      _ <- directoryDAO.enableIdentity(createdUser.id).unsafeToFuture()
+      _ <- enableUserInternal(createdUser)
       _ <- directoryDAO.addGroupMember(allUsersGroup.id, createdUser.id).unsafeToFuture()
-      _ <- cloudExtensions.onUserCreate(createdUser)
       userStatus <- getUserStatus(createdUser.id)
       res <- userStatus.toRight(new WorkbenchException("getUserStatus returned None after user was created")).fold(Future.failed, Future.successful)
     } yield res
 
   def inviteUser(invitee: InviteUser): IO[UserStatusDetails] =
     for {
+      _ <- UserService.validateEmailAddress(invitee.inviteeEmail)
       existingSubject <- directoryDAO.loadSubjectFromEmail(invitee.inviteeEmail)
       createdUser <- existingSubject match {
-        case None => directoryDAO.createUser(WorkbenchUser(invitee.inviteeId, None, invitee.inviteeEmail))
-        case Some(__) =>
+        case None => createUserInternal(WorkbenchUser(invitee.inviteeId, None, invitee.inviteeEmail))
+        case Some(_) =>
           IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"email ${invitee.inviteeEmail} already exists")))
       }
     } yield UserStatusDetails(createdUser.id, createdUser.email)
@@ -67,17 +68,24 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
                   _ <- IO.fromFuture(IO(cloudExtensions.onGroupUpdate(groups)))
                 } yield WorkbenchUser(uid, Some(user.googleSubjectId), user.email)
 
-              case Some(sub) =>
+              case Some(_) =>
                 //We don't support inviting a group account or pet service account
                 IO.raiseError[WorkbenchUser](
                   new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"$user is not a regular user. Please use a different endpoint")))
               case None =>
-                directoryDAO.createUser(WorkbenchUser(WorkbenchUserId(user.googleSubjectId.value), Some(user.googleSubjectId), user.email)) //For completely new users, we still use googleSubjectId as their userId
+                createUserInternal(WorkbenchUser(WorkbenchUserId(user.googleSubjectId.value), Some(user.googleSubjectId), user.email)) //For completely new users, we still use googleSubjectId as their userId
+
             }
           } yield updated
       }
     } yield user
 
+  private def createUserInternal(user: WorkbenchUser) = {
+    for {
+      createdUser <- directoryDAO.createUser(user)
+      _ <- IO.fromFuture(IO(cloudExtensions.onUserCreate(createdUser)))
+    } yield createdUser
+  }
   def getSubjectFromEmail(email: WorkbenchEmail): Future[Option[WorkbenchSubject]] = directoryDAO.loadSubjectFromEmail(email).unsafeToFuture()
 
   def getUserStatus(userId: WorkbenchUserId, userDetailsOnly: Boolean = false): Future[Option[UserStatus]] =
@@ -149,12 +157,18 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     directoryDAO.loadUser(userId).unsafeToFuture().flatMap {
       case Some(user) =>
         for {
-          _ <- directoryDAO.enableIdentity(user.id).unsafeToFuture()
-          _ <- cloudExtensions.onUserEnable(user)
+          _ <- enableUserInternal(user)
           userStatus <- getUserStatus(userId)
         } yield userStatus
       case None => Future.successful(None)
     }
+
+  private def enableUserInternal(user: WorkbenchUser): Future[Unit] = {
+    for {
+      _ <- directoryDAO.enableIdentity(user.id).unsafeToFuture()
+      _ <- cloudExtensions.onUserEnable(user)
+    } yield ()
+  }
 
   def disableUser(userId: WorkbenchUserId, userInfo: UserInfo): Future[Option[UserStatus]] =
     directoryDAO.loadUser(userId).unsafeToFuture().flatMap {
@@ -182,6 +196,9 @@ object UserService {
 
   val random = SecureRandom.getInstance("NativePRNGNonBlocking")
 
+  // from https://www.regular-expressions.info/email.html
+  val emailRegex: Regex = "(?i)^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$".r
+
   // Generate a 21 digits unique identifier. First char is fixed 2
   // CurrentMillis.append(randomString)
   private[workbench] def genRandom(currentMilli: Long): String = {
@@ -198,4 +215,11 @@ object UserService {
 
   def genWorkbenchUserId(currentMilli: Long): WorkbenchUserId =
     WorkbenchUserId(genRandom(currentMilli))
+
+  def validateEmailAddress(email: WorkbenchEmail) = {
+    email.value match {
+      case UserService.emailRegex() => IO.unit
+      case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "invalid email address")))
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -611,7 +611,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val lockedDownGroupSettings = Option(mockGoogleDirectoryDAO.lockedDownGroupSettings)
     verify(mockGoogleDirectoryDAO).createGroup(userEmail.value, proxyEmail, lockedDownGroupSettings)
-    verify(mockGoogleDirectoryDAO).addMemberToGroup(proxyEmail, userEmail)
     verify(mockGoogleDirectoryDAO).addMemberToGroup(allUsersGroup.email, proxyEmail)
 /* Re-enable this code after fixing rawls for GAWB-2933
     verify(mockDirectoryDAO).addProxyGroup(userId, proxyEmail)
@@ -641,7 +640,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupId = "managedGroupId"
 
     val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), AccessPolicyName("managedGroup"))
+      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
@@ -672,7 +671,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"
     val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), AccessPolicyName("managedGroup"))
+      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
 
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
@@ -707,7 +706,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"
     val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), AccessPolicyName("managedGroup"))
+      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
 
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/GAWB-4056
The gist is that a proxy group is not created when an invite is created. The intention was to create it when the user comes to the site. But this then requires a bunch of special case logic:
* exclude invites from google group sync (which we neglected)
* trigger group sync when an invite registers
* be careful in the ordering of proxy group creation and group syncing

It just seems easier, (less code and less cognitive load) to always create a proxy group.

We also need to back populate all existing invitations.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
