### PR TITLE
Remove addProxyGroup and readProxyGroup

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -165,17 +165,11 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
       val proxyGroup2_1 = Sam.user.proxyGroup(email2.value)(authToken1)
       val proxyGroup2_2 = Sam.user.proxyGroup(email2.value)(authToken2)
 
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-      val expectedProxyEmail1 = s"${username1}_$userId1@${gcsConfig.appsDomain}"
-*/
       val expectedProxyEmail1 = s"$userId1@${gcsConfig.appsDomain}"
 
       proxyGroup1_1.value should endWith (expectedProxyEmail1)
       proxyGroup1_2.value should endWith (expectedProxyEmail1)
 
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-      val expectedProxyEmail2 = s"${username2}_$userId2@${gcsConfig.appsDomain}"
-*/
       val expectedProxyEmail2 = s"$userId2@${gcsConfig.appsDomain}"
 
       proxyGroup2_1.value should endWith (expectedProxyEmail2)
@@ -197,9 +191,6 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
         val proxyGroup_1 = Sam.user.proxyGroup(petSAEmail.value)(authToken1)
         val proxyGroup_2 = Sam.user.proxyGroup(petSAEmail.value)(authToken2)
 
-        /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-      val expectedProxyEmail = s"${username}_$userId@${gcsConfig.appsDomain}"
-*/
         val expectedProxyEmail = s"$userId@${gcsConfig.appsDomain}"
 
         proxyGroup_1.value should endWith(expectedProxyEmail)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/DirectoryDAO.scala
@@ -41,8 +41,6 @@ trait DirectoryDAO {
   def loadUser(userId: WorkbenchUserId): IO[Option[WorkbenchUser]]
   def loadUsers(userIds: Set[WorkbenchUserId]): IO[Stream[WorkbenchUser]]
   def deleteUser(userId: WorkbenchUserId): IO[Unit]
-  def addProxyGroup(userId: WorkbenchUserId, proxyEmail: WorkbenchEmail): IO[Unit]
-  def readProxyGroup(userId: WorkbenchUserId): IO[Option[WorkbenchEmail]]
 
   def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]]
   def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -223,19 +223,6 @@ class LdapDirectoryDAO(
   override def deleteUser(userId: WorkbenchUserId): IO[Unit] =
     executeLdap(IO(ldapConnectionPool.delete(userDn(userId))))
 
-  override def addProxyGroup(userId: WorkbenchUserId, proxyEmail: WorkbenchEmail): IO[Unit] =
-    executeLdap(IO(ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.proxyEmail, proxyEmail.value))))
-
-  override def readProxyGroup(userId: WorkbenchUserId): IO[Option[WorkbenchEmail]] =
-    executeLdap(IO(ldapConnectionPool.getEntry(userDn(userId), Attr.proxyEmail))).map { result =>
-      for {
-        entry <- Option(result)
-        email <- Option(entry.getAttributeValue(Attr.proxyEmail))
-      } yield {
-        WorkbenchEmail(email)
-      }
-    }
-
   override def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]] = listMemberOfGroups(userId)
 
   override def listUserDirectMemberships(userId: WorkbenchUserId): IO[Stream[WorkbenchGroupIdentity]] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -68,15 +68,8 @@ class GoogleExtensions(
   private val maxGroupEmailLength = 64
 
   private[google] def toProxyFromUser(userId: WorkbenchUserId): WorkbenchEmail =
-  /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val username = user.email.value.split("@").head
-    val emailSuffix = s"_${user.id.value}@${googleServicesConfig.appsDomain}"
-    val maxUsernameLength = maxGroupEmailLength - emailSuffix.length
-    WorkbenchEmail(username.take(maxUsernameLength) + emailSuffix)
-     */
     WorkbenchEmail(s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}PROXY_${userId.value}@${googleServicesConfig.appsDomain}")
 
-  /**/
   override val emailDomain = googleServicesConfig.appsDomain
   private[google] val allUsersGroupEmail = WorkbenchEmail(
     s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}GROUP_${allUsersGroupName.value}@$emailDomain")
@@ -253,9 +246,6 @@ class GoogleExtensions(
       allUsersGroup <- getOrCreateAllUsersGroup(directoryDAO)
       _ <- googleDirectoryDAO.addMemberToGroup(allUsersGroup.email, proxyEmail)
 
-      /* Re-enable this code after fixing rawls for GAWB-2933
-      _ <- directoryDAO.addProxyGroup(user.id, proxyEmail)
-     */
     } yield ()
   }
 
@@ -540,9 +530,6 @@ class GoogleExtensions(
     }
 
   private[google] def getUserProxy(userId: WorkbenchUserId): Future[Option[WorkbenchEmail]] =
-    /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    directoryDAO.readProxyGroup(userId)
-     */
     Future.successful(Some(toProxyFromUser(userId)))
 
   private def withProxyEmail[T](userId: WorkbenchUserId)(f: WorkbenchEmail => Future[T]): Future[T] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAOSpec.scala
