### PR TITLE
[CA-675] Properly update pet service accounts in OpenDJ

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
@@ -148,6 +148,13 @@ class LdapRegistrationDAO(
   override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Unit] =
     executeLdap(IO(ldapConnectionPool.delete(petDn(petServiceAccountId))))
 
+  override def updatePetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount] = {
+    val modifications = createPetServiceAccountAttributes(petServiceAccount).map { attribute =>
+      new Modification(ModificationType.REPLACE, attribute.getName, attribute.getRawValues)
+    }
+    executeLdap(IO(ldapConnectionPool.modify(petDn(petServiceAccount.id), modifications.asJava))) *> IO.pure(petServiceAccount)
+  }
+
   override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit] =
     executeLdap(IO(ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.googleSubjectId, googleSubjectId.value))))
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/RegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/RegistrationDAO.scala
@@ -18,5 +18,6 @@ trait RegistrationDAO {
   def createPetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount]
   def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Option[PetServiceAccount]]
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId): IO[Unit]
+  def updatePetServiceAccount(petServiceAccount: PetServiceAccount): IO[PetServiceAccount]
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -342,6 +342,7 @@ class GoogleExtensions(
         // pet already exists in ldap, but a new SA was created so update ldap with new SA info
         case (Some(p), None) =>
           directoryDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
+          registrationDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
 
         // everything already existed
         case (Some(p), Some(_)) => IO.pure(p)


### PR DESCRIPTION
Ticket: [CA-675](https://broadworkbench.atlassian.net/browse/CA-675)
I'm not sure when this started, but Leo automation tests running against Alpha began failing with numerous requests from pet service accounts failing as Unauthorized. I found that those pet service accounts had different google subject ids in Postgres and OpenDJ. I also found that the google subject id in Postgres matched up with the google subject ids I was seeing in the Kibana logs. Since the google subject id in OpenDJ was different than the google subject id that was coming in with the request, the proxy returned 401s. 
This PR resolves prevents OpenDJ and Postgres from getting out of sync when updating pet service accounts by adding `updatePetServiceAccount` to the `RegistrationDAO`.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
