### PR TITLE
[CA-1274] Add create_pet_service_account action to google-project and use it

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -546,18 +546,21 @@ resourceTypes = {
       add_child = {
         description = "add child to google project"
       }
+      create_pet_service_account = {
+        description = "create pet service account in this google-project"
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "create_pet_service_account"]
         includedRoles = ["notebook-user"]
         descendantRoles = {
           kubernetes-app = ["manager"]
         }
       }
       notebook-user = {
-        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
+        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "create_pet_service_account"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -546,21 +546,21 @@ resourceTypes = {
       add_child = {
         description = "add child to google project"
       }
-      use_pet_service_account = {
-        description = "use pet service account in this google-project"
+      create_pet_service_account = {
+        description = "create pet service account in this google-project"
       }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "use_pet_service_account"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "create_pet_service_account"]
         includedRoles = ["notebook-user"]
         descendantRoles = {
           kubernetes-app = ["manager"]
         }
       }
       notebook-user = {
-        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "use_pet_service_account"]
+        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "create_pet_service_account"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -546,21 +546,21 @@ resourceTypes = {
       add_child = {
         description = "add child to google project"
       }
-      create_pet_service_account = {
-        description = "create pet service account in this google-project"
+      use_pet_service_account = {
+        description = "use pet service account in this google-project"
       }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "create_pet_service_account"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "use_pet_service_account"]
         includedRoles = ["notebook-user"]
         descendantRoles = {
           kubernetes-app = ["manager"]
         }
       }
       notebook-user = {
-        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "create_pet_service_account"]
+        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "use_pet_service_account"]
       }
     }
     reuseIds = true

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -601,6 +601,18 @@ paths:
             application/json:
               schema:
                 type: string
+        403:
+          description: caller does not have the create_pet_service_account action on this Google project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: caller does not have access to this Google project or it does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           description: Internal Server Error
           content:
@@ -667,6 +679,18 @@ paths:
         200:
           description: json format key for a pet service account, see https://cloud.google.com/iam/docs/creating-managing-service-account-keys
           content: {}
+        403:
+          description: caller does not have the create_pet_service_account action on this Google project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: caller does not have access to this Google project or it does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           description: Internal Server Error
           content:
@@ -730,6 +754,18 @@ paths:
             application/json:
               schema:
                 type: string
