### PR TITLE
DR-2065: Add set_public action to steward and custodian on datasnapshot resource

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1055,14 +1055,17 @@ resourceTypes = {
       "alter_policies" = {
         description = "Can alter policies"
       }
+      set_public = {
+        description = "set policies to public"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]
       }
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2065

This change adds the `set_public` action to the `steward` and `custodian` policies on the `datasnapshot` resource. This change will give TDR data owners the ability to make their snapshots discoverable, by enabling `public` access for the `discoverer` policy.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
