### PR TITLE
[PF-1037] Update WSM role inheritance and controlled resource permissions

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -124,7 +124,6 @@ resourceTypes = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
-          controlled-application-private-workspace-resource = []
         }
       }
       application = {
@@ -134,9 +133,7 @@ resourceTypes = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-user-private-workspace-resource = []
           controlled-application-shared-workspace-resource = ["writer", "reader"]
-          controlled-application-private-workspace-resource = []
         }
       }
       reader = {
@@ -270,6 +267,9 @@ resourceTypes = {
       }
       reader = {
         roleActions = ["read"]
+      }
+      deleter = {
+        roleActions = ["delete"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -122,9 +122,7 @@ resourceTypes = {
         descendantRoles = {
           google-project = ["owner"]
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-user-private-workspace-resource = ["assigner", "editor"]
-          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-application-private-workspace-resource = ["editor"]
+          controlled-application-shared-workspace-resource = ["writer", "reader"]
         }
       }
       application = {
@@ -134,9 +132,7 @@ resourceTypes = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-user-private-workspace-resource = ["editor"]
-          controlled-application-shared-workspace-resource = ["editor", "writer", "reader"]
-          controlled-application-private-workspace-resource = ["editor"]
+          controlled-application-shared-workspace-resource = ["writer", "reader"]
         }
       }
       reader = {
@@ -204,10 +200,10 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "read", "write", "set_parent"]
       }
       editor = {
-        roleActions = ["delete", "edit"]
+        roleActions = ["delete", "edit", "read", "write"]
       }
       writer = {
         roleActions = ["read", "write"]
@@ -253,21 +249,18 @@ resourceTypes = {
       "own" = {
         description = "perform owner actions on the resource"
       }
-      "manage_private_user" = {
-        description = "assign, remove, and reassign the private user"
-      }
     }
     ownerRoleName = "owner"
     roles = {
+      # owner is always WSM SA
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent", "read", "write"]
       }
-      assigner = {
-        roleActions = ["manage_private_user", "read_policies", "share_policy::editor", "share_policy::writer", "share_policy::reader"]
-      }
+      # editor is always the resource creator
       editor = {
-        roleActions = ["delete", "edit"]
+        roleActions = ["delete", "edit", "read", "write"]
       }
+      # we don't use writer or reader
       writer = {
         roleActions = ["read", "write"]
       }
@@ -315,15 +308,19 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
+      # owner is WSM SA
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent", "read", "write"]
       }
+      # editor is the application SA
       editor = {
-        roleActions = ["delete", "edit"]
+        roleActions = ["delete", "edit", "read", "write"]
       }
+      # writer inherits from workspace writer
       writer = {
         roleActions = ["read", "write"]
       }
+      # reader inherits from workspace reader
       reader = {
         roleActions = ["read"]
       }
@@ -371,14 +368,22 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
+      # owner is WSM SA
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent", "read", "write"]
       }
-      assigner = {
-        roleActions = ["manage_private_user", "read_policies", "share_policy::editor", "share_policy::writer", "share_policy::reader"]
-      }
+      # editor is application SA. Can assign a reader or a writer
       editor = {
-        roleActions = ["delete", "edit"]
+        roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies", "share_policy::writer", "share_policy::reader"]
+        ]
+      }
+      # workspace owner gets new role 'deleter' so they can remove private resources
+      deleter = {
+        roleActions = ["delete"]
+      }
+      # assign becomes an action, not a role. Delete it?
+      assigner = {
+        roleActions = []
       }
       writer = {
         roleActions = ["read", "write"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -143,9 +143,7 @@ resourceTypes = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["reader"]
-          controlled-user-private-workspace-resource = []
           controlled-application-shared-workspace-resource = ["reader"]
-          controlled-application-private-workspace-resource = []
         }
       }
       share-reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -134,7 +134,9 @@ resourceTypes = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = []
           controlled-application-shared-workspace-resource = ["writer", "reader"]
