### PR TITLE
[CA-1040] google project per billing project

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -11,4 +11,5 @@
     <include file="changesets/20200901_descendant_permissions.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201028_nested_roles.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201029_resource_type_fields.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20201103_add_google_project_child_for_each_billing_project.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
@@ -19,7 +19,8 @@
             FROM   sam_resource sr
                    JOIN sam_resource_type srt
                      ON sr.resource_type_id = srt.id
-            WHERE  srt.name = 'billing-project';
+            WHERE  srt.name = 'billing-project'
+            on conflict do nothing;
         </sql>
     </changeSet>
 

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="ajang" id="add_google_project_child_for_each_billing_project">
+        <sql stripComments="true">
+            INSERT INTO sam_resource
+                        (name,
+                         resource_type_id,
+                         resource_parent_id)
+            SELECT CONCAT(sr.name, '--google-project'),
+                   (SELECT id
+                    FROM   sam_resource_type
+                    WHERE  name = 'google-project'),
+                   sr.id
+            FROM   sam_resource sr
+                   JOIN sam_resource_type srt
+                     ON sr.resource_type_id = srt.id
+            WHERE  srt.name = 'billing-project';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201103_add_google_project_child_for_each_billing_project.xml
@@ -11,7 +11,7 @@
                         (name,
                          resource_type_id,
                          resource_parent_id)
-            SELECT CONCAT(sr.name, '--google-project'),
+            SELECT sr.name,
                    (SELECT id
                     FROM   sam_resource_type
                     WHERE  name = 'google-project'),


### PR DESCRIPTION

Ticket: https://broadworkbench.atlassian.net/browse/CA-1040

Adds a new google-project resource in Sam per billing project. Each google-project's parent is the billing project, which provides permissions via hierarchical resources. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
