### PR TITLE
[QA-723] add sleep between creating pet and adding it to user proxy group

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -319,6 +319,7 @@ class GoogleExtensions(
           for {
             _ <- assertProjectInTerraOrg(project)
             sa <- IO.fromFuture(IO(googleIamDAO.createServiceAccount(project, petSaName, petSaDisplayName)))
+            _ <- IO.sleep(30 seconds)(IO.timer(executionContext))
             r <- IO.fromFuture(IO(withProxyEmail(user.id) { proxyEmail =>
               googleDirectoryDAO.addMemberToGroup(proxyEmail, sa.email)
             }))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
   * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
 class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
-  implicit val timeout = RouteTestTimeout(5 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
+  implicit val timeout = RouteTestTimeout(31 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
 
   "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user" in {
     val (user, _, routes) = createTestUser()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -3,6 +3,7 @@ package google
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.RouteTestTimeout
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
@@ -11,10 +12,14 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.duration._
+
 /**
   * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
-class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
+class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with ScalaFutures {
+  implicit val timeout = RouteTestTimeout(31 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
+
   "GET /api/google/v1/user/petServiceAccount" should "get or create a pet service account for a user" in {
     val (user, _, routes) = createTestUser()
 


### PR DESCRIPTION
Ticket: [QA-723](https://broadworkbench.atlassian.net/browse/QA-723)
Google support provided this potential explanation of why we are seeing such slow permission propagation time
>What we suspect might have happened is that the Directory API created a separate, "unclaimed id" while trying to create membership for the SA inside the proxy group instead of using the ID that was created during SA creation. For these specific scenario, the account will be in limbo state while the membership get migrated over to the correct id and as such any IAM policy checks will fail  when trying to access any GCP resource (i.e. GCS, BQ, etc...) which may explain the long delay you were experiencing. 

To avoid this situation, this change adds a _long_ sleep between creating the pet and adding it to the user's proxy group. If this seems to be effective, we can test shortening the sleep to see just how short of a duration we can cut it to without sacrificing efficacy.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
