### PR TITLE
first effort at setting up scalike tables

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DatabaseId.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DatabaseId.scala
@@ -1,0 +1,7 @@
+package org.broadinstitute.dsde.workbench.sam.db
+
+trait DatabaseId {
+  val value: Long
+
+  override def toString: String = value.toString
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/WorkbenchParameterBinderFactory.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/WorkbenchParameterBinderFactory.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.workbench.sam.db
+
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc.ParameterBinderFactory
+
+// These aren't used yet, but we will want these for the queries in the DAOs
+object WorkbenchParameterBinderFactory {
+  implicit val databaseIdPbf: ParameterBinderFactory[DatabaseId] = ParameterBinderFactory[DatabaseId] {
+    value => (stmt, idx) => stmt.setLong(idx, value.value)
+  }
+
+  implicit val valueObjectPbf: ParameterBinderFactory[ValueObject] = ParameterBinderFactory[ValueObject] {
+    value => (stmt, idx) => stmt.setString(idx, value.value)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/WorkbenchParameterBinderFactory.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/WorkbenchParameterBinderFactory.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.sam.db
 import org.broadinstitute.dsde.workbench.sam.model.ValueObject
 import scalikejdbc.ParameterBinderFactory
 
-// These aren't used yet, but we will want these for the queries in the DAOs
 object WorkbenchParameterBinderFactory {
   implicit val databaseIdPbf: ParameterBinderFactory[DatabaseId] = ParameterBinderFactory[DatabaseId] {
     value => (stmt, idx) => stmt.setLong(idx, value.value)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AccessInstructionsTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AccessInstructionsTable.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import scalikejdbc._
+
+final case class AccessInstructionsId(value: Long) extends DatabaseId
+final case class AccessInstructionsRecord(id: AccessInstructionsId,
+                                          groupId: GroupId,
+                                          instructions: String)
+
+object AccessInstructionsRecord extends SQLSyntaxSupport[AccessInstructionsRecord] {
+  override def tableName: String = "SAM_ACCESS_INSTRUCTIONS"
+
+  import AccessInstructionsRecordBinders._
+  import GroupRecordBinders._
+  def apply(e: ResultName[AccessInstructionsRecord])(rs: WrappedResultSet): AccessInstructionsRecord = AccessInstructionsRecord(
+    rs.get(e.id),
+    rs.get(e.groupId),
+    rs.get(e.instructions)
+  )
+}
+
+object AccessInstructionsRecordBinders {
+  implicit val accessInstructionsIdTypeBinder: TypeBinder[AccessInstructionsId] = new TypeBinder[AccessInstructionsId] {
+    def apply(rs: ResultSet, label: String): AccessInstructionsId = AccessInstructionsId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): AccessInstructionsId = AccessInstructionsId(rs.getLong(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AuthDomainTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AuthDomainTable.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import scalikejdbc._
+
+final case class AuthDomainRecord(resourceId: ResourceId,
+                                  groupId: GroupId)
+
+object AuthDomainRecord extends SQLSyntaxSupport[AuthDomainRecord] {
+  override def tableName: String = "SAM_RESOURCE_AUTH_DOMAIN"
+
+  import GroupRecordBinders._
+  import ResourceRecordBinders._
+  def apply(e: ResultName[AuthDomainRecord])(rs: WrappedResultSet): AuthDomainRecord = AuthDomainRecord(
+    rs.get(e.resourceId),
+    rs.get(e.groupId)
+  )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupMemberTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupMemberTable.scala
@@ -15,6 +15,7 @@ object GroupMemberRecord extends SQLSyntaxSupport[GroupMemberRecord] {
   override def tableName: String = "SAM_GROUP_MEMBER"
 
   import GroupMemberRecordBinders._
+  import GroupRecordBinders._
   import UserRecordBinders._
   def apply(e: ResultName[GroupMemberRecord])(rs: WrappedResultSet): GroupMemberRecord = GroupMemberRecord(
     rs.get(e.id),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupMemberTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupMemberTable.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import scalikejdbc._
+
+final case class GroupMemberId(value: Long) extends DatabaseId
+final case class GroupMemberRecord(id: GroupMemberId,
+                                   groupId: GroupId,
+                                   memberUserId: Option[UserId],
+                                   memberGroupId: Option[GroupId])
+
+object GroupMemberRecord extends SQLSyntaxSupport[GroupMemberRecord] {
+  override def tableName: String = "SAM_GROUP_MEMBER"
+
+  import GroupMemberRecordBinders._
+  import UserRecordBinders._
+  def apply(e: ResultName[GroupMemberRecord])(rs: WrappedResultSet): GroupMemberRecord = GroupMemberRecord(
+    rs.get(e.id),
+    rs.get(e.groupId),
+    rs.get(e.memberUserId),
+    rs.get(e.memberGroupId)
+  )
+}
+
+object GroupMemberRecordBinders {
+  implicit val groupMemberIdTypeBinder: TypeBinder[GroupMemberId] = new TypeBinder[GroupMemberId] {
+    def apply(rs: ResultSet, label: String): GroupMemberId = GroupMemberId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): GroupMemberId = GroupMemberId(rs.getLong(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
@@ -1,0 +1,47 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+import java.time.Instant
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class GroupId(value: Long) extends DatabaseId
+final case class GroupName(value: String) extends ValueObject
+final case class GroupEmail(value: String) extends ValueObject
+final case class GroupRecord(id: GroupId,
+                             name: GroupName,
+                             email: GroupEmail,
+                             updatedDate: Option[Instant],
+                             synchronizedDate: Option[Instant])
+
+object GroupRecord extends SQLSyntaxSupport[GroupRecord] {
+  override def tableName: String = "SAM_GROUP"
+
+  import GroupRecordBinders._
+  def apply(e: ResultName[GroupRecord])(rs: WrappedResultSet): GroupRecord = GroupRecord(
+    rs.get(e.id),
+    rs.get(e.name),
+    rs.get(e.email),
+    rs.get(e.updatedDate),
+    rs.get(e.synchronizedDate)
+  )
+}
+
+object GroupRecordBinders {
+  implicit val groupIdTypeBinder: TypeBinder[GroupId] = new TypeBinder[GroupId] {
+    def apply(rs: ResultSet, label: String): GroupId = GroupId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): GroupId = GroupId(rs.getLong(index))
+  }
+
+  implicit val groupNameTypeBinder: TypeBinder[GroupName] = new TypeBinder[GroupName] {
+    def apply(rs: ResultSet, label: String): GroupName = GroupName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): GroupName = GroupName(rs.getString(index))
+  }
+
+  implicit val groupEmailTypeBinder: TypeBinder[GroupEmail] = new TypeBinder[GroupEmail] {
+    def apply(rs: ResultSet, label: String): GroupEmail = GroupEmail(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): GroupEmail = GroupEmail(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetServiceAccountTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetServiceAccountTable.scala
@@ -1,0 +1,44 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class PetServiceAccountGoogleProject(value: String) extends ValueObject
+final case class PetServiceAccountGoogleSubjectId(value: String) extends ValueObject
+final case class PetServiceAccountEmail(value: String) extends ValueObject
+final case class PetServiceAccountRecord(userId: UserId,
+                                         project: PetServiceAccountGoogleProject,
+                                         googleSubjectId: PetServiceAccountGoogleSubjectId,
+                                         email: PetServiceAccountEmail)
+
+object PetServiceAccountRecord extends SQLSyntaxSupport[PetServiceAccountRecord] {
+  override def tableName: String = "SAM_PET_SERVICE_ACCOUNT"
+
+  import PetServiceAccountRecordBinders._
+  import UserRecordBinders._
+  def apply(e: ResultName[PetServiceAccountRecord])(rs: WrappedResultSet): PetServiceAccountRecord = PetServiceAccountRecord(
+    rs.get(e.userId),
+    rs.get(e.project),
+    rs.get(e.googleSubjectId),
+    rs.get(e.email)
+  )
+}
+
+object PetServiceAccountRecordBinders {
+  implicit val petServiceAccountGoogleProjectTypeBinder: TypeBinder[PetServiceAccountGoogleProject] = new TypeBinder[PetServiceAccountGoogleProject] {
+    def apply(rs: ResultSet, label: String): PetServiceAccountGoogleProject = PetServiceAccountGoogleProject(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): PetServiceAccountGoogleProject = PetServiceAccountGoogleProject(rs.getString(index))
+  }
+
+  implicit val petServiceAccountGoogleSubjectIdTypeBinder: TypeBinder[PetServiceAccountGoogleSubjectId] = new TypeBinder[PetServiceAccountGoogleSubjectId] {
+    def apply(rs: ResultSet, label: String): PetServiceAccountGoogleSubjectId = PetServiceAccountGoogleSubjectId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): PetServiceAccountGoogleSubjectId = PetServiceAccountGoogleSubjectId(rs.getString(index))
+  }
+
+  implicit val petServiceAccountEmailTypeBinder: TypeBinder[PetServiceAccountEmail] = new TypeBinder[PetServiceAccountEmail] {
+    def apply(rs: ResultSet, label: String): PetServiceAccountEmail = PetServiceAccountEmail(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): PetServiceAccountEmail = PetServiceAccountEmail(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyActionTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyActionTable.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import scalikejdbc._
+
+final case class PolicyActionRecord(policyId: PolicyId,
+                                    actionId: ResourceActionId)
+
+object PolicyActionRecord extends SQLSyntaxSupport[PolicyActionRecord] {
+  override def tableName: String = "SAM_POLICY_ACTION"
+
+  import PolicyRecordBinders._
+  import ResourceActionRecordBinders._
+  def apply(e: ResultName[PolicyActionRecord])(rs: WrappedResultSet): PolicyActionRecord = PolicyActionRecord(
+    rs.get(e.policyId),
+    rs.get(e.actionId)
+  )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyRoleTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyRoleTable.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import scalikejdbc._
+
+final case class PolicyRoleRecord(policyId: PolicyId,
+                                  roleId: ResourceRoleId)
+
+object PolicyRoleRecord extends SQLSyntaxSupport[PolicyRoleRecord] {
+  override def tableName: String = "SAM_POLICY_ROLE"
+
+  import PolicyRecordBinders._
+  import ResourceRoleRecordBinders._
+  def apply(e: ResultName[PolicyRoleRecord])(rs: WrappedResultSet): PolicyRoleRecord = PolicyRoleRecord(
+    rs.get(e.policyId),
+    rs.get(e.roleId)
+  )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class PolicyId(value: Long) extends DatabaseId
+final case class PolicyName(value: String) extends ValueObject
+final case class PolicyRecord(id: PolicyId,
+                              resourceId: ResourceId,
+                              groupId: GroupId,
+                              name: PolicyName)
+
+object PolicyRecord extends SQLSyntaxSupport[PolicyRecord] {
+  override def tableName: String = "SAM_RESOURCE_POLICY"
+
+  import ResourceRecordBinders._
+  import GroupRecordBinders._
+  import PolicyRecordBinders._
+  def apply(e: ResultName[PolicyRecord])(rs: WrappedResultSet): PolicyRecord = PolicyRecord(
+    rs.get(e.id),
+    rs.get(e.resourceId),
+    rs.get(e.groupId),
+    rs.get(e.name)
+  )
+}
+
+object PolicyRecordBinders {
+  implicit val policyIdTypeBinder: TypeBinder[PolicyId] = new TypeBinder[PolicyId] {
+    def apply(rs: ResultSet, label: String): PolicyId = PolicyId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): PolicyId = PolicyId(rs.getLong(index))
+  }
+
+  implicit val policyNameTypeBinder: TypeBinder[PolicyName] = new TypeBinder[PolicyName] {
+    def apply(rs: ResultSet, label: String): PolicyName = PolicyName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): PolicyName = PolicyName(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceActionPatternTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceActionPatternTable.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class ResourceActionPatternId(value: Long) extends DatabaseId
+final case class ResourceActionPattern(value: String) extends ValueObject
+final case class ResourceActionPatternRecord(id: ResourceActionPatternId,
+                                             resourceTypeId: ResourceTypeId,
+                                             actionPattern: ResourceActionPattern)
+
+object ResourceActionPatternRecord extends SQLSyntaxSupport[ResourceActionPatternRecord] {
+  override def tableName: String = "SAM_ACTION_PATTERN"
+
+  import ResourceTypeRecordBinders._
+  import ResourceActionPatternRecordBinders._
+  def apply(e: ResultName[ResourceActionPatternRecord])(rs: WrappedResultSet): ResourceActionPatternRecord = ResourceActionPatternRecord(
+    rs.get(e.id),
+    rs.get(e.resourceTypeId),
+    rs.get(e.actionPattern)
+  )
+}
+
+object ResourceActionPatternRecordBinders {
+  implicit val resourceActionPatternIdTypeBinder: TypeBinder[ResourceActionPatternId] = new TypeBinder[ResourceActionPatternId] {
+    def apply(rs: ResultSet, label: String): ResourceActionPatternId = ResourceActionPatternId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ResourceActionPatternId = ResourceActionPatternId(rs.getLong(index))
+  }
+
+  implicit val actionPatternTypeBinder: TypeBinder[ResourceActionPattern] = new TypeBinder[ResourceActionPattern] {
+    def apply(rs: ResultSet, label: String): ResourceActionPattern = ResourceActionPattern(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ResourceActionPattern = ResourceActionPattern(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceActionTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceActionTable.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class ResourceActionId(value: Long) extends DatabaseId
+final case class ResourceActionName(value: String) extends ValueObject
+final case class ResourceActionRecord(id: ResourceActionId,
+                                      resourceTypeId: ResourceTypeId,
+                                      action: ResourceActionName)
+
+object ResourceActionRecord extends SQLSyntaxSupport[ResourceActionRecord] {
+  override def tableName: String = "SAM_RESOURCE_ACTION"
+
+  import ResourceTypeRecordBinders._
+  import ResourceActionRecordBinders._
+  def apply(e: ResultName[ResourceActionRecord])(rs: WrappedResultSet): ResourceActionRecord = ResourceActionRecord(
+    rs.get(e.id),
+    rs.get(e.resourceTypeId),
+    rs.get(e.action)
+  )
+}
+
+object ResourceActionRecordBinders {
+  implicit val resourceActionIdTypeBinder: TypeBinder[ResourceActionId] = new TypeBinder[ResourceActionId] {
+    def apply(rs: ResultSet, label: String): ResourceActionId = ResourceActionId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ResourceActionId = ResourceActionId(rs.getLong(index))
+  }
+
+  implicit val resourceActionNameTypeBinder: TypeBinder[ResourceActionName] = new TypeBinder[ResourceActionName] {
+    def apply(rs: ResultSet, label: String): ResourceActionName = ResourceActionName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ResourceActionName = ResourceActionName(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceRoleTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceRoleTable.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class ResourceRoleId(value: Long) extends DatabaseId
+final case class ResourceRoleName(value: String) extends ValueObject
+final case class ResourceRoleRecord(id: ResourceRoleId,
+                                    resourceTypeId: ResourceTypeId,
+                                    role: ResourceRoleName)
+
+object ResourceRoleRecord extends SQLSyntaxSupport[ResourceRoleRecord] {
+  override def tableName: String = "SAM_RESOURCE_ROLE"
+
+  import ResourceTypeRecordBinders._
+  import ResourceRoleRecordBinders._
+  def apply(e: ResultName[ResourceRoleRecord])(rs: WrappedResultSet): ResourceRoleRecord = ResourceRoleRecord(
+    rs.get(e.id),
+    rs.get(e.resourceTypeId),
+    rs.get(e.role)
+  )
+}
+
+object ResourceRoleRecordBinders {
+  implicit val resourceRoleIdTypeBinder: TypeBinder[ResourceRoleId] = new TypeBinder[ResourceRoleId] {
+    def apply(rs: ResultSet, label: String): ResourceRoleId = ResourceRoleId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ResourceRoleId = ResourceRoleId(rs.getLong(index))
+  }
+
+  implicit val resourceRoleNameTypeBinder: TypeBinder[ResourceRoleName] = new TypeBinder[ResourceRoleName] {
+    def apply(rs: ResultSet, label: String): ResourceRoleName = ResourceRoleName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ResourceRoleName = ResourceRoleName(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class ResourceId(value: Long) extends DatabaseId
+final case class ResourceName(value: String) extends ValueObject
+final case class ResourceRecord(id: ResourceId,
+                                name: ResourceName,
+                                resourceTypeId: ResourceTypeId)
+
+object ResourceRecord extends SQLSyntaxSupport[ResourceRecord] {
+  override def tableName: String = "SAM_RESOURCE"
+
+  import ResourceTypeRecordBinders._
+  import ResourceRecordBinders._
+  def apply(e: ResultName[ResourceRecord])(rs: WrappedResultSet): ResourceRecord = ResourceRecord(
+    rs.get(e.id),
+    rs.get(e.name),
+    rs.get(e.resourceTypeId)
+  )
+}
+
+object ResourceRecordBinders {
+  implicit val resourceIdTypeBinder: TypeBinder[ResourceId] = new TypeBinder[ResourceId] {
+    def apply(rs: ResultSet, label: String): ResourceId = ResourceId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ResourceId = ResourceId(rs.getLong(index))
+  }
+
+  implicit val resourceNameTypeBinder: TypeBinder[ResourceName] = new TypeBinder[ResourceName] {
+    def apply(rs: ResultSet, label: String): ResourceName = ResourceName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ResourceName = ResourceName(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTypeTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTypeTable.scala
@@ -1,0 +1,34 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class ResourceTypeId(value: Long) extends DatabaseId
+final case class ResourceTypeName(value: String) extends ValueObject
+final case class ResourceTypeRecord(id: ResourceTypeId,
+                                    resourceTypeName: ResourceTypeName)
+
+object ResourceTypeRecord extends SQLSyntaxSupport[ResourceTypeRecord] {
+  override def tableName: String = "SAM_RESOURCE_TYPE"
+
+  import ResourceTypeRecordBinders._
+  def apply(e: ResultName[ResourceTypeRecord])(rs: WrappedResultSet): ResourceTypeRecord = ResourceTypeRecord(
+    rs.get(e.id),
+    rs.get(e.resourceTypeName)
+  )
+}
+
+object ResourceTypeRecordBinders {
+  implicit val resourceTypeIdTypeBinder: TypeBinder[ResourceTypeId] = new TypeBinder[ResourceTypeId] {
+    def apply(rs: ResultSet, label: String): ResourceTypeId = ResourceTypeId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ResourceTypeId = ResourceTypeId(rs.getLong(index))
+  }
+
+  implicit val resourceTypeNameTypeBinder: TypeBinder[ResourceTypeName] = new TypeBinder[ResourceTypeName] {
+    def apply(rs: ResultSet, label: String): ResourceTypeName = ResourceTypeName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ResourceTypeName = ResourceTypeName(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/RoleActionTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/RoleActionTable.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import scalikejdbc._
+
+final case class RoleActionRecord(roleId: ResourceRoleId,
+                                  actionId: ResourceActionId)
+
+object RoleActionRecord extends SQLSyntaxSupport[RoleActionRecord] {
+  override def tableName: String = "SAM_ROLE_ACTION"
+
+  import ResourceActionRecordBinders._
+  import ResourceRoleRecordBinders._
+  def apply(e: ResultName[RoleActionRecord])(rs: WrappedResultSet): RoleActionRecord = RoleActionRecord(
+    rs.get(e.roleId),
+    rs.get(e.actionId)
+  )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import java.sql.ResultSet
+
+import org.broadinstitute.dsde.workbench.sam.db.DatabaseId
+import org.broadinstitute.dsde.workbench.sam.model.ValueObject
+import scalikejdbc._
+
+final case class UserId(value: Long) extends DatabaseId
+final case class UserEmail(value: String) extends ValueObject
+final case class UserGoogleSubjectId(value: String) extends ValueObject
+final case class UserRecord(id: UserId,
+                            email: UserEmail,
+                            googleSubjectId: Option[UserGoogleSubjectId])
+
+object UserRecord extends SQLSyntaxSupport[UserRecord] {
+  override def tableName: String = "SAM_USER"
+
+  import UserRecordBinders._
+  def apply(e: ResultName[UserRecord])(rs: WrappedResultSet): UserRecord = UserRecord(
+    rs.get(e.id),
+    rs.get(e.email),
+    rs.get(e.googleSubjectId)
+  )
+}
+
+object UserRecordBinders {
+  implicit val userIdTypeBinder: TypeBinder[UserId] = new TypeBinder[UserId] {
+    def apply(rs: ResultSet, label: String): UserId = UserId(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): UserId = UserId(rs.getLong(index))
+  }
+
+  implicit val userEmailTypeBinder: TypeBinder[UserEmail] = new TypeBinder[UserEmail] {
+    def apply(rs: ResultSet, label: String): UserEmail = UserEmail(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): UserEmail = UserEmail(rs.getString(index))
+  }
+
+  implicit val userGoogleSubjectIdTypeBinder: TypeBinder[UserGoogleSubjectId] = new TypeBinder[UserGoogleSubjectId] {
+    def apply(rs: ResultSet, label: String): UserGoogleSubjectId = UserGoogleSubjectId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): UserGoogleSubjectId = UserGoogleSubjectId(rs.getString(index))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
+import scalikejdbc.ParameterBinderFactory
 import spray.json.{DeserializationException, JsString, JsValue, RootJsonFormat}
 
 /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/ValueObjectFormat.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
-import scalikejdbc.ParameterBinderFactory
 import spray.json.{DeserializationException, JsString, JsValue, RootJsonFormat}
 
 /**


### PR DESCRIPTION
Ticket: [CA-327](https://broadworkbench.atlassian.net/browse/CA-327)
This PR includes the case classes we should need to model the new Postgres schema as well as the Scalike binders to turn JDBC things into our case classes and vice versa.

Much of this is inspired by Anu's work with Scalike in Hamm. It is currently entirely untested because I wasn't sure how to test these tables without any queries to use them, so if anyone has any ideas that'd be much appreciated. Input on naming would also be super useful. I tried to keep a relatively consistent naming scheme across the different tables, but let me know if there's a better/shorter/clearer way to name all these case classes.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
