### PR TITLE
DR-1484: Add read & alter policy actions to spend profile

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -594,6 +594,15 @@ resourceTypes = {
   }
   spend-profile = {
     actionPatterns = {
+      "read_policies" = {
+        description = "Can read policies"
+      }
+      "read_policy::owner" = {
+        description = "Can read the owner policy"
+      }
+      "alter_policies" = {
+        description = "Can alter policies"
+      }
       "update_billing_account" = {
         description = "Ability to update the spend profile to use a different billing account"
       }
@@ -616,10 +625,10 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "read_policies::owner", "alter_policies"]
       }
       user = {
-        roleActions = ["link"]
+        roleActions = ["link", "read_policies"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -597,9 +597,6 @@ resourceTypes = {
       "read_policies" = {
         description = "Can read policies"
       }
-      "read_policy::owner" = {
-        description = "Can read the owner policy"
-      }
       "alter_policies" = {
         description = "Can alter policies"
       }
@@ -625,10 +622,10 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "read_policies::owner", "alter_policies"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "alter_policies"]
       }
       user = {
-        roleActions = ["link", "read_policies"]
+        roleActions = ["link"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -597,9 +597,6 @@ resourceTypes = {
       "read_policies" = {
         description = "Can read policies"
       }
-      "alter_policies" = {
-        description = "Can alter policies"
-      }
       "update_billing_account" = {
         description = "Ability to update the spend profile to use a different billing account"
       }
@@ -622,7 +619,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "alter_policies"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies"]
       }
       user = {
         roleActions = ["link"]


### PR DESCRIPTION
Ticket: DR-1484
Follow on to [DR-1400 - Add Sam definition of the billing profile resource](https://broadworkbench.atlassian.net/browse/DR-1400). These changes will add the ability to read and alter spend profile policies. 

---

**PR checklist**
(None of these items should be applicable) 
- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
