### PR TITLE
CA-611 don't start a transaction if not running a query

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -640,13 +640,13 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
   }
 
   override def enableIdentity(subject: WorkbenchSubject): IO[Unit] = {
-    runInTransaction { implicit session =>
-      subject match {
-        case userId: WorkbenchUserId =>
-          val u = UserTable.column
-          samsql"update ${UserTable.table} set ${u.enabled} = true where ${u.id} = ${userId}".update().apply()
-        case _ => // other types of WorkbenchSubjects cannot be enabled
+    subject match {
+      case userId: WorkbenchUserId =>
+        runInTransaction { implicit session =>
+        val u = UserTable.column
+        samsql"update ${UserTable.table} set ${u.enabled} = true where ${u.id} = ${userId}".update().apply()
       }
+      case _ => IO.unit // other types of WorkbenchSubjects cannot be enabled
     }
   }
 


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
`enableIdentity` only does something when the identity is a user but created a transaction in either case... perhaps this is why new relic says it is so slow. This PR changes it to only create a transaction if needed which is better anyway.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
