### PR TITLE
CA-1005 Add SA to group using `uniqueId` instead of email

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
 
   val workbenchUtilV   = "0.5-6942040"
   val workbenchModelV  = "0.14-3c0b510"
-  val workbenchGoogleV = "0.21-445035e"
+  val workbenchGoogleV = "0.21-e30398d-SNAP"
   val workbenchGoogle2V = "0.6-31cacc4"
   val workbenchNotificationsV = "0.1-f2a0020"
   val workbenchNewRelicV = "0.2-24dabc8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
 
   val workbenchUtilV   = "0.5-6942040"
   val workbenchModelV  = "0.14-3c0b510"
-  val workbenchGoogleV = "0.21-658bcfe-SNAP"
+  val workbenchGoogleV = "0.21-64a7b29"
   val workbenchGoogle2V = "0.6-31cacc4"
   val workbenchNotificationsV = "0.1-f2a0020"
   val workbenchNewRelicV = "0.2-24dabc8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,8 @@ object Dependencies {
   val newRelicVersion = "4.11.0"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
+  val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
+  val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
   val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_2.12")
@@ -97,7 +99,7 @@ object Dependencies {
 
   val excludeScalaCllectionCompat =  ExclusionRule(organization = "org.scala-lang.modules", name = "scala-collection-compat_2.12")
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2" // excludeAll(excludIoGrpc, excludeCatsEffect )
-  val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" // excludeAll(excludIoGrpc, excludeCatsEffect)
+  val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" excludeAll(excludeAkkaProtobufV3, excludeAkkaStream)// excludeAll(excludIoGrpc, excludeCatsEffect)
   val opencensusStackDriverExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.25.0" // excludeAll(excludIoGrpc, excludeCatsEffect)
   val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging"     % "0.25.0" // excludeAll(excludIoGrpc, excludeCatsEffect)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
 
   val workbenchUtilV   = "0.5-6942040"
   val workbenchModelV  = "0.14-3c0b510"
-  val workbenchGoogleV = "0.21-d8edc4c-SNAP"
+  val workbenchGoogleV = "0.21-658bcfe-SNAP"
   val workbenchGoogle2V = "0.6-31cacc4"
   val workbenchNotificationsV = "0.1-f2a0020"
   val workbenchNewRelicV = "0.2-24dabc8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.6.1"
-  val akkaHttpV = "10.1.11"
+  val akkaV = "2.6.8"
+  val akkaHttpV = "10.2.0"
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.5.0"
   val scalaTestV    = "3.0.5"
@@ -43,6 +43,7 @@ object Dependencies {
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV
+  val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV
   val akkaHttp: ModuleID =          "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor)
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV
   val akkaTestKit: ModuleID =       "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test"
@@ -122,6 +123,7 @@ object Dependencies {
 
     akkaActor,
     akkaSlf4j,
+    akkaStream,
     akkaHttp,
     akkaHttpSprayJson,
     akkaTestKit,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV
-  val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV
+  val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV               excludeAll(excludeAkkaProtobufV3)
   val akkaHttp: ModuleID =          "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor)
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV
   val akkaTestKit: ModuleID =       "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
 
   val workbenchUtilV   = "0.5-6942040"
   val workbenchModelV  = "0.14-3c0b510"
-  val workbenchGoogleV = "0.21-e30398d-SNAP"
+  val workbenchGoogleV = "0.21-d8edc4c-SNAP"
   val workbenchGoogle2V = "0.6-31cacc4"
   val workbenchNotificationsV = "0.1-f2a0020"
   val workbenchNewRelicV = "0.2-24dabc8"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -80,7 +80,7 @@ object Boot extends IOApp with LazyLogging {
 
         _ <- dependencies.cloudExtensionsInitializer.onBoot(dependencies.samApplication)
 
-        binding <- IO.fromFuture(IO(Http().bindAndHandle(dependencies.samRoutes.route, "0.0.0.0", 8080))).onError {
+        binding <- IO.fromFuture(IO(Http().newServerAt("0.0.0.0", 8080).bind(dependencies.samRoutes.route))).onError {
           case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)
         }
         _ <- IO.fromFuture(IO(binding.whenTerminated))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -322,7 +322,7 @@ class GoogleExtensions(
             _ <- IO.fromFuture(IO(withProxyEmail(user.id) { proxyEmail =>
               // Add group member by uniqueId instead of email to avoid race condition
               // See: https://broadworkbench.atlassian.net/browse/CA-1005
-              googleDirectoryDAO.addMemberToGroup(proxyEmail, sa.subjectId)
+              googleDirectoryDAO.addServiceAccountToGroup(proxyEmail, sa)
             }))
           } yield sa
         // SA already exists in google, use it

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -319,13 +319,10 @@ class GoogleExtensions(
           for {
             _ <- assertProjectInTerraOrg(project)
             sa <- IO.fromFuture(IO(googleIamDAO.createServiceAccount(project, petSaName, petSaDisplayName)))
-            // Sleep added to avoid Google race condition where the GoogleDirectoryDAO doesn't yet know about the
-            // newly created service account which leads to slow permission propagation.
-            // See https://broadworkbench.atlassian.net/browse/QA-723 for details
-            // TODO: remove sleep when Google fix exists - see https://broadworkbench.atlassian.net/browse/CA-1005
-            _ <- IO.sleep(2 seconds)(IO.timer(executionContext))
-            r <- IO.fromFuture(IO(withProxyEmail(user.id) { proxyEmail =>
-              googleDirectoryDAO.addMemberToGroup(proxyEmail, sa.email)
+            _ <- IO.fromFuture(IO(withProxyEmail(user.id) { proxyEmail =>
+              // Add group member by uniqueId instead of email to avoid race condition
+              // See: https://broadworkbench.atlassian.net/browse/CA-1005
+              googleDirectoryDAO.addMemberToGroup(proxyEmail, sa.subjectId)
             }))
           } yield sa
         // SA already exists in google, use it


### PR DESCRIPTION
 When creating Pet SA and then immediately adding it to the user's proxy group, we are modifying the group using the SA's `uniqueId` instead of the SA's email address per suggestion from Google Support in order to avoid a race condition between GCP (where the SA is created) and GSuite (where the group exists)

corresponding workbench-libs PR:  https://github.com/broadinstitute/workbench-libs/pull/352

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
