### PR TITLE
Work on adding a pet conditional

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -561,7 +561,7 @@ resourceTypes = {
         description = "add child to google project"
       }
       create-pet = {
-        description = "create a pet service account in this google-project
+        description = "create a pet service account in this google-project"
       }
     }
     ownerRoleName = "owner"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -140,7 +140,7 @@ resourceTypes = {
           controlled-user-private-workspace-resource = ["editor"]
           controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-application-private-workspace-resource = ["editor"]
-          googleProject = ["pet-creator"]
+          google-project = ["pet-creator"]
         }
       }
       reader = {
@@ -148,7 +148,7 @@ resourceTypes = {
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["reader"]
           controlled-application-shared-workspace-resource = ["reader"]
-          googleProject = ["pet-creator"]
+          google-project = ["pet-creator"]
         }
       }
       share-reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -129,6 +129,9 @@ resourceTypes = {
       }
       application = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
+        descendantRoles = {
+          google-project = ["pet-creator"]
+        }
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
@@ -137,6 +140,7 @@ resourceTypes = {
           controlled-user-private-workspace-resource = ["editor"]
           controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-application-private-workspace-resource = ["editor"]
+          googleProject = ["pet-creator"]
         }
       }
       reader = {
@@ -144,13 +148,20 @@ resourceTypes = {
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["reader"]
           controlled-application-shared-workspace-resource = ["reader"]
+          googleProject = ["pet-creator"]
         }
       }
       share-reader = {
         roleActions = ["share_policy::reader", "read_policies"]
+        descendantRoles = {
+          google-project = ["pet-creator"]
+        }
       }
       share-writer = {
         roleActions = ["share_policy::writer", "share_policy::reader", "read_policies"]
+        descendantRoles = {
+          google-project = ["pet-creator"]
+        }
       }
       can-compute = {
         roleActions = ["compute"]
@@ -160,6 +171,9 @@ resourceTypes = {
       }
       can-catalog = {
         roleActions = ["catalog"]
+        descendantRoles = {
+          google-project = ["pet-creator"]
+        }
       }
     }
     authDomainConstrainable = true
@@ -546,18 +560,25 @@ resourceTypes = {
       add_child = {
         description = "add child to google project"
       }
+      create-pet = {
+        description = "create a pet service account in this google-project
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
         roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent"]
-        includedRoles = ["notebook-user"]
+        includedRoles = ["notebook-user", "pet-creator"]
         descendantRoles = {
           kubernetes-app = ["manager"]
         }
       }
       notebook-user = {
         roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
+        includedRoles = ["pet-creator"]
+      }
+      pet-creator = {
+        roleActions = ["create-pet"]
       }
     }
     reuseIds = true

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -95,7 +95,7 @@ trait SecurityDirectives {
       checkPermissionAndReturnRoute(innerRoute, resource, requestedActions, userId, samRequestContext)
     }
 
