### PR TITLE
log when GoogleGroupSyncMonitorActor is being terminated

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -188,6 +188,8 @@ class GoogleGroupSyncMonitorActor(
         message.contents.parseJson.convertTo[WorkbenchGroupName]
     }).get
 
+  override def postStop(): Unit = logger.info(s"GoogleGroupSyncMonitorActor $self terminated")
+
   override val supervisorStrategy =
     OneForOneStrategy() {
       case e => {


### PR DESCRIPTION
I tried searching `akka\:\/\/sam\/user\/` in kibana, and there were lots of actors existed when ldap exception happened.

Memory usage looks fine in new relic, so code is probably okay and we are terminating actors properly after starting new one. This PR is just to add some logging so that we know for sure terminating actors happened.

I do wonder if throwing exception and causing actor to die and spawning new ones is necessary though. Is it enough to log errors (which triggers sentry alert) in this case and GoogleGroupSyncMonitorActor will move on to process other messages, or there is a reason we do actually want GoogleGroupSyncMonitorActor to die first when error happens?

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
