### PR TITLE
CA-625 Sam crash

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/dao/PostgresGroupDAO.scala
@@ -104,10 +104,10 @@ trait PostgresGroupDAO {
     val sg = subGroupMemberTable.syntax("sg")
     val gm = GroupMemberTable.syntax(groupMemberTableAlias)
     val sgColumns = subGroupMemberTable.column
-    samsqls"""${subGroupMemberTable.table}(${sgColumns.parentGroupId}, ${sgColumns.memberGroupId}, ${sgColumns.memberUserId}) AS (
+    samsqls"""${subGroupMemberTable.table}(${sgColumns.memberGroupId}, ${sgColumns.memberUserId}) AS (
           ${directMembersQuery(groupId, groupMemberTableAlias)}
           UNION
-          SELECT ${gm.groupId}, ${gm.memberGroupId}, ${gm.memberUserId}
+          SELECT ${gm.memberGroupId}, ${gm.memberUserId}
           FROM ${subGroupMemberTable as sg}, ${GroupMemberTable as gm}
           WHERE ${gm.groupId} = ${sg.memberGroupId}
         )"""
@@ -115,7 +115,7 @@ trait PostgresGroupDAO {
 
   private def directMembersQuery(groupId: WorkbenchGroupIdentity, groupMemberTableAlias: String = "gm"): SQLSyntax = {
     val gm = GroupMemberTable.syntax(groupMemberTableAlias)
-    samsqls"""select ${gm.groupId}, ${gm.memberGroupId}, ${gm.memberUserId}
+    samsqls"""select ${gm.memberGroupId}, ${gm.memberUserId}
                from ${GroupMemberTable as gm}
                where ${gm.groupId} = (${workbenchGroupIdentityToGroupPK(groupId)})"""
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -565,7 +565,7 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
   override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity]): IO[Set[WorkbenchUserId]] = {
     // the implementation of this is a little fancy and is able to do the entire intersection in a single request
     // the general structure of the query is:
-    // WITH RECURSIVE [subGroupsQuery for each group] SELECT user_id FROM [all the subgroup queries joined on user_id]
+    // WITH RECURSIVE [subGroupsQuery for each group] [SELECT user_id FROM subGroupsQuery_1 INTERSECT SELECT user_id FROM subGroupsQuery_2 INTERSECT ...]
     case class QueryAndTable(recursiveMembersQuery: SQLSyntax, table: SubGroupMemberTable)
 
     // the toSeq below is important to fix a predictable order

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -557,9 +557,8 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
     * where N is the cardinality of the groupIds parameter.  Each of these CTEs is the flattened group membership for
     * one of the WorkbenchGroupIdentities.
     *
-    * The query maintains a table alias for each of the CTEs.  The final part of the query uses this list of aliases to
-    * join each of them based on the memberUserId column to give us the final result of only those memberUserIds that
-    * showed up as an entry in every CTE.
+    * The final part of the query intersects all the tables defined in the CTE to give us the final result of only
+    * those memberUserIds that showed up as an entry in every CTE.
     * @param groupIds
     * @return Set of WorkbenchUserIds that are members of each group specified by groupIds
     */
@@ -580,18 +579,13 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
 
     val allRecursiveMembersQueries = SQLSyntax.join(recursiveMembersQueries.map(_.recursiveMembersQuery), sqls",", false)
 
-    // need to handle the first table special, all others will join back to this
-    val firstTable = recursiveMembersQueries.head.table
-    val ft = firstTable.syntax
-    val allSubGroupTableJoins = recursiveMembersQueries.tail.map(_.table).foldLeft(samsqls"") { (joins, nextTable) =>
-      val nt = nextTable.syntax
-      samsqls"$joins join ${nextTable as nt} on ${ft.memberUserId} = ${nt.memberUserId} "
-    }
+    val intersectionQuery = recursiveMembersQueries.map { queryAndTable =>
+      val sg = queryAndTable.table.syntax
+      samsqls"select ${sg.memberUserId} from ${queryAndTable.table as sg} where ${sg.memberUserId} is not null"
+    }.reduce((left, right) => samsqls"$left INTERSECT $right")
 
     runInTransaction { implicit session =>
-      samsql"""with recursive $allRecursiveMembersQueries
-              select ${ft.memberUserId}
-              from ${firstTable as ft} $allSubGroupTableJoins where ${ft.memberUserId} is not null""".map(rs => WorkbenchUserId(rs.string(1))).list().apply().toSet
+      samsql"""with recursive $allRecursiveMembersQueries $intersectionQuery""".map(rs => WorkbenchUserId(rs.string(1))).list().apply().toSet
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.PostgresAccessPolicyDAO
 import org.postgresql.util.PSQLException
@@ -744,6 +744,29 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
 
           dao.listIntersectionGroupUsers(allGroups.map(_.id).toSet).unsafeRunSync() should contain theSameElementsAs expected
         }
+      }
+
+      "intersect lots of groups with lots of dups and overlaps" in {
+        val groupCount = 20
+        val userCount = 70
+
+        val allUsers = for (_ <- 1 to userCount) yield {
+          dao.createUser(Generator.genWorkbenchUser.sample.get).unsafeRunSync()
+        }
+
+        val allUserIds: Set[WorkbenchSubject] = allUsers.map(_.id).toSet
+        val allUsersGroup = Generator.genBasicWorkbenchGroup.sample.get.copy(members = allUserIds)
+        dao.createGroup(allUsersGroup).unsafeRunSync()
+        val allUsersGroup2 = Generator.genBasicWorkbenchGroup.sample.get.copy(members = allUserIds)
+        dao.createGroup(allUsersGroup2).unsafeRunSync()
+
+        val allGroups = for (i <- 1 to groupCount) yield {
+          // create a group with 1 user and 1 subgroup, subgroup with "allgroups" users and another user
+          val group = BasicWorkbenchGroup(WorkbenchGroupName(s"group$i"), Set(allUsersGroup.id, allUsersGroup2.id), WorkbenchEmail(s"group$i"))
+          dao.createGroup(group).unsafeRunSync()
+        }
+
+        dao.listIntersectionGroupUsers(allGroups.map(_.id).toSet).unsafeRunSync() should contain theSameElementsAs allUserIds
       }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-625
The problem was that the recursive call contained the parent group id which stymied the deduplication of the UNION

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
