### PR TITLE
SUP-437 Notification failure

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val workbenchModelV  = "0.14-74c9fc2"
   val workbenchGoogleV = "0.21-74c9fc2"
   val workbenchGoogle2V = "0.18-74c9fc2"
-  val workbenchNotificationsV = "0.3-74c9fc2"
+  val workbenchNotificationsV = "0.3-d74ff96"
   val monocleVersion = "2.0.3"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/SUP-437

Get new version of `workbench-notifications` that has the `-Xcheckinit` flag disabled so that uninitialized access does not crash the JVM.  Test was added to exercise area of code that was causing JVM to crash with the above flag enabled.  

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
