### PR TITLE
QA-973 use brand new project to test pet SA creation

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.18-8328aae"
   val workbenchGoogle2V = "0.1-8328aae"
-  val workbenchServiceTestV = "0.16-f0e5d47"
+  val workbenchServiceTestV = "0.16-c93c8f2-SNAP"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.18-8328aae"
   val workbenchGoogle2V = "0.1-8328aae"
-  val workbenchServiceTestV = "0.16-c93c8f2-SNAP"
+  val workbenchServiceTestV = "0.16-20dceaa"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -107,7 +107,7 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
       val userStatus = Sam.user.status()(userAuthToken).get
 
       // user a brand new billing project to ensure known state for pet (not present)
-      withBrandNewBillingProject("new_pet_test") { projectName =>
+      withBrandNewBillingProject("new-pet-test") { projectName =>
         val petAccountEmail = Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
         petAccountEmail.value should not be userStatus.userInfo.userEmail
         googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue.map(_.email) shouldBe Some(petAccountEmail)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKitBase
-import org.broadinstitute.dsde.workbench.auth.{AuthToken, ServiceAccountAuthTokenFromJson, ServiceAccountAuthTokenFromPem}
+import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes, ServiceAccountAuthTokenFromJson, ServiceAccountAuthTokenFromPem}
 import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
 import org.broadinstitute.dsde.workbench.dao.Google.{googleDirectoryDAO, googleIamDAO}
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
@@ -121,7 +121,7 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
 
         // who is my pet -> who is my user's pet -> it's me
         Sam.user.petServiceAccountEmail(projectName)(petAuthToken) shouldBe petAccountEmail
-      }(owner.makeAuthToken())
+      }(owner.makeAuthToken(AuthTokenScopes.billingScopes))
     }
 
     "should not treat non-pet service accounts as pets" in {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -106,17 +106,9 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
 
       val userStatus = Sam.user.status()(userAuthToken).get
 
-      withCleanBillingProject(owner) { projectName =>
-        // ensure known state for pet (not present)
-        // since projects get reused in tests it is possible that the pet SA is in google but not in ldap
-        // and if it is not in ldap sam won't try to remove it from google
-        // in order to remove it we need to create it in sam first (and thus ldap) then remove it
+      // user a brand new billing project to ensure known state for pet (not present)
+      withBrandNewBillingProject("new_pet_test") { projectName =>
         val petAccountEmail = Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
-        assert(petAccountEmail.value.contains(userStatus.userInfo.userSubjectId))
-        Sam.removePet(projectName, userStatus.userInfo)
-        eventually(googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue shouldBe None)
-
-        Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
         petAccountEmail.value should not be userStatus.userInfo.userEmail
         googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue.map(_.email) shouldBe Some(petAccountEmail)
 
@@ -129,12 +121,7 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
 
         // who is my pet -> who is my user's pet -> it's me
         Sam.user.petServiceAccountEmail(projectName)(petAuthToken) shouldBe petAccountEmail
-
-        // clean up
-
-        Sam.removePet(projectName, userStatus.userInfo)
-        eventually(googleIamDAO.findServiceAccount(GoogleProject(projectName), petAccountEmail).futureValue shouldBe None)
-      }
+      }(owner.makeAuthToken())
     }
 
     "should not treat non-pet service accounts as pets" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/QA-973
the test initial conditions need to be that a pet does not exist, since removing recreating SAs is bad I changed the test to create a new billing project. This is slower but sam tests are not the slowest. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
