### PR TITLE
CA-256: Ignore empty access groups when syncing auth domains

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -50,7 +50,6 @@ trait DirectoryDAO {
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]
   def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]]
   def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
-  def listDirectMembers(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchSubject]]
 
   def enableIdentity(subject: WorkbenchSubject): IO[Unit]
   def disableIdentity(subject: WorkbenchSubject): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -50,6 +50,7 @@ trait DirectoryDAO {
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]
   def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]]
   def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]]
+  def listDirectMembers(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchSubject]]
 
   def enableIdentity(subject: WorkbenchSubject): IO[Unit]
   def disableIdentity(subject: WorkbenchSubject): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -191,7 +191,9 @@ class GoogleExtensions(
       policies <- resources.toList.traverse { resource =>
         accessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)
       }
-      _ <- onGroupUpdateRecursive(policies.flatten.map(_.id).toList, visitedGroups)
+      filteredList = policies.flatten.collect { case accessPolicy if accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id).flatMap(_.isEmpty) => accessPolicy.id }
+     // parTraverseResult = policies.flatten.parTraverse( accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id))
+      _ <- onGroupUpdateRecursive(filteredList  , visitedGroups) //.map(_.id).toList, visitedGroups)
     } yield ()
 
   override def onUserCreate(user: WorkbenchUser): Future[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -116,7 +116,7 @@ class GoogleExtensions(
         case Some(_) =>
           IO.raiseError(
             new WorkbenchExceptionWithErrorReport(
-              ErrorReport(StatusCodes.Conflict, s"subjectId in configration ${googleServicesConfig.serviceAccountClientId} is not a valid user")))
+              ErrorReport(StatusCodes.Conflict, s"subjectId in configuration ${googleServicesConfig.serviceAccountClientId} is not a valid user")))
         case None => IO.pure(UserInfo(OAuth2BearerToken(""), genWorkbenchUserId(System.currentTimeMillis()), googleServicesConfig.serviceAccountClientEmail, 0))
       }
       _ <- IO.fromFuture(
@@ -191,22 +191,7 @@ class GoogleExtensions(
       policies <- resources.toList.traverse { resource =>
         accessPolicyDAO.listAccessPolicies(resource.fullyQualifiedId)
       }
-
-      // ~ Attempt 1 ~
-      // Separate out (1) figuring out if the access policy has any members and (2) collecting the ones that do and returning just the policy ids
-      flatPols: List[(Boolean, FullyQualifiedPolicyId)] <- policies.flatten.map(pol => accessPolicyDAO.listFlattenedPolicyMembers(pol.id).map(x => (x.isEmpty, pol.id))).sequence
-      filteredList1 = flatPols.collect { case (policyHasNoMembers, policyId) if policyHasNoMembers => policyId }
-
-      // ~ Attempt 2 ~
-      // Use filterA to filter out basted on whether the access policy has any members and then map over the policies to get a list of the policy ids
-      filteredList2 <- policies.flatten.filterA { accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id).map(memberSet => memberSet.isEmpty) }.map(x => x.map(_.id))
-
-      // ~ Attempt 3 ~
-      // Use a traverseFilter to filter based on whether the access policy has any members. traverseFilter filters based on Option, not boolean, so in
-      // this case we have to return None if the member set is empty and Some(id of the access policy) if it is not empty.
-      filteredList3 <- policies.flatten.traverseFilter { accessPolicy: AccessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id).map(x => if (x.isEmpty) None else Some(accessPolicy.id)) }
-
-      _ <- onGroupUpdateRecursive(filteredList1, visitedGroups)
+      _ <- onGroupUpdateRecursive(policies.flatten.map(_.id).toList, visitedGroups)
     } yield ()
 
   override def onUserCreate(user: WorkbenchUser): Future[Unit] = {


### PR DESCRIPTION
Ticket: [CA-256](https://broadworkbench.atlassian.net/browse/CA-256)

(Just tagging everyone who likes keeping up openDJ issues or whose ears perked up when we were discussing FP things, you don't actually have to review) 

**CONTEXT**

- Authorization domains and access policies are both "groups"

- You can have a bunch of workspaces inside an auth domain. 
 
- A user must be a member of the auth domain in order to access any of the workspaces in that auth domain. 

- If a workspace is in _multiple_ auth domains, the user must be a member of _all_ of them in order to access that workspace
 
- An access policy is specific to a single workspace (or other resource) - so you must be an Owner/Writer/... whatever in order to be able to do the relevant action on that workspace

- To access a workspace, a user must BOTH be a member in all the auth domains that workspace is in AND also be a member in one of the access policy groups.

- When someone gets added to an auth domain, we have to figure out which google buckets they suddenly have access to.

- To do this, when someone gets added to an auth domain, we retrieve a list of all of the access policies for all the workspaces in that auth domain, and for each we publish a message to a pub/sub queue telling a Sam background process to sync the user's access for all of those access policy groups

- The background process then chugs through all these messages. For each message, it does an intersection between the auth domain the user was added to and the access policy - if the user is now in BOTH, it tells google to give the user certain permissions (I believe related to bucket access)

- Most of the openDJ slowness is occurring because this group syncing background process is costly and eats up CPU - particularly when All of Us had a regularly scheduled job that added a whole bunch of people to auth domains all at once. So - how do we make this group syncing process faster?

- Most of the access policies on workspaces are empty - many of them are just a single Owner and no readers/writers. If the access policy group is empty, any intersection is going to be false. So, we can just not check access policy groups that are empty.

**CODE**

Seems simple enough - just check which access policies have no members and remove those from the list that's used to generate the pub/sub messages, right?

It wasn't quite as straightforward as that. Originally, I thought a `collect` should work (since we're filtering to get the access policies that have members and then mapping over them to only grab their ids.). But, since the method we're calling to get the members of the access policy returns an IO, we couldn't actually use `collect.` This is where I started having trouble finding a _graceful_ way of doing the thing I wanted. I asked a couple of people and came with 3 attempts. You can either pick one of these or tell me how to improve them, or come up with your own attempt if you want. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
