### PR TITLE
[CA-309] deleteResource, listResources*

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
@@ -44,6 +44,7 @@ object DbReference extends LazyLogging {
 
   def init(liquibaseConfig: LiquibaseConfig, dbName: Symbol): DbReference = {
     DBs.setup(dbName)
+    DBs.loadGlobalSettings()
     if (liquibaseConfig.initWithLiquibase) {
       initWithLiquibase(liquibaseConfig)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -207,29 +207,6 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
     samsql"update ${GroupTable.table} set ${g.updatedDate} = ${Instant.now()} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})".update().apply()
   }
 
-  private def workbenchGroupIdentityToGroupPK(groupId: WorkbenchGroupIdentity): SQLSyntax = {
-    groupId match {
-      case group: WorkbenchGroupName => GroupTable.groupPKQueryForGroup(group)
-      case policy: FullyQualifiedPolicyId => groupPKQueryForPolicy(policy)
-    }
-  }
-
-  private def groupPKQueryForPolicy(policyId: FullyQualifiedPolicyId,
-                                    resourceTypeTableAlias: String = "rt",
-                                    resourceTableAlias: String = "r",
-                                    policyTableAlias: String = "p"): SQLSyntax = {
-    val rt = ResourceTypeTable.syntax(resourceTypeTableAlias)
-    val r = ResourceTable.syntax(resourceTableAlias)
-    val p = PolicyTable.syntax(policyTableAlias)
-    samsqls"""select ${p.groupId}
-              from ${ResourceTypeTable as rt}
-              join ${ResourceTable as r} on ${rt.id} = ${r.resourceTypeId}
-              join ${PolicyTable as p} on ${r.id} = ${p.resourceId}
-              where ${rt.name} = ${policyId.resource.resourceTypeName}
-              and ${r.name} = ${policyId.resource.resourceId}
-              and ${p.name} = ${policyId.accessPolicyName}"""
-  }
-
   /**
     * @return true if the subject was removed, false if it was already gone
     */

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.sam.errorReportSource
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.db.DbReference
+import org.broadinstitute.dsde.workbench.sam.db.{DbReference, SamTypeBinders}
 import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -26,7 +26,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
   // This method obtains an EXCLUSIVE lock on the ResourceType table because if we boot multiple Sam instances at once,
   // they will all try to (re)create ResourceTypes at the same time and could collide. The lock is automatically
   // released at the end of the transaction.
-  def createResourceType(resourceType: ResourceType): IO[ResourceType] = {
+  override def createResourceType(resourceType: ResourceType): IO[ResourceType] = {
     val uniqueActions = resourceType.roles.flatMap(_.actions)
     runInTransaction { implicit session =>
       samsql"lock table ${ResourceTypeTable.table} IN EXCLUSIVE MODE".execute().apply()
@@ -156,7 +156,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
   // 1. Create Resource
   // 2. Create the entries in the join table for the auth domains
-  def createResource(resource: Resource): IO[Resource] = {
+  override def createResource(resource: Resource): IO[Resource] = {
     runInTransaction { implicit session =>
       val resourcePK = insertResource(resource)
 
@@ -196,9 +196,14 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     samsqls"""select ${rt.id} from ${ResourceTypeTable as rt} where ${rt.name} = ${resourceTypeName}"""
   }
 
-  def deleteResource(resource: FullyQualifiedResourceId): IO[Unit] = ???
+  override def deleteResource(resource: FullyQualifiedResourceId): IO[Unit] = {
+    runInTransaction { implicit session =>
+      val r = ResourceTable.syntax("r")
+      samsql"delete from ${ResourceTable as r} where ${r.name} = ${resource.resourceId} and ${r.resourceTypeId} = (${loadResourceTypePK(resource.resourceTypeName)})".update().apply()
+    }
+  }
 
-  def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[LoadResourceAuthDomainResult] = {
+  override def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[LoadResourceAuthDomainResult] = {
     runInTransaction { implicit session =>
       val ad = AuthDomainTable.syntax("ad")
       val r = ResourceTable.syntax("r")
@@ -237,20 +242,47 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     }
   }
 
-  def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]] = ???
-  def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = ???
-  def deletePolicy(policy: FullyQualifiedPolicyId): IO[Unit] = ???
-  def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Option[AccessPolicy]] = ???
-  def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject]): IO[Unit] = ???
-  def overwritePolicy(newPolicy: AccessPolicy): IO[AccessPolicy] = ???
-  def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]] = ???
-  def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = ???
-  def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]] = ???
-  def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId): IO[Option[Resource]] = ???
-  def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]] = ???
-  def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = ???
-  def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = ???
-  def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]] = ???
-  def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit] = ???
-  def evictIsMemberOfCache(subject: WorkbenchSubject): IO[Unit] = ???
+  override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]] = ???
+  override def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = ???
+  override def deletePolicy(policy: FullyQualifiedPolicyId): IO[Unit] = ???
+  override def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId): IO[Option[AccessPolicy]] = ???
+  override def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject]): IO[Unit] = ???
+  override def overwritePolicy(newPolicy: AccessPolicy): IO[AccessPolicy] = ???
+  override def listPublicAccessPolicies(resourceTypeName: ResourceTypeName): IO[Stream[ResourceIdAndPolicyName]] = ???
+  override def listPublicAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = ???
+  override def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId]): IO[Set[Resource]] = ???
+
+  override def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId): IO[Option[Resource]] = {
+    import SamTypeBinders._
+
+    runInTransaction { implicit session =>
+      val r = ResourceTable.syntax("r")
+      val ad = AuthDomainTable.syntax("ad")
+      val g = GroupTable.syntax("g")
+      val rt = ResourceTypeTable.syntax("rt")
+
+      val results = samsql"""select ${rt.result.name}, ${r.result.name}, ${g.result.name} from ${ResourceTable as r}
+              join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+              left join ${AuthDomainTable as ad} on ${r.id} = ${ad.resourceId}
+              left join ${GroupTable as g} on ${ad.groupId} = ${g.id}
+              where ${r.name} = ${resourceId.resourceId}"""
+        .map(rs => (rs.get[ResourceTypeName](rt.resultName.name), rs.get[ResourceId](r.resultName.name), rs.stringOpt(g.resultName.name).map(WorkbenchGroupName))).list().apply()
+
+      val authDomain = results.collect {
+        case (_, _, Some(authDomainGroup)) => authDomainGroup
+      }.toSet
+
+      // resource type name and resource id will be the same across results so just using the first if it exists
+      results.headOption.map { head =>
+        Resource(head._1, head._2, authDomain)
+      }
+    }
+  }
+
+  override def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId): IO[Set[ResourceIdAndPolicyName]] = ???
+  override def listAccessPolicies(resource: FullyQualifiedResourceId): IO[Stream[AccessPolicy]] = ???
+  override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId): IO[Set[AccessPolicy]] = ???
+  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId): IO[Set[WorkbenchUser]] = ???
+  override def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean): IO[Unit] = ???
+  override def evictIsMemberOfCache(subject: WorkbenchSubject): IO[Unit] = ???
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -1,8 +1,12 @@
 package org.broadinstitute.dsde.workbench.sam.util
 
 import cats.effect.{ContextShift, IO}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchGroupIdentity, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.sam.db.DbReference
