### PR TITLE
change (fix?) overwriting Resource Types

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -132,6 +132,9 @@
             <column name="role" type="VARCHAR">
                 <constraints nullable="false"/>
             </column>
+            <column name="deprecated" type="BOOLEAN" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
     </changeSet>
 

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -158,7 +158,7 @@
                 <constraints nullable="false" foreignKeyName="FK_SROLEA_ROLE" referencedTableName="SAM_RESOURCE_ROLE" referencedColumnNames="id" primaryKey="true"/>
             </column>
             <column name="resource_action_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SROLEA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SROLEA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
         </createTable>
     </changeSet>
@@ -225,7 +225,7 @@
                 <constraints nullable="false" foreignKeyName="FK_SPA_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
             <column name="resource_action_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SPA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SPA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
         </createTable>
     </changeSet>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -158,7 +158,7 @@
                 <constraints nullable="false" foreignKeyName="FK_SROLEA_ROLE" referencedTableName="SAM_RESOURCE_ROLE" referencedColumnNames="id" primaryKey="true"/>
             </column>
             <column name="resource_action_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SROLEA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SROLEA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true"/>
             </column>
         </createTable>
     </changeSet>
@@ -225,7 +225,7 @@
                 <constraints nullable="false" foreignKeyName="FK_SPA_POLICY" referencedTableName="SAM_RESOURCE_POLICY" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
             </column>
             <column name="resource_action_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SPA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true" deleteCascade="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SPA_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id" primaryKey="true"/>
             </column>
         </createTable>
     </changeSet>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceRoleTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceRoleTable.scala
