### PR TITLE
only sync groups if they change

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -87,7 +87,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                         putPolicyOverwrite(resourceType, policyId, userInfo, samRequestContext)
                     } ~ pathPrefix("memberEmails") {
                       pathEndOrSingleSlash {
-                        putPolicyMembershipOverwrite(resourceType, policyId, userInfo, samRequestContext)
+                        putPolicyMembershipOverwrite(policyId, userInfo, samRequestContext)
                       } ~ pathPrefix(Segment) { email =>
                         withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
                           pathEndOrSingleSlash {
@@ -203,7 +203,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                     pathPrefix("memberEmails") {
                       requireActionsForSharePolicy(policyId, userInfo, samRequestContext) {
                         pathEndOrSingleSlash {
-                          putPolicyMembershipOverwrite(resourceType, policyId, userInfo, samRequestContext)
+                          putPolicyMembershipOverwrite(policyId, userInfo, samRequestContext)
                         } ~
                         pathPrefix(Segment) { email =>
                           withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
@@ -356,12 +356,12 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       sharePolicy
     }
 
-  def putPolicyMembershipOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def putPolicyMembershipOverwrite(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
     put {
       requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
         entity(as[Set[WorkbenchEmail]]) { membersList =>
           complete(
-            resourceService.overwritePolicyMembers(resourceType, policyId.accessPolicyName, policyId.resource, membersList, samRequestContext).map(_ => StatusCodes.NoContent))
+            resourceService.overwritePolicyMembers(policyId, membersList, samRequestContext).map(_ => StatusCodes.NoContent))
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -128,25 +128,19 @@ class ManagedGroupService(
     }
   }
 
-  def overwritePolicyMemberEmails(resourceId: ResourceId, policyName: ManagedGroupPolicyName, emails: Set[WorkbenchEmail], samRequestContext: SamRequestContext): IO[AccessPolicy] = {
+  def overwritePolicyMemberEmails(resourceId: ResourceId, policyName: ManagedGroupPolicyName, emails: Set[WorkbenchEmail], samRequestContext: SamRequestContext): IO[Unit] = {
     val resourceAndPolicyName =
       FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, resourceId), policyName)
-    accessPolicyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).flatMap {
-      case Some(policy) => {
-        val updatedPolicy = AccessPolicyMembership(emails, policy.actions, policy.roles, Option(policy.descendantPermissions))
-        resourceService.overwritePolicy(managedGroupType, resourceAndPolicyName.accessPolicyName, resourceAndPolicyName.resource, updatedPolicy, samRequestContext)
-      }
-      case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Group or policy could not be found: $resourceAndPolicyName"))
-    }
+    resourceService.overwritePolicyMembers(resourceAndPolicyName, emails, samRequestContext)
   }
 
-  def addSubjectToPolicy(resourceId: ResourceId, policyName: ManagedGroupPolicyName, subject: WorkbenchSubject, samRequestContext: SamRequestContext): Future[Unit] = {
+  def addSubjectToPolicy(resourceId: ResourceId, policyName: ManagedGroupPolicyName, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
     val resourceAndPolicyName =
       FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, resourceId), policyName)
     resourceService.addSubjectToPolicy(resourceAndPolicyName, subject, samRequestContext)
   }
 
-  def removeSubjectFromPolicy(resourceId: ResourceId, policyName: ManagedGroupPolicyName, subject: WorkbenchSubject, samRequestContext: SamRequestContext): Future[Unit] = {
+  def removeSubjectFromPolicy(resourceId: ResourceId, policyName: ManagedGroupPolicyName, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
     val resourceAndPolicyName =
       FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, resourceId), policyName)
     resourceService.removeSubjectFromPolicy(resourceAndPolicyName, subject, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -21,7 +21,7 @@ class ResourceService(
     private[service] val policyEvaluatorService: PolicyEvaluatorService,
     private val accessPolicyDAO: AccessPolicyDAO,
     private val directoryDAO: DirectoryDAO,
-    private[service] val cloudExtensions: CloudExtensions,
+    private val cloudExtensions: CloudExtensions,
     val emailDomain: String)(implicit val executionContext: ExecutionContext)
     extends LazyLogging {
   implicit val cs = IO.contextShift(executionContext) //for running IOs in paralell

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -262,10 +262,8 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val members = Set(newGuyEmail)
 
     Put(s"/api/group/$groupId/member", members) ~> samRoutes.route ~> check {
-      withClue(responseAs[String]) {
-        status shouldEqual StatusCodes.BadRequest
-        responseAs[String] should include(newGuyEmail.toString())
-      }
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include (newGuyEmail.toString())
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -262,8 +262,10 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val members = Set(newGuyEmail)
 
     Put(s"/api/group/$groupId/member", members) ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      withClue(responseAs[String]) {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[String] should include(newGuyEmail.toString())
+      }
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/POL-60

the work on POL-60 I think will trigger more group syncing so this is an optimization to limit how many group sync messages we send.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
