### PR TITLE
Mob qa 1559

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -104,15 +104,11 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       tempUserInfo.userEmail shouldBe tempUser.email
 
       // Remove user
-
-      userStatus.userInfo.userEmail shouldBe tempUser.email
-
-      removeUser(userStatus.userInfo.userSubjectId)
+      removeUser(tempUserInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None
 
       // OK to re-remove
-
-      removeUser(userStatus.userInfo.userSubjectId)
+      removeUser(tempUserInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.test.api
+package org.broadinstitute.dsde.test.api
 
 
 import java.util.UUID
@@ -55,7 +55,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
     Thurloe.keyValuePairs.deleteAll(subjectId)
   }
 
-  "Sam test utilities" - {
+  "Sam User apis" - {
     "should be idempotent for user registration and removal" in {
 
       // use a temp user because they should not be registered.  Remove them after!
@@ -86,17 +86,19 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       // OK to re-register
 
       registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
-      Sam.user.status()(tempAuthToken).match {
-        case Some(user) => user.userInfo.userEmail shouldBe tempUser.email
+      val userStatus = Sam.user.status()(tempAuthToken).match {
+        case Some(userStatus) => userStatus
         case None => throw new Exception(s"User ${tempUser.email} failed to be registered as a new user")
       }
 
-      removeUser(tempUserInfo.userSubjectId)
+      userStatus.userInfo.userEmail shouldBe tempUser.email
+
+      removeUser(userStatus.userInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None
 
       // OK to re-remove
 
-      removeUser(tempUserInfo.userSubjectId)
+      removeUser(userStatus.userInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -78,13 +78,18 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
 
-      val tempUserInfo = Sam.user.status()(tempAuthToken).get.userInfo
-      tempUserInfo.userEmail shouldBe tempUser.email
+      Sam.user.status()(tempAuthToken).match {
+        case Some(user) => user.userInfo.userEmail shouldBe tempUser.email
+        case None => throw new Exception(s"User ${tempUser.email} failed to be registered as a new user")
+      }
 
       // OK to re-register
 
       registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
-      Sam.user.status()(tempAuthToken).get.userInfo.userEmail shouldBe tempUser.email
+      Sam.user.status()(tempAuthToken).match {
+        case Some(user) => user.userInfo.userEmail shouldBe tempUser.email
+        case None => throw new Exception(s"User ${tempUser.email} failed to be registered as a new user")
+      }
 
       removeUser(tempUserInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1559

It looks like there are two automation tests that both use the `Temps` UserPool.  

https://github.com/broadinstitute/firecloud-orchestration/blob/3cb3cb15090e37e72d546a4cdb5d592c4d065a2a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/RegistrationApiSpec.scala#L34

and

https://github.com/broadinstitute/workbench-libs/blob/2906dd05df65e7003fbf1ef7d0aa4aad94c24fd5/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/UserPool.scala#L61

Notice that the Orch test always explicitly uses Luna.  The Sam test always grabs the `head` of the Temps list, which is also always Luna.  

This means that if these two tests happen to get run at the same time, they both do checks to see if the User already exists or not and will try to remove the User at the start of the test if they already exist and then each test will try to create (and perhaps delete) that User as part of test.  If these tests are running at the same time, they could each be trying to create/remove Luna at the same time and thus cannot actually guarantee that the states they are trying to create.

This fixes the Sam test at least, so that if it fails, it will retry a few times.  I think this is OK to do in this case because if something changed in the logic of create or delete to break the idempotency of the api, the test should fail and keep failing.  If it passes just once, then we know it is good.  

There should be a corresponding change for QA-1016 as well.

This PR should be revisited after #549 merges.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
