### PR TITLE
[CA-1041] Fix bug in swagger -- missing email in AccessPolicyResponseEntry

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2767,23 +2767,29 @@ components:
       required:
         - policy
         - policyName
+        - email
       type: object
       properties:
         policyName:
           type: string
         policy:
           $ref: '#/components/schemas/AccessPolicyMembership'
+        email:
+          type: string
       description: ""
     AccessPolicyResponseEntryV2:
       required:
         - policy
         - policyName
+        - email
       type: object
       properties:
         policyName:
           type: string
         policy:
           $ref: '#/components/schemas/AccessPolicyMembershipV2'
+        email:
+          type: string
       description: ""
     AccessPolicyMembership:
       required:


### PR DESCRIPTION
Ticket: [CA-1041](https://broadworkbench.atlassian.net/browse/CA-1041)
add missing `email` field to `AccessPolicyResponseEntry` (v1 and v2) in Swagger

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
