### PR TITLE
skip tests - Docker Desktop needs more memory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ sh config/docker-rsync-local-sam.sh
 # Start up local Sam with local opendj and postgres
 LOCAL_OPENDJ=true LOCAL_POSTGRES=true sh config/docker-rsync-local-sam.sh
 ```
+NOTE: OpenDJ has some heavy memory requirements.  If you see the OpenDJ container silently dying when running this command, try opening your Docker Desktop preferenes and increasing the Memory resources, 4GB seems to be sufficient, but more may be needed as well as increasing the Swap space maybe.
 
 #### Verify that local Sam is running
 [Status endpoint:


### PR DESCRIPTION
Docker Desktop needs more memory to run Sam locally with a local OpenDJ and local Postgres

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
