### PR TITLE
[CA-921][CA-931] Add support for parent resources

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -7,5 +7,6 @@
     <include file="changesets/20191114_cascade_delete_user_membership.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20200212_identity_concentrator_id.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20200424_add_sam_resource_policy_group_id_index.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20200714_resource_parent_id.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20200714_resource_parent_id.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20200714_resource_parent_id.xml
@@ -6,7 +6,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <changeSet logicalFilePath="dummy" author="mtalbott" id="add_resource_parent_id">
-        <addColumn tableName="sam_user">
+        <addColumn tableName="sam_resource">
             <column name="resource_parent_id" type="BIGINT">
                 <constraints nullable="true" foreignKeyName="FK_SR_RESOURCE_PARENT" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
             </column>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20200714_resource_parent_id.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20200714_resource_parent_id.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="mtalbott" id="add_resource_parent_id">
+        <addColumn tableName="sam_user">
+            <column name="resource_parent_id" type="BIGINT">
+                <constraints nullable="true" foreignKeyName="FK_SR_RESOURCE_PARENT" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1631,7 +1631,7 @@ paths:
           content:
             application/json:
               schema:
-                type: '#/components/schemas/FullyQualifiedResourceId'
+                $ref: '#/components/schemas/FullyQualifiedResourceId'
         403:
           description: You do not have permission to get the parent for this resource
           content: {}
@@ -2045,6 +2045,7 @@ components:
         resourceId:
           type: string
           description: The id of the resource
+      description: type and id of a resource
     ManagedGroupMembershipEntry:
       required:
         - groupEmail

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1606,6 +1606,121 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/resources/v2/{resourceTypeName}/{resourceId}/parent:
+    get:
+      tags:
+        - Resources
+      summary: Get the parent of a resource if one exists
+      operationId: getResourceParent
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource to query
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource to query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Id and type of parent resource
+          content:
+            application/json:
+              schema:
+                type: '#/components/schemas/FullyQualifiedResourceId'
+        403:
+          description: You do not have permission to get the parent for this resource
+          content: {}
+        404:
+          description: You do not have access to this resource, it does not exist, or it does not have a parent resource
+          content: {}
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    put:
+      tags:
+        - Resources
+      summary: Set the parent of a resource
+      operationId: setResourceParent
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of child resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of child resource
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The details of the new parent resource
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/FullyQualifiedResourceId'
+      responses:
+        204:
+          description: Resource parent successfully set
+          content: {}
+        400:
+          description: Child resource has an auth domain or new parent would introduce cyclical resource hierarchy
+          content: {}
+        403:
+          description: You do not have permission to set the parent for the child resource, to remove the child of the current parent, or to add a child to the new parent
+          content: {}
+        404:
+          description: You do not have access to the child, new parent, or current resource, or they do not exist
+          content: {}
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    delete:
+      tags:
+        - Resources
+      summary: Delete the parent of a resource
+      operationId: deleteResourceParent
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource to remove parent from
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource to remove parent from
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Resource parent successfully removed
+          content: {}
+        403:
+          description: You do not have permission to set the parent for the child resource or to remove the child of the current parent
+          content: {}
+        404:
+          description: You do not have access to this resource, it does not exist, or it does not currently have a parent resource
+          content: {}
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/users/v1/{email}:
     get:
       tags:
@@ -1918,6 +2033,18 @@ components:
           items:
             $ref: '#/components/schemas/StackTraceElement'
       description: ""
