### PR TITLE
[PF-578] Add role-based inheritance back to workspaces

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -120,6 +120,10 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
         descendantRoles = {
           google-project = ["owner"]
+          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = ["assigner", "editor"]
+          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-application-private-workspace-resource = ["editor"]
         }
       }
       application = {
@@ -127,9 +131,19 @@ resourceTypes = {
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
+        descendantRoles = {
+          controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = ["editor"]
+          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-application-private-workspace-resource = ["editor"]
+        }
       }
       reader = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]
+        descendantRoles = {
+          controlled-user-shared-workspace-resource = ["reader"]
+          controlled-application-shared-workspace-resource = ["reader"]
+        }
       }
       share-reader = {
         roleActions = ["share_policy::reader", "read_policies"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -210,7 +210,7 @@ resourceTypes = {
         roleActions = ["delete", "edit"]
       }
       writer = {
-        roleActions = ["write"]
+        roleActions = ["read", "write"]
       }
       reader = {
         roleActions = ["read"]
@@ -263,13 +263,13 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
       }
       assigner = {
-        roleActions = ["manage_private_user"]
+        roleActions = ["manage_private_user", "read_policies", "share_policy::editor", "share_policy::writer", "share_policy::reader"]
       }
       editor = {
         roleActions = ["delete", "edit"]
       }
       writer = {
-        roleActions = ["write"]
+        roleActions = ["read", "write"]
       }
       reader = {
         roleActions = ["read"]
@@ -322,7 +322,7 @@ resourceTypes = {
         roleActions = ["delete", "edit"]
       }
       writer = {
-        roleActions = ["write"]
+        roleActions = ["read", "write"]
       }
       reader = {
         roleActions = ["read"]
@@ -375,13 +375,13 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
       }
       assigner = {
-        roleActions = ["manage_private_user"]
+        roleActions = ["manage_private_user", "read_policies", "share_policy::editor", "share_policy::writer", "share_policy::reader"]
       }
       editor = {
         roleActions = ["delete", "edit"]
       }
       writer = {
-        roleActions = ["write"]
+        roleActions = ["read", "write"]
       }
       reader = {
         roleActions = ["read"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -118,6 +118,7 @@ resourceTypes = {
       }
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child"]
+        # Workspace Manager also maintains a mapping of workspace roles to controlled resource roles. If you change this mapping, check that service's mapping as well.
         descendantRoles = {
           google-project = ["owner"]
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]


### PR DESCRIPTION
Ticket: [PF-578](https://broadworkbench.atlassian.net/browse/PF-578)
After discussion of WSM's approach to hierarchical resources, we decided to move back from policy-based inheritance to role-based inheritance. This change adds back the inheritance introduced in #509 and removed in #513. Since then we've removed the workspace `editor` role and given its permissions to the `writer` role, so the exact mapping is slightly different than it was in the previous change.

Because we never merged the policy-based inheritance change to WSM, there are no workspaces with old policy configurations to clean up.

This also modifies controlled resource roles in the following ways:

- For convenience, the `writer` role also includes the `read` action. Previously, we would always grant the `reader` role alongside `writer` instead.
- The `assigner` role includes direct permission for modifying membership of the `reader`, `writer`, and `editor` policies so that we do not rely on the WSM service account to actually execute changes to these policies

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
