### PR TITLE
listAncestorsGroups

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -372,36 +372,7 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
   }
 
   override def listUsersGroups(userId: WorkbenchUserId): IO[Set[WorkbenchGroupIdentity]] = {
-    runInTransaction { implicit session =>
-      val ancestorGroupsTable = SubGroupMemberTable("ancestor_groups")
-      val ag = ancestorGroupsTable.syntax("ag")
-      val agColumn = ancestorGroupsTable.column
-
-      val gm = GroupMemberTable.syntax("gm")
-      val pg = GroupMemberTable.syntax("parent_groups")
-      val g = GroupTable.syntax("g")
-      val p = PolicyTable.syntax("p")
-      val r = ResourceTable.syntax("r")
-      val rt = ResourceTypeTable.syntax("rt")
-
-      val listGroupsQuery =
-        samsql"""WITH RECURSIVE ${ancestorGroupsTable.table}(${agColumn.parentGroupId}, ${agColumn.memberGroupId}) AS (
-                    select ${gm.groupId}, ${gm.memberGroupId}
-                    from ${GroupMemberTable as gm}
-                    where ${gm.memberUserId} = ${userId}
-                    union
-                    select ${pg.groupId}, ${pg.memberGroupId}
-                    from ${GroupMemberTable as pg}
-                    join ${ancestorGroupsTable as ag} ON ${agColumn.parentGroupId} = ${pg.memberGroupId}
-          ) select distinct(${g.name}) as ${g.resultName.name}, ${p.result.name}, ${r.result.name}, ${rt.result.name}
-            from ${GroupTable as g}
-            join ${ancestorGroupsTable as ag} on ${ag.parentGroupId} = ${g.id}
-            left join ${PolicyTable as p} on ${p.groupId} = ${g.id}
-            left join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
-            left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}"""
-
-      listGroupsQuery.map(resultSetToGroupIdentity(_, g, p, r, rt)).list().apply().toSet
-    }
+    listMemberOfGroups(userId)
   }
 
   /** Extracts a WorkbenchGroupIdentity from a SQL query
@@ -530,7 +501,49 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
                where ${gm.groupId} = (${workbenchGroupIdentityToGroupPK(groupId)})"""
   }
 
-  override def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = ???
+  private def listMemberOfGroups(subject: WorkbenchSubject): IO[Set[WorkbenchGroupIdentity]] = {
+    val gm = GroupMemberTable.syntax("gm")
+    val g = GroupTable.syntax("g")
+    val p = PolicyTable.syntax("p")
+
+    val topQueryWhere = subject match {
+      case userId: WorkbenchUserId => samsqls"where ${gm.memberUserId} = ${userId}"
+      case workbenchGroupIdentity: WorkbenchGroupIdentity => samsqls"where ${gm.memberGroupId} = (${workbenchGroupIdentityToGroupPK(workbenchGroupIdentity)})"
+      case _ => throw new WorkbenchException(s"Unexpected WorkbenchSubject. Expected WorkbenchUserId or WorkbenchGroupIdentity but got ${subject}")
+    }
+
+    runInTransaction { implicit session =>
+      val ancestorGroupsTable = SubGroupMemberTable("ancestor_groups")
+      val ag = ancestorGroupsTable.syntax("ag")
+      val agColumn = ancestorGroupsTable.column
+
+      val pg = GroupMemberTable.syntax("parent_groups")
+      val r = ResourceTable.syntax("r")
+      val rt = ResourceTypeTable.syntax("rt")
+
+      val listGroupsQuery =
+        samsql"""WITH RECURSIVE ${ancestorGroupsTable.table}(${agColumn.parentGroupId}, ${agColumn.memberGroupId}) AS (
+                    select ${gm.groupId}, ${gm.memberGroupId}
+                    from ${GroupMemberTable as gm}
+                    ${topQueryWhere}
+                    union
+                    select ${pg.groupId}, ${pg.memberGroupId}
+                    from ${GroupMemberTable as pg}
+                    join ${ancestorGroupsTable as ag} ON ${agColumn.parentGroupId} = ${pg.memberGroupId}
+          ) select distinct(${g.name}) as ${g.resultName.name}, ${p.result.name}, ${r.result.name}, ${rt.result.name}
+            from ${GroupTable as g}
+            join ${ancestorGroupsTable as ag} on ${ag.parentGroupId} = ${g.id}
+            left join ${PolicyTable as p} on ${p.groupId} = ${g.id}
+            left join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
+            left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}"""
+
+      listGroupsQuery.map(resultSetToGroupIdentity(_, g, p, r, rt)).list().apply().toSet
+    }
+  }
+
+  override def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = {
+    listMemberOfGroups(groupId)
+  }
 
   override def enableIdentity(subject: WorkbenchSubject): IO[Unit] = {
     runInTransaction { implicit session =>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -508,5 +508,26 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
 
       "lists all policies that a user is in directly" is pending
     }
+
+    "listAncestorGroups" - {
+      "list all of the groups a group is in" in {
+        val subSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("ssg"), Set.empty, WorkbenchEmail("ssg@groups.r.us"))
+        val subGroup = BasicWorkbenchGroup(WorkbenchGroupName("sg"), Set(subSubGroup.id), WorkbenchEmail("sg@groups.r.us"))
+        val directParentGroup = BasicWorkbenchGroup(WorkbenchGroupName("dpg"), Set(subGroup.id, subSubGroup.id), WorkbenchEmail("dpg@groups.r.us"))
+        val indirectParentGroup = BasicWorkbenchGroup(WorkbenchGroupName("ipg"), Set(subGroup.id), WorkbenchEmail("ipg@groups.r.us"))
+
+        dao.createGroup(subSubGroup).unsafeRunSync()
+        dao.createGroup(subGroup).unsafeRunSync()
+        dao.createGroup(directParentGroup).unsafeRunSync()
+        dao.createGroup(indirectParentGroup).unsafeRunSync()
+
+        val ancestorGroups = dao.listAncestorGroups(subSubGroup.id).unsafeRunSync()
+        ancestorGroups should contain theSameElementsAs Set(subGroup.id, directParentGroup.id, indirectParentGroup.id)
+      }
+
+      "list all of the policies a group is in" is pending
+      "list all of the groups a policy is in" is pending
+      "list all of the policies a policy is in" is pending
+    }
   }
 }


### PR DESCRIPTION
Ticket: [CA-308](https://broadworkbench.atlassian.net/browse/CA-308)
implement `listAncestorsGroups` by extracting code from `listUsersGroups` query into a new private function `listMemberOfGroups`

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