+        403:
+          description: caller does not have the create_pet_service_account action on this Google project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: caller does not have access to this Google project or it does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           description: Internal Server Error
           content:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -72,7 +72,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   }
                 } ~
                 pathPrefix(Segment) { project =>
-                  requireAction(FullyQualifiedResourceId(ResourceTypeName("google-project"), ResourceId(project)), SamResourceActions.createPetServiceAccount, userInfo.userId, samRequestContext) {
+                  requireAction(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(project)), SamResourceActions.createPetServiceAccount, userInfo.userId, samRequestContext) {
                     pathPrefix("key") {
                       get {
                         complete {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -75,7 +75,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   val googleProjectResourceId = FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(project))
                     pathPrefix("key") {
                       get {
-                        requireAction(googleProjectResourceId, SamResourceActions.use_pet_service_account, userInfo.userId, samRequestContext) {
+                        requireAction(googleProjectResourceId, SamResourceActions.create_pet_service_account, userInfo.userId, samRequestContext) {
                           complete {
                             import spray.json._
                             // parse json to ensure it is json and tells akka http the right content-type
@@ -99,7 +99,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                     } ~
                       pathPrefix("token") {
                         post {
-                          requireAction(googleProjectResourceId, SamResourceActions.use_pet_service_account, userInfo.userId, samRequestContext) {
+                          requireAction(googleProjectResourceId, SamResourceActions.create_pet_service_account, userInfo.userId, samRequestContext) {
                             entity(as[Set[String]]) { scopes =>
                               complete {
                                 googleExtensions
@@ -114,7 +114,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                       } ~
                       pathEnd {
                         get {
-                          requireAction(googleProjectResourceId, SamResourceActions.use_pet_service_account, userInfo.userId, samRequestContext) {
+                          requireAction(googleProjectResourceId, SamResourceActions.create_pet_service_account, userInfo.userId, samRequestContext) {
                             complete {
                               googleExtensions.createUserPetServiceAccount(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), samRequestContext).map {
                                 petSA =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -72,7 +72,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   }
                 } ~
                 pathPrefix(Segment) { project =>
-                  requireAction(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(project)), SamResourceActions.createPetServiceAccount, userInfo.userId, samRequestContext) {
+                  requireAction(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(project)), SamResourceActions.use_pet_service_account, userInfo.userId, samRequestContext) {
                     pathPrefix("key") {
                       get {
                         complete {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -89,7 +89,7 @@ object SamResourceActions {
   val addChild = ResourceAction("add_child")
   val removeChild = ResourceAction("remove_child")
   val listChildren = ResourceAction("list_children")
-  val createPetServiceAccount = ResourceAction("create_pet_service_account")
+  val use_pet_service_account = ResourceAction("use_pet_service_account")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -89,6 +89,7 @@ object SamResourceActions {
   val addChild = ResourceAction("add_child")
   val removeChild = ResourceAction("remove_child")
   val listChildren = ResourceAction("list_children")
+  val createPetServiceAccount = ResourceAction("create_pet_service_account")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -100,6 +100,7 @@ object SamResourceActions {
 
 object SamResourceTypes {
   val resourceTypeAdminName = ResourceTypeName("resource_type_admin")
+  val googleProject = ResourceTypeName("google-project")
 }
 
 @Lenses final case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -89,7 +89,7 @@ object SamResourceActions {
   val addChild = ResourceAction("add_child")
   val removeChild = ResourceAction("remove_child")
   val listChildren = ResourceAction("list_children")
-  val use_pet_service_account = ResourceAction("use_pet_service_account")
+  val create_pet_service_account = ResourceAction("create_pet_service_account")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -85,7 +85,7 @@ object TestSupport extends TestSupport {
   def genGoogleSubjectId(): GoogleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
   def genIdentityConcentratorId(): IdentityConcentratorId = IdentityConcentratorId(genRandom(System.currentTimeMillis()))
 
-  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty, googIamDAO: Option[GoogleIamDAO] = None, googleServicesConfig: GoogleServicesConfig = googleServicesConfig, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, policyAccessDAO: Option[AccessPolicyDAO] = None)(implicit system: ActorSystem) = {
+  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty, googIamDAO: Option[GoogleIamDAO] = None, googleServicesConfig: GoogleServicesConfig = googleServicesConfig, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, policyAccessDAO: Option[AccessPolicyDAO] = None, policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None)(implicit system: ActorSystem) = {
     val googleDirectoryDAO = new MockGoogleDirectoryDAO()
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
@@ -117,7 +117,7 @@ object TestSupport extends TestSupport {
       googleServicesConfig,
       petServiceAccountConfig,
       resourceTypes))
-    val policyEvaluatorService = PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO)
+    val policyEvaluatorService = policyEvaluatorServiceOpt.getOrElse(PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO))
     val mockResourceService = new ResourceService(resourceTypes, policyEvaluatorService, policyDAO, directoryDAO, googleExt, "example.com")
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -39,7 +39,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -63,7 +63,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set(SamResourceActions.readPolicies)))
@@ -80,7 +80,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set.empty))
@@ -107,7 +107,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -198,7 +198,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -224,7 +224,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set(SamResourceActions.readPolicies)))
@@ -243,7 +243,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set.empty))
@@ -263,7 +263,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -39,7 +39,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -73,7 +73,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -164,7 +164,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -191,7 +191,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -29,7 +29,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -53,7 +53,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set(SamResourceActions.readPolicies)))
@@ -70,7 +70,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set.empty))
@@ -96,7 +96,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -189,7 +189,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -215,7 +215,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set(SamResourceActions.readPolicies)))
@@ -234,7 +234,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(false))
     when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(Set.empty))
@@ -253,7 +253,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.create_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -29,7 +29,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -62,7 +62,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -155,7 +155,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))
@@ -182,7 +182,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val projectName = "myproject"
 
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.createPetServiceAccount)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProject, ResourceId(projectName))), mockitoEq(Set(SamResourceActions.use_pet_service_account)), any[WorkbenchUserId], any[SamRequestContext]))
       .thenReturn(IO(true))
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO), policyEvaluatorServiceOpt = Option(policyEvaluatorService))


### PR DESCRIPTION
Ticket: [CA-1274](https://broadworkbench.atlassian.net/browse/CA-1274)
* Add `create_pet_service_account` action to `google-project` resources and then prevent anyone from creating a pet in a Google project unless they have this permission on the corresponding `google-project` resource.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
