### PR TITLE
[CA-577] Remove references to auth domains when deleting a resource

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -15,6 +15,7 @@ trait AccessPolicyDAO {
   def deleteResource(resource: FullyQualifiedResourceId): IO[Unit]
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId): IO[LoadResourceAuthDomainResult]
   def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]]
+  def removeAuthDomainFromResource(resource: FullyQualifiedResourceId): IO[Unit]
 
   def createPolicy(policy: AccessPolicy): IO[AccessPolicy]
   def deletePolicy(policy: FullyQualifiedPolicyId): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -90,7 +90,10 @@ class LdapAccessPolicyDAO(
 
   override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId): IO[Unit] = {
     val removeAuthDomainMod = new Modification(ModificationType.DELETE, Attr.authDomain)
-    executeLdap(IO(ldapConnectionPool.modify(resourceDn(resource), removeAuthDomainMod)))
+    executeLdap(IO(ldapConnectionPool.modify(resourceDn(resource), removeAuthDomainMod)).void)
+      .recoverWith {
+        case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_ATTRIBUTE => IO.unit
+      }
   }
 
   override def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/LdapAccessPolicyDAO.scala
@@ -88,6 +88,11 @@ class LdapAccessPolicyDAO(
       r <- res.parSequence.fold(err => IO.raiseError(new WorkbenchException(err)), r => IO.pure(r.toSet))
     } yield r
 
+  override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId): IO[Unit] = {
+    val removeAuthDomainMod = new Modification(ModificationType.DELETE, Attr.authDomain)
+    executeLdap(IO(ldapConnectionPool.modify(resourceDn(resource), removeAuthDomainMod)))
+  }
+
   override def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = {
     val attributes = List(
       new Attribute("objectclass", "top", ObjectClass.policy),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -244,7 +244,7 @@ class ResourceService(
   private def maybeDeleteResource(resource: FullyQualifiedResourceId): Future[Unit] =
     resourceTypes.get(resource.resourceTypeName) match {
       case Some(resourceType) if resourceType.reuseIds => accessPolicyDAO.deleteResource(resource).unsafeToFuture()
-      case _ => Future.successful(())
+      case _ => accessPolicyDAO.removeAuthDomainFromResource(resource).unsafeToFuture()
     }
 
   def listUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo): Future[Set[ResourceRoleName]] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -45,6 +45,11 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
         }
     }
 
+  override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId): IO[Unit] = IO {
+    val resourceToRemoveOpt = resources.get(resource)
+    resourceToRemoveOpt.map( resourceToRemove => resources += resource -> resourceToRemove.copy(authDomain = Set.empty))
+  }
+
   override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity): IO[Set[Resource]] = IO.pure(Set.empty)
 
   override def createPolicy(policy: AccessPolicy): IO[AccessPolicy] = IO {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -705,15 +705,22 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
   it should "allow for auth domain groups on a deleted resource to be deleted" in {
     val resourceType = constrainableResourceType.copy(reuseIds = false)
-    val managedGroupName = "fooGroup"
+    val authDomainGroupToDelete = "fooGroup"
+    val otherAuthDomainGroup = "barGroup"
     constrainableService.createResourceType(resourceType).unsafeRunSync()
     constrainableService.createResourceType(managedGroupResourceType).unsafeRunSync()
-    managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUserInfo).unsafeRunSync()
-    val resource = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(managedGroupName)), dummyUserInfo.userId).unsafeRunSync()
+    managedGroupService.createManagedGroup(ResourceId(authDomainGroupToDelete), dummyUserInfo).unsafeRunSync()
+    managedGroupService.createManagedGroup(ResourceId(otherAuthDomainGroup), dummyUserInfo).unsafeRunSync()
+    val resourceToDelete = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(authDomainGroupToDelete)), dummyUserInfo.userId).unsafeRunSync()
+    val otherResource = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(otherAuthDomainGroup)), dummyUserInfo.userId).unsafeRunSync()
 
-    runAndWait(constrainableService.deleteResource(resource.fullyQualifiedId))
-    runAndWait(managedGroupService.deleteManagedGroup(ResourceId(managedGroupName)))
-    managedGroupService.loadManagedGroup(ResourceId(managedGroupName)).unsafeRunSync() shouldBe None
+    runAndWait(constrainableService.deleteResource(resourceToDelete.fullyQualifiedId))
+    runAndWait(managedGroupService.deleteManagedGroup(ResourceId(authDomainGroupToDelete)))
+    managedGroupService.loadManagedGroup(ResourceId(authDomainGroupToDelete)).unsafeRunSync() shouldBe None
+
+    // Other constrained resources and managed groups should be unaffected
+    constrainableService.loadResourceAuthDomain(otherResource.fullyQualifiedId).unsafeRunSync() should contain theSameElementsAs Set(WorkbenchGroupName(otherAuthDomainGroup))
+    managedGroupService.loadManagedGroup(ResourceId(otherAuthDomainGroup)).unsafeRunSync() shouldBe Some(WorkbenchEmail(s"$otherAuthDomainGroup@$emailDomain"))
   }
 
   "add/remove SubjectToPolicy" should "add/remove subject and tolerate prior (non)existence" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, LdapDirect
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, LdapAccessPolicyDAO, PostgresAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
-import org.scalatest.concurrent.{ScalaFutures, Eventually}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 /**
   * Created by dvoet on 6/27/17.
   */
-class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with TestSupport with BeforeAndAfter with BeforeAndAfterAll with Eventually {
+class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = TestSupport.directoryConfig
   val schemaLockConfig = TestSupport.schemaLockConfig
   //Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.


### PR DESCRIPTION
Ticket: [CA-577](https://broadworkbench.atlassian.net/browse/CA-577)
From the ticket description

> When a resource that does not allow id reuse is deleted we leave its recording in the db with no policies. References to auth domain groups are not removed which prevents those groups from being deleted in postgres. This causes automation test failures during cleanup. 

This PR changes resource deletion to clean up references to auth domain groups on resources that don't allow id reuse when they are deleted.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
