### PR TITLE
[QA-1240] Only sync constrained policies that have been synced before

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -22,8 +22,6 @@ trait AccessPolicyDAO {
 
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LoadResourceAuthDomainResult]
 
-  def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[Resource]]
-
   def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedPolicyId]]
 
   def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -24,6 +24,8 @@ trait AccessPolicyDAO {
 
   def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[Resource]]
 
+  def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedPolicyId]]
+
   def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
 
   def createPolicy(policy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy]

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -94,7 +94,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
     resourceToRemoveOpt.map( resourceToRemove => resources += resource -> resourceToRemove.copy(authDomain = Set.empty))
   }
 
-  override def listResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[Resource]] = IO.pure(Set.empty)
+  override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedPolicyId]] = ???
 
   override def createPolicy(policy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy] = IO {
     policies += policy.id -> policy


### PR DESCRIPTION
Ticket: [QA-1240](https://broadworkbench.atlassian.net/browse/QA-1240)
When we update an auth domain group, we add all of the policies constrained by that auth domain to the group synchronizer queue. The group synchronizer doesn't check whether a group has been synced in the past because it is responsible for first time syncs and just blindly syncs any group it gets off the queue. This can lead to a timing issue that interferes with workspace deletion in tests with constrained resources.

1. Constrained workspace is created with all 8 of its policies and Rawls tells Sam to sync 5 of those policies immediately (`project-owner`, `owner`, `writer`, `reader`, `can-compute`). The logs indicate that the Google call to create the Google groups for these policies (aka syncing them) occurs <1 second after the workspace is created.
2. Auth domain group is modified later. This adds the auth domain group to the group sync queue along with all of the policies it constrains. This includes all of the workspace policies, not just the 5 that have been synced before.
3. The synchronizer eventually gets around to syncing the messages generated above. For the 3 previously unsynced policy groups (`can-catalog`, `share-reader`, `share-writer`), the synchronizer creates new Google groups.
4. While this is going on in the background, the test completes and begins cleaning up the workspace. This logic in Sam tries to delete all Google groups for all policies on the resource, whether those policies have been synced or not.
5. The requests to delete the policy groups are issued right around the same time as the requests to create the previously unsynced policy groups. These requests conflict with each other, and Google rightfully returns a 409. This failure prevents Sam from deleting the policies in Postgres and the workspace resource is not. deleted.
6. Since the workspace isn't deleted correctly in Sam, the billing-project can't be deleted a thse billing-project owner policy is a member of the workspace project-owner policy.

This PR makes it so we only sync policies that have been synced previously by checking for a last synchronized date before adding the policy to the group sync queue. If a constrained policy hasn't been synced in the past, then there's no point in syncing it when the auth domain group gets synced since nobody is using the unsynced policy to grant access to cloud resources.



---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
