### PR TITLE
don't fire group update message on create

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -287,9 +287,9 @@ class ResourceService(
       case Some(accessPolicy) =>
         accessPolicyDAO
           .overwritePolicy(AccessPolicy(policyIdentity, workbenchSubjects, accessPolicy.email, policy.roles, policy.actions, accessPolicy.public))
-          .unsafeToFuture()
-    } andThen {
-      case Success(_) => fireGroupUpdateNotification(policyIdentity)
+          .unsafeToFuture().andThen {
+            case Success(_) => fireGroupUpdateNotification(policyIdentity)
+          }
     }
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WB-424

performance enhancement: figuring out which group update messages to send requires an ismemberof call to opendj. When lots of policies are created at once (e.g. creating lots of workspaces at once) this causes too much strain on opendj and everything crawls. But when policies are created we don't even need to do this because there is no way we could have been told to sync to google yet. So don't.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