-  def requireOneOfActionIfWorkspace(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 = Directives.mapInnerRoute { innerRoute =>
+  def requireOneOfActionIfParentIsWorkspace(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 = Directives.mapInnerRoute { innerRoute =>
     onSuccess(resourceService.getResourceParent(resource, samRequestContext)) {
       case Some(parent) => if (parent.resourceTypeName == SamResourceTypes.workspaceName) {
         checkPermissionAndReturnRoute(innerRoute, resource, requestedActions, userId, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -8,7 +8,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, ResourceTypeName, SamResourceActions}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, ResourceTypeName, SamResourceActions, SamResourceTypes}
 import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -97,7 +97,7 @@ trait SecurityDirectives {
 
   def requireOneOfActionIfWorkspace(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 = Directives.mapInnerRoute { innerRoute =>
     onSuccess(resourceService.getResourceParent(resource, samRequestContext)) {
-      case Some(parent) => if (parent.resourceTypeName == ResourceTypeName("Workspace")) {
+      case Some(parent) => if (parent.resourceTypeName == SamResourceTypes.workspaceName) {
         checkPermissionAndReturnRoute(innerRoute, resource, requestedActions, userId, samRequestContext)
       } else {
         innerRoute

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -1,13 +1,14 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives.onSuccess
 import akka.http.scaladsl.server.{Directive0, Directives}
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, SamResourceActions}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, ResourceTypeName, SamResourceActions}
 import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -77,18 +78,33 @@ trait SecurityDirectives {
     }
   }
 
+  def checkPermissionAndReturnRoute(route: server.Route, resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): server.Route = {
+    onSuccess(policyEvaluatorService.hasPermissionOneOf(resource, requestedActions, userId, samRequestContext)) { hasPermission =>
+      if (hasPermission) {
+        route
+      } else {
+        val forbiddenErrorMessage = s"You may not perform any of ${requestedActions.mkString("[", ", ", "]").toUpperCase} on ${resource.resourceTypeName.value}/${resource.resourceId.value}"
+        determineErrorMessage(resource, userId, forbiddenErrorMessage, samRequestContext)
+      }
+    }
+  }
+
 
   def requireOneOfAction(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 =
     Directives.mapInnerRoute { innerRoute =>
-      onSuccess(policyEvaluatorService.hasPermissionOneOf(resource, requestedActions, userId, samRequestContext)) { hasPermission =>
-        if (hasPermission) {
-          innerRoute
-        } else {
-          val forbiddenErrorMessage = s"You may not perform any of ${requestedActions.mkString("[", ", ", "]").toUpperCase} on ${resource.resourceTypeName.value}/${resource.resourceId.value}"
-          determineErrorMessage(resource, userId, forbiddenErrorMessage, samRequestContext)
-        }
-      }
+      checkPermissionAndReturnRoute(innerRoute, resource, requestedActions, userId, samRequestContext)
     }
+
+  def requireOneOfActionIfWorkspace(resource: FullyQualifiedResourceId, requestedActions: Set[ResourceAction], userId: WorkbenchUserId, samRequestContext: SamRequestContext): Directive0 = Directives.mapInnerRoute { innerRoute =>
+    onSuccess(resourceService.getResourceParent(resource, samRequestContext)) {
+      case Some(parent) => if (parent.resourceTypeName == ResourceTypeName("Workspace")) {
+        checkPermissionAndReturnRoute(innerRoute, resource, requestedActions, userId, samRequestContext)
+      } else {
+        innerRoute
+      }
+      case None => innerRoute
+    }
+  }
 
   /**
     * in the case where we don't have the required action, we need to figure out if we should return

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -8,7 +8,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, ResourceTypeName, SamResourceActions, SamResourceTypes}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceType, SamResourceActions, SamResourceTypes}
 import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -96,7 +96,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   } ~
                     pathPrefix("token") {
                       requireOneOfAction(
-                        FullyQualifiedResourceId(ResourceTypeName("google-project"), ResourceId("GOOGLE PROJECT")),
+                        FullyQualifiedResourceId(ResourceTypeName("google-project"), ResourceId(project)),
                         Set(SamResourceActions.createPet),
                         userInfo.userId,
                         samRequestContext) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -95,14 +95,20 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                       }
                   } ~
                     pathPrefix("token") {
-                      post {
-                        entity(as[Set[String]]) { scopes =>
-                          complete {
-                            googleExtensions
-                              .getPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), scopes, samRequestContext)
-                              .map { token =>
-                                StatusCodes.OK -> JsString(token)
-                              }
+                      requireOneOfAction(
+                        FullyQualifiedResourceId(ResourceTypeName("google-project"), ResourceId("GOOGLE PROJECT")),
+                        Set(SamResourceActions.createPet),
+                        userInfo.userId,
+                        samRequestContext) {
+                        post {
+                          entity(as[Set[String]]) { scopes =>
+                            complete {
+                              googleExtensions
+                                .getPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), scopes, samRequestContext)
+                                .map { token =>
+                                  StatusCodes.OK -> JsString(token)
+                                }
+                            }
                           }
                         }
                       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -96,7 +96,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                   } ~
                     pathPrefix("token") {
                       requireOneOfAction(
-                        FullyQualifiedResourceId(ResourceTypeName("google-project"), ResourceId(project)),
+                        FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
                         Set(SamResourceActions.createPet),
                         userInfo.userId,
                         samRequestContext) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -100,6 +100,8 @@ object SamResourceActions {
 
 object SamResourceTypes {
   val resourceTypeAdminName = ResourceTypeName("resource_type_admin")
+  val workspaceName = ResourceTypeName("workspace")
+  val googleProjectName = ResourceTypeName("google-project")
 }
 
 @Lenses final case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -89,6 +89,7 @@ object SamResourceActions {
   val addChild = ResourceAction("add_child")
   val removeChild = ResourceAction("remove_child")
   val listChildren = ResourceAction("list_children")
+  val createPet = ResourceAction("create-pet")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -85,7 +85,7 @@ object TestSupport extends TestSupport {
   def genGoogleSubjectId(): GoogleSubjectId = GoogleSubjectId(genRandom(System.currentTimeMillis()))
   def genIdentityConcentratorId(): IdentityConcentratorId = IdentityConcentratorId(genRandom(System.currentTimeMillis()))
 
-  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty, googIamDAO: Option[GoogleIamDAO] = None, googleServicesConfig: GoogleServicesConfig = googleServicesConfig, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, policyAccessDAO: Option[AccessPolicyDAO] = None)(implicit system: ActorSystem) = {
+  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty, googIamDAO: Option[GoogleIamDAO] = None, googleServicesConfig: GoogleServicesConfig = googleServicesConfig, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, policyAccessDAO: Option[AccessPolicyDAO] = None, policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None, resourceServiceOpt: Option[ResourceService] = None)(implicit system: ActorSystem) = {
     val googleDirectoryDAO = new MockGoogleDirectoryDAO()
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
@@ -117,8 +117,8 @@ object TestSupport extends TestSupport {
       googleServicesConfig,
       petServiceAccountConfig,
       resourceTypes))
-    val policyEvaluatorService = PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO)
-    val mockResourceService = new ResourceService(resourceTypes, policyEvaluatorService, policyDAO, directoryDAO, googleExt, "example.com")
+    val policyEvaluatorService = policyEvaluatorServiceOpt.getOrElse(PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO))
+    val mockResourceService = resourceServiceOpt.getOrElse(new ResourceService(resourceTypes, policyEvaluatorService, policyDAO, directoryDAO, googleExt, "example.com"))
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
 
     SamDependencies(mockResourceService, policyEvaluatorService, new UserService(directoryDAO, googleExt, registrationDAO, Seq.empty), new StatusService(directoryDAO, registrationDAO, googleExt, dbRef), mockManagedGroupService, directoryDAO, policyDAO, googleExt)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
@@ -17,7 +18,8 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.mockito.ArgumentMatchers._
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
@@ -32,22 +34,89 @@ import org.scalatest.matchers.should.Matchers
   */
 class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
   implicit val timeout = RouteTestTimeout(5 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
+  val workspaceResourceId = "workspace"
+  val v2GoogleProjectResourceId = "v2project"
 
-  "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user" in {
-    val (user, _, routes) = createTestUser()
+  private def getPetServiceAccount(projectName: String, routes: SamRoutes) = {
+    Get(s"/api/google/user/petServiceAccount/${projectName}") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[WorkbenchEmail]
+      response.value should endWith (s"@${projectName}.iam.gserviceaccount.com")
+      response.value
+    }
+  }
+
+  private def getPetServiceAccountKey(projectName: String, expectedJson: String, routes: SamRoutes) = {
+    Get(s"/api/google/user/petServiceAccount/${projectName}/key") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      val response = responseAs[String]
+      response shouldEqual(expectedJson)
+    }
+  }
+
+  "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user in a v2 project" in {
+    val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
+    val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
+
+    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+      .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+      .thenReturn(IO(true))
+    val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
-    }
+    getPetServiceAccount(v2GoogleProjectResourceId, routes)
 
     // same result a second time
-    Get("/api/google/user/petServiceAccount/myproject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+    getPetServiceAccount(v2GoogleProjectResourceId, routes)
+  }
+
+  it should "200 when the user doesn't have the right permission on the google-project resource, but it is v1" in {
+    val projectName = "myproject"
+
+    val (_, _, routes) = createTestUser()
+
+    // try to create a pet service account
+    getPetServiceAccount(projectName, routes)
+  }
+
+  it should "403 when the user doesn't have the right permission on the google-project resource" in {
+    val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
+    val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
+
+    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+      .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[WorkbenchUserId], any[SamRequestContext]))
+      .thenReturn(IO(Set(SamResourceActions.readPolicies)))
+
+    val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
+
+    // try to create a pet service account
+    Get(s"/api/google/user/petServiceAccount/$v2GoogleProjectResourceId") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "404 when the user doesn't have any permission on the google-project resource" in {
+
+
+    val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
+    val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
+
+    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+      .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
+    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+      .thenReturn(IO(false))
+    when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[WorkbenchUserId], any[SamRequestContext]))
+      .thenReturn(IO(Set.empty))
+
+    val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
+
+    // try to create a pet service account
+    Get(s"/api/google/user/petServiceAccount/$v2GoogleProjectResourceId") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
     }
   }
 
@@ -65,12 +134,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val (user, _, routes) = createTestUser()
 
 
-    val petEmail = Get("/api/google/user/petServiceAccount/myproject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
-      response.value
-    }
+    val petEmail = getPetServiceAccount("myproject", routes)
 
     Get(s"/api/google/user/proxyGroup/$petEmail") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -151,18 +215,10 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
-    }
+    getPetServiceAccount("myproject", routes)
 
     // create a pet service account key
-    Get("/api/google/user/petServiceAccount/myproject/key") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[String]
-      response shouldEqual(expectedJson)
-    }
+    getPetServiceAccountKey("myproject", expectedJson, routes)
   }
 
   "DELETE /api/google/user/petServiceAccount/{project}/key/{keyId}" should "204 when deleting a key" in {
@@ -172,18 +228,10 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
 
     // create a pet service account
-    Get("/api/google/user/petServiceAccount/myproject") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
-    }
+    getPetServiceAccount("myproject", routes)
 
     // create a pet service account key
-    Get("/api/google/user/petServiceAccount/myproject/key") ~> routes.route ~> check {
-      status shouldEqual StatusCodes.OK
-      val response = responseAs[String]
-      response shouldEqual(expectedJson)
-    }
+    getPetServiceAccountKey("myproject", expectedJson, routes)
 
     // create a pet service account key
     Delete("/api/google/user/petServiceAccount/myproject/key/123") ~> routes.route ~> check {
@@ -244,13 +292,15 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
                              googSubjectId: Option[GoogleSubjectId] = None,
                              email: Option[WorkbenchEmail] = None,
                              identityConcentratorIdOpt: Option[IdentityConcentratorId] = None,
+                             policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
+                             resourceServiceOpt: Option[ResourceService] = None
                     ): (WorkbenchUser, SamDependencies, SamRoutes) = {
     val em = email.getOrElse(defaultUserEmail)
     val googleSubjectId = googSubjectId.map(_.value).getOrElse(genRandom(System.currentTimeMillis()))
 
     val userInfo = UserInfo(OAuth2BearerToken(""), WorkbenchUserId(googleSubjectId), em, 3600)
 
-    val samDependencies = genSamDependencies(resourceTypes, googIamDAO, googleServicesConfig)
+    val samDependencies = genSamDependencies(resourceTypes, googIamDAO, googleServicesConfig, policyEvaluatorServiceOpt = policyEvaluatorServiceOpt, resourceServiceOpt = resourceServiceOpt)
     val createRoutes = genSamRoutes(samDependencies, userInfo)
 
     // create a user


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-1274
This adds a check for v2 google projects _only_ that someone trying to create a pet service account has pet creator access. This is granted via reference.conf via any permission on the workspace. The goal here is to block use of this endpoint on v2 projects for people who shouldn't have any access to the google project, while allowing anyone to create pets in v1 projects, because there is no direct path to the google project for all users who need to create pets.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
