### PR TITLE
create, load, delete policies

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -194,9 +194,9 @@
                 <constraints nullable="false" foreignKeyName="FK_SRP_RESOURCE" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
             </column>
             <column name="group_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SRP_GROUP" referencedTableName="SAM_GROUP" referencedColumnNames="id"/>
+                <constraints nullable="false" foreignKeyName="FK_SRP_GROUP" referencedTableName="SAM_GROUP" referencedColumnNames="id" deleteCascade="true"/>
             </column>
-            <column name="name" type="VARCHAR">
+            <column name="public" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -205,7 +205,7 @@
     <changeSet logicalFilePath="dummy" author="dvoet" id="policy_role_table">
         <createTable tableName="SAM_POLICY_ROLE">
             <column name="resource_policy_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SPR_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SPR_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
             <column name="resource_role_id" type="BIGINT">
                 <constraints nullable="false" foreignKeyName="FK_SPR_ROLE" referencedTableName="SAM_RESOURCE_ROLE" referencedColumnNames="id" primaryKey="true"/>
@@ -216,7 +216,7 @@
     <changeSet logicalFilePath="dummy" author="dvoet" id="policy_action_table">
         <createTable tableName="SAM_POLICY_ACTION">
             <column name="resource_policy_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SPA_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SPA_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
             <column name="resource_action_id" type="BIGINT">
                 <constraints nullable="false" foreignKeyName="FK_SPA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true"/>
@@ -236,9 +236,9 @@
         <addUniqueConstraint tableName="SAM_RESOURCE" columnNames="resource_type_id, name"/>
     </changeSet>
 
-    <changeSet logicalFilePath="dummy" author="dvoet" id="unique_policy_name">
-        <addUniqueConstraint tableName="SAM_RESOURCE_POLICY" columnNames="resource_id, name"/>
-    </changeSet>
+    <!--<changeSet logicalFilePath="dummy" author="dvoet" id="unique_policy_name">-->
+        <!--<addUniqueConstraint tableName="SAM_RESOURCE_POLICY" columnNames="resource_id, name"/>-->
+    <!--</changeSet>-->
 
     <changeSet logicalFilePath="dummy" author="mtalbott" id="unique_subgroup_member_">
         <addUniqueConstraint tableName="SAM_GROUP_MEMBER" columnNames="group_id, member_group_id"/>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -196,6 +196,9 @@
             <column name="group_id" type="BIGINT">
                 <constraints nullable="false" foreignKeyName="FK_SRP_GROUP" referencedTableName="SAM_GROUP" referencedColumnNames="id" deleteCascade="true"/>
             </column>
+            <column name="name" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
             <column name="public" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
@@ -236,9 +239,9 @@
         <addUniqueConstraint tableName="SAM_RESOURCE" columnNames="resource_type_id, name"/>
     </changeSet>
 
-    <!--<changeSet logicalFilePath="dummy" author="dvoet" id="unique_policy_name">-->
-        <!--<addUniqueConstraint tableName="SAM_RESOURCE_POLICY" columnNames="resource_id, name"/>-->
-    <!--</changeSet>-->
+    <changeSet logicalFilePath="dummy" author="dvoet" id="unique_policy_name">
+        <addUniqueConstraint tableName="SAM_RESOURCE_POLICY" columnNames="resource_id, name"/>
+    </changeSet>
 
     <changeSet logicalFilePath="dummy" author="mtalbott" id="unique_subgroup_member_">
         <addUniqueConstraint tableName="SAM_GROUP_MEMBER" columnNames="group_id, member_group_id"/>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -24,6 +24,7 @@ import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.workbench.sam.config.{AppConfig, GoogleConfig}
 import org.broadinstitute.dsde.workbench.sam.db.DbReference
