### PR TITLE
[QA-1571] adding additional logging for createResource, foreign key violation

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -53,7 +53,7 @@ resourceTypes = {
         description = "change the membership of the reader policy for this workspace"
       }
       "share_policy::can-compute" = {
-        description = "change the member of the can-compute policy for this workspace"
+        description = "change the membership of the can-compute policy for this workspace"
       }
       "read_policy::owner" = {
         description = "view the details of the owner policy for this workspace"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -771,7 +771,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
               }.list().apply().toMap
             val problematicGroupMemberships: List[String] = samsql"""select ${g.result.name} from ${GroupTable as g}
                     join ${GroupMemberTable as gm} on ${g.id} = ${gm.groupId}
-                    where ${gm.memberGroupId} in ${problematicGroupIdsToNames.keys.toList}"""
+                    where ${gm.memberGroupId} in (${problematicGroupIdsToNames.keys})"""
               .map(_.toString).list().apply()
             Failure(new WorkbenchExceptionWithErrorReport(
               ErrorReport(StatusCodes.Conflict, s"Foreign Key Violation -- Cannot delete group(s) ${problematicGroupIdsToNames.values.toList} because they are a member of group(s): ${problematicGroupMemberships}")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -744,8 +744,6 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
   override def deleteAllResourcePolicies(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
     val p = PolicyTable.syntax("p")
     val g = GroupTable.syntax("g")
-    val pg = GroupTable.syntax("pg") // problematic groups
-    val gm = GroupMemberTable.syntax("gm")
 
     val fromAndWhereFragment = samsqls"""from ${PolicyTable as p} where ${p.resourceId} = (${loadResourcePKSubQuery(resourceId)})"""
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -103,7 +103,7 @@ class ResourceService(
     * @return Future[Resource]
     */
   def createResource(resourceType: ResourceType, resourceId: ResourceId, policiesMap: Map[AccessPolicyName, AccessPolicyMembership], authDomain: Set[WorkbenchGroupName], parentOpt: Option[FullyQualifiedResourceId], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Resource] = {
-    logger.info(s"Creating new `${resourceType}` with resourceId: `${resourceId}`")
+    logger.info(s"Creating new `${resourceType.name}` with resourceId: `${resourceId}`")
     makeValidatablePolicies(policiesMap, samRequestContext).flatMap { policies =>
       validateCreateResource(resourceType, resourceId, policies, authDomain, userId, parentOpt, samRequestContext).flatMap {
         case Seq() => persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -102,7 +102,8 @@ class ResourceService(
     * @param userId
     * @return Future[Resource]
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, policiesMap: Map[AccessPolicyName, AccessPolicyMembership], authDomain: Set[WorkbenchGroupName], parentOpt: Option[FullyQualifiedResourceId], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Resource] =
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, policiesMap: Map[AccessPolicyName, AccessPolicyMembership], authDomain: Set[WorkbenchGroupName], parentOpt: Option[FullyQualifiedResourceId], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Resource] = {
+    logger.info(s"Creating new `${resourceType}` with resourceId: `${resourceId}`")
     makeValidatablePolicies(policiesMap, samRequestContext).flatMap { policies =>
       validateCreateResource(resourceType, resourceId, policies, authDomain, userId, parentOpt, samRequestContext).flatMap {
         case Seq() => persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)
@@ -110,6 +111,7 @@ class ResourceService(
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports))
       }
     }
+  }
 
   /**
     * This method only persists the resource and then overwrites/creates the policies for that resource.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/QA-1571
<Put notes here to help reviewer understand this PR>

Adds a bit more logging to help with debugging (in general, and for QA-1571)


foreign key violation error message example (from local):
```
{"causes":[],"message":"Foreign Key Violation(s) while deleting group(s): List(Map(groupId -> 7238732, groupName -> billing-project_aj-ca-1206_owner, still used in group(s): -> {workspace_1b86b9cd-35f2-4867-ad53-54be57a65856_project-owner,workspace_77fa1cce-b004-45c9-8429-da403cf905eb_project-owner,workspace_9845724b-34d9-40ca-9452-d391677ff277_project-owner}))","source":"sam","stackTrace":[],"statusCode":500}%
```

example of new createResource:
```
{"@timestamp":"2021-09-21T21:06:01.389Z","@version":"1","message":"Creating new `billing-project` with resourceId: `gpalloc-qa-master-xnh3dtz`","logger_name":"org.broadinstitute.dsde.workbench.sam.service.ResourceService","thread_name":"scala-execution-context-global-81","severity":"INFO","level_value":20000}

```

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