@@ -92,25 +92,6 @@ class LdapDirectoryDAOSpec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  it should "add and read proxy group email" in {
-    val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))
-
-    assertResult(user) {
-      dao.createUser(user).unsafeRunSync()
-    }
-
-    assertResult(None) {
-      dao.readProxyGroup(userId).unsafeRunSync()
-    }
-
-    dao.addProxyGroup(userId, WorkbenchEmail("foo_1234@test.firecloud.org")).unsafeRunSync()
-
-    assertResult(Some(WorkbenchEmail("foo_1234@test.firecloud.org"))) {
-      dao.readProxyGroup(userId).unsafeRunSync()
-    }
-  }
-
   it should "create, read, delete pet service accounts" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
     val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/MockDirectoryDAO.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup}
-import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.Attr
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -112,10 +111,6 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
   override def deleteUser(userId: WorkbenchUserId): IO[Unit] = IO {
     users -= userId
   }
-
-  override def addProxyGroup(userId: WorkbenchUserId, proxyEmail: WorkbenchEmail): IO[Unit] = addUserAttribute(userId, Attr.proxyEmail, proxyEmail)
-
-  override def readProxyGroup(userId: WorkbenchUserId): IO[Option[WorkbenchEmail]] = readUserAttribute[WorkbenchEmail](userId, Attr.proxyEmail)
 
   override def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]] = IO {
     listSubjectsGroups(userId, Set.empty).map(_.id)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -92,11 +92,6 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
   private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
 
   "POST /api/google/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
-///* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-//    val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
-//*/
-//    val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_user123@${googleServicesConfig.appsDomain}")
-///**/
     val resourceTypes = Map(resourceType.name -> resourceType)
     val (user, headers, _, routes) = createTestUser(resourceTypes)
 
@@ -239,11 +234,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
 trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
   val defaultUserId = genWorkbenchUserId(System.currentTimeMillis())
   val defaultUserEmail = genNonPetEmail.sample.get
-  /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val defaultUserProxyEmail = WorkbenchEmail(s"newuser_$defaultUserId@${googleServicesConfig.appsDomain}")
-  */
   val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
-  /**/
 
   val configResourceTypes = TestSupport.configResourceTypes
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -74,10 +74,6 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   "POST /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
 //    val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user123"), WorkbenchEmail("user1@example.com"), 0)
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val defaultUserProxyEmail = WorkbenchEmail(s"user1_user123@${googleServicesConfig.appsDomain}")
-*/
-/**/
 
     val (user, headers, _, routes) = createTestUser(resourceTypes)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -76,30 +76,17 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val inBothSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set.empty, WorkbenchEmail("inBothSubGroup@example.com"))
 
     val inSamUserId = WorkbenchUserId("inSamUser")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val inSamUserProxyEmail = "foo_inSamUser@test.firecloud.org"
-*/
     val inSamUserProxyEmail = s"PROXY_inSamUser@${googleServicesConfig.appsDomain}"
-/**/
+
     val inGoogleUserId = WorkbenchUserId("inGoogleUser")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val inGoogleUserProxyEmail = "foo_inGoogleUser@test.firecloud.org"
-*/
     val inGoogleUserProxyEmail = s"PROXY_inGoogleUser@${googleServicesConfig.appsDomain}"
-/**/
+
     val inBothUserId = WorkbenchUserId("inBothUser")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val inBothUserProxyEmail = "foo_inBothUser@test.firecloud.org"
-*/
     val inBothUserProxyEmail = s"PROXY_inBothUser@${googleServicesConfig.appsDomain}"
-/**/
 
     val addError = WorkbenchUserId("addError")
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val addErrorProxyEmail = "foo_addError@test.firecloud.org"
-*/
     val addErrorProxyEmail = s"PROXY_addError@${googleServicesConfig.appsDomain}"
-/**/
+
     val removeError = "removeError@foo.bar"
 
     val testGroup = BasicWorkbenchGroup(groupName, Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail)
@@ -360,11 +347,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val defaultUserId = WorkbenchUserId("newuser123")
     val defaultUserEmail = WorkbenchEmail("newuser@new.com")
-    /* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val defaultUserProxyEmail = WorkbenchEmail(s"newuser_newuser123@${googleServicesConfig.appsDomain}")
-*/
     val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_newuser123@${googleServicesConfig.appsDomain}")
-    /**/
+
     val defaultUser = CreateWorkbenchUser(defaultUserId, GoogleSubjectId(defaultUserId.value), defaultUserEmail)
     (dirDAO, mockGoogleIamDAO, mockGoogleDirectoryDAO, googleExtensions, service, defaultUserId, defaultUserEmail, defaultUserProxyEmail, defaultUser)
   }
@@ -562,14 +546,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val user = WorkbenchUser(WorkbenchUserId(subjectId), None, WorkbenchEmail(s"$username@test.org"))
 
     val proxyEmail = googleExtensions.toProxyFromUser(user.id).value
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    proxyEmail shouldBe "foo_0123456789@test.cloudfire.org"
-    proxyEmail should include (username)
-    proxyEmail should include (subjectId)
-    proxyEmail should include (appsDomain)
-*/
     proxyEmail shouldBe "PROXY_0123456789@test.cloudfire.org"
