### PR TITLE
Readable policy group names

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/initial_schema.xml
@@ -197,7 +197,7 @@
                 <constraints nullable="false" foreignKeyName="FK_SRP_RESOURCE" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
             </column>
             <column name="group_id" type="BIGINT">
-                <constraints nullable="false" foreignKeyName="FK_SRP_GROUP" referencedTableName="SAM_GROUP" referencedColumnNames="id" deleteCascade="true"/>
+                <constraints nullable="false" foreignKeyName="FK_SRP_GROUP" referencedTableName="SAM_GROUP" referencedColumnNames="id"/>
             </column>
             <column name="name" type="VARCHAR">
                 <constraints nullable="false"/>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -100,8 +100,10 @@ class ManagedGroupService(
       // so failures there do not leave ldap in a bad state
       // resourceService.deleteResource also does cloudExtensions.onGroupDelete first thing
       _ <- cloudExtensions.onGroupDelete(WorkbenchEmail(constructEmail(groupId.value)))
-      _ <- resourceService.deleteResource(FullyQualifiedResourceId(managedGroupType.name, groupId))
+      managedGroupResourceId = FullyQualifiedResourceId(managedGroupType.name, groupId)
+      _ <- resourceService.cloudDeletePolicies(managedGroupResourceId)
       _ <- directoryDAO.deleteGroup(WorkbenchGroupName(groupId.value)).unsafeToFuture()
+      _ <- resourceService.deleteResource(managedGroupResourceId)
     } yield ()
 
   def listGroups(userId: WorkbenchUserId): IO[Set[ManagedGroupMembershipEntry]] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -450,6 +450,17 @@ class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndA
         dupException.errorReport.statusCode shouldEqual Some(StatusCodes.Conflict)
       }
 
+      "can recreate a deleted policy" in {
+        dao.createResourceType(resourceType).unsafeRunSync()
+        val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
+        dao.createResource(resource).unsafeRunSync()
+
+        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), false)
+        dao.createPolicy(policy).unsafeRunSync()
+        dao.deletePolicy(policy.id).unsafeRunSync()
+        dao.createPolicy(policy).unsafeRunSync()
+      }
+
       "creates a policy with actions that don't already exist" in {
         dao.createResourceType(resourceType).unsafeRunSync()
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)


### PR DESCRIPTION
Ticket: No ticket, but related to [CA-311](https://broadworkbench.atlassian.net/browse/CA-311) and [CA-309](https://broadworkbench.atlassian.net/browse/CA-309) I suppose
The changes here were inspired by a desire to change the naming convention for policy groups. These names need to be globally unique, but otherwise aren't used anywhere. Before we were using the pattern `resourcePrimaryKey_policyName`, but this PR changes the pattern to `resourceTypeName_resourceName_policyName`. 

After this change was made, I realized that we were orphaning policy groups when we deleted policies since we were never deleting the policy group itself when we deleted a policy. When I changed policy deletion to also delete policy groups, the tests started running into foreign key exceptions when deleting managed groups. This was happening because when we delete managed groups, we delete the resource for the managed group before we delete its Sam group. The `admin` and `members` policies on the resource are members of the managed group's Sam group. Since we delete the policies before the Sam group, we run into a foreign key exception because the policies are still members of the group and referenced in the `SAM_GROUP_MEMBER` table. Deleting the Sam group first would solve this problem, but it would make it possible for Google and Postgres/LDAP to get out of sync if Google errored after we had already deleted it in our DB. We had previously accounted for this by doing all Google deletion first before deleting it in our DB. To solve both problems, I separated cloud policy deletion into a new function so we could still delete the cloud resources first and avoid getting out of sync, while also deleting the Sam group before the Sam resource and its policies and avoiding any foreign key exceptions. 

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
