### PR TITLE
IA-2051 Add actions to kubernetes-application resource type

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -364,14 +364,20 @@ resourceTypes = {
       update = {
         description = "update kubernetes application"
       }
+      status = {
+        description = "view details and configuration of the kubernetes application"
+      }
+      read_policies = {
+        description = "view all policies and policy details for the kubernetes application"
+      }
     }
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["delete", "connect", "update"]
+        roleActions = ["delete", "connect", "update", "status", "read_policies"]
       }
       manager = {
-        roleActions = ["delete"]
+        roleActions = ["delete", "status", "read_policies"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-2051

Added a couple more actions to the `kubernetes-app` resource type:
- `status`: lets you view details about an app, but not actually connect to it. Leo checks this for the `getApp` endpoint. Granted to app creators and managers.
- `read_policies`: I don't think this is actually needed for Leo, but it was useful for me while testing this stuff.

By the way, the approach of having `creator` and `manager` policies at the resource level is working well: it results in cleaner Leo code and fewer Sam calls (don't need to always check things at the resource _and_ project levels). I think I'd like to migrate runtimes and disks to use this approach in the future, but I expect it will require some kind of Sam migration.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
