### PR TITLE
[CA-727] Disable users in ldap when deleting them

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
@@ -62,6 +62,7 @@ class LdapRegistrationDAO(
       unmarshalUser(results).toOption
     }
 
+  // Deleting a user in ldap will also disable them to clear them out of the enabled-users group
   override def deleteUser(userId: WorkbenchUserId): IO[Unit] =
     executeLdap(for {
       _ <- disableIdentity(userId)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAO.scala
@@ -63,7 +63,10 @@ class LdapRegistrationDAO(
     }
 
   override def deleteUser(userId: WorkbenchUserId): IO[Unit] =
-    executeLdap(IO(ldapConnectionPool.delete(userDn(userId))))
+    executeLdap(for {
+      _ <- disableIdentity(userId)
+      _ <- IO(ldapConnectionPool.delete(userDn(userId)))
+    } yield ())
 
   override def enableIdentity(subject: WorkbenchSubject): IO[Unit] =
     retryLdapBusyWithBackoff(100.millisecond, 4) {
@@ -85,7 +88,8 @@ class LdapRegistrationDAO(
     executeLdap(
       IO(ldapConnectionPool.modify(directoryConfig.enabledUsersGroupDn, new Modification(ModificationType.DELETE, Attr.member, subjectDn(subject)))).void
     ).recover {
-      case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_ATTRIBUTE =>
+      case ldape: LDAPException if ldape.getResultCode == ResultCode.NO_SUCH_ATTRIBUTE
+        || ldape.getResultCode == ResultCode.NO_SUCH_OBJECT =>
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAOSpec.scala
@@ -105,6 +105,30 @@ class LdapRegistrationDAOSpec extends FlatSpec with Matchers with TestSupport wi
       dao.loadUser(user.id).unsafeRunSync()
     }
   }
+
+  it should "disable users when deleting them" in {
+    val user = WorkbenchUser(WorkbenchUserId(UUID.randomUUID().toString), None, WorkbenchEmail("foo@bar.com"), None)
+
+    assertResult(user) {
+      dao.createUser(user).unsafeRunSync()
+    }
+
+    dao.enableIdentity(user.id).unsafeRunSync()
+
+    assertResult(true) {
+      dao.isEnabled(user.id).unsafeRunSync()
+    }
+
+    dao.deleteUser(user.id).unsafeRunSync()
+
+    assertResult(None) {
+      dao.loadUser(user.id).unsafeRunSync()
+    }
+
+    assertResult(false) {
+      dao.isEnabled(user.id).unsafeRunSync()
+    }
+  }
 }
 
 


### PR DESCRIPTION
Ticket: [CA-727](https://broadworkbench.atlassian.net/browse/CA-727)
Currently, deleting a user simply deletes their record in ldap. That leaves a membership record in the `enabled-users` group that references a now non-existent user. Since ldap only keeps track of a single group, it is simple enough to clean a user out of the `enabled-users` group when we delete the user. This will also help manage bloat in the `enabled-users` group which has shown to cause performance issues in the perf environment.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
