### PR TITLE
add reuseIds for study

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -453,6 +453,7 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "alter_policies"]
       }
     }
+    reuseIds = true
   }
   dataset = {
     actionPatternObjects = {


### PR DESCRIPTION
Ticket: No ticket
I merged our previous ticket to swap the names of our SAM resources but it looks like the tests were failing because study didn't have reuseIds set on it anymore. Adding that here.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
