### PR TITLE
[PF-1155] Add workspace manager role, grant applications read_policies permission

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -112,6 +112,10 @@ resourceTypes = {
     }
     ownerRoleName = "owner"
     roles = {
+      manager = {
+        # Workspace Manager grants this role to its own service account for admin access to workspace resources. It never gives users this role.
+        roleActions = ["read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader"]
+      }
       project-owner = {
         # this role is used for display purposes but does not confer additional actions, use in conjunction with owner role
         roleActions = []

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -131,7 +131,7 @@ resourceTypes = {
         }
       }
       application = {
-        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
+        roleActions = ["read_policies", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_controlled_application_shared", "create_controlled_application_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]
       }
       writer = {
         roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain"]


### PR DESCRIPTION
Ticket: [PF-1155](https://broadworkbench.atlassian.net/browse/PF-1155)

This change adds a new `manager` role to workspace objects. Workspace Manager will grant this role to its own service account on all workspaces it creates in order to support reading/modifying workspace membership without user credentials.
No roles have permission to alter policies on existing workspace objects so we cannot back-propagate this for existing WSM resources, but it will apply to newly created workspaces pending a related WSM change.

This change also adds the `read_policies` action to the `application` role. Applications need this to validate workspace membership before assigning application-private resources to users.

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
