### PR TITLE
[No Ticket] fix minor swagger bug around descendantPermissions 

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2831,7 +2831,9 @@ components:
           items:
             type: string
         descendantPermissions:
-          $ref: '#/components/schemas/AccessPolicyDescendantPermissions'
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessPolicyDescendantPermissions'
       description: ""
     AccessPolicyDescendantPermissions:
       required:


### PR DESCRIPTION
Ticket: No ticket
Zybjana found a minor inconsistency in the Sam swagger where the `descendantPermissions` field in `AccessPolicyMembershipV2` was not an array like it should have been.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
