### PR TITLE
No ticket - Hopeful fix for "key not found" error in tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -85,9 +85,6 @@ class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaF
       registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
       Sam.user.status()(tempAuthToken).get.userInfo.userEmail shouldBe tempUser.email
 
-      removeUser(tempUserInfo.userSubjectId)
-      Sam.user.status()(tempAuthToken) shouldBe None
-
       // OK to re-remove
 
       removeUser(tempUserInfo.userSubjectId)


### PR DESCRIPTION
tests were failing with message "Key not found" when trying to cleanup a user in Thurloe after running tests.  Looking at the test, it looks like there was identical duplicated code to remove the user from thurloe and assert its removal.  Seems like it was an accident so I removed the duplicate code.

The other thing we could look at is modifying Workbench-libs to just report a success if it tries to delete a key from thurloe and it gets back a 404.  