### PR TITLE
Exactly one member per group member record

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -2,5 +2,6 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <include file="changesets/initial_schema.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20191007_exactly_one_null_member.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20191007_exactly_one_null_member.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20191007_exactly_one_null_member.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+<changeSet logicalFilePath="dummy" author="mtalbott" id="exactly_one_null_member">
+        <sql stripComments="true">
+            alter table sam_group_member add constraint exactly_one_null_member check( ( member_user_id is null and member_group_id is not null ) or ( member_user_id is not null and member_group_id is null ) );
+            <comment>SAM_GROUP_MEMBER: ensure exactly one null member column </comment>
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -268,6 +268,15 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
         val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(memberPolicy.id)
       }
+
+      "trying to add a group that does not exist will fail" in {
+        val subGroup = emptyWorkbenchGroup("subGroup")
+        dao.createGroup(defaultGroup).unsafeRunSync()
+
+        assertThrows[PSQLException] {
+          dao.addGroupMember(defaultGroup.id, subGroup.id).unsafeRunSync() shouldBe true
+        }
+      }
     }
 
     "batchLoadGroupEmail" - {


### PR DESCRIPTION
Ticket: [CA-549](https://broadworkbench.atlassian.net/browse/CA-549)
We found that we had a whole lot of entries in the `SAM_GROUP_MEMBER` table that had null values for both `member_user_id` and `member_group_id`. This was occurring because the migration script was migrating policies too late, but that will be addressed in a future PR. It never should have been possible for this to slip through, so this PR adds a constraint to the `SAM_GROUP_MEMBER` table to prevent it.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
