### PR TITLE
CA-612 More retry

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -206,10 +206,6 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
       }
 
       resource
-    }.recoverWith {
-      case conflictException: PSQLException if conflictException.getSQLState == PSQLStateExtensions.UNIQUE_VIOLATION => {
-        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"Resource ${resource.resourceTypeName.value}/${resource.resourceId.value} already exists.", conflictException)))
-      }
     }
   }
 
@@ -234,6 +230,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
     val authDomainColumn = AuthDomainTable.column
     val insertAuthDomainQuery = samsql"insert into ${AuthDomainTable.table} (${authDomainColumn.resourceId}, ${authDomainColumn.groupId}) values ${authDomainValues}"
+
     insertAuthDomainQuery.update().apply()
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -207,9 +207,8 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
       resource
     }.recoverWith {
-      case sqlException: PSQLException => {
-        logger.debug(s"createResource psql exception on resource $resource", sqlException)
-        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"Resource ${resource.resourceTypeName} failed.", sqlException)))
+      case conflictException: PSQLException if conflictException.getSQLState == PSQLStateExtensions.UNIQUE_VIOLATION => {
+        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"Resource ${resource.resourceTypeName.value}/${resource.resourceId.value} already exists.", conflictException)))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/ShadowRunner.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/ShadowRunner.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.Executors
 import cats.effect._
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.sam.db.PSQLStateExtensions
 import org.postgresql.util.PSQLException
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/ShadowRunner.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/ShadowRunner.scala
@@ -96,7 +96,7 @@ private class ShadowRunnerDynamicProxy[DAO](realDAO: DAO, shadowDAO: DAO, val re
     if (classOf[IO[_]].isAssignableFrom(method.getReturnType)) {
       // since these are IOs any side effects should be deferred so invoking them here does not do the actual work... just creates the IO
       val realIO = attempt(method.invoke(realDAO, args: _*).asInstanceOf[IO[_]])
-      val shadowIO = retryNullConstraintViolation(attempt(method.invoke(shadowDAO, args: _*).asInstanceOf[IO[_]]), 10 milliseconds, 3)
+      val shadowIO = retryPSQLException(attempt(method.invoke(shadowDAO, args: _*).asInstanceOf[IO[_]]), 10 milliseconds, 5)
       runWithShadow(MethodCallInfo(method, args), realIO, shadowIO)
     } else {
       // return type is not IO so wrap them in IO to run with shadow then unwrap
@@ -109,12 +109,12 @@ private class ShadowRunnerDynamicProxy[DAO](realDAO: DAO, shadowDAO: DAO, val re
 
   private def attempt(io: => IO[_]): IO[_] = Try(io).recover { case e => IO.raiseError(e) }.get
 
-  def retryNullConstraintViolation[A](ioa: IO[A], initialDelay: FiniteDuration, maxRetries: Int)
+  def retryPSQLException[A](ioa: IO[A], initialDelay: FiniteDuration, maxRetries: Int)
                          (implicit timer: Timer[IO]): IO[A] = {
     ioa.handleErrorWith {
-      case error: PSQLException if error.getSQLState == PSQLStateExtensions.NULL_CONSTRAINT_VIOLATION =>
+      case error: PSQLException =>
         if (maxRetries > 0) {
-          IO.sleep(initialDelay) *> retryNullConstraintViolation(ioa, initialDelay * 2, maxRetries - 1)
+          IO.sleep(initialDelay) *> retryPSQLException(ioa, initialDelay * 2, maxRetries - 1)
         } else {
           IO.raiseError(error)
         }


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
2 things, first retry all psql exceptions and try a little more, second creating a resource where either the resource type or auth domain did not exist threw the same exception with a Conflict status, neither was right and both of which are handled correctly further up the stack anyway. Change them to pass up a PSQLException instead which is then retried appropriately.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