-import scalikejdbc.DBSession
+import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory._
+import org.broadinstitute.dsde.workbench.sam.db.tables.{GroupTable, PolicyTable, ResourceTable, ResourceTypeTable}
+import org.broadinstitute.dsde.workbench.sam.model.FullyQualifiedPolicyId
+import scalikejdbc.{DBSession, SQLSyntax}
 
 import scala.concurrent.ExecutionContext
 
@@ -15,5 +19,28 @@ trait DatabaseSupport {
     cs.evalOn(ecForDatabaseIO)(IO {
       dbRef.inLocalTransaction(databaseFunction)
     })
+  }
+
+  protected def workbenchGroupIdentityToGroupPK(groupId: WorkbenchGroupIdentity): SQLSyntax = {
+    groupId match {
+      case group: WorkbenchGroupName => GroupTable.groupPKQueryForGroup(group)
+      case policy: FullyQualifiedPolicyId => groupPKQueryForPolicy(policy)
+    }
+  }
+
+  protected def groupPKQueryForPolicy(policyId: FullyQualifiedPolicyId,
+                                    resourceTypeTableAlias: String = "rt",
+                                    resourceTableAlias: String = "r",
+                                    policyTableAlias: String = "p"): SQLSyntax = {
+    val rt = ResourceTypeTable.syntax(resourceTypeTableAlias)
+    val r = ResourceTable.syntax(resourceTableAlias)
+    val p = PolicyTable.syntax(policyTableAlias)
+    samsqls"""select ${p.groupId}
+              from ${ResourceTypeTable as rt}
+              join ${ResourceTable as r} on ${rt.id} = ${r.resourceTypeId}
+              join ${PolicyTable as p} on ${r.id} = ${p.resourceId}
+              where ${rt.name} = ${policyId.resource.resourceTypeName}
+              and ${r.name} = ${policyId.resource.resourceId}
+              and ${p.name} = ${policyId.accessPolicyName}"""
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -189,5 +189,45 @@ class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndA
         }
       }
     }
+
+    "listResourceWithAuthdomains" - {
+      "loads a resource with its auth domain" in {
+        val authDomain = BasicWorkbenchGroup(WorkbenchGroupName("aufthDomain"), Set.empty, WorkbenchEmail("authDomain@groups.com"))
+        dirDao.createGroup(authDomain).unsafeRunSync()
+        dao.createResourceType(resourceType).unsafeRunSync()
+
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set(authDomain.id))
+        dao.createResource(resource).unsafeRunSync()
+
+        dao.listResourceWithAuthdomains(resource.fullyQualifiedId).unsafeRunSync() shouldEqual Option(resource)
+      }
+
+      "loads a resource even if its unconstrained" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        dao.listResourceWithAuthdomains(resource.fullyQualifiedId).unsafeRunSync() shouldEqual Option(resource)
+      }
+
+      "returns None when resource isn't found" in {
+        dao.listResourceWithAuthdomains(FullyQualifiedResourceId(resourceTypeName, ResourceId("terribleResource"))).unsafeRunSync() shouldBe None
+      }
+    }
+
+    "deleteResource" - {
+      "deletes a resource" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        dao.listResourceWithAuthdomains(resource.fullyQualifiedId).unsafeRunSync() shouldEqual Option(resource)
+
+        dao.deleteResource(resource.fullyQualifiedId).unsafeRunSync()
+
+        dao.listResourceWithAuthdomains(resource.fullyQualifiedId).unsafeRunSync() shouldEqual None
+      }
+    }
   }
 }


### PR DESCRIPTION
Ticket: [CA-309](https://broadworkbench.atlassian.net/browse/CA-309)
PR contains the following four queries: `deleteResource`, `listResourcesConstrainedByGroup`, `listResourcesWithAuthDomains`, `listResourceWithAuthDomains`. I also moved the `workbenchGroupIdentityToGroupPK` function to DatabaseSupport to share it across DAOs and fixed a minor bug that was preventing SQL queries from being logged while testing.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
