### PR TITLE
CA-1176 allow children to be deleted without remove_child on parent

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -270,9 +270,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     delete {
       requireAction(resource, SamResourceActions.delete, userInfo.userId, samRequestContext) {
-        requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.userId, samRequestContext) {
-          complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
-        }
+        complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -269,6 +269,9 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
 
   def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     delete {
+      // Note that this does not require remove_child on the parent if it exists. remove_child is meant to prevent
+      // users from removing a child only to add it to a different parent and thus circumvent any permissions
+      // a parent may be enforcing. Deleting a child does not allow this situation.
       requireAction(resource, SamResourceActions.delete, userInfo.userId, samRequestContext) {
         complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -1413,21 +1413,6 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
-  it should "403 if user is missing remove_child on parent resource if it exists" in {
-    val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
-    val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
-    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
-
-    setupParentRoutes(samRoutes, childResource,
-      currentParentOpt = Option(currentParentResource),
-      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
-      actionsOnCurrentParent = Set(SamResourceActions.readPolicies))
-
-    Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
   "GET /api/resources/v2/{resourceType}/{resourceId}/policies/{policyName}" should "200 on existing policy of a resource with read_policies" in {
     val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty, None)
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("resource"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -411,6 +411,43 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
+  it should "204 deleting a child resource" in {
+    val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
+    val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
+    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
+
+    setupParentRoutes(samRoutes, childResource,
+      currentParentOpt = Option(currentParentResource),
+      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete))
+
+    //Delete the resource
+    Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
+      withClue(responseAs[String]) {
+        status shouldEqual StatusCodes.NoContent
+      }
+    }
+  }
+
+  it should "400 when attempting to delete a resource with children" in {
+    val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
+    val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
+    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
+
+    setupParentRoutes(samRoutes, childResource,
+      currentParentOpt = Option(parentResource),
+      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
+      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
+
+    //Throw 400 exception when delete is called
+    when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext]))
+      .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again.")))
+
+    //Delete the resource
+    Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
+
   "GET /api/resources/v2/{resourceType}" should "200" in {
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
@@ -1009,7 +1046,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       mockPermissionsForResource(samRoutes, newParent, actionsOnResource = actionsOnNewParent)
     }
 
-    if (actionsOnChild.contains(SamResourceActions.delete) && actionsOnCurrentParent.contains(SamResourceActions.removeChild)) {
+    if (actionsOnChild.contains(SamResourceActions.delete)) {
       when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext])).thenReturn(Future.unit)
     }
   }
@@ -1395,24 +1432,6 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
-  "DELETE /api/resources/v2/{resourceTypeName}/{resourceId}" should "204 on a child resource if the user has remove_child on the parent resource" in {
-    val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
-    val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
-    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
-
-    setupParentRoutes(samRoutes, childResource,
-      currentParentOpt = Option(currentParentResource),
-      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
-
-    //Delete the resource
-    Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
-      withClue(responseAs[String]) {
-        status shouldEqual StatusCodes.NoContent
-      }
-    }
-  }
-
   "GET /api/resources/v2/{resourceType}/{resourceId}/policies/{policyName}" should "200 on existing policy of a resource with read_policies" in {
     val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty, None)
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("resource"))
@@ -1464,26 +1483,6 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     Get(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyName.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  it should "400 when attempting to delete a resource with children" in {
-    val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
-    val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
-    val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
-
-    setupParentRoutes(samRoutes, childResource,
-      currentParentOpt = Option(parentResource),
-      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
-
-    //Throw 400 exception when delete is called
-    when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext]))
-      .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again.")))
-
-    //Delete the resource
-    Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.BadRequest
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-1176
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
