### PR TITLE
[CA-675] Actually really fix updating pet service accounts this time

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -341,8 +341,10 @@ class GoogleExtensions(
           } yield p
         // pet already exists in ldap, but a new SA was created so update ldap with new SA info
         case (Some(p), None) =>
-          directoryDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
-          registrationDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
+          for {
+            p <- directoryDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
+            _ <- registrationDAO.updatePetServiceAccount(p.copy(serviceAccount = serviceAccount))
+          } yield p
 
         // everything already existed
         case (Some(p), Some(_)) => IO.pure(p)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -388,7 +388,9 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
     val petServiceAccount2 = googleExtensions.createUserPetServiceAccount(defaultUser, googleProject).unsafeRunSync()
     petServiceAccount.serviceAccount shouldNot equal(petServiceAccount2.serviceAccount)
-    regDAO.loadPetServiceAccount(petServiceAccount.id).unsafeRunSync() shouldBe Some(petServiceAccount2)
+    val res = dirDAO.loadPetServiceAccount(petServiceAccount.id).unsafeRunSync()
+    res shouldBe Some(petServiceAccount2)
+    regDAO.loadPetServiceAccount(petServiceAccount.id).unsafeRunSync() shouldBe res
     mockGoogleIamDAO.findServiceAccount(googleProject, petServiceAccount.serviceAccount.email).futureValue shouldBe Some(petServiceAccount2.serviceAccount)
   }
 


### PR DESCRIPTION
Ticket: [CA-675](https://broadworkbench.atlassian.net/browse/CA-675)
I didn't put the two IOs in a for comp, so it was dropping the first IO and not updating the Directory DAO which meant Postgres was getting out of sync. I updated the test too to really make sure that this works and Postgres and OpenDJ are in sync.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