+    FullyQualifiedResourceId:
+      required:
+        - resourceTypeName
+        - resourceId
+      type: object
+      properties:
+        resourceTypeName:
+          type: string
+          description: The type of the resource
+        resourceId:
+          type: string
+          description: The id of the resource
     ManagedGroupMembershipEntry:
       required:
         - groupEmail

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
-import akka.http.scaladsl.server.{Directive1, Route}
+import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
@@ -340,7 +340,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  private def setResourceParentInternal(resource: FullyQualifiedResourceId, newResourceParent: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): Route = {
+  private def setResourceParentInternal(resource: FullyQualifiedResourceId, newResourceParent: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route = {
     requireAction(newResourceParent, SamResourceActions.addChild, userInfo.userId, samRequestContext) {
       requireAction(resource, SamResourceActions.setParent, userInfo.userId, samRequestContext) {
         complete(resourceService.setResourceParent(resource, newResourceParent, samRequestContext).map(_ => StatusCodes.NoContent))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
@@ -8,7 +8,8 @@ import scalikejdbc._
 final case class ResourcePK(value: Long) extends DatabaseKey
 final case class ResourceRecord(id: ResourcePK,
                                 name: ResourceId,
-                                resourceTypeId: ResourceTypePK)
+                                resourceTypeId: ResourceTypePK,
+                                resourceParentId: Option[ResourcePK])
 
 object ResourceTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRecord] {
   override def tableName: String = "SAM_RESOURCE"
@@ -17,7 +18,8 @@ object ResourceTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRecord] {
   def apply(e: ResultName[ResourceRecord])(rs: WrappedResultSet): ResourceRecord = ResourceRecord(
     rs.get(e.id),
     rs.get(e.name),
-    rs.get(e.resourceTypeId)
+    rs.get(e.resourceTypeId),
+    rs.longOpt(e.resourceParentId).map(ResourcePK)
   )
 
   def loadResourcePK(resource: FullyQualifiedResourceId): SQLSyntax = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -78,6 +78,10 @@ object SamResourceActions {
   val setPublic = ResourceAction("set_public")
   val readAuthDomain = ResourceAction("read_auth_domain")
   val testAnyActionAccess = ResourceAction("test_any_action_access")
+  val getParent = ResourceAction("get_parent")
+  val setParent = ResourceAction("set_parent")
+  val addChild = ResourceAction("add_child")
+  val removeChild = ResourceAction("remove_child")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -32,6 +32,10 @@ trait AccessPolicyDAO {
   def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[AccessPolicyWithoutMembers]]
   def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[WorkbenchUser]]
   def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean, samRequestContext: SamRequestContext): IO[Unit]
+
+  def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]]
+  def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
+  def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
 }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -828,7 +828,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
                 union
                 select ${pr.resourceParentId}, true
                 from ${ResourceTable as pr}
-                join ${ancestorResourceTable as ar} on ${arColumn.resourceParentId} = ${pr.id}
+                join ${ancestorResourceTable as ar} on ${ar.resourceParentId} = ${pr.id}
                 where ${pr.resourceParentId} is not null
       ) update ${ResourceTable as r}
         set ${resourceTableColumn.resourceParentId} =
@@ -842,8 +842,8 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
         and ${r.name} = ${childResource.resourceId}
         and ${rt.name} = ${childResource.resourceTypeName}
         and (${r.id}, true) not in
-            ( select ${arColumn.resourceParentId}, ${arColumn.isAncestor}
-            from ${ancestorResourceTable} )"""
+            ( select ${ar.resourceParentId}, ${ar.isAncestor}
+            from ${ancestorResourceTable as ar} )"""
 
     runInTransaction("setResourceParent", samRequestContext)({ implicit session =>
       if (query.update.apply() != 1) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -807,6 +807,9 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     })
   }
 
+  /** We need to make sure that we aren't introducing any cyclical resource hierarchies, so when we try to set the
+    * parent of a resource, we first lookup all of the ancestors of the potential new parent to make sure that the
+    * new child resource is not already an ancestor of the new parent */
   override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
     val ancestorResourceTable = AncestorResourceTable("ancestor_resource")
     val ar = ancestorResourceTable.syntax("ar")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -807,7 +807,52 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     })
   }
 
