### PR TITLE
[CA-526] remove some sleeps that got missed when removing the shadow dao

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
-import scala.concurrent.duration._
 
 /**
   * Created by mbemis on 5/22/17.
@@ -56,17 +55,9 @@ class ResourceService(
           // make sure resource type admin is added first because the rest depends on it
           createdAdminType <- createResourceType(resourceTypeAdmin, samRequestContext)
 
-          // sleep added so shadow dao can catch up, remove when removing opendj
-          // https://broadworkbench.atlassian.net/browse/CA-526
-          _ <- IO.sleep(1 second)(IO.timer(executionContext))
-
           result <- resourceTypes.values.filterNot(_.name == SamResourceTypes.resourceTypeAdminName).toList.traverse { rt =>
             for {
               _ <- createResourceType(rt, samRequestContext)
-
-              // sleep added so shadow dao can catch up, remove when removing opendj
-              // https://broadworkbench.atlassian.net/browse/CA-526
-              _ <- IO.sleep(1 second)(IO.timer(executionContext))
 
               policy = ValidatableAccessPolicy(
                 AccessPolicyName(resourceTypeAdmin.ownerRoleName.value),


### PR DESCRIPTION
Ticket: [CA-526](https://broadworkbench.atlassian.net/browse/CA-526)
This ticket was done a while ago, but while I was adding sleeps, I found these leftover sleeps in ResourceService with comments saying that they should be removed

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