+          controlled-application-private-workspace-resource = []
         }
       }
       reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -375,7 +375,7 @@ resourceTypes = {
       # editor is application SA. Can assign a reader or a writer
       editor = {
         roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies", "share_policy::writer", "share_policy::reader"]
-        ]
+        }
       }
       # workspace owner gets new role 'deleter' so they can remove private resources
       deleter = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -122,6 +122,7 @@ resourceTypes = {
         descendantRoles = {
           google-project = ["owner"]
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
+          controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
         }
       }
@@ -375,7 +376,6 @@ resourceTypes = {
       # editor is application SA. Can assign a reader or a writer
       editor = {
         roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies", "share_policy::writer", "share_policy::reader"]
-        }
       }
       # workspace owner gets new role 'deleter' so they can remove private resources
       deleter = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -124,6 +124,7 @@ resourceTypes = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
+          controlled-application-private-workspace-resource = []
         }
       }
       application = {
@@ -140,7 +141,9 @@ resourceTypes = {
         roleActions = ["read_policy::owner", "read", "read_auth_domain"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["reader"]
+          controlled-user-private-workspace-resource = []
           controlled-application-shared-workspace-resource = ["reader"]
+          controlled-application-private-workspace-resource = []
         }
       }
       share-reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -261,7 +261,7 @@ resourceTypes = {
       editor = {
         roleActions = ["delete", "edit", "read", "write"]
       }
-      # we don't use writer or reader
+      # WSM does not use these reader and writer roles
       writer = {
         roleActions = ["read", "write"]
       }
@@ -375,16 +375,13 @@ resourceTypes = {
       }
       # editor is application SA. Can assign a reader or a writer
       editor = {
-        roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies", "share_policy::writer", "share_policy::reader"]
+        roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies"]
       }
       # workspace owner gets new role 'deleter' so they can remove private resources
       deleter = {
         roleActions = ["delete"]
       }
-      # assign becomes an action, not a role. Delete it?
-      assigner = {
-        roleActions = []
-      }
+      # WSM uses writer and reader here if a user is assigned to the private resource
       writer = {
         roleActions = ["read", "write"]
       }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -253,15 +253,12 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
-      # owner is always WSM SA
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent", "read", "write"]
       }
-      # editor is always the resource creator
       editor = {
         roleActions = ["delete", "edit", "read", "write"]
       }
-      # WSM does not use these reader and writer roles
       writer = {
         roleActions = ["read", "write"]
       }
@@ -312,19 +309,15 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
-      # owner is WSM SA
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "set_parent", "read", "write"]
       }
-      # editor is the application SA
       editor = {
         roleActions = ["delete", "edit", "read", "write"]
       }
-      # writer inherits from workspace writer
       writer = {
         roleActions = ["read", "write"]
       }
-      # reader inherits from workspace reader
       reader = {
         roleActions = ["read"]
       }
@@ -372,19 +365,15 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
-      # owner is WSM SA
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "share_policy::writer", "share_policy::reader", "own", "edit", "manage_private_user", "set_parent", "read", "write"]
       }
-      # editor is application SA. Can assign a reader or a writer
       editor = {
         roleActions = ["delete", "edit", "read", "write", "manage_private_user", "read_policies"]
       }
-      # workspace owner gets new role 'deleter' so they can remove private resources
       deleter = {
         roleActions = ["delete"]
       }
-      # WSM uses writer and reader here if a user is assigned to the private resource
       writer = {
         roleActions = ["read", "write"]
       }


### PR DESCRIPTION
Ticket: PF-1037
Update the WSM role inheritance and controlled resource permissions.
This is documented in [WSM Controlled Resource Design](https://docs.google.com/document/d/1F28KHeVpTh0Zuqdux30ONabMgjj6CNmyv7B8iqcXnsE/edit?resourcekey=0-5ndsiOmBJdG7bB1gZXOy1g#heading=h.qw1bsdn5v5n7)

A summary spreadsheet of the roles and actions is here [dd Role Definition changes](https://docs.google.com/spreadsheets/d/1rHSQ8ecJehVbs591Fw-4scWMsThyyBGrbsuQ-89eSiY/edit?resourcekey=0-VmhXLfvYDRi4xPRxfYATow#gid=1430007751). The sheet "dd Inherited Role changes" shows the inheritance changes.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
