### PR TITLE
add billing-project action for owners for adding it to a perimeter

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -265,11 +265,14 @@ resourceTypes = {
       view_status = {
         description = "view status of a billing-project"
       }
+      add_to_service_perimeter = {
+        description = "add this billing-project to a service-perimeter"
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "alter_google_role"]
+        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "sync_notebook_cluster", "delete_notebook_cluster", "alter_google_role", "add_to_service_perimeter"]
       }
       workspace-creator = {
         roleActions = ["view_status", "create_workspace", "share_policy::can-compute-user", "read_policy::can-compute-user"]


### PR DESCRIPTION
Ticket: [ca-277](https://broadworkbench.atlassian.net/browse/CA-277)
add action for billing-project owners called 'add-to-service-perimeter' that enables them to add the project to a service perimeter assuming they also have action to add to that perimeter

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
