### PR TITLE
QA-1016: Remove part of Sam Registration test that tests fc-orch registration endpoint

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val akkaHttpV = "10.2.2"
 
   val workbenchGoogleV = "0.21-ae11b9f"
-  val workbenchGoogle2V = "0.22-82a345c"
+  val workbenchGoogle2V = "0.23-7ddf186"
   val workbenchServiceTestV = "0.21-6fdd209"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.21-74c9fc2"
   val workbenchGoogle2V = "0.18-74c9fc2"
-  val workbenchServiceTestV = "0.18-74c9fc2"
+  val workbenchServiceTestV = "0.20-45194e26-SNAP"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
     "com.fasterxml.jackson.module" % ("jackson-module-scala_" + scalaV) % jacksonV,
     "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.google.apis" % "google-api-services-oauth2" % "v1-rev112-1.20.0" excludeAll (
       ExclusionRule("com.google.guava", "guava-jdk5"),
       ExclusionRule("org.apache.httpcomponents", "httpclient")

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val akkaHttpV = "10.2.2"
 
   val workbenchGoogleV = "0.21-ae11b9f"
-  val workbenchGoogle2V = "0.22-f394f70"
+  val workbenchGoogle2V = "0.22-82a345c"
   val workbenchServiceTestV = "0.21-6fdd209"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaV = "2.6.10"
   val akkaHttpV = "10.2.2"
 
-  val workbenchGoogleV = "0.21-74c9fc2"
-  val workbenchGoogle2V = "0.18-74c9fc2"
-  val workbenchServiceTestV = "0.20-45194e26-SNAP"
+  val workbenchGoogleV = "0.21-ae11b9f"
+  val workbenchGoogle2V = "0.22-f394f70"
+  val workbenchServiceTestV = "0.21-6fdd209"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -56,35 +56,27 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
   }
 
   "Sam test utilities" - {
-    "should be idempotent for user registration and removal" in {
+    "should be idempotent for removal of user's registration" in {
 
       // use a temp user because they should not be registered.  Remove them after!
 
       val tempUser: Credentials = UserPool.chooseTemp
       val tempAuthToken: AuthToken = tempUser.makeAuthToken()
 
-      //It's possible that some other bad test leaves this user regsistered.
-      //Clean it up if it exists already...
+      // Register user if the user is not registered
       Sam.user.status()(tempAuthToken) match {
         case Some(user) => {
-          logger.info(s"User ${user.userInfo.userEmail} was already registered. Removing before test starts...")
-          removeUser(user.userInfo.userSubjectId)
+          logger.info(s"User ${user.userInfo.userEmail} was already registered.)
         }
-        case None => logger.info(s"User ${tempUser.email} does not yet exist! Proceeding...")
+        case None => {
+          logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")
+          registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
+          val tempUserInfo = Sam.user.status()(tempAuthToken).get.userInfo
+          tempUserInfo.userEmail shouldBe tempUser.email
+        }
       }
 
-      //Now assert that it's gone for real
-      Sam.user.status()(tempAuthToken) shouldBe None
-
-      registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
-
-      val tempUserInfo = Sam.user.status()(tempAuthToken).get.userInfo
-      tempUserInfo.userEmail shouldBe tempUser.email
-
-      // OK to re-register
-
-      registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
-      Sam.user.status()(tempAuthToken).get.userInfo.userEmail shouldBe tempUser.email
+      // Remove user
 
       removeUser(tempUserInfo.userSubjectId)
       Sam.user.status()(tempAuthToken) shouldBe None

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -66,7 +66,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       // Register user if the user is not registered
       Sam.user.status()(tempAuthToken) match {
         case Some(user) => {
-          logger.info(s"User ${user.userInfo.userEmail} was already registered.)
+          logger.info(s"User ${user.userInfo.userEmail} was already registered.")
         }
         case None => {
           logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -70,7 +70,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
         }
         case None => {
           logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")
-          registerAsNewUser(WorkbenchEmail(tempUser.email))(tempAuthToken)
+          Sam.user.registerSelf()(tempAuthToken)
           val tempUserInfo = Sam.user.status()(tempAuthToken).get.userInfo
           tempUserInfo.userEmail shouldBe tempUser.email
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -72,7 +72,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
         case None => {
           logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")
           Sam.user.registerSelf()(tempAuthToken)
-          Sam.user.status()(tempAuthToken).userInfo
+          Sam.user.status()(tempAuthToken).get.userInfo
         }
       }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -64,17 +64,19 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       val tempAuthToken: AuthToken = tempUser.makeAuthToken()
 
       // Register user if the user is not registered
-      Sam.user.status()(tempAuthToken) match {
+      val tempUserInfo = Sam.user.status()(tempAuthToken) match {
         case Some(user) => {
           logger.info(s"User ${user.userInfo.userEmail} was already registered.")
+          user.userInfo
         }
         case None => {
           logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")
           Sam.user.registerSelf()(tempAuthToken)
-          val tempUserInfo = Sam.user.status()(tempAuthToken).get.userInfo
-          tempUserInfo.userEmail shouldBe tempUser.email
+          Sam.user.status()(tempAuthToken).userInfo
         }
       }
+
+      tempUserInfo.userEmail shouldBe tempUser.email
 
       // Remove user
 


### PR DESCRIPTION
Ticket: QA-1016

This PR removes the part of the Sam registration test that is testing orchestration. The test first checks to make sure the user is unregistered (unregisters the user if they are registered), then registers the user twice, then deletes the user twice. But, when it is testing if registering the user is twice in a row returns the same response, it's actually calling fc-orch's orchestration endpoint. So it's testing if orch's registration endpoint is idempotent! This PR removes this section and only tests if we can delete the registration twice in a row. 

While this will not completely rid us of race conditions for this issue, it should at least reduce them. There is other work being done in this part of the code that will also address the parallelization issue.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
