### PR TITLE
change createResourceType api in DAO to take full object

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, _}
   * Created by dvoet on 6/26/17.
   */
 trait AccessPolicyDAO {
-  def createResourceType(resourceTypeName: ResourceTypeName): IO[ResourceTypeName]
+  def createResourceType(resourceType: ResourceType): IO[ResourceType]
 
   def createResource(resource: Resource): IO[Resource]
   def deleteResource(resource: FullyQualifiedResourceId): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -30,17 +30,17 @@ class LdapAccessPolicyDAO(
     with DirectorySubjectNameSupport
     with LdapSupport {
 
-  override def createResourceType(resourceTypeName: ResourceTypeName): IO[ResourceTypeName] =
+  override def createResourceType(resourceType: ResourceType): IO[ResourceType] =
     for {
       _ <- executeLdap(
         IO(
           ldapConnectionPool.add(
-            resourceTypeDn(resourceTypeName),
+            resourceTypeDn(resourceType.name),
             new Attribute("objectclass", List("top", ObjectClass.resourceType).asJava),
             new Attribute(Attr.ou, "resources")))).void.recover {
         case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS => ()
       }
-    } yield resourceTypeName
+    } yield resourceType
 
   override def createResource(resource: Resource): IO[Resource] = {
     val attributes = List(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -74,8 +74,8 @@ class ResourceService(
         } yield result :+ resourceTypeAdmin
     }
 
-  def createResourceType(resourceType: ResourceType): IO[ResourceTypeName] =
-    accessPolicyDAO.createResourceType(resourceType.name)
+  def createResourceType(resourceType: ResourceType): IO[ResourceType] =
+    accessPolicyDAO.createResourceType(resourceType)
 
   /**
     * Create a resource with default policies. The default policies contain 1 policy with the same name as the

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -49,6 +49,8 @@ trait TestSupport{
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
   implicit val timer = IO.timer(scala.concurrent.ExecutionContext.global)
   implicit val eqWorkbenchException: Eq[WorkbenchException] = (x: WorkbenchException, y: WorkbenchException) => x.getMessage == y.getMessage
+
+  def dummyResourceType(name: ResourceTypeName) = ResourceType(name, Set.empty, Set(ResourceRole(ResourceRoleName("owner"), Set.empty)), ResourceRoleName("owner"))
 }
 
 trait PropertyBasedTesting extends PropertyChecks with Configuration with Matchers {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -319,7 +319,7 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     val policy1 = AccessPolicy(
       FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("role1-a")), Set(userId), WorkbenchEmail("p1@example.com"), Set(ResourceRoleName("role1")), Set(ResourceAction("action1"), ResourceAction("action2")), public = false)
 
-    policyDAO.createResourceType(typeName1).unsafeRunSync()
+    policyDAO.createResourceType(dummyResourceType(typeName1)).unsafeRunSync()
     policyDAO.createResource(resource).unsafeRunSync()
     policyDAO.createPolicy(policy1).unsafeRunSync()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAOSpec.scala
@@ -48,8 +48,8 @@ class LdapAccessPolicyDAOSpec extends FlatSpec with ScalaFutures with Matchers w
 
     val res = for{
       _ <- setup()
-      _ <- dao.createResourceType(typeName1)
-      _ <- dao.createResourceType(typeName2)
+      _ <- dao.createResourceType(dummyResourceType(typeName1))
+      _ <- dao.createResourceType(dummyResourceType(typeName2))
       _ <- dao.createResource(resource1)
       //policy2's resource already exists
       _ <- dao.createResource(resource3)
@@ -95,7 +95,7 @@ class LdapAccessPolicyDAOSpec extends FlatSpec with ScalaFutures with Matchers w
     val resource2 = Resource(resourceTypeName, ResourceId("rid2"), Set(authDomain))
 
     val res = for {
-      _ <- dao.createResourceType(resourceTypeName)
+      _ <- dao.createResourceType(dummyResourceType(resourceTypeName))
       _ <- dao.createResource(resource1)
       _ <- dao.createResource(resource2)
       resources <- dao.listResourcesConstrainedByGroup(authDomain)
@@ -114,7 +114,7 @@ class LdapAccessPolicyDAOSpec extends FlatSpec with ScalaFutures with Matchers w
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(genPolicy.sample.get)
     val res = for{
       _ <- setup()
-      _ <- testDao.createResourceType(resource.resourceTypeName)
+      _ <- testDao.createResourceType(dummyResourceType(resource.resourceTypeName))
       _ <- testDao.createResource(resource)
       // put cachedResource in ldap with different auth domains so we are sure we don't actually look it up
       _ <- testDao.createResource(Resource.authDomain.set(genAuthDomains.sample.get)(cachedResource))
@@ -136,7 +136,7 @@ class LdapAccessPolicyDAOSpec extends FlatSpec with ScalaFutures with Matchers w
     val res = for{
       _ <- setup()
       _ <- dirDao.createUser(user)
-      _ <- dao.createResourceType(policy.id.resource.resourceTypeName)
+      _ <- dao.createResourceType(dummyResourceType(policy.id.resource.resourceTypeName))
       _ <- dao.createResource(resource)
       _ <- dao.createPolicy(policy)
       resources <- dao.listAccessPolicies(policy.id.resource.resourceTypeName, user.id)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()) extends AccessPolicyDAO {
   val resources = new TrieMap[FullyQualifiedResourceId, Resource]()
 
-  override def createResourceType(resourceTypeName: ResourceTypeName): IO[ResourceTypeName] = IO.pure(resourceTypeName)
+  override def createResourceType(resourceType: ResourceType): IO[ResourceType] = IO.pure(resourceType)
 
   override def createResource(resource: Resource): IO[Resource] = IO {
     resources += resource.fullyQualifiedId -> resource

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -58,7 +58,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
     runAndWait(schemaDao.init())
   }
 
-  def makeResourceType(resourceType: ResourceType): ResourceTypeName = resourceService.createResourceType(resourceType).unsafeRunSync()
+  def makeResourceType(resourceType: ResourceType): ResourceType = resourceService.createResourceType(resourceType).unsafeRunSync()
 
   def assertPoliciesOnResource(resource: FullyQualifiedResourceId, policyDAO: AccessPolicyDAO = policyDAO, expectedPolicies: Stream[AccessPolicyName] = Stream(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName)) = {
     val policies = policyDAO.listAccessPolicies(resource).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -146,7 +146,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
 
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
+      _ <- policyDAO.createResourceType(defaultResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId)
@@ -168,7 +168,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
 
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
+      _ <- policyDAO.createResourceType(defaultResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId)
@@ -191,7 +191,7 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
     val res = for{
       _ <- setup()
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
+      _ <- policyDAO.createResourceType(defaultResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId)
@@ -238,8 +238,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
 
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
-      _ <- policyDAO.createResourceType(managedGroupResourceType.name)
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResourceType(managedGroupResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       _ <- resource.authDomain.toList.parTraverse{
@@ -264,8 +264,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
 
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
-      _ <- policyDAO.createResourceType(managedGroupResourceType.name)
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResourceType(managedGroupResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId)
@@ -289,8 +289,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
       _ <- dirDAO.createUser(WorkbenchUser(probeUser.userId, Some(GoogleSubjectId(probeUser.userId.value)), probeUser.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
-      _ <- policyDAO.createResourceType(managedGroupResourceType.name)
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResourceType(managedGroupResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       _ <- resource.authDomain.toList.parTraverse{
@@ -317,8 +317,8 @@ class PolicyEvaluatorServiceSpec extends AsyncFlatSpec with Matchers with TestSu
     val res = for{
       _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
       _ <- dirDAO.createUser(WorkbenchUser(probeUser.userId, Some(GoogleSubjectId(probeUser.userId.value)), probeUser.userEmail))
-      _ <- policyDAO.createResourceType(policy.id.resource.resourceTypeName)
-      _ <- policyDAO.createResourceType(managedGroupResourceType.name)
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResourceType(managedGroupResourceType)
       _ <- policyDAO.createResource(resource)
       _ <- policyDAO.createPolicy(policy)
       _ <- resource.authDomain.toList.parTraverse{


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>
prep for createResourceType in postgres
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
