### PR TITLE
Use smart nulls to provide better error messaging from Mockito

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -41,8 +41,8 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
     val registrationDAO = new MockDirectoryDAO()
     val emailDomain = "example.com"
 
-    val policyEvaluatorService = mock[PolicyEvaluatorService]
-    val mockResourceService = mock[ResourceService]
+    val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
+    val mockResourceService = mock[ResourceService](RETURNS_SMART_NULLS)
     resourceTypes.map { case (resourceTypeName, resourceType) =>
       when(mockResourceService.getResourceType(resourceTypeName)).thenReturn(IO(Option(resourceType)))
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -34,7 +34,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
     override implicit val executionContext: ExecutionContext = null
     override val directoryDAO: DirectoryDAO = new MockDirectoryDAO()
     override val cloudExtensions: CloudExtensions = null
-    override val identityConcentratorService: Option[IdentityConcentratorService] = Option(mock[IdentityConcentratorService])
+    override val identityConcentratorService: Option[IdentityConcentratorService] = Option(mock[IdentityConcentratorService](RETURNS_SMART_NULLS))
     override val userService: UserService = null
   }
 
@@ -133,7 +133,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
     val identityConcentratorId = TestSupport.genIdentityConcentratorId()
     val email = genNonPetEmail.sample.get
     directoryDAO.createUser(WorkbenchUser(uid, Some(googleSubjectId), email, Option(identityConcentratorId)), samRequestContext).unsafeRunSync()
-    val userInfo = getUserInfoFromJwt(validJwtUserInfo(identityConcentratorId), OAuth2BearerToken(""), directoryDAO, mock[IdentityConcentratorService], samRequestContext).unsafeRunSync()
+    val userInfo = getUserInfoFromJwt(validJwtUserInfo(identityConcentratorId), OAuth2BearerToken(""), directoryDAO, mock[IdentityConcentratorService](RETURNS_SMART_NULLS), samRequestContext).unsafeRunSync()
     assert(userInfo.tokenExpiresIn <= 0)
     assert(userInfo.tokenExpiresIn > -30)
     userInfo.copy(tokenExpiresIn = 0) shouldEqual UserInfo(OAuth2BearerToken(""), uid, email, 0)
@@ -148,7 +148,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
 
     directoryDAO.createUser(WorkbenchUser(uid, Some(googleSubjectId), email, None), samRequestContext).unsafeRunSync()
 
-    val icService = mock[IdentityConcentratorService]
+    val icService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
     val bearerToken = OAuth2BearerToken("shhhh, secret")
     when(icService.getGoogleIdentities(bearerToken)).thenReturn(IO.pure(Seq((googleSubjectId, email))))
     getUserInfoFromJwt(validJwtUserInfo(identityConcentratorId), bearerToken, directoryDAO, icService, samRequestContext).unsafeRunSync()
