### PR TITLE
DR-1400: Add spend profile resource

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -511,6 +511,38 @@ resourceTypes = {
     }
     reuseIds = true
   }
+  spendProfile = {
+    actionPatternObjects = {
+      "share_policy::admin" = {
+        description = "Can grant and revoke a users' admin permission"
+      }
+      "share_policy::steward" = {
+        description = "Can grant and revoke a users' steward permission"
+      }
+      "read_policies" = {
+        description = "Can read policies"
+      }
+      "read_policy::steward" = {
+        description = "Can read the steward policy"
+      }
+      "alter_policies" = {
+        description = "Can alter policies"
+      }
+      "delete" = {
+        description = "Can delete policies/resources"
+      }
+    }
+    ownerRoleName = "admin"
+    roles = {
+      admin = {
+        roleActions = ["share_policy::steward", "share_policy::admin", "read_policies", "alter_policies"]
+      }
+      steward = {
+        roleActions = ["share_policy::steward", "read_policy::steward"]
+      }
+    }
+    reuseIds = true
+  }
   study = {
     actionPatternObjects = {
       delete = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -513,35 +513,35 @@ resourceTypes = {
   }
   spend-profile = {
     actionPatternObjects = {
-      "create" = {
-        description = "Can create profiles"
-      }
-      "update" = {
-        description = "Can update profiles"
+      "update_billing_account" = {
+        description = "Ability to update the spend profile to use a different billing account"
       }
       "delete" = {
-        description = "Can delete profiles"
-      }
-      "list" = {
-        description = "Can read profiles"
+        description = "Ability to delete profiles"
       }
       "link" = {
-        description = "Can link profiles"
+        description = "Ability to link a spend profile to an object, thus allowing the object to spend funds from the designated billing account"
       }
       "share_policy::owner" = {
-        description = "Can grant and revoke a users' owner permission"
+        description = "Ability to grant and revoke a users' owner permission"
+      }
+      "share_policy::user" = {
+        description = "Ability to grant and revoke a users' user permission"
+      }
+      "share_policy::admin" = {
+        description = "Ability to grant and revoke a users' admin permission"
       }
     }
     ownerRoleName = "owner"
     roles = {
       admin = {
-        roleActions = ["share_policy::owner"]
+        roleActions = ["share_policy::owner", "share_policy::user", "share_policy::admin"]
       }
       owner = {
-        roleActions = ["create", "update", "delete", "list", "link", "share_policy::owner"]
+        roleActions = ["update_billing_account", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::admin"]
       }
       user = {
-        roleActions = ["list", "link", "share_policy::owner"]
+        roleActions = ["link"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -511,19 +511,10 @@ resourceTypes = {
     }
     reuseIds = true
   }
-  spendProfile = {
+  spend-profile = {
     actionPatternObjects = {
-      "share_policy::admin" = {
+      "share_policy::owner" = {
         description = "Can grant and revoke a users' admin permission"
-      }
-      "share_policy::steward" = {
-        description = "Can grant and revoke a users' steward permission"
-      }
-      "read_policies" = {
-        description = "Can read policies"
-      }
-      "read_policy::steward" = {
-        description = "Can read the steward policy"
       }
       "alter_policies" = {
         description = "Can alter policies"
@@ -531,14 +522,20 @@ resourceTypes = {
       "delete" = {
         description = "Can delete policies/resources"
       }
+      "read_policies" = {
+        description = "Can read policies"
+      }
     }
-    ownerRoleName = "admin"
+    ownerRoleName = "owner"
     roles = {
       admin = {
-        roleActions = ["share_policy::steward", "share_policy::admin", "read_policies", "alter_policies"]
+        roleActions = ["share_policy::owner"]
       }
-      steward = {
-        roleActions = ["share_policy::steward", "read_policy::steward"]
+      owner = {
+        roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete"]
+      }
+      user = {
+        roleActions = [ "read_policies", "share_policy::owner"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -514,19 +514,19 @@ resourceTypes = {
   spend-profile = {
     actionPatternObjects = {
       "create" = {
-        description = "Can create policies"
+        description = "Can create profiles"
       }
       "update" = {
-        description = "Can update policies"
+        description = "Can update profiles"
       }
       "delete" = {
-        description = "Can delete policies"
+        description = "Can delete profiles"
       }
       "list" = {
-        description = "Can read policies"
+        description = "Can read profiles"
       }
       "link" = {
-        description = "Can link policies"
+        description = "Can link profiles"
       }
       "share_policy::owner" = {
         description = "Can grant and revoke a users' owner permission"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -516,6 +516,9 @@ resourceTypes = {
       "update_billing_account" = {
         description = "Ability to update the spend profile to use a different billing account"
       }
+      "update_metadata" = {
+        description = "Ability to update the spend profile's metadata, including name and description"
+      }
       "delete" = {
         description = "Ability to delete profiles"
       }
@@ -528,17 +531,11 @@ resourceTypes = {
       "share_policy::user" = {
         description = "Ability to grant and revoke a users' user permission"
       }
-      "share_policy::admin" = {
-        description = "Ability to grant and revoke a users' admin permission"
-      }
     }
     ownerRoleName = "owner"
     roles = {
-      admin = {
-        roleActions = ["share_policy::owner", "share_policy::user", "share_policy::admin"]
-      }
       owner = {
-        roleActions = ["update_billing_account", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::admin"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user"]
       }
       user = {
         roleActions = ["link"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -513,17 +513,23 @@ resourceTypes = {
   }
   spend-profile = {
     actionPatternObjects = {
-      "share_policy::owner" = {
-        description = "Can grant and revoke a users' admin permission"
+      "create" = {
+        description = "Can create policies"
       }
-      "alter_policies" = {
-        description = "Can alter policies"
+      "update" = {
+        description = "Can update policies"
       }
       "delete" = {
-        description = "Can delete policies/resources"
+        description = "Can delete policies"
       }
-      "read_policies" = {
+      "list" = {
         description = "Can read policies"
+      }
+      "link" = {
+        description = "Can link policies"
+      }
+      "share_policy::owner" = {
+        description = "Can grant and revoke a users' owner permission"
       }
     }
     ownerRoleName = "owner"
@@ -532,10 +538,10 @@ resourceTypes = {
         roleActions = ["share_policy::owner"]
       }
       owner = {
-        roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete"]
+        roleActions = ["create", "update", "delete", "list", "link", "share_policy::owner"]
       }
       user = {
-        roleActions = [ "read_policies", "share_policy::owner"]
+        roleActions = ["list", "link", "share_policy::owner"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: [DR-1400 - Add Sam definition of the billing profile resource](https://broadworkbench.atlassian.net/browse/DR-1400)
- Add new "spend-profile" resource as a part of work for [DR-1370](https://broadworkbench.atlassian.net/browse/DR-1370).  The aim of this work is to add authorization around the use of billing profiles
- The actions listed were defined as a part of our work to clarify and [update our permissions model](https://broadworkbench.atlassian.net/browse/DR-663). 

---

**PR checklist**

N/A - I don't think I have made any changes to the api nor any security related changes. There also should not be any manual steps required.
- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
