### PR TITLE
[CA-674] Fix invited user registration

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
@@ -148,4 +148,6 @@ class LdapRegistrationDAO(
   override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Unit] =
     executeLdap(IO(ldapConnectionPool.delete(petDn(petServiceAccountId))))
 
+  override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit] =
+    executeLdap(IO(ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.googleSubjectId, googleSubjectId.value))))
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/RegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/RegistrationDAO.scala
@@ -18,4 +18,5 @@ trait RegistrationDAO {
   def createPetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount]
   def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Option[PetServiceAccount]]
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Unit]
+  def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -68,6 +68,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
                 for {
                   groups <- directoryDAO.listUserDirectMemberships(uid)
                   _ <- directoryDAO.setGoogleSubjectId(uid, user.googleSubjectId)
+                  _ <- registrationDAO.setGoogleSubjectId(uid, user.googleSubjectId)
                   _ <- IO.fromFuture(IO(cloudExtensions.onGroupUpdate(groups)))
                 } yield WorkbenchUser(uid, Some(user.googleSubjectId), user.email)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -197,7 +197,9 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     val user = genCreateWorkbenchUser.sample.get
     service.registerUser(user).unsafeRunSync()
     val res = dirDAO.loadUser(user.id).unsafeRunSync()
+    val registrationRes = registrationDAO.loadUser(user.id).unsafeRunSync()
     res shouldBe Some(WorkbenchUser(user.id, Some(user.googleSubjectId), user.email))
+    registrationRes shouldEqual res
   }
 
   /**
@@ -206,10 +208,12 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     */
   it should "update googleSubjectId when there's no existing subject for a given googleSubjectId and but there is one for email" in{
     val user = genCreateWorkbenchUser.sample.get
-    dirDAO.createUser(WorkbenchUser(user.id, None, user.email)).unsafeRunSync()
+    service.inviteUser(InviteUser(user.id, user.email)).unsafeRunSync()
     service.registerUser(user).unsafeRunSync()
     val res = dirDAO.loadUser(user.id).unsafeRunSync()
+    val registrationRes = registrationDAO.loadUser(user.id).unsafeRunSync()
     res shouldBe Some(WorkbenchUser(user.id, Some(user.googleSubjectId), user.email))
+    registrationRes shouldEqual res
   }
 
   /**
@@ -239,7 +243,9 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     val user = genInviteUser.sample.get
     service.inviteUser(user).unsafeRunSync()
     val res = dirDAO.loadUser(user.inviteeId).unsafeRunSync()
+    val registrationRes = registrationDAO.loadUser(user.inviteeId).unsafeRunSync()
     res shouldBe Some(WorkbenchUser(user.inviteeId, None, user.inviteeEmail))
+    registrationRes shouldEqual res
   }
 
   it should "return conflict when there's an existing subject for a given userId" in{
@@ -262,11 +268,15 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
     val user = genCreateWorkbenchUser.sample.get
     service.inviteUser(InviteUser(user.id, user.email)).unsafeRunSync()
     val res = dirDAO.loadUser(user.id).unsafeRunSync()
+    val registrationRes = registrationDAO.loadUser(user.id).unsafeRunSync()
     res shouldBe Some(WorkbenchUser(user.id, None, user.email))
+    registrationRes shouldEqual res
 
     service.createUser(user).futureValue
     val updated = dirDAO.loadUser(user.id).unsafeRunSync()
+    val updatedRegistrationRes = registrationDAO.loadUser(user.id).unsafeRunSync()
     updated shouldBe Some(WorkbenchUser(user.id, Some(user.googleSubjectId), user.email))
+    updatedRegistrationRes shouldEqual updated
   }
 
   "UserService getUserIdInfoFromEmail" should "return the email along with the userSubjectId and googleSubjectId" in {


### PR DESCRIPTION
Ticket: [CA-674](https://broadworkbench.atlassian.net/browse/CA-674)
When invited users register, we were not adding their google subject id to OpenDJ which was causing problems for them when they tried to use the site. This PR updates that and adds some checks to related tests to better ensure that we are keeping OpenDJ and Postgres in sync.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
