### PR TITLE
CA-603 and CA-599

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val scalaCheckV    = "1.14.0"
   val catsEffectV         = "1.2.0"
   val scalikejdbcVersion    = "3.3.5"
-  val postgresDriverVersion = "42.2.4"
+  val postgresDriverVersion = "42.2.8"
 
   val workbenchUtilV   = "0.5-6942040"
   val workbenchModelV  = "0.13-d4e0782"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporter.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.util
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.WorkbenchExceptionWithErrorReport
@@ -95,6 +96,9 @@ class NewRelicShadowResultReporter(val daoName: String, val newRelicMetrics: New
 
       case (Right(realTraversable: Traversable[_]), Right(shadowTraversable: Traversable[_])) =>
         traversablesContainSameElements(realTraversable, shadowTraversable)
+
+      case (Right(realNEL: NonEmptyList[_]), Right(shadowNEL: NonEmptyList[_])) =>
+        traversablesContainSameElements(realNEL.toList, shadowNEL.toList)
 
       case (Right(realCaseClass: Product), Right(shadowCaseClass: Product)) =>
         caseClassesMatch(realCaseClass, shadowCaseClass)

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -129,7 +129,7 @@ db {
     poolMaxSize = 5
     poolConnectionTimeoutMillis = 5000
     driver = "org.postgresql.Driver"
-    url = "jdbc:postgresql://"${postgres.host}":"${postgres.port}"/testdb"
+    url = "jdbc:postgresql://"${postgres.host}":"${postgres.port}"/testdb?stringtype=unspecified"
     user = "sam-test"
     password = "sam-test"
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -973,6 +973,13 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
         dao.loadSubjectFromEmail(defaultUser.email).unsafeRunSync() shouldBe Some(defaultUser.id)
       }
 
+      "load a user subject from their email case insensitive" in {
+        val email = WorkbenchEmail("Mixed.Case.Email@foo.com")
+        dao.createUser(defaultUser.copy(email = email)).unsafeRunSync()
+
+        dao.loadSubjectFromEmail(new WorkbenchEmail(email.value.toLowerCase())).unsafeRunSync() shouldBe Some(defaultUser.id)
+      }
+
       "load a group subject from its email" in {
         dao.createGroup(defaultGroup).unsafeRunSync()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporterSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/NewRelicShadowResultReporterSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.util
 
 import akka.http.scaladsl.model.StatusCodes
+import cats.data.NonEmptyList
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, ValueObject, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.newrelic.NewRelicMetrics
@@ -8,6 +9,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import org.scalatest.mockito.MockitoSugar
+
 import scala.concurrent.duration._
 
 class NewRelicShadowResultReporterSpec extends FlatSpec with Matchers with MockitoSugar {
@@ -52,6 +54,25 @@ class NewRelicShadowResultReporterSpec extends FlatSpec with Matchers with Mocki
     val reporter = createResultReporter
     val real = Seq(3,2,6,2,5,2)
     val shadow = Seq(3,2,5,6,2,2)
+    val result = reporter.resultsMatch(Right(real), Right(shadow))
+    withClue(result.mismatchReasons) {
+      result.matches should be (true)
+    }
+  }
+
+  it should "match NonEmptyList" in {
+    val reporter = createResultReporter
+    val probe = NonEmptyList(3,List(2,5,6,2))
+    val result = reporter.resultsMatch(Right(probe), Right(probe))
+    withClue(result.mismatchReasons) {
+      result.matches should be (true)
+    }
+  }
+
+  it should "match NonEmptyList independent of order" in {
+    val reporter = createResultReporter
+    val real = NonEmptyList(3,List(2,6,2,5,2))
+    val shadow = NonEmptyList(2,List(3,5,6,2,2))
     val result = reporter.resultsMatch(Right(real), Right(shadow))
     withClue(result.mismatchReasons) {
       result.matches should be (true)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-603
a cats `NonEmptyList` is not a `Traversable` so needed to add special code to treat it as such

https://broadworkbench.atlassian.net/browse/CA-599
special connection property to make citext work

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