+import org.broadinstitute.dsde.workbench.sam.db.dao.PostgresGroupDAO
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.google._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -206,8 +207,9 @@ object Boot extends IOApp with LazyLogging {
       ldapExecutionContext <- ExecutionContexts.fixedThreadPool[IO](appConfig.directoryConfig.connectionPoolSize)
       postgresExecutionContext <- ExecutionContexts.fixedThreadPool[IO](DBs.config.getInt(s"db.${dbName.name}.poolMaxSize"))
 
-      directoryDAO = createDirectoryDAO(appConfig, ldapExecutionContext, ldapConnectionPool, dbReference, postgresExecutionContext, memberOfCache, newRelicMetrics)
-      accessPolicyDAO = createAccessPolicyDAO(appConfig, ldapExecutionContext, ldapConnectionPool, dbReference, postgresExecutionContext, memberOfCache, resourceCache, newRelicMetrics)
+      postgresGroupDAO = new PostgresGroupDAO(dbReference, postgresExecutionContext)
+      directoryDAO = createDirectoryDAO(appConfig, ldapExecutionContext, ldapConnectionPool, dbReference, postgresExecutionContext, memberOfCache, newRelicMetrics, postgresGroupDAO)
+      accessPolicyDAO = createAccessPolicyDAO(appConfig, ldapExecutionContext, ldapConnectionPool, dbReference, postgresExecutionContext, memberOfCache, resourceCache, newRelicMetrics, postgresGroupDAO)
     } yield (directoryDAO, accessPolicyDAO, ldapExecutionContext)
   }
 
@@ -217,22 +219,24 @@ object Boot extends IOApp with LazyLogging {
                                  dbReference: DbReference,
                                  postgresExecutionContext: ExecutionContext,
                                  memberOfCache: Cache[WorkbenchSubject, Set[String]],
-                                 newRelicMetrics: NewRelicMetrics): DirectoryDAO = {
+                                 newRelicMetrics: NewRelicMetrics,
+                                 postgresGroupDAO: PostgresGroupDAO): DirectoryDAO = {
     val ldapDirectoryDAO = new LdapDirectoryDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache)
