### PR TITLE
AP-145 only constrained auth domain needs sync

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.workbench.sam.openam
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, _}
 
 /**
   * Created by dvoet on 6/26/17.
@@ -12,7 +13,7 @@ trait AccessPolicyDAO {
 
   def createResource(resource: Resource): IO[Resource]
   def deleteResource(resource: FullyQualifiedResourceId): IO[Unit]
-  def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[Set[WorkbenchGroupName]]
+  def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[LoadResourceAuthDomainResult]
   def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]]
 
   def createPolicy(policy: AccessPolicy): IO[AccessPolicy]
@@ -23,6 +24,7 @@ trait AccessPolicyDAO {
   def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]]
   def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]]
+  def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId): IO[Option[Resource]]
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]]
   def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]]
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]]
@@ -30,4 +32,12 @@ trait AccessPolicyDAO {
   def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit]
 
   def evictIsMemberOfCache(subject: WorkbenchSubject): IO[Unit]
+}
+
+
+sealed abstract class LoadResourceAuthDomainResult
+object LoadResourceAuthDomainResult {
+  final case object ResourceNotFound extends LoadResourceAuthDomainResult
+  final case object NotConstrained extends LoadResourceAuthDomainResult
+  final case class Constrained(authDomain: NonEmptyList[WorkbenchGroupName]) extends LoadResourceAuthDomainResult
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -974,7 +974,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     intersectionGroup shouldEqual Set(inBothSubGroupUser.userId)
   }
 
-  it should "return empty set if there is no auth domain set" in {
+  it should "return the policy members if there is no auth domain set" in {
     val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
 
     val inPolicyUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("inPolicy"), WorkbenchEmail("inPolicy@example.com"), 0)
@@ -988,7 +988,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.userEmail, inBothUser.userEmail), Set.empty, Set.empty)))
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy).unsafeRunSync()
-    intersectionGroup shouldEqual Set()
+    intersectionGroup shouldEqual Set(inBothUser.userId, inPolicyUser.userId)
   }
 
   it should "return an empty set if none of the policy members are in the auth domain" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AP-145

Please check test change to see if the logic is what we want.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
