### PR TITLE
Change _ to / in new relic metric for better chart creation

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporter.scala
@@ -26,9 +26,9 @@ class NewRelicShadowResultReporter(val daoName: String, val newRelicMetrics: New
     for {
       matchResult <- IO(resultsMatch(realTimedResult.result, shadowTimedResult.result))
       matchString = if(matchResult.matches) "match" else "mismatch"
-      _ <- newRelicMetrics.incrementCounterIO(s"${daoName}_${methodCallInfo.functionName}_$matchString")
+      _ <- newRelicMetrics.incrementCounterIO(s"${daoName}/${methodCallInfo.functionName}/$matchString")
       perfImprovement = (realTimedResult.time - shadowTimedResult.time).toMillis
-      _ <- if (matchResult.matches) newRelicMetrics.gauge(s"${daoName}_${methodCallInfo.functionName}_perf", perfImprovement.toFloat)
+      _ <- if (matchResult.matches) newRelicMetrics.gauge(s"${daoName}/${methodCallInfo.functionName}/perf", perfImprovement.toFloat)
            else logMismatch(methodCallInfo: MethodCallInfo, realTimedResult: TimedResult[T], shadowTimedResult: TimedResult[T], matchResult)
     } yield ()
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporterSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporterSpec.scala
@@ -203,15 +203,15 @@ class NewRelicShadowResultReporterSpec extends FlatSpec with Matchers with Mocki
     val reporter = createResultReporter
     reporter.reportResult(MethodCallInfo("fxn", Array("param"), Array("arg")), TimedResult(Right(27), 100 seconds), TimedResult(Right(27), 10 seconds)).unsafeRunSync()
 
-    verify(reporter.newRelicMetrics).gauge(s"${reporter.daoName}_fxn_perf", 90000f)
-    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}_fxn_match")
+    verify(reporter.newRelicMetrics).gauge(s"${reporter.daoName}/fxn/perf", 90000f)
+    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}/fxn/match")
   }
 
   it should "report mismatch" in {
     val reporter = createResultReporter
     reporter.reportResult(MethodCallInfo("fxn", Array("param"), Array("arg")), TimedResult(Right(20), 100 seconds), TimedResult(Right(27), 10 seconds)).unsafeRunSync()
 
-    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}_fxn_mismatch")
+    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}/fxn/mismatch")
   }
 
   it should "report complex mismatch" in {
@@ -220,7 +220,7 @@ class NewRelicShadowResultReporterSpec extends FlatSpec with Matchers with Mocki
     val shadow = TestCaseClass("asdfasdf", Seq(TestInnerCaseClass(MyValueObject("qqq"), 88), TestInnerCaseClass(MyValueObject("ppp"), 99)))
     reporter.reportResult(MethodCallInfo("fxn", Array("param"), Array("arg")), TimedResult(Right(real), 100 seconds), TimedResult(Right(shadow), 10 seconds)).unsafeRunSync()
 
-    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}_fxn_mismatch")
+    verify(reporter.newRelicMetrics).incrementCounterIO(s"${reporter.daoName}/fxn/mismatch")
   }
 
   it should "truncate too long message" in {


### PR DESCRIPTION
Ticket: [CA-527](https://broadworkbench.atlassian.net/browse/CA-527)
Metrics in New Relic have the form `category/sub-category/sub-sub-category` and charts can easily be changed to include all members of a category. This change will make our metrics have the form `Custom/sam/DAO/function/(match|mismatch|perf)`. This should allow us to create charts with better comparisons than we could when the metrics had the form `Custom/sam/DAO_function_(match|mismatch|perf)`. I tested it out with sam locally and it works as expected.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
