### PR TITLE
[CA-1616] swagger update -- update incorrect description on group policies APIs

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -366,7 +366,7 @@ paths:
       tags:
         - Group
       summary: Get email addresses for members of the policy
-      operationId: GetGroupAdminEmails
+      operationId: GetGroupPolicyEmails
       parameters:
         - name: groupName
           in: path
@@ -404,7 +404,7 @@ paths:
       tags:
         - Group
       summary: Overwrite email addresses of members of the policy
-      operationId: OverwriteGroupAdminEmails
+      operationId: OverwriteGroupPolicyEmails
       parameters:
         - name: groupName
           in: path

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -365,7 +365,7 @@ paths:
     get:
       tags:
         - Group
-      summary: Get email addresses for members of the "admin" policy
+      summary: Get email addresses for members of the policy
       operationId: GetGroupAdminEmails
       parameters:
         - name: groupName
@@ -385,7 +385,7 @@ paths:
               - admin
       responses:
         200:
-          description: Email addresses in the "admin" policy
+          description: Email addresses in the policy
           content:
             application/json:
               schema:
@@ -403,7 +403,7 @@ paths:
     put:
       tags:
         - Group
-      summary: Overwrite email addresses of members of the "admin" policy
+      summary: Overwrite email addresses of members of the policy
       operationId: OverwriteGroupAdminEmails
       parameters:
         - name: groupName


### PR DESCRIPTION


Ticket: https://broadworkbench.atlassian.net/browse/CA-1616

the API description was incorrectly stating that the group policies APIs only handles "admin" policies. Take a look at the APIs (https://sam.dsde-prod.broadinstitute.org/#/Group/OverwriteGroupAdminEmails and https://sam.dsde-prod.broadinstitute.org/#/Group/GetGroupAdminEmails ; click Try it out) and you'll see that users can choose admin or members.
![Screen Shot 2021-11-15 at 4 06 13 PM](https://user-images.githubusercontent.com/5375000/141853832-cfda6d5d-96bc-4c55-84ff-e08f95fc22c9.png)



---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
