### PR TITLE
[AS-902] When user accepts ToS, add user to OpenDJ if they are enabled

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -143,9 +143,8 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       case Some(_) =>
         for {
           _ <- tosService.acceptTosStatus(userId)
-          _ <- directoryDAO.isEnabled(userId, samRequestContext).flatMap(enabled => {
-            if (enabled) registrationDAO.enableIdentity(userId, samRequestContext) else IO.none
-          })
+          enabled <- directoryDAO.isEnabled(userId, samRequestContext) 
+          _ <- if (enabled) registrationDAO.enableIdentity(userId, samRequestContext) else IO.none
           status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
         } yield status
       case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Could not accept the Terms of Service. User not found.")))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -143,6 +143,9 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       case Some(_) =>
         for {
           _ <- tosService.acceptTosStatus(userId)
+          _ <- directoryDAO.isEnabled(userId, samRequestContext).flatMap(enabled => {
+            if (enabled) registrationDAO.enableIdentity(userId, samRequestContext) else IO.none
+          })
           status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
         } yield status
       case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Could not accept the Terms of Service. User not found.")))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -204,7 +204,7 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
         status shouldEqual StatusCodes.OK
         val res = responseAs[UserStatus]
         res.userInfo.userEmail shouldBe userEmail
-        val enabledBaseArray = Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true)
+        val enabledBaseArray = Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
         res.enabled shouldBe enabledBaseArray + ("tosAccepted" -> true) + ("adminEnabled" -> true)
 
         WorkbenchUser(res.userInfo.userSubjectId, Some(GoogleSubjectId(res.userInfo.userSubjectId.value)), res.userInfo.userEmail, azureB2CId)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -50,7 +50,7 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
       val res = responseAs[UserStatus]
       res.userInfo.userSubjectId.value.length shouldBe 21
       res.userInfo.userEmail shouldBe defaultUserEmail
-      res.enabled shouldBe Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)
     }
   }
 
@@ -70,7 +70,7 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
     Get("/register/user/v1") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val res = responseAs[UserStatus]
-      res.enabled shouldBe Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)
+      res.enabled shouldBe Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -60,7 +60,7 @@ class UserRoutesV2Spec extends UserRoutesSpecHelper {
 
     Get("/register/user/v2/self/diagnostics") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatusDiagnostics] shouldEqual UserStatusDiagnostics(false, true, true, Option(true), true)
+      responseAs[UserStatusDiagnostics] shouldEqual UserStatusDiagnostics(true, true, true, Option(true), true)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -232,7 +232,7 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
 
     // it should be enabled
     dirDAO.isEnabled(defaultUserId, samRequestContext).unsafeRunSync() shouldBe true
-    registrationDAO.isEnabled(defaultUserId, samRequestContext).unsafeRunSync() shouldBe false
+    registrationDAO.isEnabled(defaultUserId, samRequestContext).unsafeRunSync() shouldBe true
   }
 
   private def updateTosVersionThenEnableUser(tosEnabled: Boolean = true, userAcceptsNewTos: Boolean = false): Unit = {
@@ -282,7 +282,7 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
 
     val status = serviceTosEnabled.getUserStatus(defaultUserId, samRequestContext = samRequestContext).futureValue
-    status shouldBe Some(UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)))
+    status shouldBe Some(UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)))
   }
 
   it should "not accept the tos for users who do not exist" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AS-902
- Added logic to enabled OpenDJ when ToS is accepted
- Updated tests to reflect the change

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
