### PR TITLE
[no ticket] bump scalatest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ configure.rb
 /config/
 
 # build specific
+.bsp
 env.properties
 .sbtopts
 .cache/

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM bigtruedata/sbt
+FROM hseeberger/scala-sbt:graalvm-ce-20.3.0-java8_1.4.4_2.13.4
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/hotswap.sh
+++ b/automation/hotswap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Updates the Leo jar of a FIAB to reflect current local code.
+# Run using "./automation/hotswap.sh <your FIAB name>" at the root of the sam repo clone
+
+set -eu
+
+# see https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash
+if [ -z ${1+x} ]; then
+      echo "No arguments supplied. Please provide FIAB name as an argument."
+      exit 1
+fi
+
+FIAB=$1
+ENV=${2:-dev}
+
+printf "Generating the Sam jar...\n\n"
+sbt -Dsbt.log.noformat=true clean assembly
+SAM_JAR_PATH=$(ls target/scala-2.12/sam-assembly*)
+
+printf "\n\nJar successfully generated."
+
+SAM_JAR_NAME=$(basename $SAM_JAR_PATH)
+#
+## Rename the jar to leonardo-assembly-0.1-437ee4a9-SNAPSHOT.jar so the fiab-start Jenkins job picks up the right jar file
+#NEW_SAM_JAR_NAME=$(echo ${LEO_JAR_NAME}|sed 's/http\-/leonardo\-/g' )
+
+printf "\n\nCopying ${SAM_JAR_PATH} to /tmp on FIAB '${FIAB}'...\n\n"
+gcloud compute scp ${SAM_JAR_PATH} ${FIAB}:/tmp --zone=us-central1-a --project broad-dsde-${ENV}
+
+printf "\n\nRemoving the old Leo jars on the FIAB...\n\n"
+# For some reason including the rm command to be executed on the FIAB within the EOSSH block below doesn't work
+gcloud compute ssh --project broad-dsde-${ENV} --zone us-central1-a ${FIAB} -- 'sudo docker exec -it firecloud_sam-app_1 sh -c "rm -f /sam/*jar"'
+
+printf "\n\nCopying the Leo jar to the right location on the FIAB, and restarting the Leo app and proxy...\n\n"
+gcloud compute ssh --project broad-dsde-${ENV} --zone us-central1-a ${FIAB} << EOSSH
+    sudo docker cp /tmp/${SAM_JAR_NAME} firecloud_sam-app_1:/sam/${SAM_JAR_NAME}
+    sudo docker restart firecloud_sam-app_1
+    sudo docker restart firecloud_sam-proxy_1
+EOSSH

--- a/automation/hotswap.sh
+++ b/automation/hotswap.sh
@@ -21,18 +21,15 @@ SAM_JAR_PATH=$(ls target/scala-2.12/sam-assembly*)
 printf "\n\nJar successfully generated."
 
 SAM_JAR_NAME=$(basename $SAM_JAR_PATH)
-#
-## Rename the jar to leonardo-assembly-0.1-437ee4a9-SNAPSHOT.jar so the fiab-start Jenkins job picks up the right jar file
-#NEW_SAM_JAR_NAME=$(echo ${LEO_JAR_NAME}|sed 's/http\-/leonardo\-/g' )
 
 printf "\n\nCopying ${SAM_JAR_PATH} to /tmp on FIAB '${FIAB}'...\n\n"
 gcloud compute scp ${SAM_JAR_PATH} ${FIAB}:/tmp --zone=us-central1-a --project broad-dsde-${ENV}
 
-printf "\n\nRemoving the old Leo jars on the FIAB...\n\n"
+printf "\n\nRemoving the old Sam jars on the FIAB...\n\n"
 # For some reason including the rm command to be executed on the FIAB within the EOSSH block below doesn't work
 gcloud compute ssh --project broad-dsde-${ENV} --zone us-central1-a ${FIAB} -- 'sudo docker exec -it firecloud_sam-app_1 sh -c "rm -f /sam/*jar"'
 