-    val postgresDirectoryDAO = new PostgresDirectoryDAO(dbReference, postgresExecutionContext)
+    val postgresDirectoryDAO = new PostgresDirectoryDAO(dbReference, postgresExecutionContext, postgresGroupDAO)
     DaoWithShadow(ldapDirectoryDAO, postgresDirectoryDAO, new NewRelicShadowResultReporter("directoryDAO", newRelicMetrics), timer.clock)
   }
 
   private def createAccessPolicyDAO(appConfig: AppConfig,
-                                 ldapExecutionContext: ExecutionContext,
-                                 ldapConnectionPool: LDAPConnectionPool,
-                                 dbReference: DbReference,
-                                 postgresExecutionContext: ExecutionContext,
-                                 memberOfCache: Cache[WorkbenchSubject, Set[String]],
-                                 resourceCache: Cache[FullyQualifiedResourceId, Resource],
-                                 newRelicMetrics: NewRelicMetrics): AccessPolicyDAO = {
+                                    ldapExecutionContext: ExecutionContext,
+                                    ldapConnectionPool: LDAPConnectionPool,
+                                    dbReference: DbReference,
+                                    postgresExecutionContext: ExecutionContext,
+                                    memberOfCache: Cache[WorkbenchSubject, Set[String]],
+                                    resourceCache: Cache[FullyQualifiedResourceId, Resource],
+                                    newRelicMetrics: NewRelicMetrics,
+                                    postgresGroupDAO: PostgresGroupDAO): AccessPolicyDAO = {
     val ldapAccessPolicyDao = new LdapAccessPolicyDAO(ldapConnectionPool, appConfig.directoryConfig, ldapExecutionContext, memberOfCache, resourceCache)
-    val foregroundPostgresAccessPolicyDAO = new PostgresAccessPolicyDAO(dbReference, postgresExecutionContext)
+    val foregroundPostgresAccessPolicyDAO = new PostgresAccessPolicyDAO(dbReference, postgresExecutionContext, postgresGroupDAO)
     DaoWithShadow(ldapAccessPolicyDao, foregroundPostgresAccessPolicyDAO, new NewRelicShadowResultReporter("directoryDAO", newRelicMetrics), timer.clock)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsde.workbench.sam.db.dao
+import cats.effect.{ContextShift, IO}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchException, WorkbenchGroupIdentity, WorkbenchSubject, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.db.{DbReference, SamTypeBinders}
+import org.broadinstitute.dsde.workbench.sam.db.tables.{GroupMemberTable, GroupPK, GroupTable}
+import org.broadinstitute.dsde.workbench.sam.util.DatabaseSupport
+import scalikejdbc.{DBSession, SQLSyntax}
+import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory.SqlInterpolationWithSamBinders
+
+import scala.concurrent.ExecutionContext
+
+class PostgresGroupDAO(protected val dbRef: DbReference,
+               protected val ecForDatabaseIO: ExecutionContext)(implicit executionContext: ExecutionContext) extends DatabaseSupport {
+  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
+
+  def insertGroupMembers(groupId: GroupPK, members: Set[WorkbenchSubject])(implicit session: DBSession): Int = {
+    if (members.isEmpty) {
+      0
+    } else {
+      val memberUsers: List[SQLSyntax] = members.collect {
+        case userId: WorkbenchUserId => samsqls"(${groupId}, ${Option(userId)}, ${None})"
+      }.toList
+
+      val memberGroupPKQueries = members.collect {
+        case id: WorkbenchGroupIdentity => samsqls"(${workbenchGroupIdentityToGroupPK(id)})"
+      }
+
+      import SamTypeBinders._
+      val memberGroupPKs: List[GroupPK] = if (memberGroupPKQueries.nonEmpty) {
+        val g = GroupTable.syntax("g")
+        samsql"select ${g.result.id} from ${GroupTable as g} where ${g.id} in (${memberGroupPKQueries})"
+          .map(rs => rs.get[GroupPK](g.resultName.id)).list().apply()
+      } else {
+        List.empty
+      }
+
+      val memberGroups: List[SQLSyntax] = memberGroupPKs.map { groupPK =>
+        samsqls"(${groupId}, ${None}, ${Option(groupPK)})"
+      }
+
+      if (memberGroups.size != memberGroupPKQueries.size) {
+        throw new WorkbenchException(s"Some member groups not found.")
+      } else {
+        val gm = GroupMemberTable.column
+        samsql"insert into ${GroupMemberTable.table} (${gm.groupId}, ${gm.memberUserId}, ${gm.memberGroupId}) values ${memberUsers ++ memberGroups}"
+          .update().apply()
+      }
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
@@ -19,7 +19,7 @@ class PostgresGroupDAO(protected val dbRef: DbReference,
       0
     } else {
       val memberUsers: List[SQLSyntax] = members.collect {
-        case userId: WorkbenchUserId => samsqls"(${groupId}, ${Option(userId)}, ${None})"
+        case userId: WorkbenchUserId => samsqls"(${groupId}, ${userId}, ${None})"
       }.toList
 
       val memberGroupPKQueries = members.collect {
@@ -27,6 +27,7 @@ class PostgresGroupDAO(protected val dbRef: DbReference,
       }
 
       import SamTypeBinders._
+      // TODO: is there a way to do this without needing N subqueries?
       val memberGroupPKs: List[GroupPK] = if (memberGroupPKQueries.nonEmpty) {
         val g = GroupTable.syntax("g")
         samsql"select ${g.result.id} from ${GroupTable as g} where ${g.id} in (${memberGroupPKQueries})"
@@ -36,7 +37,7 @@ class PostgresGroupDAO(protected val dbRef: DbReference,
       }
 
       val memberGroups: List[SQLSyntax] = memberGroupPKs.map { groupPK =>
-        samsqls"(${groupId}, ${None}, ${Option(groupPK)})"
+        samsqls"(${groupId}, ${None}, ${groupPK})"
       }
 
       if (memberGroups.size != memberGroupPKQueries.size) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
@@ -1,14 +1,13 @@
 package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
-import org.broadinstitute.dsde.workbench.sam.model.AccessPolicyName
 import scalikejdbc._
 
 final case class PolicyPK(value: Long) extends DatabaseKey
 final case class PolicyRecord(id: PolicyPK,
                               resourceId: ResourcePK,
                               groupId: GroupPK,
-                              name: AccessPolicyName)
+                              public: Boolean)
 
 object PolicyTable extends SQLSyntaxSupportWithDefaultSamDB[PolicyRecord] {
   override def tableName: String = "SAM_RESOURCE_POLICY"
@@ -18,6 +17,6 @@ object PolicyTable extends SQLSyntaxSupportWithDefaultSamDB[PolicyRecord] {
     rs.get(e.id),
     rs.get(e.resourceId),
     rs.get(e.groupId),
-    rs.get(e.name)
+    rs.get(e.public)
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PolicyTable.scala
@@ -1,12 +1,14 @@
 package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
+import org.broadinstitute.dsde.workbench.sam.model.AccessPolicyName
 import scalikejdbc._
 
 final case class PolicyPK(value: Long) extends DatabaseKey
 final case class PolicyRecord(id: PolicyPK,
                               resourceId: ResourcePK,
                               groupId: GroupPK,
+                              name: AccessPolicyName,
                               public: Boolean)
 
 object PolicyTable extends SQLSyntaxSupportWithDefaultSamDB[PolicyRecord] {
@@ -17,6 +19,7 @@ object PolicyTable extends SQLSyntaxSupportWithDefaultSamDB[PolicyRecord] {
     rs.get(e.id),
     rs.get(e.resourceId),
     rs.get(e.groupId),
+    rs.get(e.name),
     rs.get(e.public)
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
-import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory.SqlInterpolationWithSamBinders
 import scalikejdbc._
 
@@ -20,10 +20,9 @@ object ResourceTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRecord] {
     rs.get(e.resourceTypeId)
   )
 
-  def pkQuery(resourceId: ResourceId, resourceTypeName: ResourceTypeName, resourceTableAlias: String = "r"): SQLSyntax = {
-    val r = ResourceTable.syntax(resourceTableAlias)
-    samsqls"""select ${r.id}
-              from ${ResourceTable as r}
-              where ${r.name} = ${resourceId} and ${r.resourceTypeId} = (${ResourceTypeTable.pkQuery(resourceTypeName)})"""
+  def loadResourcePK(resource: FullyQualifiedResourceId): SQLSyntax = {
+    val r = ResourceTable.syntax("r")
+    val rt = ResourceTypeTable.syntax("rt")
+    samsqls"select ${r.id} from ${ResourceTable as r} join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id} where ${r.name} = ${resource.resourceId} and ${rt.name} = ${resource.resourceTypeName}"
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
-import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId}
 import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory.SqlInterpolationWithSamBinders
 import scalikejdbc._
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -331,6 +331,9 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
     val r = ResourceTable.syntax("r")
     val rt = ResourceTypeTable.syntax("rt")
+    // Group.name in DB cannot be null and must be unique.  Policy names are stored in the SAM_POLICY table, and
+    // policies don't care about the group.name, but it must be set.  So we are building something unique here, in order
+    // to satisfy the db constraint, but it's otherwise irrelevant for polices.
     val policyGroupName =
       samsqls"""select concat(${r.id}, '_', ${policy.id.accessPolicyName}) from ${ResourceTable as r}
                join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -29,18 +29,21 @@ trait DatabaseSupport {
   }
 
   protected def groupPKQueryForPolicy(policyId: FullyQualifiedPolicyId,
-                                    resourceTypeTableAlias: String = "rt",
-                                    resourceTableAlias: String = "r",
-                                    policyTableAlias: String = "p"): SQLSyntax = {
+                                      resourceTypeTableAlias: String = "rt",
+                                      resourceTableAlias: String = "r",
+                                      policyTableAlias: String = "p",
+                                      groupTableAlias: String = "g"): SQLSyntax = {
     val rt = ResourceTypeTable.syntax(resourceTypeTableAlias)
     val r = ResourceTable.syntax(resourceTableAlias)
     val p = PolicyTable.syntax(policyTableAlias)
+    val g = GroupTable.syntax(groupTableAlias)
     samsqls"""select ${p.groupId}
               from ${ResourceTypeTable as rt}
               join ${ResourceTable as r} on ${rt.id} = ${r.resourceTypeId}
               join ${PolicyTable as p} on ${r.id} = ${p.resourceId}
+              join ${GroupTable as g} on ${g.id} = ${p.groupId}
               where ${rt.name} = ${policyId.resource.resourceTypeName}
               and ${r.name} = ${policyId.resource.resourceId}
-              and ${p.name} = ${policyId.accessPolicyName}"""
+              and ${g.name} = ${policyId.accessPolicyName}"""
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -1,12 +1,8 @@
 package org.broadinstitute.dsde.workbench.sam.util
 
 import cats.effect.{ContextShift, IO}
-import org.broadinstitute.dsde.workbench.model.{WorkbenchGroupIdentity, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.sam.db.DbReference
-import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory._
-import org.broadinstitute.dsde.workbench.sam.db.tables.{GroupTable, PolicyTable, ResourceTable, ResourceTypeTable}
-import org.broadinstitute.dsde.workbench.sam.model.FullyQualifiedPolicyId
-import scalikejdbc.{DBSession, SQLSyntax}
+import scalikejdbc.DBSession
 
 import scala.concurrent.ExecutionContext
 
@@ -19,31 +15,5 @@ trait DatabaseSupport {
     cs.evalOn(ecForDatabaseIO)(IO {
       dbRef.inLocalTransaction(databaseFunction)
     })
-  }
-
-  protected def workbenchGroupIdentityToGroupPK(groupId: WorkbenchGroupIdentity): SQLSyntax = {
-    groupId match {
-      case group: WorkbenchGroupName => GroupTable.groupPKQueryForGroup(group)
-      case policy: FullyQualifiedPolicyId => groupPKQueryForPolicy(policy)
-    }
-  }
-
-  protected def groupPKQueryForPolicy(policyId: FullyQualifiedPolicyId,
-                                      resourceTypeTableAlias: String = "rt",
-                                      resourceTableAlias: String = "r",
-                                      policyTableAlias: String = "p",
-                                      groupTableAlias: String = "g"): SQLSyntax = {
-    val rt = ResourceTypeTable.syntax(resourceTypeTableAlias)
-    val r = ResourceTable.syntax(resourceTableAlias)
-    val p = PolicyTable.syntax(policyTableAlias)
-    val g = GroupTable.syntax(groupTableAlias)
-    samsqls"""select ${p.groupId}
-              from ${ResourceTypeTable as rt}
-              join ${ResourceTable as r} on ${rt.id} = ${r.resourceTypeId}
-              join ${PolicyTable as p} on ${r.id} = ${p.resourceId}
-              join ${GroupTable as g} on ${g.id} = ${p.groupId}
-              where ${rt.name} = ${policyId.resource.resourceTypeName}
-              and ${r.name} = ${policyId.resource.resourceId}
-              and ${g.name} = ${policyId.accessPolicyName}"""
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -5,6 +5,7 @@ import java.util.Date
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.db.dao.PostgresGroupDAO
 import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
 import org.postgresql.util.PSQLException
 import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
@@ -13,7 +14,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
-  val dao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc)
+  val groupDAO = new PostgresGroupDAO(TestSupport.dbRef, TestSupport.blockingEc)
+  val dao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc, groupDAO)
 
   val defaultGroupName = WorkbenchGroupName("group")
   val defaultGroup = BasicWorkbenchGroup(defaultGroupName, Set.empty, WorkbenchEmail("foo@bar.com"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.openam
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.db.dao.PostgresGroupDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.openam.LoadResourceAuthDomainResult.{Constrained, NotConstrained, ResourceNotFound}
@@ -13,8 +14,9 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
-  val dao = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.blockingEc)
-  val dirDao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc)
+  val groupDAO = new PostgresGroupDAO(TestSupport.dbRef, TestSupport.blockingEc)
+  val dao = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.blockingEc, groupDAO)
+  val dirDao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc, groupDAO)
 
   override protected def beforeEach(): Unit = {
     TestSupport.truncateAll

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -1,15 +1,15 @@
 package org.broadinstitute.dsde.workbench.sam.openam
 
 import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchGroupName}
+import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.openam.LoadResourceAuthDomainResult.{Constrained, NotConstrained, ResourceNotFound}
 import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
-import scala.concurrent.{Future, Await}
-import scala.concurrent.duration._
 
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
@@ -306,6 +306,60 @@ class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndA
 
       "returns an empty list if group doesn't exist" in {
         dao.listResourcesConstrainedByGroup(WorkbenchGroupName("notEvenReal")).unsafeRunSync() shouldEqual Set.empty
+      }
+    }
+    val defaultGroupName = WorkbenchGroupName("group")
+    val defaultGroup = BasicWorkbenchGroup(defaultGroupName, Set.empty, WorkbenchEmail("foo@bar.com"))
+    val defaultUserId = WorkbenchUserId("testUser")
+    val defaultUser = WorkbenchUser(defaultUserId, Option(GoogleSubjectId("testGoogleSubject")), WorkbenchEmail("user@foo.com"))
+    "createPolicy" - {
+      "creates a policy" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), false)
+        dao.createPolicy(policy).unsafeRunSync()
+        dao.loadPolicy(policy.id).unsafeRunSync() shouldEqual Option(policy)
+      }
+
+      "creates a policy with users and groups as members" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        dirDao.createGroup(defaultGroup).unsafeRunSync()
+        dirDao.createUser(defaultUser).unsafeRunSync()
+
+        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultGroup.id, defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), false)
+        dao.createPolicy(policy).unsafeRunSync()
+        dao.loadPolicy(policy.id).unsafeRunSync() shouldEqual Option(policy)
+      }
+    }
+
+    "loadPolicy" - {
+      "returns None for a nonexistent policy" in {
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.loadPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("fakePolicy"))).unsafeRunSync() shouldBe None
+      }
+    }
+
+    "deletePolicy" - {
+      "deletes a policy and the associated group" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        dirDao.createGroup(defaultGroup).unsafeRunSync()
+        dirDao.createUser(defaultUser).unsafeRunSync()
+
+        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultGroup.id, defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), false)
+        dao.createPolicy(policy).unsafeRunSync()
+        dao.loadPolicy(policy.id).unsafeRunSync() shouldBe Option(policy)
+        dirDao.loadGroup(WorkbenchGroupName(policy.id.accessPolicyName.value)).unsafeRunSync() shouldBe defined // we just want this to exist, we don't actually care about what the group is
+        dao.deletePolicy(policy.id).unsafeRunSync()
+        dao.loadPolicy(policy.id).unsafeRunSync() shouldBe None
+        dirDao.loadGroup(WorkbenchGroupName(policy.id.accessPolicyName.value)).unsafeRunSync() shouldBe None
       }
     }
   }


### PR DESCRIPTION
Ticket: [CA-309](https://broadworkbench.atlassian.net/browse/CA-309)
Queries in this PR: `createPolicy`, `loadPolicy`, `deletePolicy`

- also of note, we ran into an issue where we wanted to share code (specifically queries) between the `AccessPolicyDAO` and the `DirectoryDAO`. The only place where code was shared between the two DAOs was in `DatabaseSupport`, but we didn't feel that that was a good place to share queries and that it should be reserved for utility functions like `runInTransaction` or (in the future) streaming functions. We considered putting the code in the table classes, but that didn't feel like a good fit either as the code we wanted to share spanned multiple tables. We considered a couple other options, but felt like the best option was to create a new DAO that both the `AccessPolicyDAO` and the `DirectoryDAO` would use. Since the code we shared was related to groups, we called this DAO the `GroupDAO`. Our hope is that in the future, we can further break down the existing DAOs into smaller DAOs. For example, we might be able to break the `DirectoryDAO` into a `GroupDAO`, `UserDAO`, and `PetServiceAccountDAO`. We are open to alternative means of sharing code between DAOs, but this felt like the best choice.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
