### PR TITLE
[DDO-641] Fix swatomation pipeline breakage by removing JVM flag that disables SNI extension

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -5,7 +5,7 @@ echo $SBT_CMD
 
 set -o pipefail
 
-sbt -Djsse.enableSNIExtension=false -Dheadless=true "${SBT_CMD}"
+sbt -Dheadless=true "${SBT_CMD}"
 TEST_EXIT_CODE=$?
 sbt clean
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-641

Details in the ticket, but in short, this flag is breaking the swatomation pipeline. Removing it fixes the build so that Sam's tests actually run: https://fc-jenkins.dsp-techops.broadinstitute.org/job/sam-fiab-test-runner/24150/ 

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
