### PR TITLE
[CA-866] prevent googleSubjectIds from being overwritten in Postgres

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -839,7 +839,7 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
                 where ${u.id} = ${userId} and ${u.googleSubjectId} is null"""
 
       if (updateGoogleSubjectIdQuery.update().apply() != 1) {
-        throw new WorkbenchException(s"Cannot overwrite an existing googleSubjectId for user ${userId}")
+        throw new WorkbenchException(s"Cannot update googleSubjectId for user ${userId} because user does not exist or the googleSubjectId has already been set for this user")
       }
     })
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAO.scala
@@ -834,7 +834,13 @@ class PostgresDirectoryDAO(protected val dbRef: DbReference,
   override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] = {
     runInTransaction("setGoogleSubjectId", samRequestContext)({ implicit session =>
       val u = UserTable.column
-      samsql"update ${UserTable.table} set ${u.googleSubjectId} = ${googleSubjectId} where ${u.id} = ${userId}".update().apply()
+      val updateGoogleSubjectIdQuery =
+        samsql"""update ${UserTable.table} set ${u.googleSubjectId} = ${googleSubjectId}
+                where ${u.id} = ${userId} and ${u.googleSubjectId} is null"""
+
+      if (updateGoogleSubjectIdQuery.update().apply() != 1) {
+        throw new WorkbenchException(s"Cannot overwrite an existing googleSubjectId for user ${userId}")
+      }
     })
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -1012,6 +1012,15 @@ class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfte
 
         dao.loadUser(defaultUser.id, samRequestContext).unsafeRunSync().flatMap(_.googleSubjectId) shouldBe Option(newGoogleSubjectId)
       }
+
+      "throw an exception when trying to overwrite an existing googleSubjectId" in {
+        val newGoogleSubjectId = GoogleSubjectId("newGoogleSubjectId")
+        dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
+
+        assertThrows[WorkbenchException] {
+          dao.setGoogleSubjectId(defaultUser.id, newGoogleSubjectId, samRequestContext).unsafeRunSync()
+        }
+      }
     }
 
     "loadSubjectFromEmail" - {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -231,6 +231,18 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
 
   /**
     * GoogleSubjectId    Email
+    *    different        yes     ---> The user's email has already been registered, but the googleSubjectId for the new user is different from what has already been registered. We should throw an exception to prevent the googleSubjectId from being overwritten
+    */
+  it should "throw an exception when trying to re-register a user with a changed googleSubjectId" in {
+    val user = genCreateWorkbenchUser.sample.get.copy(email = genNonPetEmail.sample.get)
+    service.registerUser(user, samRequestContext).unsafeRunSync()
+    assertThrows[WorkbenchException] {
+      service.registerUser(user.copy(googleSubjectId = GoogleSubjectId("newGoogleSubjectId")), samRequestContext).unsafeRunSync()
+    }
+  }
+
+  /**
+    * GoogleSubjectId    Email
     *      yes            skip    ---> User exists. Do nothing.
     */
   it should "return conflict when there's an existing subject for a given googleSubjectId" in{


### PR DESCRIPTION
Ticket: [CA-866](https://broadworkbench.atlassian.net/browse/CA-866)
OpenDJ already prevents us from overwriting an existing GoogleSubjectId, so this PR changes Postgres to do the same thing as OpenDJ and also prevent existing GoogleSubjectIds from being overwritten. See the ticket for a description of what can happen when this situation arises and Postgres _doesn't_ prevent the overwrite.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