-  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
+  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
+    val ancestorResourceTable = AncestorResourceTable("ancestor_resource")
+    val ar = ancestorResourceTable.syntax("ar")
+    val arColumn = ancestorResourceTable.column
+
+    val r = ResourceTable.syntax("r")
+    val rt = ResourceTypeTable.syntax("rt")
+    val pr = ResourceTable.syntax("pr")
+    val prt = ResourceTypeTable.syntax("prt")
+    val resourceTableColumn = ResourceTable.column
+
+    val query =
+      samsql"""with recursive ${ancestorResourceTable.table}(${arColumn.resourceParentId}, ${arColumn.isAncestor}) as (
+                select ${r.id}, false
+                from ${ResourceTable as r}
+                join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+                where ${r.name} = ${parentResource.resourceId}
+                and ${rt.name} = ${parentResource.resourceTypeName}
+                union
+                select ${pr.resourceParentId}, true
+                from ${ResourceTable as pr}
+                join ${ancestorResourceTable as ar} on ${arColumn.resourceParentId} = ${pr.id}
+                where ${pr.resourceParentId} is not null
+      ) update ${ResourceTable as r}
+        set ${resourceTableColumn.resourceParentId} =
+            ( select ${pr.id}
+              from ${ResourceTable as pr}
+              join ${ResourceTypeTable as prt} on ${prt.id} = ${pr.resourceTypeId}
+              where ${pr.name} = ${parentResource.resourceId}
+              and ${prt.name} = ${parentResource.resourceTypeName} )
+        from ${ResourceTypeTable as rt}
+        where ${rt.id} = ${r.resourceTypeId}
+        and ${r.name} = ${childResource.resourceId}
+        and ${rt.name} = ${childResource.resourceTypeName}
+        and (${r.id}, true) not in
+            ( select ${arColumn.resourceParentId}, ${arColumn.isAncestor}
+            from ${ancestorResourceTable} )"""
+
+    runInTransaction("setResourceParent", samRequestContext)({ implicit session =>
+      if (query.update.apply() != 1) {
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Cannot set parent as this would introduce a cyclical resource hierarchy")
+        )
+      }
+    })
+  }
 
   override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
     val r = ResourceTable.syntax("r")
@@ -845,3 +890,11 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 }
 
 private final case class PolicyInfo(name: AccessPolicyName, resourceId: ResourceId, resourceTypeName: ResourceTypeName, email: WorkbenchEmail, public: Boolean)
