### PR TITLE
[QA-1309] Add index on policy id in policy role table

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -12,4 +12,5 @@
     <include file="changesets/20201028_nested_roles.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201029_resource_type_fields.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201102_flattened_role_materialized_view.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20201117_policy_role_index" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201117_policy_role_index.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20201117_policy_role_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="mtalbott" id="index_spr_resource_policy_id">
+        <createIndex tableName="SAM_POLICY_ROLE" indexName="IDX_SPR_RESOURCE_POLICY_ID">
+            <column name="resource_policy_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -1366,7 +1366,8 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
           select ${policy.id}, ${ancestorResource.baseResourceTypeId}, ${ancestorResource.baseResourceName}, ${ancestorResource.isAncestor}, ${policy.public}
           from ${ancestorResourceTable as ancestorResource}
           join ${PolicyTable as policy} on ${policy.resourceId} = ${ancestorResource.resourceId}
-          where ${policy.public} OR ${policy.groupId} in (select ${ancestorGroup.parentGroupId} from ${ancestorGroupsTable as ancestorGroup}))"""
+          where ${policy.public} OR ${policy.groupId} in (select ${ancestorGroup.parentGroupId} from ${ancestorGroupsTable as ancestorGroup})
+          order by ${policy.id})"""
 
     UserPoliciesCommonTableExpression(userResourcePolicyTable, userResourcePolicy, queryFragment)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAO.scala
@@ -1366,8 +1366,7 @@ class PostgresAccessPolicyDAO(protected val dbRef: DbReference,
           select ${policy.id}, ${ancestorResource.baseResourceTypeId}, ${ancestorResource.baseResourceName}, ${ancestorResource.isAncestor}, ${policy.public}
           from ${ancestorResourceTable as ancestorResource}
           join ${PolicyTable as policy} on ${policy.resourceId} = ${ancestorResource.resourceId}
-          where ${policy.public} OR ${policy.groupId} in (select ${ancestorGroup.parentGroupId} from ${ancestorGroupsTable as ancestorGroup})
-          order by ${policy.id})"""
+          where ${policy.public} OR ${policy.groupId} in (select ${ancestorGroup.parentGroupId} from ${ancestorGroupsTable as ancestorGroup}))"""
 
     UserPoliciesCommonTableExpression(userResourcePolicyTable, userResourcePolicy, queryFragment)
   }


### PR DESCRIPTION
Ticket: [QA-1309](https://broadworkbench.atlassian.net/browse/QA-1309)
After I merged https://github.com/broadinstitute/sam/pull/481, `listWorkspaces` in Rawls saw a significant decrease in performance. The explain plans before and after the problematic change showed that one side effect of the change was a couple of merge joins had become hash joins. These hash joins were ~2x slower and ~100x more memory intensive. As I understand it, Postgres attempts to choose the best method for joins based on the information it has available. When it does not have much information about the tables it is joining, it chooses a hash join. Before https://github.com/broadinstitute/sam/pull/481, the join between the `userResourcePolicy` CTE and the `sam_policy_role` table was joined on `${userResourcePolicy.policyId} = ${policyRole.resourcePolicyId}` and `${userResourcePolicy.inherited} = ${policyRole.descendantsOnly}`. When https://github.com/broadinstitute/sam/pull/481 removed the second criteria for the join, Postgres did not have enough information to choose a merge join and went with a hash join instead. Adding this index provides Postgres with enough information to select a merge join. Performance test results after adding the index confirm that Postgres is choosing a more optimal query as results are back to where they were before https://github.com/broadinstitute/sam/pull/481.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
