### PR TITLE
[CA-930] Don't delete resources with children

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1720,10 +1720,10 @@ paths:
           description: Child resource has an auth domain or new parent would introduce cyclical resource hierarchy
           content: {}
         403:
-          description: You do not have permission to set the parent for the child resource, to remove the child of the current parent, or to add a child to the new parent
+          description: You do not have permission to set the parent for the child resource, to remove the child of the current parent, to add a child to the new parent, or the new parent does not exist
           content: {}
         404:
-          description: You do not have access to the child, new parent, or current resource, or they do not exist
+          description: You do not have access to this resource, it does not exist
           content: {}
         500:
           description: Internal Server Error
@@ -1754,7 +1754,7 @@ paths:
           description: Resource parent successfully removed
           content: {}
         403:
-          description: You do not have permission to set the parent for the child resource or to remove the child of the current parent
+          description: You do not have permission to set the parent for the this resource or to remove this resource of its current parent
           content: {}
         404:
           description: You do not have access to this resource, it does not exist, or it does not currently have a parent resource

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1723,7 +1723,7 @@ paths:
           description: You do not have permission to set the parent for the child resource, to remove the child of the current parent, to add a child to the new parent, or the new parent does not exist
           content: {}
         404:
-          description: You do not have access to this resource, it does not exist
+          description: You do not have access to this resource, or it does not exist
           content: {}
         500:
           description: Internal Server Error
@@ -1754,7 +1754,7 @@ paths:
           description: Resource parent successfully removed
           content: {}
         403:
-          description: You do not have permission to set the parent for the this resource or to remove this resource of its current parent
+          description: You do not have permission to set the parent for this resource or to remove this (child) resource from its current parent
           content: {}
         404:
           description: You do not have access to this resource, it does not exist, or it does not currently have a parent resource

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -970,8 +970,11 @@ paths:
         204:
           description: Successfully deleted resource
           content: {}
+        400:
+          description: Cannot delete a resource with children. Delete the children first then try again.
+          content: {}
         403:
