### PR TITLE
[PF-504] Followup changes to WSM controlled resources

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -123,40 +123,22 @@ resourceTypes = {
         roleActions = []
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::writer", "share_policy::reader", "own", "edit", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "edit", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
         descendantRoles = {
           google-project = ["owner"]
-          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-user-private-workspace-resource = ["assigner", "editor"]
-          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-application-private-workspace-resource = ["editor"]
         }
       }
       editor = {
-        roleActions = ["read_policy::owner", "edit", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "add_child", "remove_child", "read_auth_domain"]
-        descendantRoles = {
-          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-user-private-workspace-resource = ["editor"]
-          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-application-private-workspace-resource = ["editor"]
-        }
+        roleActions = ["read_policy::owner", "edit", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
       }
       application = {
-        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "add_child", "remove_child", "read_auth_domain"]
+        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "read_auth_domain"]
-        descendantRoles = {
-          controlled-user-shared-workspace-resource = ["writer", "reader"]
-          controlled-application-shared-workspace-resource = ["writer", "reader"]
-        }
       }
       reader = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]
-        descendantRoles = {
-          controlled-user-shared-workspace-resource = ["reader"]
-          controlled-application-shared-workspace-resource = ["reader"]
-        }
       }
       share-reader = {
         roleActions = ["share_policy::reader", "read_policies"]


### PR DESCRIPTION
Ticket: [PF-504](https://broadworkbench.atlassian.net/browse/PF-504)
This PR makes a number of tweaks to the controlled resource object model introduced previously in #509:

- First, this removes the `inheritedRole` mappings on workspace roles. In order to sync Sam policies (which only exist on workspace objects and not individual resources) to cloud resources, WSM still needs to maintain its own mapping of the workspace role -> resource role inheritance. Rather than duplicate that mapping in both WSM and Sam, it's more appropriate to have one canonical mapping in WSM and use policy-based inheritance in Sam (where the specification can live in WSM), rather than role-based inheritance.
- Second, this grants workspace owners the ability to share the new editor and application workspace roles. Workspace owners should have the ability to add other users to a workspace, and I forgot to add this permission when I previously introduced the new workspace roles.
- Third, this grants workspace editors and applications permission to list children of the workspace (i.e. the resources in that workspace). They already have the ability to add or remove children, and listing existing children is convenient.

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
