### PR TITLE
skip tests - [no ticket] Local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:
 https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
 ### Test newrelic metrics locally
-  * Follow directions above for Local Setup
-  * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
-  * Put `newrelic-agent-x.x.x.jar` under `config` directory
-  * In `config/newrelic.yml`, update `agent_enabled` to `true`
-  * In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
-  * Follow directions above Using dev or local DBs when starting up local Sam.
-  * Send some requests to local Sam.
-  * Go to `https://newrelic.com/`, and log in
-  * Look for `sam - local - dev` and check if metrics look good.
+* Follow directions above for Local Setup
+* Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+* Put `newrelic-agent-x.x.x.jar` under `config` directory
+* In `config/newrelic.yml`, update `agent_enabled` to `true`
+* In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+* Follow directions above Using dev or local DBs when starting up local Sam.
+* Send some requests to local Sam.
+* Go to `https://newrelic.com/`, and log in
+* Look for `sam - local - dev` and check if metrics look good.
 
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
 
 You can then start Sam against dev DBs or local DBs following the instructions below.
 
-
 #### Using dev DBs
 You must be connected to the Broad Internal network to connect to the Dev DBs.
 
@@ -190,7 +189,6 @@ You must be connected to the Broad Internal network to connect to the Dev DBs.
 # Start up local Sam
 sh config/docker-rsync-local-sam.sh
 ```
-
 
 #### Using local DBs
 
@@ -214,17 +212,16 @@ https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:
 [Swagger page:
 https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
-
 ### Test newrelic metrics locally
-* Follow directions above for Local Setup
-* Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
-* Put `newrelic-agent-x.x.x.jar` under `config` directory
-* In `config/newrelic.yml`, update `agent_enabled` to `true`
-* In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
-* Follow directions above Using dev or local DBs when starting up local Sam.
-* Send some requests to local Sam.
-* Go to `https://newrelic.com/`, and log in
-* Look for `sam - local - dev` and check if metrics look good.
+*  Follow directions above for Local Setup
+*  Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+*  Put `newrelic-agent-x.x.x.jar` under `config` directory
+*  In `config/newrelic.yml`, update `agent_enabled` to `true`
+*  In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+*  Follow directions above Using dev or local DBs when starting up local Sam.
+*  Send some requests to local Sam.
+*  Go to `https://newrelic.com/`, and log in
+*  Look for `sam - local - dev` and check if metrics look good.
 
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ sh docker/run-postgres.sh stop
 
 #### Local setup
 
-Set up configs using the [firecloud-develop config quick start guide](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs).
+Set up configs using the [firecloud-develop quick start guide for configs](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs).
 
 If you haven't already, add `127.0.0.1       local.broadinstitute.org` to `/etc/hosts`:
 ```
@@ -190,8 +190,6 @@ You must be connected to the Broad Internal network to connect to the Dev DBs.
 # Start up local Sam
 sh config/docker-rsync-local-sam.sh
 ```
-
-Then you can verify that it is running by using the commands that are a couple sections down.
 
 
 #### Using local DBs
@@ -210,11 +208,11 @@ sh config/docker-rsync-local-sam.sh
 ```
 
 #### Verify that local Sam is running
-Sam Status endpoint:
-https://local.broadinstitute.org:50443/status
+[Status endpoint:
+https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:50443/status)
 
-Swagger page:
-https://local.broadinstitute.org:50443/#/
+[Swagger page:
+https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
 
 ### Test newrelic metrics locally

--- a/README.md
+++ b/README.md
@@ -169,13 +169,69 @@ Stop your local postgres:
 sh docker/run-postgres.sh stop
 ```
 
