### PR TITLE
GAWB-4016 upgrade akka-http and add doc for testing newrelic metrics locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,15 @@ Stop your local opendj:
 sh docker/run-opendj.sh stop
 ```
 
+### Test newrelic metrics locally
+* Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+* Put `newrelic-agent-x.x.x.jar` under `config` directory (If you haven't set up config, follow instructions [here](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs))
+* Rename newrelic config file, `mv newrelic-v4.yml newrelic.yml`
+* In newrelic.yml, update `agent_enabled` to `true`
+* In `docker-rsync-local-sam.sh` file, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+* Start sam locally, `./config/docker-rsync-local-sam.sh`
+* Send some requests to local sam.
+* Go to `https://newrelic.com/`, and log in
+* Look for `sam - local - dev` and check if metrics look good.
+
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ sh docker/run-opendj.sh stop
 ### Test newrelic metrics locally
 * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
 * Put `newrelic-agent-x.x.x.jar` under `config` directory (If you haven't set up config, follow instructions [here](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs))
-* Rename newrelic config file, `mv newrelic-v4.yml newrelic.yml`
 * In newrelic.yml, update `agent_enabled` to `true`
 * In `docker-rsync-local-sam.sh` file, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
 * Start sam locally, `./config/docker-rsync-local-sam.sh`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.5.16"
-  val akkaHttpV = "10.1.3"
+  val akkaV = "2.5.19"
+  val akkaHttpV = "10.1.7"
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.5.0"
   val scalaTestV    = "3.0.5"
@@ -14,7 +14,7 @@ object Dependencies {
   val workbenchGoogle2V = "0.1-8328aae"
   val workbenchNotificationsV = "0.1-f2a0020"
   val monocleVersion = "1.5.1-cats"
-  val newRelicVersion = "4.6.0"
+  val newRelicVersion = "4.11.0"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/secure/GAWB-4016

akka-http 10.1.7 requires akka 2.5.19
This is on hold until firecloud-develop has upgraded newrelic.
Tested locally and metrics look good (see https://rpm.newrelic.com/accounts/1862859/applications/194648810 3/7 around 4am)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
