### PR TITLE
CA-548 release connection at end of ldapSearchStream, don't close

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -36,27 +36,32 @@ trait LdapSupport extends DirectorySubjectNameSupport {
   protected def ldapSearchStream[T](baseDn: String, searchScope: SearchScope, filters: Filter*)(unmarshaller: Entry => T): Stream[T] =
     filters.flatMap { filter =>
       val search = new SearchRequest(baseDn, searchScope, filter)
-      val entrySource = new LDAPEntrySource(ldapConnectionPool.getConnection, search, true)
-      ldapEntrySourceStream(entrySource)(unmarshaller)
+      val connection = ldapConnectionPool.getConnection
+      val entrySource = new LDAPEntrySource(connection, search, false)
+      ldapEntrySourceStream(entrySource, connection)(unmarshaller)
     }.toStream
 
   // this is the magic recursive stream generator
-  private def ldapEntrySourceStream[T](entrySource: LDAPEntrySource)(unmarshaller: Entry => T): Stream[T] =
+  private def ldapEntrySourceStream[T](entrySource: LDAPEntrySource, connection: LDAPConnection)(unmarshaller: Entry => T): Stream[T] =
     Try(Option(entrySource.nextEntry)) match {
       case Success(None) =>
         // reached the last element, Stream.empty terminates the stream
+        ldapConnectionPool.releaseConnection(connection)
         Stream.empty
 
       case Success(Some(next)) =>
         // next element exists, return a Stream starting with unmarshalled next followed by the rest of the stream
         // (streams are smart and lazily evaluate the second parameter)
-        Stream.cons(unmarshaller(next), ldapEntrySourceStream(entrySource)(unmarshaller))
+        Stream.cons(unmarshaller(next), ldapEntrySourceStream(entrySource, connection)(unmarshaller))
 
       case Failure(ldape: EntrySourceException)
           if ldape.getCause.isInstanceOf[LDAPException] &&
             ldape.getCause.asInstanceOf[LDAPException].getResultCode == ResultCode.NO_SUCH_OBJECT =>
+        ldapConnectionPool.releaseConnection(connection)
         Stream.empty // the base dn does not exist, treat as empty search
-      case Failure(regrets) => throw regrets
+      case Failure(regrets) =>
+        ldapConnectionPool.releaseConnection(connection)
+        throw regrets
     }
 
   protected def getAttribute(result: Entry, key: String): Option[String] = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-548
during profiling I saw that ldap threads were being created and killed in great numbers despite connection pooling. I discovered that `close` on a connection really closes it even if it is part of a pool. Generally we let unboundid handle getting and release connections from the pool but there is this one place where we do it ourselves.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
