### PR TITLE
[CA540]add action description back for delete action

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -269,7 +269,7 @@ resourceTypes = {
         description = "add this billing-project to a service-perimeter"
       }
       delete = {
-        description = ""
+        description = "delete this billing-project"
       }
     }
     ownerRoleName = "owner"


### PR DESCRIPTION
Ticket: <https://broadworkbench.atlassian.net/browse/CA-540>
<In my previous PR, the test won't pass because there are two delete action with different descriptions. I have to remove the description at that moment to make the test pass. Now as the firecloud config is also updated. It's the time to bring the description back. >

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
