### PR TITLE
Fix loadGroups and default user enabled status

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -197,6 +197,16 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
 
         dao.loadGroups(Set(group1.id, group2.id, WorkbenchGroupName("fakeGroup"))).unsafeRunSync() should contain theSameElementsAs Set(group1, group2)
       }
+
+      "should return member policies" in {
+        val group = BasicWorkbenchGroup(WorkbenchGroupName("group"), Set(defaultPolicy.id), WorkbenchEmail("group@example.com"))
+        policyDAO.createResourceType(resourceType).unsafeRunSync()
+        policyDAO.createResource(defaultResource).unsafeRunSync()
+        policyDAO.createPolicy(defaultPolicy).unsafeRunSync()
+        dao.createGroup(group).unsafeRunSync()
+
+        dao.loadGroups(Set(group.id)).unsafeRunSync() should contain theSameElementsAs Set(group)
+      }
     }
 
     "addGroupMember" - {
@@ -728,13 +738,13 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
     "enableIdentity and disableIdentity" - {
       "can enable and disable users" in {
         dao.createUser(defaultUser).unsafeRunSync()
-        dao.isEnabled(defaultUser.id).unsafeRunSync() shouldBe true
-
-        dao.disableIdentity(defaultUser.id).unsafeRunSync()
         dao.isEnabled(defaultUser.id).unsafeRunSync() shouldBe false
 
         dao.enableIdentity(defaultUser.id).unsafeRunSync()
         dao.isEnabled(defaultUser.id).unsafeRunSync() shouldBe true
+
+        dao.disableIdentity(defaultUser.id).unsafeRunSync()
+        dao.isEnabled(defaultUser.id).unsafeRunSync() shouldBe false
       }
 
       "cannot enable and disable pet service accounts" in {


### PR DESCRIPTION
Ticket: No ticket, found while trying to merge feature branch
We noticed that `loadGroups` was not loading policy members properly, while `loadGroup` was. We made the same change that had been made in `loadGroup` so that `loadGroups` would work as expected. We also saw that newly created users were enabled automatically in Postgres, while in OpenDJ they defaulted to disabled. This could have allowed invited users to be enabled without registering.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
