### PR TITLE
AS-908 fixed tests to be resilient to changes in ToS text

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -103,7 +103,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       response.status shouldEqual StatusCodes.OK
       whenReady(textFuture) { text =>
-        text should include("Terms as of February 12, 2020.")
+        text.isEmpty shouldBe false
       }
     }
 
@@ -115,7 +115,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       response.status shouldEqual StatusCodes.OK
       whenReady(textFuture) { text =>
-        text should include("Terms as of February 12, 2020.")
+        text.isEmpty shouldBe false
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
@@ -14,8 +14,7 @@ class TermsOfServiceRouteSpec extends AnyFlatSpec with Matchers with ScalatestRo
     eventually {
       Get("/tos/text") ~> samRoutes.route ~> check {
         status shouldEqual StatusCodes.OK
-        responseAs[String] should include("Your access to systems and networks owned by The Broad Institute")
-        responseAs[String] should include("Terms as of February 12, 2020.")
+        responseAs[String].isEmpty shouldBe false
       }
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AS-908

Updated integration tests for SAM to not depend directly on the Terms of service text contents, so the tests won't break when the text changes. Tested that unit tests and integration tests running correctly and passing

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