-/**/
   }
 
   it should "truncate username if proxy group email would otherwise be too long" in {
@@ -579,23 +556,14 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val user = WorkbenchUser(WorkbenchUserId("0123456789"), None, WorkbenchEmail("foo-bar-baz-qux-quux-corge-grault-garply@test.org"))
 
     val proxyEmail = googleExtensions.toProxyFromUser(user.id).value
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    proxyEmail shouldBe "foo-bar-baz-qux-quux-corge-grault-_0123456789@test.cloudfire.org"
-    proxyEmail should have length 64
-*/
     proxyEmail shouldBe "PROXY_0123456789@test.cloudfire.org"
-/**/
   }
 
   it should "do Googley stuff onUserCreate" in {
     val userId = WorkbenchUserId(UUID.randomUUID().toString)
     val userEmail = WorkbenchEmail("foo@test.org")
     val user = WorkbenchUser(userId, None, userEmail)
-/* Re-enable this code and remove the temporary code below after fixing rawls for GAWB-2933
-    val proxyEmail = WorkbenchEmail(s"foo_$userId@${googleServicesConfig.appsDomain}")
-*/
     val proxyEmail = WorkbenchEmail(s"PROXY_$userId@${googleServicesConfig.appsDomain}")
-/**/
 
     val mockDirectoryDAO = mock[DirectoryDAO]
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
@@ -616,9 +584,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val lockedDownGroupSettings = Option(mockGoogleDirectoryDAO.lockedDownGroupSettings)
     verify(mockGoogleDirectoryDAO).createGroup(userEmail.value, proxyEmail, lockedDownGroupSettings)
     verify(mockGoogleDirectoryDAO).addMemberToGroup(allUsersGroup.email, proxyEmail)
-/* Re-enable this code after fixing rawls for GAWB-2933
-    verify(mockDirectoryDAO).addProxyGroup(userId, proxyEmail)
-*/
   }
 
   it should "do Googley stuff onGroupDelete" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -124,10 +124,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
       when(mockDirectoryDAO.loadGroup(ge.allUsersGroupName)).thenReturn(IO.pure(Option(BasicWorkbenchGroup(ge.allUsersGroupName, Set.empty, ge.allUsersGroupEmail))))
       when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(IO.unit)
       when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity])).thenReturn(IO.pure(Some((new GregorianCalendar(2017, 11, 22).getTime()))))
-      when(mockDirectoryDAO.readProxyGroup(WorkbenchUserId("addError"))).thenReturn(IO.pure(Some(WorkbenchEmail(addErrorProxyEmail))))
-      when(mockDirectoryDAO.readProxyGroup(WorkbenchUserId("inSamUser"))).thenReturn(IO.pure(Some(WorkbenchEmail(inSamUserProxyEmail))))
-      when(mockDirectoryDAO.readProxyGroup(WorkbenchUserId("inGoogleUser"))).thenReturn(IO.pure(Some(WorkbenchEmail(inGoogleUserProxyEmail))))
-      when(mockDirectoryDAO.readProxyGroup(WorkbenchUserId("inBothUser"))).thenReturn(IO.pure(Some(WorkbenchEmail(inBothUserProxyEmail))))
 
       val subGroups = Seq(inSamSubGroup, inGoogleSubGroup, inBothSubGroup)
       subGroups.foreach { g => when(mockDirectoryDAO.loadSubjectEmail(g.id)).thenReturn(IO.pure(Option(g.email))) }
@@ -611,7 +607,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     }
     when(mockDirectoryDAO.createGroup(argThat(allUsersGroupMatcher), isNull())).thenReturn(IO.pure(allUsersGroup))
 
-    when(mockDirectoryDAO.addProxyGroup(userId, proxyEmail)).thenReturn(IO.unit)
     when(mockGoogleDirectoryDAO.getGoogleGroup(any[WorkbenchEmail])).thenReturn(Future.successful(None))
     when(mockGoogleDirectoryDAO.createGroup(any[String], any[WorkbenchEmail], any[Option[Groups]])).thenReturn(Future.successful(()))
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))


### PR DESCRIPTION
Ticket: [CA-308](https://broadworkbench.atlassian.net/browse/CA-308) and [GAWB-2933](https://broadinstitute.atlassian.net/browse/GAWB-2933)
I was starting to look at implementing the proxy group related `DirectoryDAO` queries for Postgres when I realized that they aren't currently used. From what I understand, there was an effort (GAWB-2933) ~18 months ago to make proxy group emails more readable so that users would know who they were sharing with. However, this caused some unforeseen problems so it was rolled back and we eventually decided not to do it. Rather than re-implement unused code, this PR will remove it. I also removed a bunch of comments referencing the related ticket (GAWB-2933).

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