@@ -159,7 +159,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
   it should "500 when user is linked to more than 1 google account" in {
     val directoryDAO = new MockDirectoryDAO()
     val identityConcentratorId = TestSupport.genIdentityConcentratorId()
-    val icService = mock[IdentityConcentratorService]
+    val icService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
     val bearerToken = OAuth2BearerToken("shhhh, secret")
 
     when(icService.getGoogleIdentities(bearerToken)).thenReturn(IO.pure(Seq(
@@ -178,7 +178,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
   it should "404 for valid jwt but user does not exist in sam db" in {
     val directoryDAO = new MockDirectoryDAO()
     val t = intercept[WorkbenchExceptionWithErrorReport] {
-      val identityConcentratorService = mock[IdentityConcentratorService]
+      val identityConcentratorService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
       when(identityConcentratorService.getGoogleIdentities(any[OAuth2BearerToken])).thenReturn(IO.pure(Seq((GoogleSubjectId(""), WorkbenchEmail("")))))
       getUserInfoFromJwt(validJwtUserInfo(TestSupport.genIdentityConcentratorId()), OAuth2BearerToken(""), directoryDAO, identityConcentratorService, samRequestContext).unsafeRunSync()
     }
@@ -190,7 +190,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
   it should "500 for valid jwt but no linked accounts in ic" in {
     val directoryDAO = new MockDirectoryDAO()
     val t = intercept[WorkbenchExceptionWithErrorReport] {
-      val identityConcentratorService = mock[IdentityConcentratorService]
+      val identityConcentratorService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
       when(identityConcentratorService.getGoogleIdentities(any[OAuth2BearerToken])).thenReturn(IO.pure(Seq.empty))
       getUserInfoFromJwt(validJwtUserInfo(TestSupport.genIdentityConcentratorId()), OAuth2BearerToken(""), directoryDAO, identityConcentratorService, samRequestContext).unsafeRunSync()
     }
@@ -204,7 +204,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
     val identityConcentratorId = TestSupport.genIdentityConcentratorId()
     val email = genNonPetEmail.sample.get
 
-    val icService = mock[IdentityConcentratorService]
+    val icService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
     val bearerToken = OAuth2BearerToken("shhhh, secret")
     when(icService.getGoogleIdentities(bearerToken)).thenReturn(IO.pure(Seq((googleSubjectId, email))))
     val createUser = newCreateWorkbenchUserFromJwt(validJwtUserInfo(identityConcentratorId), bearerToken, icService).unsafeRunSync()
@@ -217,7 +217,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
   it should "500 for 0 google accounts" in {
     val identityConcentratorId = TestSupport.genIdentityConcentratorId()
 
-    val icService = mock[IdentityConcentratorService]
+    val icService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
     val bearerToken = OAuth2BearerToken("shhhh, secret")
     when(icService.getGoogleIdentities(bearerToken)).thenReturn(IO.pure(Seq.empty))
     val t = intercept[WorkbenchExceptionWithErrorReport] {
@@ -230,7 +230,7 @@ class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting 
   it should "500 for more than 1 google account" in {
     val identityConcentratorId = TestSupport.genIdentityConcentratorId()
 
-    val icService = mock[IdentityConcentratorService]
+    val icService = mock[IdentityConcentratorService](RETURNS_SMART_NULLS)
     val bearerToken = OAuth2BearerToken("shhhh, secret")
     when(icService.getGoogleIdentities(bearerToken)).thenReturn(IO.pure(Seq(
       (GoogleSubjectId(genRandom(System.currentTimeMillis())), genNonPetEmail.sample.get),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -266,7 +266,7 @@ trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with Scalat
   }
 
   def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
-    val googleIamDAO = mock[GoogleIamDAO]
+    val googleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
     val expectedJson = """{"json":"yes I am"}"""
     when(googleIamDAO.findServiceAccount(any[GoogleProject], any[ServiceAccountName])).thenReturn(Future.successful(None))
     when(googleIamDAO.createServiceAccount(any[GoogleProject], any[ServiceAccountName], any[ServiceAccountDisplayName])).thenReturn(Future.successful(ServiceAccount(ServiceAccountSubjectId("12312341234"), WorkbenchEmail("pet@myproject.iam.gserviceaccount.com"), ServiceAccountDisplayName(""))))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -95,11 +95,11 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
         FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty, public = true)
 
     Seq(testGroup, testPolicy).foreach { target =>
-      val mockAccessPolicyDAO = mock[AccessPolicyDAO]
-      val mockDirectoryDAO = mock[DirectoryDAO]
-      val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
+      val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
+      val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+      val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
       val mockGooglePubSubDAO = new MockGooglePubSubDAO
-      val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+      val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
       val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, ge, configResourceTypes)
 
       target match {
@@ -202,10 +202,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val rpn = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("ap"))
     val testPolicy = AccessPolicy(rpn, Set(policyOnlySamUserId, intersectionSamUserId, authorizedGoogleUserId, policyOnlySamSubGroup.id, intersectionSamSubGroup.id, authorizedGoogleSubGroup.id, addError), WorkbenchEmail("testPolicy@example.com"), Set(constrainableRole.roleName), constrainableRole.actions, public = false)
 
-    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
-    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, mockGoogleDirectoryDAO, null, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes)
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
+    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, mockGoogleDirectoryDAO, null, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes)
     val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, constrainableResourceTypes)
 
     when(mockAccessPolicyDAO.loadPolicy(testPolicy.id, samRequestContext)).thenReturn(IO.pure(Option(testPolicy)))
@@ -254,12 +254,12 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val subGroup = BasicWorkbenchGroup(subGroupName, Set.empty, subGroupEmail)
     val topGroup = BasicWorkbenchGroup(groupName, Set.empty, groupEmail)
 
-    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
     val mockDirectoryDAO = new MockDirectoryDAO
-    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
-    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGooglePubSubDAO, mockGoogleIamDAO, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
     val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
 
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
@@ -398,9 +398,9 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   it should "get a group's last synchronized date" in {
     val groupName = WorkbenchGroupName("group1")
 
-    val mockDirectoryDAO = mock[DirectoryDAO]
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
 
-    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], null, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
+    val ge = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes)
 
     when(mockDirectoryDAO.getSynchronizedDate(groupName, samRequestContext)).thenReturn(IO.pure(None))
     ge.getSynchronizedDate(groupName, samRequestContext).unsafeRunSync() shouldBe None
@@ -576,9 +576,9 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
     val user = WorkbenchUser(userId, None, userEmail, None)
     val proxyEmail = WorkbenchEmail(s"PROXY_$userId@${googleServicesConfig.appsDomain}")
 
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
-    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
+    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val allUsersGroup = BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
     val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
@@ -598,9 +598,9 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "do Googley stuff onGroupDelete" in {
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO]
-    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
+    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val testPolicy = BasicWorkbenchGroup(WorkbenchGroupName("blahblahblah"), Set.empty, WorkbenchEmail(s"blahblahblah@test.firecloud.org"))
 
@@ -612,10 +612,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   "onGroupUpdate" should "trigger updates to constrained policies if updating a managed group" in {
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
-    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO]
-    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
+    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
+    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val managedGroupId = "managedGroupId"
 
@@ -642,10 +642,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "trigger updates to constrained policies when updating a group that is a part of a managed group" in {
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
-    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO]
-    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
+    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
+    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"
@@ -676,10 +676,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "break out of the loop" in {
-    val mockDirectoryDAO = mock[DirectoryDAO]
-    val mockAccessPolicyDAO = mock[AccessPolicyDAO]
-    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO]
-    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO], mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
+    val mockGooglePubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
+    val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), mockAccessPolicyDAO, null, mockGooglePubSubDAO, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -37,7 +37,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
   "GoogleGroupSyncMonitor" should "handle sync message" in {
     implicit val patienceConfig = PatienceConfig(timeout = 1 second)
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleExtensions = mock[GoogleGroupSynchronizer]
+    val mockGoogleExtensions = mock[GoogleGroupSynchronizer](RETURNS_SMART_NULLS)
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")
@@ -69,7 +69,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
   it should "handle missing target group" in {
     implicit val patienceConfig = PatienceConfig(timeout = 1 second)
     val mockGooglePubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleExtensions = mock[GoogleGroupSynchronizer]
+    val mockGoogleExtensions = mock[GoogleGroupSynchronizer](RETURNS_SMART_NULLS)
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, PostgresAccessPolicyDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
@@ -112,7 +112,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   }
 
   it should "sync the new group with Google" in {
-    val mockGoogleExtensions = mock[GoogleExtensions]
+    val mockGoogleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
     val managedGroupService = new ManagedGroupService(resourceService, null, resourceTypeMap, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
     val groupName = WorkbenchGroupName(resourceId.value)
 
@@ -169,7 +169,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   // because the resource no longer exists
   "ManagedGroupService delete" should "delete policies associated to that resource in LDAP and in Google" in {
     val groupEmail = WorkbenchEmail(resourceId.value + "@" + testDomain)
-    val mockGoogleExtensions = mock[GoogleExtensions]
+    val mockGoogleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
     when(mockGoogleExtensions.onGroupDelete(groupEmail)).thenReturn(Future.successful(()))
     when(mockGoogleExtensions.publishGroup(WorkbenchGroupName(resourceId.value))).thenReturn(Future.successful(()))
     val managedGroupService = new ManagedGroupService(resourceService, null, resourceTypeMap, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
@@ -404,7 +404,7 @@ class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport wi
   }
 
   "ManagedGroupService requestAccess" should "send notifications" in {
-    val mockCloudExtension = mock[CloudExtensions]
+    val mockCloudExtension = mock[CloudExtensions](RETURNS_SMART_NULLS)
     when(mockCloudExtension.publishGroup(ArgumentMatchers.any[WorkbenchGroupName])).thenReturn(Future.successful(()))
     val testManagedGroupService = new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, policyDAO, dirDAO, mockCloudExtension, testDomain)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -65,7 +65,7 @@ class UserServiceSpec extends FlatSpec with Matchers with TestSupport with Mocki
   before {
     clearDatabase()
 
-    googleExtensions = mock[GoogleExtensions]
+    googleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
     when(googleExtensions.allUsersGroupName).thenReturn(NoExtensions.allUsersGroupName)
     when(googleExtensions.getOrCreateAllUsersGroup(any[DirectoryDAO], any[SamRequestContext])(any[ExecutionContext])).thenReturn(NoExtensions.getOrCreateAllUsersGroup(dirDAO, samRequestContext))
     when(googleExtensions.onUserCreate(any[WorkbenchUser], any[SamRequestContext])).thenReturn(Future.successful(()))


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-1012
<Put notes here to help reviewer understand this PR>

When Mockito hits a method that hasn't been mocked, it throws an NPE. This PR changes that default behavior to instead throw a "smart null" which gives a better error message for these unstubbed method calls.


This whole PR just adds a `(RETURNS_SMART_NULLS)` param in all places where the mockito mock is used.

----

examples:

old nulls
```
500 Internal Server Error entity: {"causes":[],"exceptionClass":"java.lang.NullPointerException","message":"NullPointerException","source":"sam","stackTrace":[{"className":"org.broadinstitute.dsde.workbench.sam.api.SecurityDirectives","fileName":"SecurityDirectives.scala","lineNumber":96,"methodName":"hasParentPermissionOneOf"},{"className":"org.broadinstitute.dsde.workbench.sam.api.SecurityDirectives","fileName":"SecurityDirectives.scala","lineNumber":41,"methodName":"$anonfun$requireOneOfParentAction$1"},{"className":"akka.http.scaladsl.server.directives.BasicDirectives","fileName":"BasicDirectives.scala","lineNumber":39,"methodName":"$anonfun$mapInnerRoute$1"},
```

new smart nulls
```
500 Internal Server Error entity: {"causes":[],"exceptionClass":"scala.MatchError","message":"SmartNull returned by this unstubbed method call on a mock:\npolicyEvaluatorService.hasPermission(\n    FullyQualifiedResourceId(rt,child),\n    delete,\n    user1,\n    SamRequestContext(Some(io.opencensus.implcore.trace.NoRecordEventsSpanImpl@aa1bb14))\n); (of class cats.effect.IO$MockitoMock$80096492)","source":"sam",
```


---

To quickly find and make the changes needed, I used this regex combo in intellij's find and replace tool:

Find: 
`(mock\[.*\])`

Replace with: 
`$1(RETURNS_SMART_NULLS)`

![Screen Shot 2020-09-18 at 4 42 36 PM](https://user-images.githubusercontent.com/5375000/93643666-7a615600-f9ce-11ea-9ef1-3acc2d3fe157.png)

Kaboom!*

*Some imports may be needed

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
