### PR TITLE
perf fixes

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -960,17 +960,17 @@ class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with 
                                          resource: FullyQualifiedResourceId,
                                          actionsOnResource: Set[ResourceAction]): Unit = {
 
-    val actionAllowed = new ArgumentMatcher[ResourceAction] {
-      override def matches(argument: ResourceAction): Boolean = actionsOnResource.contains(argument)
+    val actionAllowed = new ArgumentMatcher[Iterable[ResourceAction]] {
+      override def matches(argument: Iterable[ResourceAction]): Boolean = actionsOnResource.intersect(argument.toSet).nonEmpty
     }
-    val actionNotAllowed = new ArgumentMatcher[ResourceAction] {
-      override def matches(argument: ResourceAction): Boolean = !actionsOnResource.contains(argument)
+    val actionNotAllowed = new ArgumentMatcher[Iterable[ResourceAction]] {
+      override def matches(argument: Iterable[ResourceAction]): Boolean = actionsOnResource.intersect(argument.toSet).isEmpty
     }
 
-    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(resource), argThat(actionAllowed), mockitoEq(defaultUserInfo.userId), any[SamRequestContext])).
+    when(samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionAllowed), mockitoEq(defaultUserInfo.userId), any[SamRequestContext])).
       thenReturn(IO.pure(true))
 
-    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(resource), argThat(actionNotAllowed), mockitoEq(defaultUserInfo.userId), any[SamRequestContext])).
+    when(samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionNotAllowed), mockitoEq(defaultUserInfo.userId), any[SamRequestContext])).
       thenReturn(IO.pure(false))
 
     when(samRoutes.policyEvaluatorService.listUserResourceActions(mockitoEq(resource), mockitoEq(defaultUserInfo.userId), any[SamRequestContext])).


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
2 fixes that came out of looking at traces of the AoU 100 concurrent user test:
- `hasPermissionOneOf` used to has `hasPermission` for each action which does the same work multiply times. Fixed to do the work once
- Auth domain check list all the groups a user is in. It is cheaper to get the roles only on the groups in question.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