-          description: You do not have permission to perform this action on the resource
+          description: You do not have permission to perform this action on the resource or permissions on the resource's parent
           content: {}
         404:
           description: Resource type does not exist or you are not a member of any

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -137,7 +137,9 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
             withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
               pathPrefix(Segment) { resourceId =>
                 val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
-                path("parent") {
+                pathEndOrSingleSlash {
+                  deleteResourceV2(resource, userInfo, samRequestContext)
+                } ~ path("parent") {
                   getResourceParent(resource, userInfo, samRequestContext) ~
                   setResourceParent(resource, userInfo, samRequestContext) ~
                   deleteResourceParent(resource, userInfo, samRequestContext)
@@ -185,6 +187,11 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     }
 
   def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+    delete {
+      deleteResourceInternal(resource, userInfo, samRequestContext)
+    }
+
+  def deleteResourceV2(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     delete {
       withCurrentParentOption(resource, samRequestContext) {
         case Some(currentResourceParent) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -195,6 +195,11 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
+  def deleteResourceInternal(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext) =
+    requireAction(resource, SamResourceActions.delete, userInfo.userId, samRequestContext) {
+      complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
+    }
+
   def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     post {
       complete(resourceService.createResource(resourceType, resource.resourceId, userInfo, samRequestContext).map(_ => StatusCodes.NoContent))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -137,9 +137,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
             withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
               pathPrefix(Segment) { resourceId =>
                 val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
-                pathEndOrSingleSlash {
-                  deleteResourceV2(resource, userInfo, samRequestContext)
-                } ~ path("parent") {
+                path("parent") {
                   getResourceParent(resource, userInfo, samRequestContext) ~
                   setResourceParent(resource, userInfo, samRequestContext) ~
                   deleteResourceParent(resource, userInfo, samRequestContext)
@@ -187,11 +185,6 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     }
 
   def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
-    delete {
-      deleteResourceInternal(resource, userInfo, samRequestContext)
-    }
-
-  def deleteResourceV2(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     delete {
       withCurrentParentOption(resource, samRequestContext) {
         case Some(currentResourceParent) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -186,8 +186,12 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
 
   def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     delete {
-      requireAction(resource, SamResourceActions.delete, userInfo.userId, samRequestContext) {
-        complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
+      withCurrentParentOption(resource, samRequestContext) {
+        case Some(currentResourceParent) =>
+          requireAction(currentResourceParent, SamResourceActions.removeChild, userInfo.userId, samRequestContext) {
+            deleteResourceInternal(resource, userInfo, samRequestContext)
+          }
+        case None => deleteResourceInternal(resource, userInfo, samRequestContext)
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -69,8 +69,6 @@ trait SecurityDirectives {
     * a Not Found (you have no access) vs a Forbidden (you have access, just not the right kind)
     */
   private def determineErrorMessage(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, forbiddenErrorMessage: String, samRequestContext: SamRequestContext) = {
-    // in the case where we don't have the required action, we need to figure out if we should return
-    // a Not Found (you have no access) vs a Forbidden (you have access, just not the right kind)
     onSuccess(policyEvaluatorService.listResourceAccessPoliciesForUser(resource, userId, samRequestContext)) { policies =>
       if (policies.isEmpty) {
         Directives.failWith(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -3,20 +3,50 @@ package org.broadinstitute.dsde.workbench.sam.api
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.onSuccess
 import akka.http.scaladsl.server.{Directive0, Directives}
+import cats.effect.IO
+import cats.implicits._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction}
-import org.broadinstitute.dsde.workbench.sam.service.PolicyEvaluatorService
-import ImplicitConversions.ioOnSuccessMagnet
-import cats.implicits._
-import cats.effect.IO
+import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 trait SecurityDirectives {
   def policyEvaluatorService: PolicyEvaluatorService
+  def resourceService: ResourceService
 
   def requireAction(resource: FullyQualifiedResourceId, action: ResourceAction, userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 =
     requireOneOfAction(resource, Set(action), userId, samRequestContext)
+
+  /**
+    * see requireOneOfParentAction
+    */
+  def requireParentAction(resource: FullyQualifiedResourceId, newParent: Option[FullyQualifiedResourceId], parentAction: ResourceAction, userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 =
+    requireOneOfParentAction(resource, newParent, Set(parentAction), userId, samRequestContext)
+
+  /**
+    * Ensures the user has one of parentActions on the parent of childResource. Passes if no parent exists.
+    *
+    * @param childResource the child resource
+    * @param newParent if this is None this function will check permissions on the current parent of childResource,
+    *                  if this is Some this function will check permissions on the specified resource
+    * @param parentActions the actions to check for
+    * @param userId
+    * @param samRequestContext
+    * @return
+    */
+  def requireOneOfParentAction(childResource: FullyQualifiedResourceId, newParent: Option[FullyQualifiedResourceId], parentActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 =
+    Directives.mapInnerRoute { innerRoute =>
+      onSuccess(hasParentPermissionOneOf(childResource, newParent, parentActions, userId, samRequestContext)) { hasPermission =>
+        if (hasPermission) {
+          innerRoute
+        } else {
+          val forbiddenErrorMessage = s"You may not perform any of ${parentActions.mkString("[", ", ", "]").toUpperCase} on parent of ${childResource.resourceTypeName.value}/${childResource.resourceId.value}"
+          determineErrorMessage(childResource, userId, forbiddenErrorMessage, samRequestContext)
+        }
+      }
+    }
 
   def requireOneOfAction(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 =
     Directives.mapInnerRoute { innerRoute =>
@@ -24,27 +54,48 @@ trait SecurityDirectives {
         if (hasPermission) {
           innerRoute
         } else {
-
-          // in the case where we don't have the required action, we need to figure out if we should return
-          // a Not Found (you have no access) vs a Forbidden (you have access, just not the right kind)
-          onSuccess(policyEvaluatorService.listResourceAccessPoliciesForUser(resource, userId, samRequestContext)) { policies =>
-
-            if (policies.isEmpty) {
-              Directives.failWith(
-                new WorkbenchExceptionWithErrorReport(
-                  ErrorReport(StatusCodes.NotFound, s"Resource ${resource.resourceTypeName.value}/${resource.resourceId.value} not found")))
-            } else {
-              Directives.failWith(
-                new WorkbenchExceptionWithErrorReport(ErrorReport(
-                  StatusCodes.Forbidden,
-                  s"You may not perform any of ${requestedActions.mkString("[", ", ", "]").toString.toUpperCase} on ${resource.resourceTypeName.value}/${resource.resourceId.value}"
-                )))
-            }
-          }
+          val forbiddenErrorMessage = s"You may not perform any of ${requestedActions.mkString("[", ", ", "]").toUpperCase} on ${resource.resourceTypeName.value}/${resource.resourceId.value}"
+          determineErrorMessage(resource, userId, forbiddenErrorMessage, samRequestContext)
         }
       }
     }
 
+  /**
+    * in the case where we don't have the required action, we need to figure out if we should return
+    * a Not Found (you have no access) vs a Forbidden (you have access, just not the right kind)
+    */
+  private def determineErrorMessage(resource: FullyQualifiedResourceId, userId: WorkbenchUserId, forbiddenErrorMessage: String, samRequestContext: SamRequestContext) = {
+    // in the case where we don't have the required action, we need to figure out if we should return
+    // a Not Found (you have no access) vs a Forbidden (you have access, just not the right kind)
+    onSuccess(policyEvaluatorService.listResourceAccessPoliciesForUser(resource, userId, samRequestContext)) { policies =>
+      if (policies.isEmpty) {
+        Directives.failWith(
+          new WorkbenchExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, s"Resource ${resource.resourceTypeName.value}/${resource.resourceId.value} not found")))
+      } else {
+        Directives.failWith(
+          new WorkbenchExceptionWithErrorReport(ErrorReport(
+            StatusCodes.Forbidden,
+            forbiddenErrorMessage
+          )))
+      }
+    }
+  }
+
   private def hasPermissionOneOf(resource: FullyQualifiedResourceId, actions: Iterable[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
     actions.toList.existsM(policyEvaluatorService.hasPermission(resource, _, userId, samRequestContext))
+
+  private def hasParentPermissionOneOf(resource: FullyQualifiedResourceId, newParent: Option[FullyQualifiedResourceId], actions: Iterable[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] = {
+    val parentIO = newParent match {
+      case Some(_) => IO.pure(newParent)
+      case None => resourceService.getResourceParent(resource, samRequestContext)
+    }
+
+    parentIO.flatMap {
+      case Some(resourceParent) => hasPermissionOneOf(resourceParent, actions, userId, samRequestContext)
+      case None =>
+        // there is no parent so permission is granted
+        IO.pure(true)
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -42,7 +42,11 @@ trait SecurityDirectives {
         if (hasPermission) {
           innerRoute
         } else {
-          val forbiddenErrorMessage = s"You may not perform any of ${parentActions.mkString("[", ", ", "]").toUpperCase} on parent of ${childResource.resourceTypeName.value}/${childResource.resourceId.value}"
+          val parentResourceString = newParent match {
+            case None => s"parent of ${childResource.resourceTypeName.value}/${childResource.resourceId.value}"
+            case Some(newParentId) => s"${newParentId.resourceTypeName.value}/${newParentId.resourceId.value} or it may not exist"
+          }
+          val forbiddenErrorMessage = s"You may not perform any of ${parentActions.mkString("[", ", ", "]").toUpperCase} on $parentResourceString"
           determineErrorMessage(childResource, userId, forbiddenErrorMessage, samRequestContext)
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/AccessPolicyDAO.scala
@@ -35,7 +35,7 @@ trait AccessPolicyDAO {
 
   def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]]
   def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
-  def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
+  def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean]
   def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]]
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -857,7 +857,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     })
   }
 
-  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
+  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = {
     val r = ResourceTable.syntax("r")
     val resourceTableColumn = ResourceTable.column
     val rt = ResourceTypeTable.syntax("rt")
@@ -871,7 +871,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
           and ${r.name} = ${resource.resourceId}
           and ${rt.name} = ${resource.resourceTypeName}"""
 
-      query.update.apply()
+      query.update.apply() > 0
     })
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -197,7 +197,7 @@ class ResourceService(
   //      but not the Resource itself, thereby orphaning the Resource so that it cannot be used or accessed anymore and
   //      preventing a new Resource with the same ID from being created
   // Resources with children cannot be deleted and will throw a 400.
-  @throws(classOf[WorkbenchExceptionWithErrorReport])
+  @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy
   def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Unit] =
     for {
       _ <- checkNoChildren(resource, samRequestContext).unsafeToFuture()
@@ -492,6 +492,7 @@ class ResourceService(
       workbenchUsers.map(user => UserIdInfo(user.id, user.email, user.googleSubjectId))
     }
 
+  @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy
   def getResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = {
     accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -196,21 +196,32 @@ class ResourceService(
   // ELSE Resource ID reuse is not allowed, and we enforce this by deleting all policies associated with the Resource,
   //      but not the Resource itself, thereby orphaning the Resource so that it cannot be used or accessed anymore and
   //      preventing a new Resource with the same ID from being created
-  // Resources with children cannot be deleted.
   def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Unit] =
     for {
-      // First check if children exist. If so, then return a 400.
-      _ <- hasChildren(resource, samRequestContext).unsafeToFuture() map {
-        case true => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again."))
-        case false =>
-      }
-
       // remove from cloud extensions first so a failure there does not leave ldap in a bad state
       policiesToDelete <- cloudDeletePolicies(resource, samRequestContext)
 
       _ <- policiesToDelete.toList.parTraverse(p => accessPolicyDAO.deletePolicy(p.id, samRequestContext)).unsafeToFuture()
       _ <- maybeDeleteResource(resource, samRequestContext)
     } yield ()
+
+  // Resources with children cannot be deleted and will throw a 400.
+  def deleteResourceV2(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Unit] =
+    for {
+      // First check if children exist. If so, then throw a 400.
+      _ <- hasChildren(resource, samRequestContext).unsafeToFuture() map {
+        case true => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again."))
+        case false =>
+      }
+      _ <- deleteResource(resource, samRequestContext)
+    } yield ()
+
+  /** Checks if a resource has any children */
+  def hasChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = {
+    for {
+      children <- listResourceChildren(resource, samRequestContext)
+    } yield (children.nonEmpty)
+  }
 
   // TODO: CA-993 Once we can check if a policy applies to any children, we need to update this to throw if we try
   // to delete any policies that apply to children
@@ -221,13 +232,6 @@ class ResourceService(
       _ <- IO.fromFuture(IO(cloudExtensions.onGroupDelete(policyEmail)))
       _ <- accessPolicyDAO.deletePolicy(policyId, samRequestContext)
     } yield ()
-  }
-
-  /** Checks if a resource has any children */
-  def hasChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = {
-    for {
-      children <- listResourceChildren(resource, samRequestContext)
-    } yield (children.nonEmpty)
   }
 
   def cloudDeletePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Stream[AccessPolicy]] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -211,10 +211,7 @@ class ResourceService(
   /** Check if a resource has any children. If so, then throw a 400. */
   def checkNoChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
     listResourceChildren(resource, samRequestContext) map { list =>
-      list.nonEmpty match {
-        case true => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again."))
-        case false =>
-      }
+      if (list.nonEmpty) throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again."))
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -519,7 +519,7 @@ class ResourceService(
     } yield ()
   }
 
-  def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
+  def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = {
     accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -197,6 +197,7 @@ class ResourceService(
   //      but not the Resource itself, thereby orphaning the Resource so that it cannot be used or accessed anymore and
   //      preventing a new Resource with the same ID from being created
   // Resources with children cannot be deleted and will throw a 400.
+  @throws(classOf[WorkbenchExceptionWithErrorReport])
   def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Unit] =
     for {
       _ <- checkNoChildren(resource, samRequestContext).unsafeToFuture()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -60,6 +60,7 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
                                 childResource: FullyQualifiedResourceId,
                                 currentParentOpt: Option[FullyQualifiedResourceId] = None,
                                 newParentOpt: Option[FullyQualifiedResourceId] = None,
+                                parentExists: Boolean = true,
                                 actionsOnChild: Set[ResourceAction] = Set.empty,
                                 actionsOnCurrentParent: Set[ResourceAction] = Set.empty,
                                 actionsOnNewParent: Set[ResourceAction] = Set.empty,
@@ -123,8 +124,14 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
             .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
         }
       case None =>
-        when(samRoutes.resourceService.getResourceParent(mockitoEq(childResource), any[SamRequestContext]))
-          .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource parent not found")))
+    }
+
+    if (!parentExists) {
+      when(samRoutes.resourceService.getResourceParent(mockitoEq(childResource), any[SamRequestContext]))
+        .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource parent not found")))
+//      when(samRoutes.resourceService.setResourceParent(mockitoEq(childResource), any[FullyQualifiedResourceId], any[SamRequestContext]))
+//        .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource parent not found")))
+      // todo: probably throws: StatusCodes.BadRequest, "Cannot set parent as this would introduce a cyclical resource hierarchy"
     }
 
     if (accessToChild && accessToCurrentParent) {
@@ -335,6 +342,7 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     setupParentRoutes(samRoutes, fullyQualifiedChildResource,
       currentParentOpt = None,
       newParentOpt = None,
+      parentExists = false,
       actionsOnChild = Set(SamResourceActions.setParent),
       )
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -540,18 +540,4 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  it should "happy path without any children/parents" in {
-    val fullyQualifiedResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
-    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
-
-    setupParentRoutes(samRoutes, fullyQualifiedResource,
-      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
-
-    //Delete the resource
-    Delete(s"/api/resources/v1/${defaultResourceType.name}/${fullyQualifiedResource.resourceId.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
-    }
-  }
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -509,7 +509,7 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     }
   }
 
-  "DELETE /api/resources/v2/{resourceTypeName}/{resourceId}" should "204 on a child resource if the user has remove_child on the parent resource" in {
+  "DELETE /api/resources/v1/{resourceTypeName}/{resourceId}" should "204 on a child resource if the user has remove_child on the parent resource" in {
     val fullyQualifiedChildResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -107,22 +107,20 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
           .thenReturn(IO.pure(false))
     }
 
-    newParentOpt match {
-      case Some(newParent) =>
-        when(samRoutes.resourceService.setResourceParent(mockitoEq(childResource), mockitoEq(newParent), any[SamRequestContext]))
-            .thenReturn(IO.unit)
-        actionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
-          .thenReturn(IO(true)))
-        missingActionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
-          .thenReturn(IO(false)))
-        if (accessToNewParent) {
-          when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
-            .thenReturn(IO(Set(otherPolicy)))
-        } else {
-          when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
-            .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
-        }
-      case None =>
+    newParentOpt.map { newParent =>
+      when(samRoutes.resourceService.setResourceParent(mockitoEq(childResource), mockitoEq(newParent), any[SamRequestContext]))
+        .thenReturn(IO.unit)
+      actionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+        .thenReturn(IO(true)))
+      missingActionsOnNewParent.map(action => when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(newParent), mockitoEq(action), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+        .thenReturn(IO(false)))
+      if (accessToNewParent) {
+        when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+          .thenReturn(IO(Set(otherPolicy)))
+      } else {
+        when(samRoutes.policyEvaluatorService.listResourceAccessPoliciesForUser(mockitoEq(newParent), mockitoEq(defaultUserInfo.userId), any[SamRequestContext]))
+          .thenReturn(IO(Set[AccessPolicyWithoutMembers]()))
+      }
     }
 
     if (accessToChild && accessToCurrentParent) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -151,7 +151,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
 
-  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
+  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = ???
 
   override def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -147,11 +147,11 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
     )
   }
 
-  override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = ???
+  override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = IO(None)
 
   override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
 
   override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = ???
 
-  override def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = ???
+  override def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = IO(Set.empty)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAO.scala
@@ -151,7 +151,7 @@ class MockAccessPolicyDAO(private val policies: mutable.Map[WorkbenchGroupIdenti
 
   override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
-  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
+  override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
 
   override def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = IO(Set.empty)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -725,7 +725,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
     assert(policyDAO.listAccessPolicies(childResource, samRequestContext).unsafeRunSync().nonEmpty)
 
-    runAndWait(service.deleteResourceV2(childResource, samRequestContext))
+    runAndWait(service.deleteResource(childResource, samRequestContext))
 
     assert(policyDAO.listAccessPolicies(childResource, samRequestContext).unsafeRunSync().isEmpty)
   }
@@ -744,7 +744,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
     // try to delete the parent resource and then validate the error
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.deleteResourceV2(parentResource, samRequestContext))
+      runAndWait(service.deleteResource(parentResource, samRequestContext))
     }
 
     exception.errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -715,7 +715,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
     managedGroupService.loadManagedGroup(ResourceId(otherAuthDomainGroup), samRequestContext).unsafeRunSync() shouldBe Some(WorkbenchEmail(s"$otherAuthDomainGroup@$emailDomain"))
   }
 
-  "deleteResourceV2" should "delete a child resource that has a parent" in {
+  it should "delete a child resource that has a parent" in {
     val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-parent"))
     val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-child"))
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -730,7 +730,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
     assert(policyDAO.listAccessPolicies(childResource, samRequestContext).unsafeRunSync().isEmpty)
   }
 
-  it should "return 400 for a parent resource that has any children" in {
+  it should "fail deleting a parent resource that has children" in {
     // create a resource with a child
     val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-parent"))
     val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-child"))
@@ -749,7 +749,7 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
 
     exception.errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
 
-    // just to be sure, make sure the parent still exists
+    // make sure the parent still exists
     assert(policyDAO.listAccessPolicies(parentResource, samRequestContext).unsafeRunSync().nonEmpty)
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-930

This PR updates the existing API for delete resource to check for resources with parents or children.

a few notes:
- 403 if the resource has a parent and the user does not have remove_child access on the parent resource
- instead of a new v2 API, this will update the v1 API. Part of the reason for this is that this uses v2 behavior (adding parent info) and also the v1 API would need to be updated with the same or similar behavior to prevent deleting a resource that has children.
- tests for this are being put in v2 spec, partly because it uses v2 behavior, but mostly because v0, v1 behavior should not have changed anyway and we should be putting new tests into the latest version spec file.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