+
+// these 2 case classes represent the logical table used in recursive ancestor resource queries
+// this table does not actually exist but looks like a table in a WITH RECURSIVE query
+final case class AncestorResourceRecord(resourceParentId: ResourcePK, isAncestor: Boolean)
+final case class AncestorResourceTable(override val tableName: String) extends SQLSyntaxSupport[AncestorResourceRecord] {
+  // need to specify column names explicitly because this table does not actually exist in the database
+  override val columnNames: Seq[String] = Seq("resource_parent_id", "is_ancestor")
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -483,7 +483,6 @@ class ResourceService(
     accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
   }
 
-  // need to determine if this would introduce a cycle
   def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId,  samRequestContext: SamRequestContext): IO[Unit] = {
     for {
       authDomain <- accessPolicyDAO.loadResourceAuthDomain(childResource, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -478,4 +478,16 @@ class ResourceService(
     } yield {
       workbenchUsers.map(user => UserIdInfo(user.id, user.email, user.googleSubjectId))
     }
+
+  def getResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = {
+    accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
+  }
+
+  // need to determine if this would introduce a cycle OR if the resource has an auth domain
+  def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId,  samRequestContext: SamRequestContext): IO[Unit] = ???
+
+  def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
+    accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -483,6 +483,9 @@ class ResourceService(
     accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
   }
 
+  /** In this iteration of hierarchical resources, we do not allow child resources to be in an auth domain because it
+    * would introduce additional complications when keeping Sam policies with their Google Groups. For more details,
+    * see https://docs.google.com/document/d/10qGxsV9BeM6-N_Zk27_JIayE509B8LUQBGiGrqB0taY/edit#heading=h.dxz6xjtnz9la */
   def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId,  samRequestContext: SamRequestContext): IO[Unit] = {
     for {
       authDomain <- accessPolicyDAO.loadResourceAuthDomain(childResource, samRequestContext)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -158,7 +158,6 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  // this one feels a bit like it's testing the security directives not the route itself but whatever
   it should "404 if user doesn't have access to resource" in {
     val fullyQualifiedChildResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
     val samRoutes = createSamRoutes()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -1,0 +1,588 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.TestSupport.genGoogleSubjectId
+import org.broadinstitute.dsde.workbench.sam.directory.MockDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.service._
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+
+
+class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
+
+  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+
+  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo) = {
+    val accessPolicyDAO = new MockAccessPolicyDAO()
+    val directoryDAO = new MockDirectoryDAO()
+    val registrationDAO = new MockDirectoryDAO()
+    val emailDomain = "example.com"
+
+    val policyEvaluatorService = mock[PolicyEvaluatorService]
+    val mockResourceService = mock[ResourceService]
+    resourceTypes.map { case (resourceTypeName, resourceType) =>
+      when(mockResourceService.getResourceType(resourceTypeName)).thenReturn(IO(Option(resourceType)))
+    }
+    val mockUserService = new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty)
+    val mockStatusService = new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef)
+    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
+
+    mockUserService.createUser(CreateWorkbenchUser(defaultUserInfo.userId, genGoogleSubjectId(), defaultUserInfo.userEmail, None), samRequestContext)
+
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO)
+  }
+
+  private def setupRoutesTest(samRoutes: SamRoutes,
+                              childResource: FullyQualifiedResourceId,
+                              currentParentOpt: Option[FullyQualifiedResourceId] = None,
+                              newParentOpt: Option[FullyQualifiedResourceId] = None,
+                              actionsOnChild: Set[ResourceAction] = Set.empty,
+                              actionsOnCurrentParent: Set[ResourceAction] = Set.empty,
+                              actionsOnNewParent: Set[ResourceAction] = Set.empty,
+                              missingActionsOnChild: Set[ResourceAction] = Set.empty,
+                              missingActionsOnCurrentParent: Set[ResourceAction] = Set.empty,
+                              missingActionsOnNewParent: Set[ResourceAction] = Set.empty,
+                              accessToChild: Boolean = true,
+                              accessToCurrentParent: Boolean = true,
+                              accessToNewParent: Boolean = true): Unit = {
+    val otherPolicy = AccessPolicyWithoutMembers(FullyQualifiedPolicyId(childResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false)
+
+    actionsOnChild.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(childResource), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true)))
+    missingActionsOnChild.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(childResource), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false)))
+    if (accessToChild) {
+      when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(childResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+        .thenReturn(IO(Set(otherPolicy)))
+    }
+
+    currentParentOpt match {
+      case Some(currentParent) =>
+        when(samRoutes.resourceService.getResourceParent(mockitoEq(childResource), any[SamRequestContext]))
+          .thenReturn(IO(Option(currentParent)))
+        actionsOnCurrentParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+          .thenReturn(IO(true)))
+        missingActionsOnCurrentParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+          .thenReturn(IO(false)))
+        if (accessToCurrentParent) {
+          when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(currentParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+            .thenReturn(IO(Set(otherPolicy)))
+        }
+      case None =>
+        when(samRoutes.resourceService.getResourceParent(mockitoEq(childResource), any[SamRequestContext]))
+          .thenReturn(IO(None))
+    }
+
+    newParentOpt.map { newParent =>
+      actionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+        .thenReturn(IO(true)))
+      missingActionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+        .thenReturn(IO(false)))
+      if (accessToNewParent) {
+        when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+          .thenReturn(IO(Set(otherPolicy)))
+      }
+    }
+  }
+
+  "GET /api/resources/v2/{resourceTypeName}/{resourceId}/parent" should "200 if user has get_parent on resource and resource has parent" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val fullyQualifiedParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("parent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(fullyQualifiedParentResource)))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.getParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+
+    Get(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[FullyQualifiedResourceId] shouldEqual fullyQualifiedParentResource
+    }
+  }
+
+  it should "403 if user is missing get_parent on resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val fullyQualifiedParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("parent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(fullyQualifiedParentResource)))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.getParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+    Get(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 if resource has no parent" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(None))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.getParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+
+    Get(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  // this one feels a bit like it's testing the security directives not the route itself but whatever
+  it should "404 if user doesn't have access to resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.getParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+    Get(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "PUT /api/resources/v2/{resourceTypeName}/{resourceId}/parent" should "204 on success when there is not a parent already set" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val fullyQualifiedParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("parent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(fullyQualifiedParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(None))
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", fullyQualifiedParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "204 on success when there is a parent already set" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  // test in ResourceService?
+  ignore should "400 if child resource has an auth domain" in {}
+
+  // test in PostgresAccessPolicyDAO?
+  ignore should "400 if adding parent would introduce a cyclical resource hierarchy" in {}
+
+  it should "403 if user is missing set_parent on child resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "403 if user is missing add_child on new parent resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "403 if user is missing remove_child on existing parent resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(currentParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 if user doesn't have access to child resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 if user doesn't have access to new parent resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 if user doesn't have access to existing parent resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val newParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("newParent"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.setResourceParent(mockitoEq(fullyQualifiedChildResource), mockitoEq(newParentResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParentResource), mockitoEq(SamResourceActions.addChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(currentParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+
+    Put(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  "DELETE /api/resources/v2/{resourceTypeName}/{resourceId}/parent" should "204 on success" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+  }
+
+  it should "403 if user is missing set_parent on child resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "403 if user is missing remove_child on parent resource if it exists" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(currentParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set(AccessPolicyWithoutMembers(FullyQualifiedPolicyId(fullyQualifiedChildResource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false))))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 if resource has no parent" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(None))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 if user doesn't have access to child resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(fullyQualifiedChildResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 if user doesn't have access to existing parent resource" in {
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set.empty,
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.getParent))),
+      ResourceRoleName("owner")
+    )
+    val fullyQualifiedChildResource = FullyQualifiedResourceId(resourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
+
+    when(samRoutes.resourceService.deleteResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(fullyQualifiedChildResource), mockitoEq(SamResourceActions.setParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(true))
+    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(currentParentResource), mockitoEq(SamResourceActions.removeChild), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(samRoutes.resourceService.getResourceParent(mockitoEq(fullyQualifiedChildResource), any[SamRequestContext]))
+      .thenReturn(IO(Option(currentParentResource)))
+    when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(currentParentResource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+      .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+
+    Delete(s"/api/resources/v2/${resourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -204,12 +204,6 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  // test in ResourceService?
-  ignore should "400 if child resource has an auth domain" in {}
-
-  // test in PostgresAccessPolicyDAO?
-  ignore should "400 if adding parent would introduce a cyclical resource hierarchy" in {}
-
   it should "403 if user is missing set_parent on child resource" in {
     val fullyQualifiedChildResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
     val newParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("newParent"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -146,4 +146,8 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
       }.toStream
     )
   }
+
+  override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = ???
+  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
+  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -147,29 +147,9 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     )
   }
 
-  // Each resource has a list of
-  val resourceParents = TrieMap[FullyQualifiedResourceId, FullyQualifiedResourceId]()
+  override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = IO(None)
 
-  override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = IO.pure(resourceParents.get(resource))
+  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
-  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
-    if (createsCycle(childResource, parentResource)) {
-      throw new WorkbenchExceptionWithErrorReport(
-        ErrorReport(StatusCodes.BadRequest, "Cannot set parent as this would introduce a cyclical resource hierarchy")
-      )
-    } else {
-      resourceParents += childResource -> parentResource
-    }
-  }
-
-  private def createsCycle(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId): Boolean = {
-    resourceParents.get(parentResource) match {
-      case Some(grandparentResource) => childResource == grandparentResource || createsCycle(childResource, grandparentResource)
-      case None => false
-    }
-  }
-
-  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
-    resourceParents -= resource
-  }
+  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 }


### PR DESCRIPTION
Ticket: [CA-921](https://broadworkbench.atlassian.net/browse/CA-921), [CA-931](https://broadworkbench.atlassian.net/browse/CA-931)
Add 3 endpoints to get, set and remove the parent of a resource. There is now a nullable `resource_parent_id` column on the `sam_resource` table which can be accessed by these endpoints.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
