### PR TITLE
[PF-413] Support for WSM controlled resources

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -228,7 +228,6 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
-    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-user-private-workspace-resource = {
@@ -288,7 +287,6 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
-    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-application-shared-workspace-resource = {
@@ -342,7 +340,6 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
-    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-application-private-workspace-resource = {
@@ -402,7 +399,6 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
-    authDomainConstrainable = true
     reuseIds = false
   }
   managed-group = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -33,7 +33,6 @@ resourceTypes = {
     reuseIds = false
   }
   workspace = {
-;   todo forcing travis retest
     actionPatterns = {
       delete = {
         description = "delete this workspace"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -33,6 +33,7 @@ resourceTypes = {
     reuseIds = false
   }
   workspace = {
+;   todo forcing travis retest
     actionPatterns = {
       delete = {
         description = "delete this workspace"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -128,7 +128,8 @@ resourceTypes = {
           google-project = ["owner"]
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-user-private-workspace-resource = ["assigner", "editor"]
-          controlled-application-shared-workspace-resource = ["writer", "reader"]
+          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-application-private-workspace-resource = ["editor"]
         }
       }
       editor = {
@@ -136,7 +137,8 @@ resourceTypes = {
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-user-private-workspace-resource = ["editor"]
-          controlled-application-shared-workspace-resource = ["writer", "reader"]
+          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-application-private-workspace-resource = ["editor"]
         }
       }
       application = {
@@ -214,7 +216,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent"]
       }
       editor = {
         roleActions = ["delete", "edit"]
@@ -270,7 +272,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "manage_private_user", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
       }
       assigner = {
         roleActions = ["manage_private_user"]
@@ -326,7 +328,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent"]
       }
       editor = {
         roleActions = ["delete", "edit"]
@@ -382,7 +384,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "manage_private_user", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
       }
       assigner = {
         roleActions = ["manage_private_user"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -228,6 +228,7 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
+    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-user-private-workspace-resource = {
@@ -287,6 +288,7 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
+    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-application-shared-workspace-resource = {
@@ -340,6 +342,7 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
+    authDomainConstrainable = true
     reuseIds = false
   }
   controlled-application-private-workspace-resource = {
@@ -399,6 +402,7 @@ resourceTypes = {
         roleActions = ["read"]
       }
     }
+    authDomainConstrainable = true
     reuseIds = false
   }
   managed-group = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -43,6 +43,12 @@ resourceTypes = {
       "share_policy::owner" = {
         description = "change the membership of the owner policy for this workspace"
       }
+      "share_policy::application" = {
+        description = "change the membership of the application policy for this workspace"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this workspace"
+      }
       "share_policy::writer" = {
         description = "change the membership of the writer policy for this workspace"
       }
@@ -63,6 +69,9 @@ resourceTypes = {
         description = "perform writer actions on the workspace"
         authDomainConstrainable = true
       }
+      "edit" = {
+        description = "perform editor actions on the workspace"
+      }
       "own" = {
         description = "perform owner actions on the workspace"
         authDomainConstrainable = true
@@ -75,6 +84,27 @@ resourceTypes = {
       }
       "read_auth_domain" = {
         description = "view the auth domain of the workspace"
+      }
+      "create_controlled_user_private" = {
+        description = "create controlled, user-owned private resources in the workspace"
+      }
+      "create_controlled_user_shared" = {
+        description = "create controlled, user-owned shared resources in the workspace"
+      }
+      "create_controlled_application_private" = {
+        description = "create controlled, application-owned private resources in the workspace"
+      }
+      "create_controlled_application_shared" = {
+        description = "create controlled, application-owned shared resources in the workspace"
+      }
+      "create_referenced_resource" = {
+        description = "create references to resources in the workspace"
+      }
+      "update_referenced_resource" = {
+        description = "update references to resources in the workspace"
+      }
+      "delete_referenced_resource" = {
+        description = "delete references to resources in the workspace"
       }
       add_child = {
         description = "add a child resource"
@@ -93,16 +123,38 @@ resourceTypes = {
         roleActions = []
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "list_children", "remove_child", "add_child"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "edit", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
         descendantRoles = {
           google-project = ["owner"]
+          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = ["assigner", "editor"]
+          controlled-application-shared-workspace-resource = ["writer", "reader"]
         }
+      }
+      editor = {
+        roleActions = ["read_policy::owner", "edit", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "add_child", "remove_child", "read_auth_domain"]
+        descendantRoles = {
+          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = ["editor"]
+          controlled-application-shared-workspace-resource = ["writer", "reader"]
+        }
+      }
+      application = {
+        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "add_child", "remove_child", "read_auth_domain"]
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "read_auth_domain"]
+        descendantRoles = {
+          controlled-user-shared-workspace-resource = ["writer", "reader"]
+          controlled-application-shared-workspace-resource = ["writer", "reader"]
+        }
       }
       reader = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]
+        descendantRoles = {
+          controlled-user-shared-workspace-resource = ["reader"]
+          controlled-application-shared-workspace-resource = ["reader"]
+        }
       }
       share-reader = {
         roleActions = ["share_policy::reader", "read_policies"]
@@ -121,6 +173,230 @@ resourceTypes = {
       }
     }
     authDomainConstrainable = true
+    reuseIds = false
+  }
+  controlled-user-shared-workspace-resource = {
+    actionPatterns = {
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      set_parent = {
+        description = "set the parent workspace of this resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this resource"
+      }
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this resource"
+      }
+      "read" = {
+        description = "perform reader actions on the resource"
+      }
+      "write" = {
+        description = "perform writer actions on the resource"
+      }
+      "edit" = {
+        description = "perform editor actions on the resource"
+      }
+      "own" = {
+        description = "perform owner actions on the resource"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "set_parent"]
+      }
+      editor = {
+        roleActions = ["delete", "edit"]
+      }
+      writer = {
+        roleActions = ["write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = false
+  }
+  controlled-user-private-workspace-resource = {
+    actionPatterns = {
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      set_parent = {
+        description = "set the parent workspace of this resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this resource"
+      }
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this resource"
+      }
+      "read" = {
+        description = "perform reader actions on the resource"
+      }
+      "write" = {
+        description = "perform writer actions on the resource"
+      }
+      "edit" = {
+        description = "perform editor actions on the resource"
+      }
+      "own" = {
+        description = "perform owner actions on the resource"
+      }
+      "manage_private_user" = {
+        description = "assign, remove, and reassign the private user"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "manage_private_user", "set_parent"]
+      }
+      assigner = {
+        roleActions = ["manage_private_user"]
+      }
+      editor = {
+        roleActions = ["delete", "edit"]
+      }
+      writer = {
+        roleActions = ["write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = false
+  }
+  controlled-application-shared-workspace-resource = {
+    actionPatterns = {
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      set_parent = {
+        description = "set the parent workspace of this resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this resource"
+      }
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this resource"
+      }
+      "read" = {
+        description = "perform reader actions on the resource"
+      }
+      "write" = {
+        description = "perform writer actions on the resource"
+      }
+      "edit" = {
+        description = "perform editor actions on the resource"
+      }
+      "own" = {
+        description = "perform owner actions on the resource"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "set_parent"]
+      }
+      editor = {
+        roleActions = ["delete", "edit"]
+      }
+      writer = {
+        roleActions = ["write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = false
+  }
+  controlled-application-private-workspace-resource = {
+    actionPatterns = {
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      set_parent = {
+        description = "set the parent workspace of this resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this resource"
+      }
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this resource"
+      }
+      "read" = {
+        description = "perform reader actions on the resource"
+      }
+      "write" = {
+        description = "perform writer actions on the resource"
+      }
+      "edit" = {
+        description = "perform editor actions on the resource"
+      }
+      "own" = {
+        description = "perform owner actions on the resource"
+      }
+      "manage_private_user" = {
+        description = "assign, remove, and reassign the private user"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "manage_private_user", "set_parent"]
+      }
+      assigner = {
+        roleActions = ["manage_private_user"]
+      }
+      editor = {
+        roleActions = ["delete", "edit"]
+      }
+      writer = {
+        roleActions = ["write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+    }
     reuseIds = false
   }
   managed-group = {


### PR DESCRIPTION
Ticket: [PF-413](https://broadworkbench.atlassian.net/browse/PF-413)
This change adds controlled resource types and expands the workspace resource model to also grant certain inherited roles on child resources of a workspace. I didn't use `authDomainConstrainable` for new workspace roles or the new resources - I'm not sure if we need this or not.

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
