### PR TITLE
CA-573: LDAP Retries -- User Registration

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -298,17 +298,19 @@ class LdapDirectoryDAO(
   override def listAncestorGroups(groupId: WorkbenchGroupIdentity): IO[Set[WorkbenchGroupIdentity]] = listMemberOfGroups(groupId)
 
   override def enableIdentity(subject: WorkbenchSubject): IO[Unit] =
-    executeLdap(
-      IO(ldapConnectionPool.modify(directoryConfig.enabledUsersGroupDn, new Modification(ModificationType.ADD, Attr.member, subjectDn(subject)))).void
-    ).recoverWith {
-      case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
-        executeLdap(
-          IO(
-            ldapConnectionPool.add(
-              directoryConfig.enabledUsersGroupDn,
-              new Attribute("objectclass", Seq("top", "groupofnames").asJava),
-              new Attribute(Attr.member, subjectDn(subject))))).void
-      case ldape: LDAPException if ldape.getResultCode == ResultCode.ATTRIBUTE_OR_VALUE_EXISTS => IO.unit
+    retryLdapBusyWithBackoff(100.millisecond, 4) {
+      executeLdap(
+        IO(ldapConnectionPool.modify(directoryConfig.enabledUsersGroupDn, new Modification(ModificationType.ADD, Attr.member, subjectDn(subject)))).void
+      ).recoverWith {
+        case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
+          executeLdap(
+            IO(
+              ldapConnectionPool.add(
+                directoryConfig.enabledUsersGroupDn,
+                new Attribute("objectclass", Seq("top", "groupofnames").asJava),
+                new Attribute(Attr.member, subjectDn(subject))))).void
+        case ldape: LDAPException if ldape.getResultCode == ResultCode.ATTRIBUTE_OR_VALUE_EXISTS => IO.unit
+      }
     }
 
   override def disableIdentity(subject: WorkbenchSubject): IO[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapDirectoryDAO.scala
@@ -111,7 +111,9 @@ class LdapDirectoryDAO(
         case ldape: LDAPException if maxRetries > 0 && ldape.getResultCode == ResultCode.BUSY =>
           logger.info(s"Retrying LDAP Operation due to BUSY (Error code ${ldape.getResultCode})")
           IO.sleep(initialDelay) *> retryLdapBusyWithBackoff(initialDelay * 2, maxRetries - 1)(ioa)
-        case _ => IO.raiseError(error)
+        case e =>
+          logger.info(s"NOT Retrying LDAP Operation ${e.getMessage}) with ${maxRetries}")
+          IO.raiseError(error)
       }
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-573

Basic retries around problematic LDAP operations (essentially where we attempt to add users to a single, global group that under contention responds with BUSY).  Short retries (100ms, exponential,  4 retries).

Fixes problems observed in perf tests when large numbers of users register at the same time (n>50)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