+### To run Sam locally
+
+#### Local setup
+
+Add `127.0.0.1       local.broadinstitute.org` to `/etc/hosts` if it isn't already:
+```
+sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
+```
+
+
+Set up configs from the [firecloud-develop repo](https://github.com/broadinstitute/firecloud-develop/)
+```
+# Run from the root directory of firecloud-develop and follow the instructions
+sh run-context/local/scripts/firecloud-setup.sh
+```
+
+Make sure Docker is running.
+
+You can start Sam against dev DBs or local DBs following the instructions below.
+
+
+#### Using dev DBs
+You will need to be connected to the Broad Internal network to connect to the Dev DBs.
+
+```
+# Start up local Sam
+sh config/docker-rsync-local-sam.sh
+```
+
+
+Then you can verify that it is running by using the commands that are a couple sections down.
+
+
+#### Using local DBs
+
+```
+# Start up local opendj and postgres
+sh docker/run-opendj.sh start
+sh docker/run-postgres.sh start 
+
+# Set environment variables for using local opendj and postgres
+LOCAL_OPENDJ=true
+LOCAL_POSTGRES=true
+
+# Start up local Sam
+sh config/docker-rsync-local-sam.sh
+```
+
+#### Verify that local Sam is running
+Sam Status endpoint:
+https://local.broadinstitute.org:50443/status
+
+Swagger page:
+https://local.broadinstitute.org:50443/#/
+
+
 ### Test newrelic metrics locally
 * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
 * Put `newrelic-agent-x.x.x.jar` under `config` directory (If you haven't set up config, follow instructions [here](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs))
 * In newrelic.yml, update `agent_enabled` to `true`
 * In `docker-rsync-local-sam.sh` file, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
 * Start sam locally, `./config/docker-rsync-local-sam.sh`
-* Send some requests to local sam.
+* Send some requests to local Sam.
 * Go to `https://newrelic.com/`, and log in
 * Look for `sam - local - dev` and check if metrics look good.
 

--- a/README.md
+++ b/README.md
@@ -173,31 +173,23 @@ sh docker/run-postgres.sh stop
 
 #### Local setup
 
-Add `127.0.0.1       local.broadinstitute.org` to `/etc/hosts` if it isn't already:
+Set up configs using the [firecloud-develop config quick start guide](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs).
+
+If you haven't already, add `127.0.0.1       local.broadinstitute.org` to `/etc/hosts`:
 ```
 sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
 ```
 
-
-Set up configs from the [firecloud-develop repo](https://github.com/broadinstitute/firecloud-develop/)
-```
-# Run from the root directory of firecloud-develop and follow the instructions
-sh run-context/local/scripts/firecloud-setup.sh
-```
-
-Make sure Docker is running.
-
-You can start Sam against dev DBs or local DBs following the instructions below.
+You can then start Sam against dev DBs or local DBs following the instructions below.
 
 
 #### Using dev DBs
-You will need to be connected to the Broad Internal network to connect to the Dev DBs.
+You must be connected to the Broad Internal network to connect to the Dev DBs.
 
 ```
 # Start up local Sam
 sh config/docker-rsync-local-sam.sh
 ```
-
 
 Then you can verify that it is running by using the commands that are a couple sections down.
 
@@ -226,11 +218,12 @@ https://local.broadinstitute.org:50443/#/
 
 
 ### Test newrelic metrics locally
+* Follow directions above for Local Setup
 * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
-* Put `newrelic-agent-x.x.x.jar` under `config` directory (If you haven't set up config, follow instructions [here](https://github.com/broadinstitute/firecloud-develop#quick-start---how-do-i-set-up-my-configs))
-* In newrelic.yml, update `agent_enabled` to `true`
-* In `docker-rsync-local-sam.sh` file, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
-* Start sam locally, `./config/docker-rsync-local-sam.sh`
+* Put `newrelic-agent-x.x.x.jar` under `config` directory
+* In `config/newrelic.yml`, update `agent_enabled` to `true`
+* In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+* Follow directions above Using dev or local DBs when starting up local Sam.
 * Send some requests to local Sam.
 * Go to `https://newrelic.com/`, and log in
 * Look for `sam - local - dev` and check if metrics look good.

--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:
 https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
 ### Test newrelic metrics locally
-* Follow directions above for Local Setup
-* Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
-* Put `newrelic-agent-x.x.x.jar` under `config` directory
-* In `config/newrelic.yml`, update `agent_enabled` to `true`
-* In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
-* Follow directions above Using dev or local DBs when starting up local Sam.
-* Send some requests to local Sam.
-* Go to `https://newrelic.com/`, and log in
-* Look for `sam - local - dev` and check if metrics look good.
+ * Follow directions above for Local Setup
+ * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+ * Put `newrelic-agent-x.x.x.jar` under `config` directory
+ * In `config/newrelic.yml`, update `agent_enabled` to `true`
+ * In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+ * Follow directions above Using dev or local DBs when starting up local Sam.
+ * Send some requests to local Sam.
+ * Go to `https://newrelic.com/`, and log in
+ * Look for `sam - local - dev` and check if metrics look good.
 
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:
 https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
 ### Test newrelic metrics locally
- * Follow directions above for Local Setup
- * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
- * Put `newrelic-agent-x.x.x.jar` under `config` directory
- * In `config/newrelic.yml`, update `agent_enabled` to `true`
- * In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
- * Follow directions above Using dev or local DBs when starting up local Sam.
- * Send some requests to local Sam.
- * Go to `https://newrelic.com/`, and log in
- * Look for `sam - local - dev` and check if metrics look good.
+* Follow directions above for Local Setup
+* Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+* Put `newrelic-agent-x.x.x.jar` under `config` directory
+* In `config/newrelic.yml`, update `agent_enabled` to `true`
+* In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+* Follow directions above Using dev or local DBs when starting up local Sam.
+* Send some requests to local Sam.
+* Go to `https://newrelic.com/`, and log in
+* Look for `sam - local - dev` and check if metrics look good.
 
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -213,15 +213,15 @@ https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:
 https://local.broadinstitute.org:50443/#/](https://local.broadinstitute.org:50443/#/)
 
 ### Test newrelic metrics locally
-*  Follow directions above for Local Setup
-*  Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
-*  Put `newrelic-agent-x.x.x.jar` under `config` directory
-*  In `config/newrelic.yml`, update `agent_enabled` to `true`
-*  In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
-*  Follow directions above Using dev or local DBs when starting up local Sam.
-*  Send some requests to local Sam.
-*  Go to `https://newrelic.com/`, and log in
-*  Look for `sam - local - dev` and check if metrics look good.
+  * Follow directions above for Local Setup
+  * Download a newrelic agent jar from https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes
+  * Put `newrelic-agent-x.x.x.jar` under `config` directory
+  * In `config/newrelic.yml`, update `agent_enabled` to `true`
+  * In `config/docker-rsync-local-sam.sh`, add `-javaagent:/app/config/newrelic-agent-4.11.0.jar` to server startup java options.
+  * Follow directions above Using dev or local DBs when starting up local Sam.
+  * Send some requests to local Sam.
+  * Go to `https://newrelic.com/`, and log in
+  * Look for `sam - local - dev` and check if metrics look good.
 
 ### [CONTRIBUTING.md](../CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
 
 You can then start Sam against dev DBs or local DBs following the instructions below.
 
-#### Using dev DBs
+##### Using dev DBs
 You must be connected to the Broad Internal network to connect to the Dev DBs.
 
 ```
@@ -190,19 +190,11 @@ You must be connected to the Broad Internal network to connect to the Dev DBs.
 sh config/docker-rsync-local-sam.sh
 ```
 
-#### Using local DBs
+##### Using local DBs
 
 ```
-# Start up local opendj and postgres
-sh docker/run-opendj.sh start
-sh docker/run-postgres.sh start 
-
-# Set environment variables for using local opendj and postgres
-LOCAL_OPENDJ=true
-LOCAL_POSTGRES=true
-
-# Start up local Sam
-sh config/docker-rsync-local-sam.sh
+# Start up local Sam with local opendj and postgres
+LOCAL_OPENDJ=true LOCAL_POSTGRES=true sh config/docker-rsync-local-sam.sh
 ```
 
 #### Verify that local Sam is running


### PR DESCRIPTION
Make the local setup instruction more clear.

Not sure why Codacy tests are flagging the unordered list as violating spacing rules. I've added 2
spaces as instructed, which results in errors advising me to remove 2 spaces. The current spacing seems to make sense but I'm interested to see/hear other ideas. https://github.com/remarkjs/remark-lint/tree/master/packages/remark-lint-list-item-indent