-printf "\n\nCopying the Leo jar to the right location on the FIAB, and restarting the Leo app and proxy...\n\n"
+printf "\n\nCopying the Sam jar to the right location on the FIAB, and restarting the Leo app and proxy...\n\n"
 gcloud compute ssh --project broad-dsde-${ENV} --zone us-central1-a ${FIAB} << EOSSH
     sudo docker cp /tmp/${SAM_JAR_NAME} firecloud_sam-app_1:/sam/${SAM_JAR_NAME}
     sudo docker restart firecloud_sam-app_1

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
     workbenchGoogle2,
 
   // force grpc version
-    "io.grpc" % "grpc-core" % "1.31.1",
+//    "io.grpc" % "grpc-core" % "1.34.0",
   // required by workbenchGoogle
     "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.11" % "provided"
   )

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -46,9 +46,7 @@ object Dependencies {
     workbenchGoogle,
     workbenchGoogle2,
 
-  // force grpc version
-//    "io.grpc" % "grpc-core" % "1.34.0",
   // required by workbenchGoogle
-    "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.11" % "provided"
+    "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV % "provided"
   )
 }

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -4,14 +4,14 @@ object Dependencies {
   val scalaV = "2.12"
 
   val jacksonV = "2.8.4"
-  val akkaV = "2.6.1"
-  val akkaHttpV = "10.1.11"
+  val akkaV = "2.6.10"
+  val akkaHttpV = "10.2.2"
 
-  val workbenchModelV  = "0.13-7e86fba"
+  val workbenchModelV  = "0.14-74c9fc2"
 
-  val workbenchGoogleV = "0.18-8328aae"
-  val workbenchGoogle2V = "0.18-4631ebf"
-  val workbenchServiceTestV = "0.18-c9edd8e"
+  val workbenchGoogleV = "0.21-74c9fc2"
+  val workbenchGoogle2V = "0.18-74c9fc2"
+  val workbenchServiceTestV = "0.18-74c9fc2"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -1,26 +1,22 @@
 import sbt._
 
 object Dependencies {
-  val scalaV = "2.12"
+  val scalaV = "2.13"
 
-  val jacksonV = "2.8.4"
+  val jacksonV = "2.12.0"
   val akkaV = "2.6.10"
   val akkaHttpV = "10.2.2"
-
-  val workbenchModelV  = "0.14-74c9fc2"
 
   val workbenchGoogleV = "0.21-74c9fc2"
   val workbenchGoogle2V = "0.18-74c9fc2"
   val workbenchServiceTestV = "0.18-74c9fc2"
 
-  val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll excludeWorkbenchModel
-  val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
 
-  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests"
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
@@ -47,7 +43,6 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
 
     workbenchServiceTest,
-    workbenchModel,
     workbenchGoogle,
     workbenchGoogle2,
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -10,8 +10,8 @@ object Dependencies {
   val workbenchModelV  = "0.13-7e86fba"
 
   val workbenchGoogleV = "0.18-8328aae"
-  val workbenchGoogle2V = "0.1-8328aae"
-  val workbenchServiceTestV = "0.16-20dceaa"
+  val workbenchGoogle2V = "0.18-4631ebf"
+  val workbenchServiceTestV = "0.18-c9edd8e"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
@@ -42,8 +42,8 @@ object Dependencies {
     "com.typesafe.akka"   %%  "akka-http"           % akkaHttpV,
     "com.typesafe.akka"   %%  "akka-testkit"        % akkaV     % "test",
     "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
-    "org.scalatest"       %%  "scalatest"     % "3.0.5"   % "test",
-    "org.scalacheck"      %%  "scalacheck"    % "1.14.0" % "test",
+    "org.scalatest"       %%  "scalatest"     % "3.1.0"   % Test,
+    "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.0" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
 
     workbenchServiceTest,

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -46,8 +46,9 @@ object Dependencies {
     workbenchGoogle,
     workbenchGoogle2,
 
-
-    // required by workbenchGoogle
+  // force grpc version
+    "io.grpc" % "grpc-core" % "1.31.1",
+  // required by workbenchGoogle
     "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.11" % "provided"
   )
 }

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -42,9 +42,9 @@ object Dependencies {
     "com.typesafe.akka"   %%  "akka-http"           % akkaHttpV,
     "com.typesafe.akka"   %%  "akka-testkit"        % akkaV     % "test",
     "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
-    "org.scalatest"       %%  "scalatest"     % "3.1.0"   % Test,
-    "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.0" % Test,
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
+    "org.scalatest"       %%  "scalatest"     % "3.2.3"   % Test,
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0" % Test,
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
 
     workbenchServiceTest,
     workbenchModel,

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -23,9 +23,7 @@ object Settings {
     "-feature",
     "-encoding", "utf8",
     "-language:postfixOps",
-    "-target:jvm-1.8",
-    "-Xmax-classfile-name", "100",
-    "-Ypartial-unification" // Enable partial unification in type constructor inference
+    "-target:jvm-1.8"
   )
 
   // test parameters explanation:
@@ -42,7 +40,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ testSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
-    scalaVersion  := "2.12.7",
+    scalaVersion  := "2.13.4",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.4.4

--- a/automation/project/plugins.sbt
+++ b/automation/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.1.1")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -192,12 +192,12 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         withCleanUp {
-          val key1 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken)
-          val key2 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken)
+          val key1 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken())
+          val key2 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken())
 
           key1 shouldBe key2
 
