### PR TITLE
Start the listPoliciesQuery on the ResourceTable instead of the GroupTable

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -600,10 +600,10 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
     val listPoliciesQuery =
       samsql"""select ${p.result.name}, ${r.result.name}, ${rt.result.name}, ${g.result.email}, ${p.result.public}, ${gm.result.memberUserId}, ${sg.result.name}, ${sp.result.name}, ${sr.result.name}, ${srt.result.name}, ${rr.result.role}, ${ra.result.action}
-          from ${GroupTable as g}
-          join ${PolicyTable as p} on ${g.id} = ${p.groupId}
-          join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
+          from ${ResourceTable as r}
           join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+          join ${PolicyTable as p} on ${r.id} = ${p.resourceId}
+          join ${GroupTable as g} on ${p.groupId} = ${g.id}
           left join ${GroupMemberTable as gm} on ${g.id} = ${gm.groupId}
           left join ${GroupTable as sg} on ${gm.memberGroupId} = ${sg.id}
           left join ${PolicyTable as sp} on ${sg.id} = ${sp.groupId}


### PR DESCRIPTION
Start with the ResrouceTable that we can apply the 'where' matching the resource in question immediately instead of after we've joined all the groups with all the policies with the resources matching the resource in question. This should allow us to use the index on the group table to select some of the groups instead of having to look at all of them.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
