### PR TITLE
[QA-723] 4 second sleep in case 2 is too short

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -323,7 +323,7 @@ class GoogleExtensions(
             // newly created service account which leads to slow permission propagation.
             // See https://broadworkbench.atlassian.net/browse/QA-723 for details
             // TODO: remove sleep when Google fix exists - see https://broadworkbench.atlassian.net/browse/CA-1005
-            _ <- IO.sleep(2 seconds)(IO.timer(executionContext))
+            _ <- IO.sleep(4 seconds)(IO.timer(executionContext))
             r <- IO.fromFuture(IO(withProxyEmail(user.id) { proxyEmail =>
               googleDirectoryDAO.addMemberToGroup(proxyEmail, sa.email)
             }))


### PR DESCRIPTION
Ticket: [QA-723](https://broadworkbench.atlassian.net/browse/QA-723)
We added this sleep in [this PR](https://github.com/broadinstitute/sam/pull/451), but are still seeing ~10% failure rate. We need a pass rate >90% to release, so after a night of test runs, it seems that 2 seconds puts us right on the edge of being able to release. If we see the current 10% failure rate increase at all, we want to be able to go more conservative with the sleep duration so that we can release. That's where this PR comes in. 

By bumping the sleep duration up to 4 seconds, we decrease the odds of hitting the Google race condition and improve our chances of releasing next week. If we see more `bucket did not become readable` failures today (8/21/20), then I will merge this PR in the hopes that our automation pass rate climbs above 90% over the weekend and we can release next week. If we don't see any `bucket did not become readable` failures today, then we will let the current code run over the weekend in the hopes that we remain at a pass rate >90% and can still release without increasing the duration of the sleep.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