-          register cleanUp Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key1, "private_key_id"))(user.makeAuthToken)
+          register cleanUp Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key1, "private_key_id"))(user.makeAuthToken())
         }
       }
     }
@@ -208,11 +208,11 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         withCleanUp {
 
-          val key1 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken)
-          Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key1, "private_key_id"))(user.makeAuthToken)
+          val key1 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken())
+          Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key1, "private_key_id"))(user.makeAuthToken())
 
-          val key2 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken)
-          register cleanUp Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key2, "private_key_id"))(user.makeAuthToken)
+          val key2 = Sam.user.petServiceAccountKey(project)(user.makeAuthToken())
+          register cleanUp Sam.user.deletePetServiceAccountKey(project, getFieldFromJson(key2, "private_key_id"))(user.makeAuthToken())
 
           key1 shouldNot be(key2)
         }
@@ -229,21 +229,21 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       //may have unexpected side effects
       withCleanBillingProject(user) { projectName =>
         withCleanUp {
-          val petSaKeyOriginal = Sam.user.petServiceAccountKey(projectName)(user.makeAuthToken)
+          val petSaKeyOriginal = Sam.user.petServiceAccountKey(projectName)(user.makeAuthToken())
           val petSaEmailOriginal = getFieldFromJson(petSaKeyOriginal, "client_email")
           val petSaKeyIdOriginal = getFieldFromJson(petSaKeyOriginal, "private_key_id")
           val petSaName = petSaEmailOriginal.split('@').head
 
-          register cleanUp Sam.user.deletePetServiceAccountKey(projectName, petSaKeyIdOriginal)(user.makeAuthToken)
+          register cleanUp Sam.user.deletePetServiceAccountKey(projectName, petSaKeyIdOriginal)(user.makeAuthToken())
 
           //act as a rogue process and delete the pet SA without telling sam
           Await.result(googleIamDAO.removeServiceAccount(GoogleProject(projectName), ServiceAccountName(petSaName)), Duration.Inf)
 
-          val petSaKeyNew = Sam.user.petServiceAccountKey(projectName)(user.makeAuthToken)
+          val petSaKeyNew = Sam.user.petServiceAccountKey(projectName)(user.makeAuthToken())
           val petSaEmailNew = getFieldFromJson(petSaKeyNew, "client_email")
           val petSaKeyIdNew = getFieldFromJson(petSaKeyNew, "private_key_id")
 
-          register cleanUp Sam.user.deletePetServiceAccountKey(projectName, petSaKeyIdNew)(user.makeAuthToken)
+          register cleanUp Sam.user.deletePetServiceAccountKey(projectName, petSaKeyIdNew)(user.makeAuthToken())
 
           petSaEmailOriginal should equal(petSaEmailNew) //sanity check to make sure the SA is the same
           petSaKeyIdOriginal should not equal petSaKeyIdNew //make sure we were able to generate a new key and that a new one was returned
@@ -256,12 +256,12 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         // get my pet's email
-        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken)
+        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
 
         val scopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
 
         // get my pet's token
-        val petToken = Sam.user.petServiceAccountToken(project, scopes)(user.makeAuthToken)
+        val petToken = Sam.user.petServiceAccountToken(project, scopes)(user.makeAuthToken())
 
         // convert string token to an AuthToken
         val petAuthToken = new AuthToken {
@@ -279,7 +279,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
     "should arbitrarily choose a project to return a pet key for when the user has existing pets" in {
       val user = UserPool.chooseStudent
-      val userToken = user.makeAuthToken
+      val userToken = user.makeAuthToken()
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project1 =>
         withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project2 =>
@@ -312,12 +312,12 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         // get my pet's email
-        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken)
+        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
 
         val scopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
 
         // get my pet's token
-        val petToken = Sam.user.arbitraryPetServiceAccountToken(scopes)(user.makeAuthToken)
+        val petToken = Sam.user.arbitraryPetServiceAccountToken(scopes)(user.makeAuthToken())
 
         // convert string token to an AuthToken
         val petAuthToken = new AuthToken {
@@ -339,7 +339,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       val scopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
 
       // get my pet's token
-      val petToken = Sam.user.arbitraryPetServiceAccountToken(scopes)(user.makeAuthToken)
+      val petToken = Sam.user.arbitraryPetServiceAccountToken(scopes)(user.makeAuthToken())
 
       // convert string token to an AuthToken
       val petAuthToken = new AuthToken {
@@ -348,7 +348,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       }
 
       // get my pet's email using my pet's token
-      val petEmail1 = getFieldFromJson(Sam.user.arbitraryPetServiceAccountKey()(user.makeAuthToken), "client_email")
+      val petEmail1 = getFieldFromJson(Sam.user.arbitraryPetServiceAccountKey()(user.makeAuthToken()), "client_email")
       val petEmail2 = getFieldFromJson(Sam.user.arbitraryPetServiceAccountKey()(petAuthToken), "client_email")
 
       // result should be the same

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -17,13 +17,14 @@ import org.broadinstitute.dsde.workbench.service.{Orchestration, Sam, Thurloe, _
 import org.broadinstitute.dsde.workbench.test.SamConfig
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers}
 import org.broadinstitute.dsde.workbench.service.util.Tags
 
 import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, _}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SamApiSpec extends FreeSpec with BillingFixtures with Matchers with ScalaFutures with CleanUp with Eventually with TestKitBase {
+class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with ScalaFutures with CleanUp with Eventually with TestKitBase {
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)))
   implicit lazy val system = ActorSystem()
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
@@ -8,12 +8,13 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.google2.GoogleFirestoreInterpreter
 import org.broadinstitute.dsde.workbench.google2.util.{DistributedLock, DistributedLockConfig, FailToObtainLock}
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
-import org.scalatest.{AsyncFlatSpec, Matchers}
 import org.broadinstitute.dsde.workbench.test.Generators.genLockPath
 import org.broadinstitute.dsde.workbench.test.SamConfig.GCS
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class DistributedLockSpec extends AsyncFlatSpec with Matchers {
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
 import cats.kernel.Eq
-import cats.implicits._
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.GoogleFirestoreInterpreter
 import org.broadinstitute.dsde.workbench.google2.util.{DistributedLock, DistributedLockConfig, FailToObtainLock}
 import org.broadinstitute.dsde.workbench.model.WorkbenchException

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/util/DistributedLockSpec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.test.Generators.genLockPath
 import org.broadinstitute.dsde.workbench.test.SamConfig.GCS
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,5 @@ sys.env.getOrElse("JAVA_OPTS", "").split(" ").toSeq.map { opt =>
   javaOptions in reStart += opt
 }
 
-addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
-addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
-
-bloopAggregateSourceDependencies in Global := true
+addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
+addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,27 +1,25 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.6.8"
-  val akkaHttpV = "10.2.0"
+  val akkaV = "2.6.10"
+  val akkaHttpV = "10.2.2"
   val jacksonV = "2.9.5"
-  val scalaLoggingV = "3.5.0"
-  val scalaTestV    = "3.0.5"
+  val scalaLoggingV = "3.9.2"
+  val scalaTestV    = "3.2.3"
   val scalaCheckV    = "1.14.0"
-  val catsEffectV         = "2.1.1"
   val scalikejdbcVersion    = "3.4.1"
   val postgresDriverVersion = "42.2.8"
   val http4sVersion = "0.21.0-M5"
   val circeVersion = "0.12.2"
 
-  val workbenchUtilV   = "0.6-1e1f697"
-  val workbenchUtil2V   = "0.1-1e1f697"
-  val workbenchModelV  = "0.14-1e1f697"
-  val workbenchGoogleV = "0.21-1e1f697"
-  val workbenchGoogle2V = "0.17-1e1f697"
+  val workbenchUtilV   = "0.6-4631ebf"
+  val workbenchUtil2V   = "0.1-4631ebf"
+  val workbenchModelV  = "0.14-4631ebf"
+  val workbenchGoogleV = "0.21-4631ebf"
+  val workbenchGoogle2V = "0.18-4631ebf"
   val workbenchNotificationsV = "0.3-1e1f697"
   val workbenchNewRelicV = "0.2-24dabc8"
   val monocleVersion = "1.5.1-cats"
-  val newRelicVersion = "4.11.0"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
@@ -33,7 +31,6 @@ object Dependencies {
 
   val jwtSpray: ModuleID = "com.pauldijou" %% "jwt-spray-json" % "4.1.0"
   val jwtCirce: ModuleID = "com.pauldijou" %% "jwt-circe" % "4.1.0"
-  val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % newRelicVersion
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
   val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV
   val jacksonCore: ModuleID =        "com.fasterxml.jackson.core" % "jackson-core"        % jacksonV
@@ -52,7 +49,6 @@ object Dependencies {
   val akkaTestKit: ModuleID =       "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
   val scalaCheck: ModuleID =        "org.scalacheck"      %%  "scalacheck"           % scalaCheckV % "test"
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % catsEffectV
 
   val http4s: ModuleID = "org.http4s" %% "http4s-dsl" % http4sVersion
   val http4sClient: ModuleID = "org.http4s" %% "http4s-blaze-client" % http4sVersion
@@ -71,7 +67,8 @@ object Dependencies {
   val monocleMacro: ModuleID = "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion
 
   val scalaTest: ModuleID =       "org.scalatest" %% "scalatest"    % scalaTestV % "test"
-  val mockito: ModuleID =         "org.mockito"    % "mockito-core" % "2.7.22"   % "test"
+  val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestV}.0" % Test
+  val scalaTestMockito = "org.scalatestplus" %% "mockito-3-4" % s"${scalaTestV}.0" % Test
 
   val unboundid: ModuleID = "com.unboundid" % "unboundid-ldapsdk" % "4.0.12"
 
@@ -92,7 +89,7 @@ object Dependencies {
   val workbenchNewRelic: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.1" % "test" //needed for mocking google cloud storage
 
-  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "3.6.3"
+  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 
   val scalikeCore =       "org.scalikejdbc"                   %% "scalikejdbc"         % scalikejdbcVersion
   val scalikeCoreConfig = "org.scalikejdbc"                   %% "scalikejdbc-config"  % scalikejdbcVersion
@@ -138,11 +135,11 @@ object Dependencies {
 
     monocle,
     monocleMacro,
-    newRelic,
 
     scalaTest,
-    mockito,
+    scalaTestScalaCheck,
     scalaCheck,
+    scalaTestMockito,
 
     workbenchUtil,
     workbenchModel,
@@ -155,7 +152,6 @@ object Dependencies {
     workbenchNewRelic,
 
     unboundid,
-    catsEffect,
     commonsCodec,
 
     liquibaseCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,13 +12,12 @@ object Dependencies {
   val http4sVersion = "0.21.0-M5"
   val circeVersion = "0.12.2"
 
-  val workbenchUtilV   = "0.6-4631ebf"
-  val workbenchUtil2V   = "0.1-4631ebf"
-  val workbenchModelV  = "0.14-4631ebf"
-  val workbenchGoogleV = "0.21-4631ebf"
-  val workbenchGoogle2V = "0.18-4631ebf"
-  val workbenchNotificationsV = "0.3-1e1f697"
-  val workbenchNewRelicV = "0.2-24dabc8"
+  val workbenchUtilV   = "0.6-74c9fc2"
+  val workbenchUtil2V   = "0.1-74c9fc2"
+  val workbenchModelV  = "0.14-74c9fc2"
+  val workbenchGoogleV = "0.21-74c9fc2"
+  val workbenchGoogle2V = "0.18-74c9fc2"
+  val workbenchNotificationsV = "0.3-74c9fc2"
   val monocleVersion = "1.5.1-cats"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
@@ -58,7 +57,7 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
 
   val excludIoGrpc =  ExclusionRule(organization = "io.grpc", name = "grpc-core")
-  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.33.1"
+  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.0"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll(excludIoGrpc)
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20181013-1.27.0" excludeAll(excludIoGrpc) //force this version
@@ -86,8 +85,7 @@ object Dependencies {
   val workbenchNotifications: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll(excludeWorkbenchGoogle, excludeWorkbenchModel)
   val workbenchGoogleTests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
   val workbenchGoogle2Tests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
-  val workbenchNewRelic: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % workbenchNewRelicV excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.1" % "test" //needed for mocking google cloud storage
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.3" % "test" //needed for mocking google cloud storage
 
   val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 
@@ -149,7 +147,6 @@ object Dependencies {
     workbenchGoogleTests,
     workbenchGoogle2Tests,
     googleStorageLocal,
-    workbenchNewRelic,
 
     unboundid,
     commonsCodec,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
 
   val excludIoGrpc =  ExclusionRule(organization = "io.grpc", name = "grpc-core")
-  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.0"
+  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.33.1"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll(excludIoGrpc)
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20181013-1.27.0" excludeAll(excludIoGrpc) //force this version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
 
   val excludIoGrpc =  ExclusionRule(organization = "io.grpc", name = "grpc-core")
-  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.33.1"
+  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.0"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll(excludIoGrpc)
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20181013-1.27.0" excludeAll(excludIoGrpc) //force this version

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
     "-unchecked", // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-//    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
     "-Xfuture", // Turn on future language features.
     "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
     "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
     "-unchecked", // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+//    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
     "-Xfuture", // Turn on future language features.
     "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
     "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.1.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -132,7 +132,6 @@ class GoogleGroupSyncMonitorActor(
       import Tracing._
       trace("GoogleGroupSyncMonitor-PubSubMessage") { span =>
         val groupId: WorkbenchGroupIdentity = parseMessage(message)
-
         groupSynchronizer
           .synchronizeGroupMembers(groupId, samRequestContext = SamRequestContext(Option(span))) // Since this is an internal pub/sub call, we have to start a new SamRequestContext.
           .toTry

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -31,9 +31,9 @@ import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, MockAccess
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.scalatest.Matchers
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.prop.{Configuration, PropertyChecks}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.prop.Configuration
 import org.scalatest.time.{Seconds, Span}
 import scalikejdbc.withSQL
 import scalikejdbc.QueryDSL.delete
@@ -41,6 +41,7 @@ import scalikejdbc.QueryDSL.delete
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Awaitable, ExecutionContext}
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/27/17.
@@ -59,7 +60,7 @@ trait TestSupport{
   def dummyResourceType(name: ResourceTypeName) = ResourceType(name, Set.empty, Set(ResourceRole(ResourceRoleName("owner"), Set.empty)), ResourceRoleName("owner"))
 }
 
-trait PropertyBasedTesting extends PropertyChecks with Configuration with Matchers {
+trait PropertyBasedTesting extends ScalaCheckPropertyChecks with Configuration with Matchers {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -17,17 +17,19 @@ import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import spray.json.DefaultJsonProtocol._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by gpolumbo on 2/26/2017.
   */
-class ManagedGroupRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
+class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
 
   private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
   private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -13,15 +13,17 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import spray.json.DefaultJsonProtocol._
 
 import scala.language.reflectiveCalls
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by gpolumbo on 2/26/2017.
   */
-class ManagedGroupRoutesV1Spec extends FlatSpec with ScalaFutures with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
+class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
 
   private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
   private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -14,16 +14,18 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
 import scala.collection.concurrent.TrieMap
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/7/17.
   */
-class ResourceRoutesSpec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
+class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
   def defaultGoogleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
@@ -14,18 +14,20 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.MockAccessPolicyDAO
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 
 import scala.collection.concurrent.TrieMap
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/7/17.
   */
 @deprecated("this allows testing of deprecated functions, remove as part of CA-1031", "")
-class ResourceRoutesV1Spec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
+class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
   val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -20,14 +20,16 @@ import org.broadinstitute.dsde.workbench.sam.{TestSupport, model}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.{any, argThat, eq => mockitoEq}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.AppendedClues
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ResourceRoutesV2Spec extends FlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
+class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
 
   implicit val errorReportSource = ErrorReportSource("sam")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -20,16 +20,16 @@ import org.broadinstitute.dsde.workbench.sam.directory.{DirectoryDAO, MockDirect
 import org.broadinstitute.dsde.workbench.sam.identityConcentrator.IdentityConcentratorService
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, UserService}
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
-import org.scalatest.FlatSpec
 import pdi.jwt.JwtSprayJson
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext
+import org.scalatest.flatspec.AnyFlatSpec
 
-class StandardUserInfoDirectivesSpec extends FlatSpec with PropertyBasedTesting with ScalatestRouteTest with ScalaFutures with MockitoSugar {
+class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesting with ScalatestRouteTest with ScalaFutures with MockitoSugar {
   def directives: StandardUserInfoDirectives = new StandardUserInfoDirectives {
     override implicit val executionContext: ExecutionContext = null
     override val directoryDAO: DirectoryDAO = new MockDirectoryDAO()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -13,12 +13,13 @@ import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.{Database, OpenDJ}
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StatusRouteSpec extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport {
+class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
 
   "GET /version" should "give 200 for ok" in {
     val samRoutes = TestSamRoutes(Map.empty)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -14,10 +14,11 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genWorkbenchUserId
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, NoExtensions, StatusService, UserService}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/7/17.
@@ -145,7 +146,7 @@ class UserRoutesSpec extends UserRoutesSpecHelper {
   }
 }
 
-trait UserRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport{
+trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport{
   val defaultUserId = WorkbenchUserId("newuser")
   val defaultUserEmail = WorkbenchEmail("newuser@new.com")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/NonEmptyListConfigSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/NonEmptyListConfigSpec.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
-import org.scalatest.{FlatSpec, Matchers}
 import com.typesafe.config._
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.nonEmptyListReader
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class NonEmptyListConfigReaderSpec extends FlatSpec with Matchers {
+class NonEmptyListConfigReaderSpec extends AnyFlatSpec with Matchers {
   "NonEmptyListConfigReader" should "read missing list" in {
     val c = ConfigFactory.empty()
     val test = c.as[Option[NonEmptyList[String]]]("test")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/LdapRegistrationDAOSpec.scala
@@ -10,14 +10,16 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 5/30/17.
   */
-class LdapRegistrationDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll with DirectorySubjectNameSupport {
+class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll with DirectorySubjectNameSupport {
   override lazy val directoryConfig: DirectoryConfig = TestSupport.directoryConfig
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password), directoryConfig.connectionPoolSize)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/directory/PostgresDirectoryDAOSpec.scala
@@ -11,11 +11,13 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.openam.PostgresAccessPolicyDAO
 import org.postgresql.util.PSQLException
-import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.duration._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class PostgresDirectoryDAOSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
+class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach {
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
   val dao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc)
   val policyDAO = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.blockingEc)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -20,11 +20,12 @@ import org.broadinstitute.dsde.workbench.sam.service._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
@@ -230,7 +231,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
   }
 }
 
-trait GoogleExtensionRoutesSpecHelper extends FlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
+trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
   val defaultUserId = genWorkbenchUserId(System.currentTimeMillis())
   val defaultUserEmail = genNonPetEmail.sample.get
   val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -33,16 +33,18 @@ import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, PrivateMethodTester}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, PrivateMethodTester}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Success, Try}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
+class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with AnyFlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -8,8 +8,8 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, Wor
 import org.broadinstitute.dsde.workbench.sam.{TestSupport, _}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.ArgumentMatchers.{ eq => mockitoEq }
 
 import org.mockito.Mockito._
@@ -21,8 +21,10 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import spray.json._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with TestSupport with MockitoSugar with BeforeAndAfterAll with Eventually {
+class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) with AnyFlatSpecLike with Matchers with TestSupport with MockitoSugar with BeforeAndAfterAll with Eventually {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/identityConcentrator/IdentityConcentratorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/identityConcentrator/IdentityConcentratorServiceSpec.scala
@@ -5,11 +5,12 @@ import java.nio.charset.StandardCharsets
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{GoogleSubjectId, WorkbenchEmail}
-import org.scalatest.{FlatSpec, Matchers}
 import IdentityConcentratorModel._
 import pdi.jwt.JwtCirce
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class IdentityConcentratorServiceSpec extends FlatSpec with Matchers {
+class IdentityConcentratorServiceSpec extends AnyFlatSpec with Matchers {
   class TestICApi(userInfo: UserInfo) extends IdentityConcentratorApi {
     override def getUserInfo(accessToken: OAuth2BearerToken): IO[UserInfo] = {
       IO.pure(userInfo)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/MockAccessPolicyDAOSpec.scala
@@ -12,17 +12,19 @@ import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.reflectiveCalls
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/26/17.
   */
-class MockAccessPolicyDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig: DirectoryConfig = TestSupport.appConfig.directoryConfig
   val schemaLockConfig = TestSupport.appConfig.schemaLockConfig
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/openam/PostgresAccessPolicyDAOSpec.scala
@@ -14,13 +14,15 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.directory._
 import org.broadinstitute.dsde.workbench.sam.openam.LoadResourceAuthDomainResult.{Constrained, NotConstrained, ResourceNotFound}
 import org.postgresql.util.PSQLException
-import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class PostgresAccessPolicyDAOSpec extends FreeSpec with Matchers with BeforeAndAfterEach {
+class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach {
   implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
   val dao = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.blockingEc)
   val dirDao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.blockingEc)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAOSpec.scala
@@ -7,11 +7,13 @@ import org.scalatest.{Ignore => _, _}
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by mbemis on 3/12/18.
   */
-class JndiSchemaDAOSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+class JndiSchemaDAOSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = TestSupport.appConfig.directoryConfig
   val schemaLockConfig = TestSupport.appConfig.schemaLockConfig
   val schemaDao = new JndiSchemaDAO(directoryConfig, schemaLockConfig)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -17,15 +17,17 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by gpolumbo on 2/21/2018
   */
-class ManagedGroupServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSugar
+class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport with MockitoSugar
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures with OptionValues {
   val directoryConfig = TestSupport.appConfig.directoryConfig
   val schemaLockConfig = TestSupport.appConfig.schemaLockConfig

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -17,8 +17,10 @@ import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, PostgresAc
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.scalatest._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PolicyEvaluatorServiceSpec extends FlatSpec with Matchers with TestSupport with BeforeAndAfterEach {
+class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfterEach {
   val dirURI = new URI(directoryConfig.directoryUrl)
   val connectionPool = new LDAPConnectionPool(
     new LDAPConnection(dirURI.getHost, dirURI.getPort, directoryConfig.user, directoryConfig.password),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -19,15 +19,17 @@ import org.broadinstitute.dsde.workbench.sam.openam.{AccessPolicyDAO, PostgresAc
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by dvoet on 6/27/17.
   */
-class ResourceServiceSpec extends FlatSpec with Matchers with ScalaFutures with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
+class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   val directoryConfig = TestSupport.directoryConfig
   val schemaLockConfig = TestSupport.schemaLockConfig
   //Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
@@ -11,15 +11,17 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.{Database, GoogleGroups, OpenDJ}
 import org.broadinstitute.dsde.workbench.util.health.{StatusCheckResponse, SubsystemStatus, Subsystems}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import scalikejdbc.config.DBs
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class StatusServiceSpec extends FreeSpec with Matchers with BeforeAndAfterAll with TestSupport with Eventually {
+class StatusServiceSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with TestSupport with Eventually {
   implicit val system = ActorSystem("StatusServiceSpec")
   val allUsersEmail = WorkbenchEmail("allusers@example.com")
   val dbReference = TestSupport.dbRef

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -22,17 +22,19 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by rtitle on 10/6/17.
   */
-class UserServiceSpec extends FlatSpec with Matchers with TestSupport with MockitoSugar with PropertyBasedTesting
+class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with MockitoSugar with PropertyBasedTesting
   with BeforeAndAfter with BeforeAndAfterAll with ScalaFutures {
 
   override implicit val patienceConfig = PatienceConfig(timeout = scaled(5.seconds))


### PR DESCRIPTION
* Bumped scalatest version to latest. 3.0.x to 3.1.x is breaking change, hence the majority of the diff. Used [this](https://github.com/scalatest/autofix/tree/master/3.1.x#autofix-for-scalatest-31x) for migrating.
* Remove Bloop.
* Remove newrelic from dependencies file.
* Bump google2 to latest version
* Bump liquibase version. I upgraded version in leo a while ago, and noticed no breaking change.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
