### PR TITLE
[CA-849] Trace auth calls

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -22,7 +22,7 @@ LOCAL_UI=true ./render-local-env.sh
 ```
 
 ##### Against a local Sam
-Run `./render-local-env.sh` and then update the URIs in `src/test/resources/application.conf` to:
+Run `./render-local-env.sh` and then update the URIs in `automation/src/test/resources/application.conf` to:
 ```
   baseUrl = "https://firecloud.dsde-dev.broadinstitute.org/"
   orchApiUrl = "https://firecloud-orchestration.dsde-dev.broadinstitute.org/"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -27,7 +27,7 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
   val managedGroupService: ManagedGroupService
 
   def groupRoutes: server.Route = withSamRequestContext { samRequestContext =>
-    requireUserInfo { userInfo =>
+    requireUserInfo(samRequestContext) { userInfo =>
       (pathPrefix("groups" / "v1") | pathPrefix("group")) {
         pathPrefix(Segment) { groupId =>
           val managedGroup = FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, ResourceId(groupId))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext
 /**
   * Created by gpolumbo on 2/20/2018.
   */
-trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives {
+trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
 
   val managedGroupService: ManagedGroupService

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -30,7 +30,7 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 /**
   * Created by mbemis on 5/22/17.
   */
-trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives {
+trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with SamModelDirectives with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
   val resourceService: ResourceService
   val liquibaseConfig: LiquibaseConfig

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -43,7 +43,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
 
   def resourceRoutes: server.Route =
     pathPrefix("initializeResourceTypes") {
-      requireUserInfo { userInfo =>
+      requireUserInfo(SamRequestContext(None)) { userInfo => // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods ; these in particular are unpublished APIs
         asWorkbenchAdmin(userInfo) {
           pathEndOrSingleSlash {
             put {
@@ -54,7 +54,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     } ~
     (pathPrefix("config" / "v1" / "resourceTypes") | pathPrefix("resourceTypes")) {
-        requireUserInfo { userInfo =>
+        requireUserInfo(SamRequestContext(None)) { userInfo => // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods ; these in particular are unpublished APIs
           pathEndOrSingleSlash {
             get {
               complete(resourceService.getResourceTypes().map(typeMap => StatusCodes.OK -> typeMap.values.toSet))
@@ -64,7 +64,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     } ~
     (pathPrefix("resources" / "v1") | pathPrefix("resource")) {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo { userInfo =>
+        requireUserInfo(samRequestContext) { userInfo =>
           pathPrefix(Segment) { resourceTypeName =>
             withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
               pathEndOrSingleSlash {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -1,22 +1,13 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
-import akka.http.scaladsl.server.{Directive1, ExceptionHandler}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives.{onSuccess, _}
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
-import io.opencensus.scala.Tracing
-import io.opencensus.scala.akka.http.TracingDirective.traceRequest
-import io.opencensus.scala.Tracing.startSpanWithParent
-import io.opencensus.scala.akka.http.trace.HttpExtractors._
-import io.opencensus.scala.akka.http.utils.ExecuteAfterResponse
-import io.opencensus.scala.http.{HttpAttributes, StatusTranslator}
-import io.opencensus.trace.{Span, Status}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-
-import scala.util.control.NonFatal
 
 /**
   * Created by gpolumbo on 3/26/2018
@@ -38,77 +29,5 @@ trait SamModelDirectives {
         entity(unmarshaller).flatMap(e => provide(Some(e)))
       }
     }
-
-  /**
-    * Provides a new SamRequestContext with a root tracing span.
-    */
-  def withSamRequestContext: Directive1[SamRequestContext] =
-    traceRequest.map { span => SamRequestContext(Option(span)) }
-
-  /**
-    * Provides a new SamRequestContext with a tracing span that is a child of the existing SamRequestContext's `parentSpan`.
-    *
-    * @param spanName name of the new parentSpan in the new SamRequestContext. This span is a child of the existing parentSpan.
-    * @param samRequestContext the existing samRequestContext.
-    */
-  def withNewTraceSpan(spanName: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
-    samRequestContext.parentSpan match {
-      case Some (parentSpan) =>
-        val newSpan = startSpanWithParent(spanName, parentSpan)
-        val newSamRequestContext = samRequestContext.copy(parentSpan = Option(newSpan))
-        recordSuccess(newSpan) & recordException(newSpan) & provide(newSamRequestContext)
-
-      case None => provide(SamRequestContext(None)) // for contexts without spans, do not start new spans
-    }
-
-  protected def tracing: Tracing = Tracing
-
-  private def recordSuccess(span: Span) =
-    mapResponse(EndSpanResponse.forServer(tracing, _, span))
-
-  private def recordException(span: Span) =
-    handleExceptions(ExceptionHandler {
-      case NonFatal(ex) =>
-        tracing.endSpan(span, Status.INTERNAL)
-        throw ex
-    })
-
-
-  private object EndSpanResponse {
-
-    def forServer(
-                   tracing: Tracing,
-                   response: HttpResponse,
-                   span: Span
-                 ): HttpResponse =
-      end(tracing, response, span, "response sent")
-
-    def forClient(
-                   tracing: Tracing,
-                   response: HttpResponse,
-                   span: Span
-                 ): HttpResponse =
-      end(tracing, response, span, "response received")
-
-    private def end(
-                     tracing: Tracing,
-                     response: HttpResponse,
-                     span: Span,
-                     responseAnnotation: String
-                   ): HttpResponse = {
-      HttpAttributes.setAttributesForResponse(span, response)
-      span.addAnnotation(responseAnnotation)
-      tracing.setStatus(
-        span,
-        StatusTranslator.translate(response.status.intValue())
-      )
-
-      ExecuteAfterResponse.onComplete(
-        response,
-        onFinish = () => tracing.endSpan(span),
-        onFailure = _ => tracing.endSpan(span)
-      )
-    }
-  }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -49,7 +49,7 @@ trait SamModelDirectives {
       case Some (parentSpan) =>
         val newSpan = startSpanWithParent(spanName, parentSpan)
         val newSamRequestContext = samRequestContext.copy(parentSpan = Option(newSpan))
-        provide(newSamRequestContext)
+        recordSuccess(newSpan) & recordException(newSpan) & provide(newSamRequestContext)
 
       case None => provide(SamRequestContext(None)) // for contexts without spans, do not start new spans
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -1,22 +1,15 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
-import akka.http.scaladsl.server.{Directive1, ExceptionHandler}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives.{onSuccess, _}
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
-import io.opencensus.scala.Tracing
 import io.opencensus.scala.akka.http.TracingDirective.traceRequest
-import io.opencensus.scala.Tracing.startSpanWithParent
-import io.opencensus.scala.akka.http.trace.HttpExtractors._
-import io.opencensus.scala.akka.http.utils.ExecuteAfterResponse
-import io.opencensus.scala.http.{HttpAttributes, StatusTranslator}
-import io.opencensus.trace.{Span, Status}
+import io.opencensus.scala.Tracing.{startSpanWithParent}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-
-import scala.util.control.NonFatal
 
 /**
   * Created by gpolumbo on 3/26/2018
@@ -60,55 +53,5 @@ trait SamModelDirectives {
 
       case None => provide(SamRequestContext(None)) // for contexts without spans, do not start new spans
     }
-
-  protected def tracing: Tracing = Tracing
-
-  private def recordSuccess(span: Span) =
-    mapResponse(EndSpanResponse.forServer(tracing, _, span))
-
-  private def recordException(span: Span) =
-    handleExceptions(ExceptionHandler {
-      case NonFatal(ex) =>
-        tracing.endSpan(span, Status.INTERNAL)
-        throw ex
-    })
-
-
-  private object EndSpanResponse {
-
-    def forServer(
-                   tracing: Tracing,
-                   response: HttpResponse,
-                   span: Span
-                 ): HttpResponse =
-      end(tracing, response, span, "response sent")
-
-    def forClient(
-                   tracing: Tracing,
-                   response: HttpResponse,
-                   span: Span
-                 ): HttpResponse =
-      end(tracing, response, span, "response received")
-
-    private def end(
-                     tracing: Tracing,
-                     response: HttpResponse,
-                     span: Span,
-                     responseAnnotation: String
-                   ): HttpResponse = {
-      HttpAttributes.setAttributesForResponse(span, response)
-      span.addAnnotation(responseAnnotation)
-      tracing.setStatus(
-        span,
-        StatusTranslator.translate(response.status.intValue())
-      )
-
-      ExecuteAfterResponse.onComplete(
-        response,
-        onFinish = () => tracing.endSpan(span),
-        onFailure = _ => tracing.endSpan(span)
-      )
-    }
-  }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -47,7 +47,7 @@ trait SamModelDirectives {
   def withNewTraceSpan(spanName: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
     samRequestContext.parentSpan match {
       case Some (parentSpan) =>
-        val newSpan = startSpanWithParent (spanName, parentSpan)
+        val newSpan = startSpanWithParent(spanName, parentSpan)
         val newSamRequestContext = samRequestContext.copy(parentSpan = Option(newSpan))
         provide(newSamRequestContext)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -35,7 +35,7 @@ trait SamModelDirectives {
   /**
     * Provides a new SamRequestContext with a root tracing span.
     */
-  def withSamRequestContext(): Directive1[SamRequestContext] =
+  def withSamRequestContext: Directive1[SamRequestContext] =
     traceRequest.map { span => SamRequestContext(Option(span)) }
 
   /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server._
-import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives.{onSuccess, _}
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
-import io.opencensus.scala.akka.http.TracingDirective._
-import io.opencensus.scala.Tracing._
+import io.opencensus.scala.akka.http.TracingDirective.traceRequest
+import io.opencensus.scala.Tracing.{startSpanWithParent}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
@@ -49,13 +49,7 @@ trait SamModelDirectives {
       case Some (parentSpan) =>
         val newSpan = startSpanWithParent(spanName, parentSpan)
         val newSamRequestContext = samRequestContext.copy(parentSpan = Option(newSpan))
-
-        val recordSuccess = io.opencensus.scala.akka.http.TracingDirective.getClass.getDeclaredMethod("recordSuccess")
-        recordSuccess.setAccessible(true)
-        val recordException = io.opencensus.scala.akka.http.TracingDirective.getClass.getDeclaredMethod("recordException")
-        recordException.setAccessible(true)
-
-        recordSuccess.invoke(newSpan) & recordException.invoke(newSpan) & provide(newSamRequestContext)
+        recordSuccess(newSpan) & recordException(newSpan) & provide(newSamRequestContext)
 
       case None => provide(SamRequestContext(None)) // for contexts without spans, do not start new spans
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -36,6 +36,7 @@ trait SamModelDirectives {
     traceRequest.map { span => SamRequestContext(Option(span)) }
 
   // todo: overload? or check for optional name/samrequestcontext?
+  // todo: rename
   def withParentSamRequestContext(name: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
     samRequestContext.parentSpan match {
       case Some (parentSpan) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives.{onSuccess, _}
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
 import io.opencensus.scala.akka.http.TracingDirective.traceRequest
+import io.opencensus.scala.Tracing.{startSpanWithParent}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
@@ -34,5 +35,16 @@ trait SamModelDirectives {
   def withSamRequestContext: Directive1[SamRequestContext] =
     traceRequest.map { span => SamRequestContext(Option(span)) }
 
+  // todo: overload? or check for optional name/samrequestcontext?
+  def withParentSamRequestContext(name: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
+    samRequestContext.parentSpan match {
+      case Some (parentSpan) =>
+        val newSpan = startSpanWithParent (name, parentSpan)
+        val newSamRequestContext = SamRequestContext(Option(newSpan))
+        provide(newSamRequestContext)
+
+      // todo: should we use name in the new span here?
+      case None => traceRequest.map {span => SamRequestContext(Option(span))}
+    }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -1,15 +1,22 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.{Directive1, ExceptionHandler}
 import akka.http.scaladsl.server.Directives.{onSuccess, _}
 import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
+import io.opencensus.scala.Tracing
 import io.opencensus.scala.akka.http.TracingDirective.traceRequest
-import io.opencensus.scala.Tracing.{startSpanWithParent}
+import io.opencensus.scala.Tracing.startSpanWithParent
+import io.opencensus.scala.akka.http.trace.HttpExtractors._
+import io.opencensus.scala.akka.http.utils.ExecuteAfterResponse
+import io.opencensus.scala.http.{HttpAttributes, StatusTranslator}
+import io.opencensus.trace.{Span, Status}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import scala.util.control.NonFatal
 
 /**
   * Created by gpolumbo on 3/26/2018
@@ -53,5 +60,55 @@ trait SamModelDirectives {
 
       case None => provide(SamRequestContext(None)) // for contexts without spans, do not start new spans
     }
+
+  protected def tracing: Tracing = Tracing
+
+  private def recordSuccess(span: Span) =
+    mapResponse(EndSpanResponse.forServer(tracing, _, span))
+
+  private def recordException(span: Span) =
+    handleExceptions(ExceptionHandler {
+      case NonFatal(ex) =>
+        tracing.endSpan(span, Status.INTERNAL)
+        throw ex
+    })
+
+
+  private object EndSpanResponse {
+
+    def forServer(
+                   tracing: Tracing,
+                   response: HttpResponse,
+                   span: Span
+                 ): HttpResponse =
+      end(tracing, response, span, "response sent")
+
+    def forClient(
+                   tracing: Tracing,
+                   response: HttpResponse,
+                   span: Span
+                 ): HttpResponse =
+      end(tracing, response, span, "response received")
+
+    private def end(
+                     tracing: Tracing,
+                     response: HttpResponse,
+                     span: Span,
+                     responseAnnotation: String
+                   ): HttpResponse = {
+      HttpAttributes.setAttributesForResponse(span, response)
+      span.addAnnotation(responseAnnotation)
+      tracing.setStatus(
+        span,
+        StatusTranslator.translate(response.status.intValue())
+      )
+
+      ExecuteAfterResponse.onComplete(
+        response,
+        onFinish = () => tracing.endSpan(span),
+        onFailure = _ => tracing.endSpan(span)
+      )
+    }
+  }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
@@ -35,7 +35,7 @@ trait SamRequestContextDirectives {
     *                 parentSpan.
     * @param samRequestContext the existing samRequestContext.
     */
-  def withNewTraceSpan(spanName: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
+  def withChildTraceSpan(spanName: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
     samRequestContext.parentSpan match {
       case Some (parentSpan) =>
         val newSpan = startSpanWithParent(spanName, parentSpan)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
@@ -1,0 +1,95 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive1, ExceptionHandler}
+import io.opencensus.scala.Tracing
+import io.opencensus.scala.Tracing.startSpanWithParent
+import io.opencensus.scala.akka.http.TracingDirective.traceRequest
+import io.opencensus.scala.akka.http.trace.HttpExtractors._
+import io.opencensus.scala.akka.http.utils.ExecuteAfterResponse
+import io.opencensus.scala.http.{HttpAttributes, StatusTranslator}
+import io.opencensus.trace.{Span, Status}
+import org.broadinstitute.dsde.workbench.sam.service.UserService
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import scala.util.control.NonFatal
+
+/**
+  * Created by ajang on 2020-05-28
+  */
+trait SamRequestContextDirectives {
+  val userService: UserService
+
+  /**
+    * Provides a new SamRequestContext with a root tracing span.
+    */
+  def withSamRequestContext: Directive1[SamRequestContext] =
+    traceRequest.map { span => SamRequestContext(Option(span)) }
+
+  /**
+    * Provides a new SamRequestContext with a tracing span that is a child of the existing SamRequestContext's
+    * `parentSpan`. If a parentSpan does not exist, this will NOT create a new one.
+    *
+    * @param spanName name of the new parentSpan in the new SamRequestContext. This span is a child of the existing
+    *                 parentSpan.
+    * @param samRequestContext the existing samRequestContext.
+    */
+  def withNewTraceSpan(spanName: String, samRequestContext: SamRequestContext): Directive1[SamRequestContext] =
+    samRequestContext.parentSpan match {
+      case Some (parentSpan) =>
+        val newSpan = startSpanWithParent(spanName, parentSpan)
+        val newSamRequestContext = samRequestContext.copy(parentSpan = Option(newSpan))
+        recordSuccess(newSpan) & recordException(newSpan) & provide(newSamRequestContext)
+      case None => provide(SamRequestContext(None))
+    }
+
+  // The private methods and objects below are copied wholesale from io/opencensus/scala/akka/http/TracingDirective
+  // which seems to be the lesser evil compared to accessing the package's private methods.
+  private def tracing: Tracing = Tracing
+  private def recordSuccess(span: Span) =
+    mapResponse(EndSpanResponse.forServer(tracing, _, span))
+  private def recordException(span: Span) =
+    handleExceptions(ExceptionHandler {
+      case NonFatal(ex) =>
+        tracing.endSpan(span, Status.INTERNAL)
+        throw ex
+    })
+  private object EndSpanResponse {
+
+    def forServer(
+                   tracing: Tracing,
+                   response: HttpResponse,
+                   span: Span
+                 ): HttpResponse =
+      end(tracing, response, span, "response sent")
+
+    def forClient(
+                   tracing: Tracing,
+                   response: HttpResponse,
+                   span: Span
+                 ): HttpResponse =
+      end(tracing, response, span, "response received")
+
+    private def end(
+                     tracing: Tracing,
+                     response: HttpResponse,
+                     span: Span,
+                     responseAnnotation: String
+                   ): HttpResponse = {
+      HttpAttributes.setAttributesForResponse(span, response)
+      span.addAnnotation(responseAnnotation)
+      tracing.setStatus(
+        span,
+        StatusTranslator.translate(response.status.intValue())
+      )
+
+      ExecuteAfterResponse.onComplete(
+        response,
+        onFinish = () => tracing.endSpan(span),
+        onFailure = _ => tracing.endSpan(span)
+      )
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -27,7 +27,7 @@ import DefaultJsonProtocol._
 import WorkbenchIdentityJsonSupport.identityConcentratorIdFormat
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
-trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging with SamModelDirectives {
+trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
   val identityConcentratorService: Option[IdentityConcentratorService] = None
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -43,14 +43,14 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
     * @return
     */
   private def handleAuthHeaders[T](fromJwt: (JwtUserInfo, OAuth2BearerToken, IdentityConcentratorService, SamRequestContext) => Directive1[T], fromOIDC: (OIDCHeaders, SamRequestContext) => Directive1[T], samRequestContext: SamRequestContext): Directive1[T] =
-    withNewTraceSpan("handleAuthHeaders", samRequestContext).flatMap { samRequestContext =>
+    withChildTraceSpan("handleAuthHeaders", samRequestContext).flatMap { samRequestContext =>
       (headerValueByName(authorizationHeader) &
         provide(identityConcentratorService)) tflatMap {
         // order of these cases is important: if the authorization header is a valid jwt we must ignore
         // any OIDC headers otherwise we may be vulnerable to a malicious user specifying a valid JWT
         // but different user information in the OIDC headers
         case (JwtAuthorizationHeader(Success(jwtUserInfo), bearerToken), Some(icService)) =>
-          withNewTraceSpan("JWT-request", samRequestContext).flatMap { samRequestContext =>
+          withChildTraceSpan("JWT-request", samRequestContext).flatMap { samRequestContext =>
             fromJwt(jwtUserInfo, bearerToken, icService, samRequestContext)
           }
 
@@ -63,7 +63,7 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
 
         case _ =>
           // request coming through Apache proxy with OIDC headers
-          withNewTraceSpan("OIDC-request", samRequestContext).flatMap { samRequestContext =>
+          withChildTraceSpan("OIDC-request", samRequestContext).flatMap { samRequestContext =>
             (headerValueByName(accessTokenHeader).as(OAuth2BearerToken) &
               headerValueByName(googleSubjectIdHeader).as(GoogleSubjectId) &
               headerValueByName(expiresInHeader) &

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.directory.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 /**
   * Directives to get user information.
@@ -15,9 +16,9 @@ trait UserInfoDirectives {
   val directoryDAO: DirectoryDAO
   val cloudExtensions: CloudExtensions
 
-  def requireUserInfo: Directive1[UserInfo]
+  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo]
 
-  def requireCreateUser: Directive1[CreateWorkbenchUser]
+  def requireCreateUser(samRequestContext: SamRequestContext): Directive1[CreateWorkbenchUser]
 
   def asWorkbenchAdmin(userInfo: UserInfo): Directive0 =
     Directives.mapInnerRoute { r =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -25,14 +25,14 @@ trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
         pathEndOrSingleSlash {
           post {
             withSamRequestContext { samRequestContext =>
-              requireCreateUser { createUser =>
+              requireCreateUser(samRequestContext) { createUser =>
                 complete {
                   userService.createUser(createUser, samRequestContext).map(userStatus => StatusCodes.Created -> userStatus)
                 }
               }
             }
           } ~ withSamRequestContext { samRequestContext =>
-            requireUserInfo { user =>
+            requireUserInfo(samRequestContext) { user =>
               get {
                 parameter("userDetailsOnly".?) { userDetailsOnly =>
                   complete {
@@ -54,7 +54,7 @@ trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
           pathEndOrSingleSlash {
             post {
               withSamRequestContext { samRequestContext =>
-                requireCreateUser { createUser =>
+                requireCreateUser(samRequestContext) { createUser =>
                   complete {
                     userService.createUser(createUser, samRequestContext).map(userStatus => StatusCodes.Created -> userStatus)
                   }
@@ -62,7 +62,7 @@ trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
               }
             }
           } ~ withSamRequestContext { samRequestContext =>
-            requireUserInfo { user =>
+            requireUserInfo(samRequestContext) { user =>
               path("info") {
                 get {
                   complete {
@@ -98,7 +98,7 @@ trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
   def adminUserRoutes: server.Route =
     pathPrefix("admin") {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo { userInfo =>
+        requireUserInfo(samRequestContext) { userInfo =>
           asWorkbenchAdmin(userInfo) {
             pathPrefix("user") {
               path("email" / Segment) { email =>
@@ -182,7 +182,7 @@ trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
   val apiUserRoutes: server.Route = pathPrefix("users") {
     pathPrefix("v1") {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo { userInfo =>
+        requireUserInfo(samRequestContext) { userInfo =>
           get {
             path(Segment) { email =>
               pathEnd {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext
 /**
   * Created by mbemis on 5/22/17.
   */
-trait UserRoutes extends UserInfoDirectives with SamModelDirectives {
+trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
   val userService: UserService
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -25,7 +25,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
   override def extensionRoutes: server.Route =
     (pathPrefix("google" / "v1") | pathPrefix("google")) {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo { userInfo =>
+        requireUserInfo(samRequestContext) { userInfo =>
           path("petServiceAccount" / Segment / Segment) { (project, userEmail) =>
             get {
               requireAction(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUser}
-import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SamModelDirectives, SecurityDirectives, UserInfoDirectives, ioMarshaller}
+import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SamModelDirectives, SamRequestContextDirectives, SecurityDirectives, UserInfoDirectives, ioMarshaller}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
@@ -17,7 +17,7 @@ import spray.json.JsString
 
 import scala.concurrent.ExecutionContext
 
-trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with SecurityDirectives with SamModelDirectives {
+trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with SecurityDirectives with SamModelDirectives with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
   val googleExtensions: GoogleExtensions
   val googleGroupSynchronizer: GoogleGroupSynchronizer

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 /**
   * Created by dvoet on 6/7/17.
@@ -18,13 +19,13 @@ trait MockUserInfoDirectives extends UserInfoDirectives {
   private def isPetSA(email: String) = {
     petSAdomain.pattern.matcher(email).matches
   }
-  override def requireUserInfo: Directive1[UserInfo] = provide(if(isPetSA(userInfo.userEmail.value)) {
+  override def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo] = provide(if(isPetSA(userInfo.userEmail.value)) {
     new UserInfo(OAuth2BearerToken(""),WorkbenchUserId("newuser"), WorkbenchEmail("newuser@new.com"), userInfo.tokenExpiresIn)
   } else
     userInfo
   )
 
-  override def requireCreateUser: Directive1[CreateWorkbenchUser] = createWorkbenchUser match {
+  override def requireCreateUser(samRequestContext: SamRequestContext): Directive1[CreateWorkbenchUser] = createWorkbenchUser match {
     case None => failWith(new Exception("createWorkbenchUser not specified"))
     case Some(u) => provide(u)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.sam.api.SamRoutes.myExceptionHandler
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
 import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.identityConcentrator.IdentityConcentratorService
-import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, UserService}
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.scalatest.FlatSpec
 import pdi.jwt.JwtSprayJson
@@ -35,6 +35,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
     override val directoryDAO: DirectoryDAO = new MockDirectoryDAO()
     override val cloudExtensions: CloudExtensions = null
     override val identityConcentratorService: Option[IdentityConcentratorService] = Option(mock[IdentityConcentratorService])
+    override val userService: UserService = null
   }
 
   def genAuthorizationHeader(id: Option[IdentityConcentratorId] = None): RawHeader = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-849
Goal: trace auth calls.
Follow on work from Sam tracing work: https://github.com/broadinstitute/sam/pull/421#discussion_r422182607

<Put notes here to help reviewer understand this PR>

This PR includes:
Adds tracing for auth calls
Adds SamRequestContextDirectives
Adds a new directive `withNewTraceSpan` 
Light plumbing

Example trace:
![Screen Shot 2020-05-27 at 7 01 27 PM](https://user-images.githubusercontent.com/5375000/83161264-36241000-a0d6-11ea-94ae-8af524410ba8.png)


---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
