### PR TITLE
QA-1500 all write txns are serializable, stop using default isolation level

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -47,7 +47,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
     */
   override def upsertResourceTypes(resourceTypes: Set[ResourceType], samRequestContext: SamRequestContext): IO[Set[ResourceTypeName]] = {
     val result = if (resourceTypes.nonEmpty) {
-      writeTransaction("upsertResourceTypes", samRequestContext) { implicit session =>
+      serializableWriteTransaction("upsertResourceTypes", samRequestContext) { implicit session =>
         samsql"lock table ${ResourceTypeTable.table} IN EXCLUSIVE MODE".execute().apply()
 
         val existingResourceTypes = loadResourceTypesInSession(resourceTypes.map(_.name))
@@ -602,7 +602,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
     val ad = AuthDomainTable.syntax("ad")
     val rt = ResourceTypeTable.syntax("rt")
 
-    writeTransaction("removeAuthDomainFromResource", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("removeAuthDomainFromResource", samRequestContext)({ implicit session =>
       samsql"""delete from ${AuthDomainTable as ad}
               where ${ad.resourceId} =
               (select ${r.id} from ${ResourceTable as r}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -208,7 +208,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("updateSynchronizedDate", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("updateSynchronizedDate", samRequestContext)({ implicit session =>
       val g = GroupTable.column
       samsql"update ${GroupTable.table} set ${g.synchronizedDate} = ${Instant.now()} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})".update().apply()
     })
@@ -385,7 +385,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser] = {
-    writeTransaction("createUser", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("createUser", samRequestContext)({ implicit session =>
       val userColumn = UserTable.column
 
       val insertUserQuery = samsql"insert into ${UserTable.table} (${userColumn.id}, ${userColumn.email}, ${userColumn.googleSubjectId}, ${userColumn.enabled}, ${userColumn.azureB2cId}) values (${user.id}, ${user.email}, ${user.googleSubjectId}, false, ${user.azureB2CId})"
@@ -421,7 +421,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Int] = {
-    writeTransaction("setUserAzureB2CId", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("setUserAzureB2CId", samRequestContext)({ implicit session =>
       val u = UserTable.column
       val results = samsql"update ${UserTable.table} set ${u.azureB2cId} = $b2cId where ${u.id} = $userId and ${u.azureB2cId} is null".update().apply()
 
@@ -447,7 +447,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
   // Not worrying about cascading deletion of user's pet SAs because LDAP doesn't delete user's pet SAs automatically
   override def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("deleteUser", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("deleteUser", samRequestContext)({ implicit session =>
       val userTable = UserTable.syntax
       samsql"delete from ${UserTable.table} where ${userTable.id} = ${userId}".update().apply()
     })
@@ -581,7 +581,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   override def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] = {
     subject match {
       case userId: WorkbenchUserId =>
-        writeTransaction("enableIdentity", samRequestContext)({ implicit session =>
+        serializableWriteTransaction("enableIdentity", samRequestContext)({ implicit session =>
         val u = UserTable.column
         samsql"update ${UserTable.table} set ${u.enabled} = true where ${u.id} = ${userId}".update().apply()
       })
@@ -590,7 +590,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("disableIdentity", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("disableIdentity", samRequestContext)({ implicit session =>
       subject match {
         case userId: WorkbenchUserId =>
           val u = UserTable.column
@@ -633,7 +633,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
-    writeTransaction("createPetServiceAccount", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("createPetServiceAccount", samRequestContext)({ implicit session =>
       val petServiceAccountColumn = PetServiceAccountTable.column
 
       samsql"""insert into ${PetServiceAccountTable.table} (${petServiceAccountColumn.userId}, ${petServiceAccountColumn.project}, ${petServiceAccountColumn.googleSubjectId}, ${petServiceAccountColumn.email}, ${petServiceAccountColumn.displayName})
@@ -657,7 +657,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("deletePetServiceAccount", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("deletePetServiceAccount", samRequestContext)({ implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax
       val deletePetQuery = samsql"delete from ${PetServiceAccountTable.table} where ${petServiceAccountTable.userId} = ${petServiceAccountId.userId} and ${petServiceAccountTable.project} = ${petServiceAccountId.project}"
       if (deletePetQuery.update().apply() != 1) {
@@ -679,7 +679,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
-    writeTransaction("updatePetServiceAccount", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("updatePetServiceAccount", samRequestContext)({ implicit session =>
       val petServiceAccountColumn = PetServiceAccountTable.column
       val updatePetQuery = samsql"""update ${PetServiceAccountTable.table} set
         ${petServiceAccountColumn.googleSubjectId} = ${petServiceAccount.serviceAccount.subjectId},
@@ -744,7 +744,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("setManagedGroupAccessInstructions", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("setManagedGroupAccessInstructions", samRequestContext)({ implicit session =>
       val groupPKQuery = workbenchGroupIdentityToGroupPK(groupName)
       val accessInstructionsColumn = AccessInstructionsTable.column
 
@@ -760,7 +760,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   }
 
   override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] = {
-    writeTransaction("setGoogleSubjectId", samRequestContext)({ implicit session =>
+    serializableWriteTransaction("setGoogleSubjectId", samRequestContext)({ implicit session =>
       val u = UserTable.column
       val updateGoogleSubjectIdQuery =
         samsql"""update ${UserTable.table} set ${u.googleSubjectId} = ${googleSubjectId}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
@@ -100,7 +100,7 @@ case class DbReference(dbName: DatabaseName, dbExecutionContext: ExecutionContex
   }
 
   def inLocalTransaction[A](f: DBSession => A): A =
-    inLocalTransactionWithIsolationLevel(IsolationLevel.Default)(f)
+    inLocalTransactionWithIsolationLevel(IsolationLevel.ReadCommitted)(f)
 
   def inLocalTransactionWithIsolationLevel[A](isolationLevel: IsolationLevel)(f: DBSession => A): A = {
     NamedDB(dbName.name).isolationLevel(isolationLevel).localTx[A] { implicit session =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -13,18 +13,6 @@ trait DatabaseSupport {
   protected val writeDbRef: DbReference
   protected val readDbRef: DbReference
 
-  /**
-    * Executes postgres query.
-    *
-    * @param dbQueryName name of the database query. Used to identify the name of the tracing span.
-    * @param samRequestContext context of the request. If it contains a parentSpan, then a child span will be
-    *                          created under the parent span.
-    */
-  protected def writeTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A)(implicit cs: ContextShift[IO]): IO[A] = {
-    val databaseIO = IO(writeDbRef.inLocalTransaction(databaseFunction))
-    writeDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO, cs)
-  }
-
   protected def readOnlyTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A)(implicit cs: ContextShift[IO]): IO[A] = {
     val databaseIO = IO(readDbRef.readOnly(databaseFunction))
     readDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO, cs)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/QA-1500

Removes the `writeTransaction` function and for remaining code using `inLocalTransaction` use read committed isolation instead of default because default in scalikejdbc does not actually do anything and just reuses whatever isolation level was used last.

Switching to serializable isolation level is ok because in effect that is what has been happening anyway. The write database connection pool is small and was shared between `writeTransaction` and `serializableWriteTransaction` meaning all connections would quickly flip serializable.

This is important because write transactions were being executed in serializable isolation _without_ retries. `serializableWriteTransaction` retries appropriately.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
