### PR TITLE
Write formerly pending unit tests

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
@@ -73,6 +73,6 @@ class PostgresGroupDAO(protected val dbRef: DbReference,
               join ${GroupTable as g} on ${g.id} = ${p.groupId}
               where ${rt.name} = ${policyId.resource.resourceTypeName}
               and ${r.name} = ${policyId.resource.resourceId}
-              and ${g.name} = ${policyId.accessPolicyName}"""
+              and ${p.name} = ${policyId.accessPolicyName}"""
   }
 }


### PR DESCRIPTION
Ticket: [CA-309](https://broadworkbench.atlassian.net/browse/CA-309)
There were a bunch of unit tests in the `DirectoryDAO` spec that were pending because we hadn't written any basic policy-related functionality (create, load, delete). Since we have written that basic functionality, this PR turns the pending unit tests into written unit tests. It also fixes a number of bugs that manifested themselves when we started actually testing this part of our code.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
