### PR TITLE
CA-571 short circuit for hasPermission

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -35,7 +35,7 @@ class PolicyEvaluatorService(
   }
 
   def hasPermission(resource: FullyQualifiedResourceId, action: ResourceAction, userId: WorkbenchUserId): IO[Boolean] = {
-    // first attempt the cheap, short circuit and fallback to the full check if it returns false
+    // first attempt the shallow check and fallback to the full check if it returns false
     for {
       attempt1 <- hasPermissionShallowCheck(resource, action, userId)
       attempt2 <- if (attempt1) IO.pure(attempt1) else hasPermissionFullCheck(resource, action, userId)
@@ -59,8 +59,8 @@ class PolicyEvaluatorService(
   }
 
   /**
-    * Check if the user has the action on the resource.  A true result means they do, and can be trusted.  A false result only means that the short
-    * circuit approach did not find that to be true, but a more exhaustive check might.
+    * Check if the user has the action on the resource.  A true result means they do, and can be trusted.  A false result only means that
+    * the shallow check did not find that to be true, but a more exhaustive check might.
     *
     * In many cases users are direct members of policies, and it is very fast to query direct members of a policy (as opposed to
     * calling isMemberOf for a user), this method leverages that to do a fast check for presence

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -206,6 +206,104 @@ class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport
     res.unsafeRunSync()
   }
 
+
+  "hasPermission" should "return false if given action is not allowed for a user using the short circuit" in {
+    val user = genUserInfo.sample.get
+    val samplePolicy = genPolicy.sample.get
+    val action = ResourceAction("weirdAction")
+    val resource = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
+    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.userId)(samplePolicy)
+    val policyExcludeAction = AccessPolicy.actions.set(samplePolicy.actions - action)(policyWithUser)
+    val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyExcludeAction)
+
+    val res = for{
+      _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResource(resource)
+      _ <- policyDAO.createPolicy(policy)
+      r <- service.policyEvaluatorService.hasPermissionShortCircuit(policy.id.resource, action, user.userId)
+    } yield {
+      r shouldBe false
+    }
+
+    res.unsafeToFuture()
+  }
+
+
+  it should "return true if given action is on a policy directly for a direct member of the policy using the short circuit" in {
+    val user = genUserInfo.sample.get
+    val samplePolicy = genPolicy.sample.get
+    val action = defaultResourceType.roles.head.actions.head
+
+    val resource = genResource.sample.get.copy(authDomain = Set.empty, resourceTypeName = defaultResourceType.name)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithAction = AccessPolicy.actions.modify(_ + action)(policyWithUser)
+    val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithAction)
+
+    val res = for{
+      _ <- setup()
+      _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResource(resource)
+      _ <- policyDAO.createPolicy(policy)
+      r <- service.policyEvaluatorService.hasPermissionShortCircuit(policy.id.resource, action, user.userId)
+    } yield {
+      r shouldBe(true)
+    }
+
+    res.unsafeToFuture()
+  }
+
+  it should "return true if given action is allowed via a role for a direct member of the policy using the short circuit" in {
+    val user = genUserInfo.sample.get
+    val samplePolicy = genPolicy.sample.get
+    val sampleRole = defaultResourceType.roles.head.roleName
+    val action = defaultResourceType.roles.head.actions.head
+
+    val resource = genResource.sample.get.copy(authDomain = Set.empty, resourceTypeName = defaultResourceType.name)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithRole = AccessPolicy.roles.modify(_ + sampleRole)(policyWithUser)
+    val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithRole)
+
+    val res = for{
+      _ <- setup()
+      _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResource(resource)
+      _ <- policyDAO.createPolicy(policy)
+      r <- service.policyEvaluatorService.hasPermissionShortCircuit(policy.id.resource, action, user.userId)
+    } yield {
+      r shouldBe(true)
+    }
+
+    res.unsafeToFuture()
+  }
+
+  it should "return false if given action is not present for a user via a role using the short circuit" in {
+    val user = genUserInfo.sample.get
+    val samplePolicy = genPolicy.sample.get
+    val sampleRole = ResourceRoleName("owner")
+    val action = ResourceAction("non_owner_action") // an action not given to owner
+
+    val resource = genResource.sample.get.copy(authDomain = Set.empty, resourceTypeName = defaultResourceType.name)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithRole = AccessPolicy.roles.modify(_ + sampleRole)(policyWithUser)
+    val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithRole)
+
+    val res = for{
+      _ <- setup()
+      _ <- dirDAO.createUser(WorkbenchUser(user.userId, Some(GoogleSubjectId(user.userId.value)), user.userEmail))
+      _ <- policyDAO.createResourceType(defaultResourceType)
+      _ <- policyDAO.createResource(resource)
+      _ <- policyDAO.createPolicy(policy)
+      r <- service.policyEvaluatorService.hasPermissionShortCircuit(policy.id.resource, action, user.userId)
+    } yield {
+      r shouldBe(false)
+    }
+
+    res.unsafeToFuture()
+  }
+
   it should "return true if given action is allowed for a user and resource is not constrained by auth domains" in {
     val user = genUserInfo.sample.get
     val samplePolicy = genPolicy.sample.get

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -226,7 +226,7 @@ class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport
       r shouldBe false
     }
 
-    res.unsafeToFuture()
+    res.unsafeRunSync()
   }
 
 
@@ -251,7 +251,7 @@ class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport
       r shouldBe(true)
     }
 
-    res.unsafeToFuture()
+    res.unsafeRunSync()
   }
 
   it should "return true if given action is allowed via a role for a direct member of the policy using the short circuit" in {
@@ -276,7 +276,7 @@ class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport
       r shouldBe(true)
     }
 
-    res.unsafeToFuture()
+    res.unsafeRunSync()
   }
 
   it should "return false if given action is not present for a user via a role using the short circuit" in {
@@ -301,7 +301,7 @@ class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport
       r shouldBe(false)
     }
 
-    res.unsafeToFuture()
+    res.unsafeRunSync()
   }
 
   it should "return true if given action is allowed for a user and resource is not constrained by auth domains" in {


### PR DESCRIPTION
Ticket: CA-571 

Performance improvement for hasPermission, based on short-circuiting for most common case with a cheaper check

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
