### PR TITLE
[IA-2341] Add stop_start action to kubernetes-app resources

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -451,6 +451,9 @@ resourceTypes = {
       status = {
         description = "view details and configuration of the kubernetes application"
       }
+      stop_start = {
+        description = "stop and start kubernetes application"
+      }
       read_policies = {
         description = "view all policies and policy details for the kubernetes application"
       }
@@ -458,7 +461,7 @@ resourceTypes = {
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["delete", "connect", "update", "status", "read_policies"]
+        roleActions = ["delete", "connect", "update", "status", "stop_start", "read_policies"]
       }
       manager = {
         roleActions = ["delete", "status", "read_policies"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -451,8 +451,11 @@ resourceTypes = {
       status = {
         description = "view details and configuration of the kubernetes application"
       }
-      stop_start = {
-        description = "stop and start kubernetes application"
+      stop = {
+        description = "stop kubernetes application"
+      }
+      start = {
+        description = "start kubernetes application"
       }
       read_policies = {
         description = "view all policies and policy details for the kubernetes application"
@@ -461,7 +464,7 @@ resourceTypes = {
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["delete", "connect", "update", "status", "stop_start", "read_policies"]
+        roleActions = ["delete", "connect", "update", "status", "stop", "start", "read_policies"]
       }
       manager = {
         roleActions = ["delete", "status", "read_policies"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-2341

This will support Leo changes (not quite ready yet) to stop, start, and auto-stop Kubernetes (e.g. Galaxy) applications.

Planning to test end-to-end before merging this.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