@@ -7,7 +7,8 @@ import scalikejdbc._
 final case class ResourceRolePK(value: Long) extends DatabaseKey
 final case class ResourceRoleRecord(id: ResourceRolePK,
                                     resourceTypeId: ResourceTypePK,
-                                    role: ResourceRoleName)
+                                    role: ResourceRoleName,
+                                    deprecated: Boolean)
 
 object ResourceRoleTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRoleRecord] {
   override def tableName: String = "SAM_RESOURCE_ROLE"
@@ -16,6 +17,7 @@ object ResourceRoleTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRoleRe
   def apply(e: ResultName[ResourceRoleRecord])(rs: WrappedResultSet): ResourceRoleRecord = ResourceRoleRecord(
     rs.get(e.id),
     rs.get(e.resourceTypeId),
-    rs.get(e.role)
+    rs.get(e.role),
+    rs.get(e.deprecated)
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -68,10 +68,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
         .update().apply()
     } else {
       samsql"""delete from ${RoleActionTable as ra}
-                 using ${ResourceRoleTable as rr}
-                 where ${ra.resourceRoleId} = ${rr.id}
-                 and ${ra.resourceRoleId} in (${resourceTypeRoles.map(_.id)})
-                 and ${rr.role} not in (${roles.map(_.roleName)})"""
+                 where (${ra.resourceRoleId}, ${ra.resourceActionId}) not in (${roleActionValues})"""
         .update().apply()
 
       val insertQuery =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -37,7 +37,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
       insertActionPatterns(resourceType.actionPatterns, resourceTypePK)
       insertRoles(resourceType.roles, resourceTypePK)
-      insertActions(uniqueActions, resourceTypePK)
+      overwriteActions(uniqueActions, resourceTypePK)
       insertRoleActions(resourceType.roles, resourceTypePK)
 
       resourceType
@@ -59,10 +59,15 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     }
 
     if (roleActionValues.nonEmpty) {
+      val ra = RoleActionTable.syntax("ra")
+
+      samsql"""delete from ${RoleActionTable as ra}
+              where ${ra.resourceRoleId} in (${resourceTypeRoles.map(_.id)})"""
+        .update().apply()
+
       val insertQuery =
         samsql"""insert into ${RoleActionTable.table}(${RoleActionTable.column.resourceRoleId}, ${RoleActionTable.column.resourceActionId})
-                    values ${roleActionValues}
-                 on conflict do nothing"""
+                    values ${roleActionValues}"""
       insertQuery.update().apply()
     } else {
       0
@@ -84,36 +89,57 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     val actionsQuery =
       samsql"""select ${rrt.result.*}
                from ${ResourceRoleTable as rrt}
-               where ${rrt.resourceTypeId} = ${resourceTypePK}"""
+               where ${rrt.resourceTypeId} = ${resourceTypePK}
+               and ${rrt.deprecated} = false"""
 
     actionsQuery.map(ResourceRoleTable(rrt.resultName)).list().apply()
   }
 
   private def insertRoles(roles: Set[ResourceRole], resourceTypePK: ResourceTypePK)(implicit session: DBSession): Int = {
     val roleValues = roles.map(role => samsqls"(${resourceTypePK}, ${role.roleName})")
+
+    val resourceRoleColumn = ResourceRoleTable.column
+    samsql"""update ${ResourceRoleTable.table}
+            set ${resourceRoleColumn.deprecated} = true
+            where ${resourceRoleColumn.resourceTypeId} = ${resourceTypePK}"""
+      .update().apply()
+
     val insertRolesQuery =
-      samsql"""insert into ${ResourceRoleTable.table}(${ResourceRoleTable.column.resourceTypeId}, ${ResourceRoleTable.column.role})
+      samsql"""insert into ${ResourceRoleTable.table}(${resourceRoleColumn.resourceTypeId}, ${resourceRoleColumn.role})
                   values ${roleValues}
-               on conflict do nothing"""
+               on conflict (${resourceRoleColumn.resourceTypeId}, ${resourceRoleColumn.role})
+               do update set ${resourceRoleColumn.deprecated} = false"""
 
     insertRolesQuery.update().apply()
   }
 
-  private def insertActions(actions: Set[ResourceAction], resourceTypePK: ResourceTypePK)(implicit session: DBSession): Int = {
+  private def overwriteActions(actions: Set[ResourceAction], resourceTypePK: ResourceTypePK)(implicit session: DBSession): Int = {
+    val ra = ResourceActionTable.syntax("ra")
     if (actions.isEmpty) {
-      return 0
+      samsql"""delete from ${ResourceActionTable as ra}
+              where ${ra.resourceTypeId} = ${resourceTypePK}"""
+        .update().apply()
     } else {
-      val uniqueActionValues = actions.map { action =>
-        samsqls"(${resourceTypePK}, ${action})"
-      }
+      samsql"""delete from ${ResourceActionTable as ra}
+              where ${ra.resourceTypeId} = ${resourceTypePK}
+              and ${ra.action} not in (${actions})"""
+        .update().apply()
 
-      val insertActionQuery =
-        samsql"""insert into ${ResourceActionTable.table}(${ResourceActionTable.column.resourceTypeId}, ${ResourceActionTable.column.action})
+      insertActions(actions, resourceTypePK)
+    }
+  }
+
+  private def insertActions(actions: Set[ResourceAction], resourceTypePK: ResourceTypePK)(implicit session: DBSession): Int = {
+    val uniqueActionValues = actions.map { action =>
+      samsqls"(${resourceTypePK}, ${action})"
+    }
+
+    val insertActionQuery =
+      samsql"""insert into ${ResourceActionTable.table}(${ResourceActionTable.column.resourceTypeId}, ${ResourceActionTable.column.action})
                     values ${uniqueActionValues}
                  on conflict do nothing"""
 
-      insertActionQuery.update().apply()
-    }
+    insertActionQuery.update().apply()
   }
 
   /**
@@ -127,17 +153,19 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
       samsqls"(${resourceTypePK}, ${actionPattern.value}, ${actionPattern.description}, ${actionPattern.authDomainConstrainable})"
     }
 
+    val rap = ResourceActionPatternTable.syntax("rap")
+
+    samsql"""delete from ${ResourceActionPatternTable as rap}
+            where ${rap.resourceTypeId} = ${resourceTypePK}"""
+      .update().apply()
+
     val actionPatternQuery =
       samsql"""insert into ${ResourceActionPatternTable.table}
                   (${resourceActionPatternTableColumn.resourceTypeId},
                    ${resourceActionPatternTableColumn.actionPattern},
                    ${resourceActionPatternTableColumn.description},
                    ${resourceActionPatternTableColumn.isAuthDomainConstrainable})
-                  values ${actionPatternValues}
-               on conflict (${resourceActionPatternTableColumn.resourceTypeId}, ${resourceActionPatternTableColumn.actionPattern})
-                  do update
-                      set ${resourceActionPatternTableColumn.description} = EXCLUDED.${resourceActionPatternTableColumn.description},
-                          ${resourceActionPatternTableColumn.isAuthDomainConstrainable} = EXCLUDED.${resourceActionPatternTableColumn.isAuthDomainConstrainable}"""
+                  values ${actionPatternValues}"""
     actionPatternQuery.update().apply()
   }
 
@@ -305,10 +333,19 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
   private def insertPolicyActions(actions: Set[ResourceAction], policyId: PolicyPK)(implicit session: DBSession): Int = {
     val ra = ResourceActionTable.syntax("ra")
+    val rt = ResourceTypeTable.syntax("rt")
+    val r = ResourceTable.syntax("r")
+    val p = PolicyTable.syntax("p")
     val paCol = PolicyActionTable.column
     if (actions.nonEmpty) {
       val insertQuery = samsqls"""insert into ${PolicyActionTable.table} (${paCol.resourcePolicyId}, ${paCol.resourceActionId})
-            select ${policyId}, ${ra.result.id} from ${ResourceActionTable as ra} where ${ra.action} in (${actions})"""
+            select ${policyId}, ${ra.result.id}
+            from ${ResourceActionTable as ra}
+            join ${ResourceTypeTable as rt} on ${ra.resourceTypeId} = ${rt.id}
+            join ${ResourceTable as r} on ${r.resourceTypeId} = ${rt.id}
+            join ${PolicyTable as p} on ${p.resourceId} = ${r.id}
+            where ${ra.action} in (${actions})
+            and ${p.id} = ${policyId}"""
 
       val inserted = samsql"$insertQuery".update().apply()
 
@@ -317,8 +354,6 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
         // add them now and rerun the insert ignoring conflicts
         // this case should happen rarely
         import SamTypeBinders._
-        val r = ResourceTable.syntax("r")
-        val p = PolicyTable.syntax("p")
         val resourceTypePK = samsql"select ${r.result.resourceTypeId} from ${PolicyTable as p} join ${ResourceTable as r} on ${p.resourceId} = ${r.id} where ${p.id} = ${policyId}"
           .map(rs => rs.get[ResourceTypePK](r.resultName.resourceTypeId)).single().apply().getOrElse(throw new WorkbenchException(s"could not find resource type id for policy id $policyId"))
         insertActions(actions, resourceTypePK)
@@ -336,10 +371,19 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
   private def insertPolicyRoles(roles: Set[ResourceRoleName], policyId: PolicyPK)(implicit session: DBSession): Int = {
     val rr = ResourceRoleTable.syntax("rr")
+    val rt = ResourceTypeTable.syntax("rt")
+    val r = ResourceTable.syntax("r")
+    val p = PolicyTable.syntax("p")
     val prCol = PolicyRoleTable.column
     if (roles.nonEmpty) {
       samsql"""insert into ${PolicyRoleTable.table} (${prCol.resourcePolicyId}, ${prCol.resourceRoleId})
-            select ${policyId}, ${rr.result.id} from ${ResourceRoleTable as rr} where ${rr.role} in (${roles})"""
+            select ${policyId}, ${rr.result.id}
+            from ${ResourceRoleTable as rr}
+            join ${ResourceTypeTable as rt} on ${rr.resourceTypeId} = ${rt.id}
+            join ${ResourceTable as r} on ${r.resourceTypeId} = ${rt.id}
+            join ${PolicyTable as p} on ${p.resourceId} = ${r.id}
+            where ${rr.role} in (${roles})
+            and ${p.id} = ${policyId}"""
         .update().apply()
     } else {
       0

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -45,27 +45,39 @@ class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndA
         dao.createResourceType(resourceType).unsafeRunSync() shouldEqual resourceType
       }
 
-      "succeeds when there is exactly one Role that has no actions" in {
-        val myResourceType = resourceType.copy(roles = Set(actionlessRole))
-        dao.createResourceType(myResourceType).unsafeRunSync() shouldEqual myResourceType
-      }
-
-      // This test is hard to write at the moment.  We don't have an easy way to guarantee the race condition at exactly the right time.  Nor do
-      // we have a good way to check if the data that was saved is what we intended.   This spec class could implement DatabaseSupport.  Or the
-      // createResourceType could minimally return the ResourceTypePK in its results.  Or we need some way to get all
-      // of the ResourceTypes from the DB and compare them to what we were trying to save.
-      "succeeds and only creates 1 ResourceType when trying to create multiple identical ResourceTypes at the same time" in {
-
-        pending
-
-        // Since we can't directly force a collision at exactly the right time, kick off a bunch of inserts in parallel
-        // and hope for the best.  <- That's how automated testing is supposed to work right?  Just cross your fingers?
-        val allMyFutures = 0.to(20).map { _ =>
-          dao.createResourceType(resourceType).unsafeToFuture()
+      "succeeds" - {
+        "when there are no action patterns" in {
+          val myResourceType = resourceType.copy(actionPatterns = Set.empty)
+          dao.createResourceType(myResourceType).unsafeRunSync() shouldEqual myResourceType
         }
 
-        Await.result(Future.sequence(allMyFutures), 5 seconds)
-        // This is the part where I would want to assert that the database contains only one ResourceType
+        "when there are no roles" in {
+          val myResourceType = resourceType.copy(roles = Set.empty)
+          dao.createResourceType(myResourceType).unsafeRunSync() shouldEqual myResourceType
+        }
+
+        "when there is exactly one Role that has no actions" in {
+          val myResourceType = resourceType.copy(roles = Set(actionlessRole))
+          dao.createResourceType(myResourceType).unsafeRunSync() shouldEqual myResourceType
+        }
+
+        // This test is hard to write at the moment.  We don't have an easy way to guarantee the race condition at exactly the right time.  Nor do
+        // we have a good way to check if the data that was saved is what we intended.   This spec class could implement DatabaseSupport.  Or the
+        // createResourceType could minimally return the ResourceTypePK in its results.  Or we need some way to get all
+        // of the ResourceTypes from the DB and compare them to what we were trying to save.
+        "and only creates 1 ResourceType when trying to create multiple identical ResourceTypes at the same time" in {
+
+          pending
+
+          // Since we can't directly force a collision at exactly the right time, kick off a bunch of inserts in parallel
+          // and hope for the best.  <- That's how automated testing is supposed to work right?  Just cross your fingers?
+          val allMyFutures = 0.to(20).map { _ =>
+            dao.createResourceType(resourceType).unsafeToFuture()
+          }
+
+          Await.result(Future.sequence(allMyFutures), 5 seconds)
+          // This is the part where I would want to assert that the database contains only one ResourceType
+        }
       }
 
       "overwriting a ResourceType with the same name" - {


### PR DESCRIPTION
Ticket: [CA-309](https://broadworkbench.atlassian.net/browse/CA-309)
This PR changes how using `createResourceType` to overwrite resource types works. `createResourceType` can be used to update the action patterns, roles, and those roles' actions for a resource type. 

Action patterns can be added and removed at will. There's nothing special here, we just delete all of the existing action patterns for the resource type and then insert all of the given action patterns for a full overwrite.

Roles cannot be deleted. If they are removed in the overwrite, they will be designated as deprecated. Deprecated roles still behave as they did before deprecation, but they cannot be added to any new policies and overwriting an existing policy with that role will remove the role from the policy.

Actions can be added and removed from roles at will. We delete all actions from non-deprecated roles and then re-add them all. Records in the ResourceAction and PolicyAction tables are unaffected.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
