### PR TITLE
[CA-1062, CA-1075] Add nested roles to config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -261,6 +261,7 @@ resourceTypes = {
     roles = {
       owner = {
         roleActions = ["read_policies", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "delete"]
+        includedRoles = ["notebook-user"]
       }
       notebook-user = {
         roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app"]
@@ -329,6 +330,9 @@ resourceTypes = {
     roles = {
       owner = {
         roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete"]
+        descendantRoles = {
+          google-project = ["owner"]
+        }
       }
       workspace-creator = {
         roleActions = ["view_status", "create_workspace", "share_policy::can-compute-user", "read_policy::can-compute-user"]
@@ -338,6 +342,9 @@ resourceTypes = {
       }
       notebook-user = {
         roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app"]
+        descendantRoles = {
+          google-project = ["notebook-user"]
+        }
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -85,6 +85,9 @@ resourceTypes = {
       }
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain"]
+        descendantRoles = {
+          google-project = ["owner"]
+        }
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "read_auth_domain"]
@@ -100,6 +103,9 @@ resourceTypes = {
       }
       can-compute = {
         roleActions = ["compute"]
+        descendantRoles = {
+          google-project = ["notebook-user"]
+        }
       }
       can-catalog = {
         roleActions = ["catalog"]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -43,7 +43,12 @@ object AppConfig {
       val uqPath = unquoteAndEscape(path)
       ResourceRole(
         ResourceRoleName(uqPath),
-        config.as[Set[String]](s"$uqPath.roleActions").map(ResourceAction.apply)
+        config.as[Set[String]](s"$uqPath.roleActions").map(ResourceAction.apply),
+        config.as[Option[Set[String]]](s"$uqPath.includedRoles").getOrElse(Set.empty).map(ResourceRoleName.apply),
+        config.as[Option[Map[String, Set[String]]]](s"$uqPath.descendantRoles").getOrElse(Map.empty)
+          .map { case (resourceTypeName, roleNames) =>
+            (ResourceTypeName(resourceTypeName), roleNames.map(ResourceRoleName.apply))
+          }
       )
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -142,7 +142,7 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
             (accessPolicy.actions.exists(actionPattern.matches) ||
               accessPolicy.roles.exists { accessPolicyRole =>
                 resourceType.roles.exists {
-                  case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _) => resourceTypeRole.actions.exists(actionPattern.matches)
+                  case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _, _, _) => resourceTypeRole.actions.exists(actionPattern.matches)
                   case _ => false
                 }
               })

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -18,9 +18,9 @@ object SamJsonSupport {
 
   implicit val ResourceRoleNameFormat = ValueObjectFormat(ResourceRoleName.apply)
 
-  implicit val ResourceRoleFormat = jsonFormat2(ResourceRole.apply)
-
   implicit val ResourceTypeNameFormat = ValueObjectFormat(ResourceTypeName.apply)
+
+  implicit val ResourceRoleFormat = jsonFormat4(ResourceRole.apply)
 
   implicit val ResourceTypeFormat = jsonFormat5(ResourceType.apply)
 
@@ -112,7 +112,10 @@ object SamResourceTypes {
 }
 @Lenses final case class ResourceAction(value: String) extends ValueObject
 @Lenses case class ResourceRoleName(value: String) extends ValueObject
-@Lenses final case class ResourceRole(roleName: ResourceRoleName, actions: Set[ResourceAction])
+@Lenses final case class ResourceRole(roleName: ResourceRoleName,
+                                      actions: Set[ResourceAction],
+                                      includedRoles: Set[ResourceRoleName] = Set.empty,
+                                      descendantRoles: Map[ResourceTypeName, Set[ResourceRoleName]] = Map.empty)
 
 @Lenses final case class ResourceTypeName(value: String) extends ValueObject
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -55,6 +55,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
           upsertRoles(resourceTypes, resourceTypeNameToPKs)
           insertActions(resourceTypes, resourceTypeNameToPKs)
           upsertRoleActions(resourceTypes, resourceTypeNameToPKs)
+          upsertNestedRoles(resourceTypes, resourceTypeNameToPKs)
           logger.info(s"upsertResourceTypes: completed updates to resource types [$changedResourceTypeNames]")
         }
         changedResourceTypeNames
@@ -87,18 +88,27 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     val rr = ResourceRoleTable.syntax("rr")
     val roleAction = RoleActionTable.syntax("roleAction")
     val ra = ResourceActionTable.syntax("ra")
+    val nestedRole = NestedRoleTable.syntax("nestedRole")
+    val nrr = ResourceRoleTable.syntax("nrr")
+    val nrrt = ResourceTypeTable.syntax("nrrt")
     val roleQuery =
-      samsql"""select ${rr.resultAll}, ${ra.resultAll}
+      samsql"""select ${rr.resultAll}, ${ra.resultAll}, ${nrr.resultAll}, ${nestedRole.result.descendantsOnly}, ${nrrt.result.name}
                  from ${ResourceRoleTable as rr}
                  left join ${RoleActionTable as roleAction} on ${roleAction.resourceRoleId} = ${rr.id}
                  left join ${ResourceActionTable as ra} on ${roleAction.resourceActionId} = ${ra.id}
+                 left join ${NestedRoleTable as nestedRole} on ${nestedRole.baseRoleId} = ${rr.id}
+                 left join ${ResourceRoleTable as nrr} on ${nestedRole.nestedRoleId} = ${nrr.id}
+                 left join ${ResourceTypeTable as nrrt} on ${nrr.resourceTypeId} = ${nrrt.id}
                  where ${rr.resourceTypeId} in (${resourceTypeRecords.map(_.id)})
                  and ${rr.deprecated} = false"""
 
     roleQuery.map { rs =>
       val roleRecord = ResourceRoleTable(rr.resultName)(rs)
       val actionRecord = rs.anyOpt(ra.resultName.id).map(_ => ResourceActionTable(ra.resultName)(rs))
-      (roleRecord, actionRecord)
+      val nestedRoleRecord = rs.anyOpt(nrr.resultName.id).map(_ => ResourceRoleTable(nrr.resultName)(rs))
+      val descendantsOnly = rs.booleanOpt(nestedRole.resultName.descendantsOnly)
+      val nestedRoleResourceType = rs.stringOpt(nrrt.resultName.name).map(ResourceTypeName.apply)
+      (roleRecord, actionRecord, nestedRoleRecord, descendantsOnly, nestedRoleResourceType)
     }.list().apply()
   }
 
@@ -139,13 +149,30 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
     }
   }
 
-  private def unmarshalResourceRoles(roleAndActionRecords: List[(ResourceRoleRecord, Option[ResourceActionRecord])]): Map[ResourceTypePK, Set[ResourceRole]] = {
-    roleAndActionRecords.groupBy { case (role, _) => role.resourceTypeId }.map { case (resourceTypeId, rolesAndActions) =>
-      val roles = rolesAndActions.groupBy { case (role, _) => role.role }.map { case (roleName, actionsForRole) =>
-        ResourceRole(roleName, actionsForRole.flatMap { case (_, actionRec) => actionRec.map(_.action) }.toSet)
+  private def unmarshalResourceRoles(rolesActionsAndNestedRolesRecords: List[(ResourceRoleRecord, Option[ResourceActionRecord], Option[ResourceRoleRecord], Option[Boolean], Option[ResourceTypeName])]): Map[ResourceTypePK, Set[ResourceRole]] = {
+    rolesActionsAndNestedRolesRecords.groupBy { case (role, _, _, _, _) => role.resourceTypeId }.map { case (resourceTypeId, rolesActionsAndNestedRolesForResourceType) =>
+      val roles = rolesActionsAndNestedRolesForResourceType.groupBy { case (role, _, _, _, _) => role.role }.map { case (roleName, actionsAndNestedRolesForRole) =>
+        val roleActions = actionsAndNestedRolesForRole.flatMap { case (_, actionRec, _, _, _) => actionRec.map(_.action) }.toSet
+        val (descendantRoles, includedRoles) = unmarshalNestedRoles(actionsAndNestedRolesForRole)
+
+        ResourceRole(roleName, roleActions, includedRoles, descendantRoles)
       }
       resourceTypeId -> roles.toSet
     }
+  }
+
+  private def unmarshalNestedRoles(actionsAndNestedRolesByRole: List[(ResourceRoleRecord, Option[ResourceActionRecord], Option[ResourceRoleRecord], Option[Boolean], Option[ResourceTypeName])]): (Map[ResourceTypeName, Set[ResourceRoleName]], Set[ResourceRoleName]) = {
+    val (maybeDescendantRoles, maybeIncludedRoles) = actionsAndNestedRolesByRole.collect { case (_, _, Some(nestedRoleRecord), Some(descendantsOnly), Some(resourceTypeName)) =>
+      if (descendantsOnly) {
+        (Option(resourceTypeName -> nestedRoleRecord.role), None)
+      } else {
+        (None, Option(nestedRoleRecord.role))
+      }
+    }.unzip
+    val descendantRoles = maybeDescendantRoles.toSet.flatten.groupBy(_._1).mapValues(rolesWithResourceTypeNames => rolesWithResourceTypeNames.map(_._2))
+    val includedRoles = maybeIncludedRoles.toSet.flatten
+
+    (descendantRoles, includedRoles)
   }
 
   private def loadResourceTypePKsByName(resourceTypes: Iterable[ResourceType])(implicit session: DBSession): Map[ResourceTypeName, ResourceTypePK] = {
@@ -157,6 +184,47 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
 
   override def createResourceType(resourceType: ResourceType, samRequestContext: SamRequestContext): IO[ResourceType] = {
     upsertResourceTypes(Set(resourceType), samRequestContext).map(_ => resourceType)
+  }
+
+  private def upsertNestedRoles(resourceTypes: Iterable[ResourceType], resourceTypeNameToPKs: Map[ResourceTypeName, ResourceTypePK])(implicit session: DBSession): Int = {
+    val includedRoles = for {
+      rt <- resourceTypes
+      baseRole <- rt.roles
+      includedRole <- baseRole.includedRoles
+    } yield {
+      samsqls"(${resourceTypeNameToPKs(rt.name)}, ${baseRole.roleName}, ${resourceTypeNameToPKs(rt.name)}, ${includedRole}, false)"
+    }
+    val descendantRoles = for {
+      rt <- resourceTypes
+      baseRole <- rt.roles
+      (descendantResourceType, descendantRoles) <- baseRole.descendantRoles
+      descendantRole <- descendantRoles
+    } yield {
+      samsqls"(${resourceTypeNameToPKs(rt.name)}, ${baseRole.roleName}, ${resourceTypeNameToPKs(descendantResourceType)}, ${descendantRole}, true)"
+    }
+    val nestedRoles = includedRoles ++ descendantRoles
+
+    val resourceRole = ResourceRoleTable.syntax("resourceRole")
+    val nestedRole = NestedRoleTable.syntax("nestedRole")
+    samsql"""delete from ${NestedRoleTable as nestedRole}
+            using ${ResourceRoleTable as resourceRole}
+            where ${nestedRole.baseRoleId} = ${resourceRole.id}
+            and ${resourceRole.resourceTypeId} in (${resourceTypeNameToPKs.values})"""
+      .update.apply()
+
+    val nestedResourceRole = ResourceRoleTable.syntax("nestedResourceRole")
+    if (nestedRoles.nonEmpty) {
+      val insertQuery =
+        samsql"""
+                insert into ${NestedRoleTable.table}(${NestedRoleTable.column.baseRoleId}, ${NestedRoleTable.column.nestedRoleId}, ${NestedRoleTable.column.descendantsOnly})
+                select ${resourceRole.id}, ${nestedResourceRole.id}, insertValues.descendants_only from
+                (values ${nestedRoles}) as insertValues (base_resource_type_id, base_role_name, nested_resource_type_id, nested_role_name, descendants_only)
+                join ${ResourceRoleTable as resourceRole} on insertValues.base_role_name = ${resourceRole.role} and insertValues.base_resource_type_id = ${resourceRole.resourceTypeId}
+                join ${ResourceRoleTable as nestedResourceRole} on insertValues.nested_role_name = ${nestedResourceRole.role} and insertValues.nested_resource_type_id = ${nestedResourceRole.resourceTypeId}"""
+      insertQuery.update().apply()
+    } else {
+      0
+    }
   }
 
   private def upsertRoleActions(resourceTypes: Iterable[ResourceType], resourceTypeNameToPKs: Map[ResourceTypeName, ResourceTypePK])(implicit session: DBSession): Int = {

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -87,7 +87,11 @@ testStuff = {
       ownerRoleName = "owner"
       roles = {
         owner = {
-          roleActions = ["alter_policies", "read_policies"]
+          roleActions = ["alter_policies", "read_policies"],
+          includedRoles = ["nonOwner"],
+          descendantRoles = {
+            otherType = ["owner"]
+          }
         },
         nonOwner = {
           roleActions = []

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -147,6 +147,7 @@ object TestSupport extends TestSupport {
         ResourceTable,
         RoleActionTable,
         ResourceActionTable,
+        NestedRoleTable,
         ResourceRoleTable,
         ResourceActionPatternTable,
         ResourceTypeTable,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -109,6 +109,21 @@ class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with 
     constrainedAction.authDomainConstrainable shouldEqual true
   }
 
+  it should "read included and descendant roles" in {
+    val testResourceTypes = TestSupport.config.as[Map[String, ResourceType]]("testStuff.resourceTypes").values.toSet
+    val testType = testResourceTypes.find(_.name == ResourceTypeName("testType")).getOrElse(fail("Missing test resource type, please check src/test/resources/reference.conf"))
+    val ownerRoleName = ResourceRoleName("owner")
+    val nonOwnerRoleName = ResourceRoleName("nonOwner")
+    val expectedRoles = Set(
+      ResourceRole(ownerRoleName,
+        Set(ResourceAction("read_policies"), ResourceAction("alter_policies")),
+        Set(nonOwnerRoleName),
+        Map(ResourceTypeName("otherType") -> Set(ownerRoleName))),
+      ResourceRole(nonOwnerRoleName, Set.empty))
+
+    testType.roles should contain theSameElementsAs expectedRoles
+  }
+
   "ResourceService" should "create and delete resource" in {
     val resourceName = ResourceId("resource")
     val resource = FullyQualifiedResourceId(defaultResourceType.name, resourceName)


### PR DESCRIPTION
Ticket: [CA-1062](https://broadworkbench.atlassian.net/browse/CA-1062), [CA-1075](https://broadworkbench.atlassian.net/browse/CA-1075)

- read descendant and included roles from config
- add descendant and included roles for `google-project` resource types
- update `ResourceRole` to include descendant and included roles
- upsert nested resource roles during resource type init 

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
