### PR TITLE
[PF-504] Remove workspace editor role, give its permissions to writers

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -117,7 +117,7 @@ resourceTypes = {
         roleActions = []
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "edit", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
         descendantRoles = {
           google-project = ["owner"]
         }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -46,9 +46,6 @@ resourceTypes = {
       "share_policy::application" = {
         description = "change the membership of the application policy for this workspace"
       }
-      "share_policy::editor" = {
-        description = "change the membership of the editor policy for this workspace"
-      }
       "share_policy::writer" = {
         description = "change the membership of the writer policy for this workspace"
       }
@@ -68,9 +65,6 @@ resourceTypes = {
       "write" = {
         description = "perform writer actions on the workspace"
         authDomainConstrainable = true
-      }
-      "edit" = {
-        description = "perform editor actions on the workspace"
       }
       "own" = {
         description = "perform owner actions on the workspace"
@@ -128,14 +122,11 @@ resourceTypes = {
           google-project = ["owner"]
         }
       }
-      editor = {
-        roleActions = ["read_policy::owner", "edit", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
-      }
       application = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
       }
       writer = {
-        roleActions = ["read_policy::owner", "write", "read", "read_auth_domain"]
+        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
       }
       reader = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]


### PR DESCRIPTION
Ticket: [PF-504](https://broadworkbench.atlassian.net/browse/PF-504)

This ticket removes the recently added editor role from workspace objects and instead grants its permissions around child resources to the writer role. This is more in line with existing Rawls behavior, and will simplify future migrations. In the future, we may add an additional workspace role for "modifying objects without creating or deleting", which was previously the writer role.

I've intentionally left the editor role in all four controlled resource definitions. It's different than the workspace editor role, and separating delete permission from read/write permission is core to our model of private resources.

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
