### PR TITLE
[CA-551] Continue to use trusty instead of switching to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 jdk:
 - oraclejdk8
+dist: trusty
 language: scala
 scala:
 - 2.12.7


### PR DESCRIPTION
Ticket: [CA-551](https://broadworkbench.atlassian.net/browse/CA-551)
Trusty used to be the default distribution, but Travis changed the default. This PR is so we can continue to use Trusty.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
