### PR TITLE
[TOAZ-11] [TOAZ-13] B2C in Sam LDAP, swagger

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val logbackClassic: ModuleID = "ch.qos.logback"             %  "logback-classic" % "1.2.3"
   val ravenLogback: ModuleID =   "com.getsentry.raven"        %  "raven-logback"   % "7.8.6"
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
-  val swaggerUi: ModuleID =      "org.webjars"                %  "swagger-ui"      % "3.52.3"
+  val swaggerUi: ModuleID =      "org.webjars"                %  "swagger-ui"      % "4.1.2"
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.5.0"
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -15,7 +15,6 @@ security:
       - openid
       - email
       - profile
-  # Uncomment when Azure B2C is ready to roll out
   - b2coauth:
       - openid
       - email
@@ -3310,7 +3309,6 @@ components:
             openid: open id authorization
             email: email authorization
             profile: profile authorization
-    # Uncomment when Azure B2C is ready to roll out
     b2coauth:
       type: oauth2
       x-tokenName: id_token

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -15,6 +15,11 @@ security:
       - openid
       - email
       - profile
+  # Uncomment when Azure B2C is ready to roll out
+  #- b2coauth:
+  #    - openid
+  #    - email
+  #    - profile
 paths:
   /api/admin/user/{userId}:
     get:
@@ -3305,3 +3310,14 @@ components:
             openid: open id authorization
             email: email authorization
             profile: profile authorization
+    # Uncomment when Azure B2C is ready to roll out
+    #b2coauth:
+    #  type: oauth2
+    #  x-tokenName: id_token
+    #  flows:
+    #    implicit:
+    #      authorizationUrl: https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1A_SIGNUP_SIGNIN
+    #      scopes:
+    #        openid: open id authorization
+    #        email: email authorization
+    #        profile: profile authorization

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -16,10 +16,10 @@ security:
       - email
       - profile
   # Uncomment when Azure B2C is ready to roll out
-  #- b2coauth:
-  #    - openid
-  #    - email
-  #    - profile
+  - b2coauth:
+      - openid
+      - email
+      - profile
 paths:
   /api/admin/user/{userId}:
     get:
@@ -3311,13 +3311,13 @@ components:
             email: email authorization
             profile: profile authorization
     # Uncomment when Azure B2C is ready to roll out
-    #b2coauth:
-    #  type: oauth2
-    #  x-tokenName: id_token
-    #  flows:
-    #    implicit:
-    #      authorizationUrl: https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1A_SIGNUP_SIGNIN
-    #      scopes:
-    #        openid: open id authorization
-    #        email: email authorization
-    #        profile: profile authorization
+    b2coauth:
+      type: oauth2
+      x-tokenName: id_token
+      flows:
+        implicit:
+          authorizationUrl: https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1A_SIGNUP_SIGNIN
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -316,7 +316,7 @@ object Boot extends IOApp with LazyLogging {
 
     cloudExtensionsInitializer match {
       case GoogleExtensionsInitializer(googleExt, synchronizer) =>
-        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, config.termsOfServiceConfig, directoryDAO, policyEvaluatorService, tosService, config.liquibaseConfig)
+        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig)
         with StandardUserInfoDirectives with GoogleExtensionRoutes {
           val googleExtensions = googleExt
           val cloudExtensions = googleExt
@@ -324,7 +324,7 @@ object Boot extends IOApp with LazyLogging {
         }
         AppDependencies(routes, samApplication, cloudExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
       case _ =>
-        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, config.termsOfServiceConfig, directoryDAO, policyEvaluatorService, tosService, config.liquibaseConfig)
+        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.swaggerConfig, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig)
         with StandardUserInfoDirectives with NoExtensionRoutes
         AppDependencies(routes, samApplication, NoExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionW
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes._
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, SwaggerConfig, TermsOfServiceConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,6 +33,7 @@ abstract class SamRoutes(
     val swaggerConfig: SwaggerConfig,
     val termsOfServiceConfig: TermsOfServiceConfig,
     val directoryDAO: DirectoryDAO,
+    val registrationDAO: RegistrationDAO,
     val policyEvaluatorService: PolicyEvaluatorService,
     val tosService: TosService,
     val liquibaseConfig: LiquibaseConfig)(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -11,7 +11,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -24,7 +24,7 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
 
   def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getUserInfo(directoryDAO, oidcHeaders, samRequestContext).unsafeToFuture()
+      getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeToFuture()
     }
   }
 
@@ -82,7 +82,7 @@ object StandardUserInfoDirectives {
   val userIdHeader = "OIDC_CLAIM_user_id"
   val googleIdFromAzureHeader = "OAUTH2_CLAIM_google_id"
 
-  def getUserInfo(directoryDAO: DirectoryDAO, oidcHeaders: OIDCHeaders, samRequestContext: SamRequestContext): IO[UserInfo] = {
+  def getUserInfo(directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, oidcHeaders: OIDCHeaders, samRequestContext: SamRequestContext): IO[UserInfo] = {
     oidcHeaders match {
       case OIDCHeaders(_, Left(googleSubjectId), _, saEmail@WorkbenchEmail(SAdomain(_)), _) =>
         // If it's a PET account, we treat it as its owner
@@ -95,26 +95,28 @@ object StandardUserInfoDirectives {
         lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext).map(uid => UserInfo(oidcHeaders.token, uid, oidcHeaders.email, oidcHeaders.expiresIn))
 
       case OIDCHeaders(_, Right(azureB2CId), _, _, _) =>
-        loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, samRequestContext).map(user => UserInfo(oidcHeaders.token, user.id, oidcHeaders.email, oidcHeaders.expiresIn))
+        loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, registrationDAO, samRequestContext).map(user => UserInfo(oidcHeaders.token, user.id, oidcHeaders.email, oidcHeaders.expiresIn))
     }
   }
 
-  private def loadUserMaybeUpdateAzureB2CId(azureB2CId: AzureB2CId, maybeGoogleSubjectId: Option[GoogleSubjectId], directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext) = {
+  private def loadUserMaybeUpdateAzureB2CId(azureB2CId: AzureB2CId, maybeGoogleSubjectId: Option[GoogleSubjectId], directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, samRequestContext: SamRequestContext) = {
     for {
       maybeUser <- directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext)
       maybeUserAgain <- (maybeUser, maybeGoogleSubjectId) match {
         case (None, Some(googleSubjectId)) =>
-          updateUserAzureB2CId(azureB2CId, googleSubjectId, directoryDAO, samRequestContext)
+          updateUserAzureB2CId(azureB2CId, googleSubjectId, directoryDAO, registrationDAO, samRequestContext)
         case _ => IO.pure(maybeUser)
       }
     } yield maybeUserAgain.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Azure Id $azureB2CId not found in sam")))
   }
 
-  private def updateUserAzureB2CId(azureB2CId: AzureB2CId, googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext) = {
+  private def updateUserAzureB2CId(azureB2CId: AzureB2CId, googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, samRequestContext: SamRequestContext) = {
     for {
       maybeSubject <- directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
       _ <- maybeSubject match {
-        case Some(userId: WorkbenchUserId) => directoryDAO.setUserAzureB2CId(userId, azureB2CId, samRequestContext)
+        case Some(userId: WorkbenchUserId) =>
+          directoryDAO.setUserAzureB2CId(userId, azureB2CId, samRequestContext)
+            .flatMap(_ => registrationDAO.setUserAzureB2CId(userId, azureB2CId, samRequestContext))
         case _ => IO.unit
       }
       maybeUser <- directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SwaggerRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SwaggerRoutes.scala
@@ -77,7 +77,7 @@ trait SwaggerRoutes extends LazyLogging {
             .replace("""url: "https://petstore.swagger.io/v2/swagger.json"""", "url: '/api-docs.yaml'")
             .replace("""layout: "StandaloneLayout"""", s"""layout: "StandaloneLayout", $swaggerOptions""")
             .replace("window.ui = ui", s"""ui.initOAuth({
-                                          |        clientId: "${swaggerConfig.googleClientId}",
+                                          |        clientId: "${swaggerConfig.clientId}",
                                           |        clientSecret: "${swaggerConfig.realm}",
                                           |        realm: "${swaggerConfig.realm}",
                                           |        appName: "${swaggerConfig.realm}",

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.RejectionHandlers.{MethodDisabled, termsOfServiceRejectionHandler}
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.TermsOfServiceAcceptance
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
   */
 trait UserInfoDirectives {
   val directoryDAO: DirectoryDAO
+  val registrationDAO: RegistrationDAO
   val cloudExtensions: CloudExtensions
   val termsOfServiceConfig: TermsOfServiceConfig
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SwaggerConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/SwaggerConfig.scala
@@ -3,4 +3,4 @@ package org.broadinstitute.dsde.workbench.sam.config
 /**
   * Created by dvoet on 7/18/17.
   */
-case class SwaggerConfig(googleClientId: String, realm: String)
+case class SwaggerConfig(clientId: String, realm: String)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -43,7 +43,6 @@ trait DirectoryDAO extends RegistrationDAO {
   def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
   def loadUsers(userIds: Set[WorkbenchUserId], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchUser]]
   def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
-  def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Int]
 
 
   def listUsersGroups(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
@@ -176,4 +176,8 @@ class LdapRegistrationDAO(
     }
     ldapIsHealthy
   }
+
+  override def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] =
+    executeLdap(IO(ldapConnectionPool.modify(userDn(userId), new Modification(ModificationType.ADD, Attr.azureB2CId, b2CId.value))), "setUserAzureB2CId", samRequestContext)
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
@@ -51,7 +51,10 @@ class LdapRegistrationDAO(
       new Attribute(Attr.cn, user.id.value),
       new Attribute(Attr.uid, user.id.value),
       new Attribute("objectclass", Seq("top", "workbenchPerson").asJava)
-    ) ++ user.googleSubjectId.map(gsid => List(new Attribute(Attr.googleSubjectId, gsid.value))).getOrElse(List.empty)
+    ) ++ List(
+      user.googleSubjectId.map(gsid => new Attribute(Attr.googleSubjectId, gsid.value)),
+      user.azureB2CId.map(b2cId => new Attribute(Attr.azureB2CId, b2cId.value))
+    ).flatten
 
     executeLdap(IO(ldapConnectionPool.add(userDn(user.id), attrs: _*)), "createUser", samRequestContext).adaptError {
       case ldape: LDAPException if ldape.getResultCode == ResultCode.ENTRY_ALREADY_EXISTS =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -420,7 +420,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     })
   }
 
-  override def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Int] = {
+  override def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] = {
     serializableWriteTransaction("setUserAzureB2CId", samRequestContext)({ implicit session =>
       val u = UserTable.column
       val results = samsql"update ${UserTable.table} set ${u.azureB2cId} = $b2cId where ${u.id} = $userId and ${u.azureB2cId} is null".update().apply()
@@ -428,7 +428,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       if (results != 1) {
         throw new WorkbenchException(s"Cannot update azureB2cId for user ${userId} because user does not exist or the azureB2cId has already been set for this user")
       } else {
-        results
+        ()
       }
     })
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/RegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/RegistrationDAO.scala
@@ -25,4 +25,5 @@ trait RegistrationDAO {
   def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount]
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit]
   def checkStatus(samRequestContext: SamRequestContext): Boolean
+  def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
@@ -47,6 +47,7 @@ object JndiSchemaDAO {
     val sn = "sn"
     val uid = "uid"
     val googleSubjectId = "googleSubjectId"
+    val azureB2CId = "azureB2CId"
     val project = "project"
     val proxyEmail = "proxyEmail"
     val authDomain = "authDomain"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/schema/JndiSchemaDAO.scala
@@ -24,7 +24,7 @@ object JndiSchemaDAO {
     * This is the version of the schema reflected by this code. Update this when adding code that updates the schema.
     * If schemaVersion is not updated your changes may not be applied.
     */
-  val schemaVersion = 3
+  val schemaVersion = 4
 
   object Attr {
     val resourceId = "resourceId"
@@ -47,11 +47,11 @@ object JndiSchemaDAO {
     val sn = "sn"
     val uid = "uid"
     val googleSubjectId = "googleSubjectId"
-    val azureB2CId = "azureB2CId"
     val project = "project"
     val proxyEmail = "proxyEmail"
     val authDomain = "authDomain"
     val public = "public"
+    val azureB2CId = "azureB2CId"
   }
 
   object ObjectClass {
@@ -254,6 +254,7 @@ class JndiSchemaDAO(
 
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.30", Attr.proxyEmail, "proxy group email", true)
     createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.34", Attr.googleSubjectId, "google subject Id", true)
+    createAttributeDefinition(schema, "1.3.6.1.4.1.18060.0.4.3.2.38", Attr.azureB2CId, "azure b2c id", true)
 
     val attrs = new BasicAttributes(true) // Ignore case
     attrs.put("NUMERICOID", "1.3.6.1.4.1.18060.0.4.3.2.300")
@@ -269,6 +270,7 @@ class JndiSchemaDAO(
     val may = new BasicAttribute("MAY")
     may.add(Attr.proxyEmail)
     may.add(Attr.googleSubjectId)
+    may.add(Attr.azureB2CId)
 
     attrs.put(may)
 
@@ -329,6 +331,7 @@ class JndiSchemaDAO(
     Try { schema.destroySubcontext("ClassDefinition/" + ObjectClass.workbenchPerson) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.proxyEmail) }
     Try { schema.destroySubcontext("AttributeDefinition/" + Attr.googleSubjectId) }
+    Try { schema.destroySubcontext("AttributeDefinition/" + Attr.azureB2CId) }
   }
 
   private def removeWorkbenchGroupSchema(): Future[Unit] = withContext { ctx =>

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -121,13 +121,13 @@ object TestSupport extends TestSupport {
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, tosConfig.copy(enabled = tosEnabled))
 
-    SamDependencies(mockResourceService, policyEvaluatorService, tosService, new UserService(directoryDAO, googleExt, registrationDAO, Seq.empty, tosService), new StatusService(directoryDAO, registrationDAO, googleExt, dbRef), mockManagedGroupService, directoryDAO, policyDAO, googleExt)
+    SamDependencies(mockResourceService, policyEvaluatorService, tosService, new UserService(directoryDAO, googleExt, registrationDAO, Seq.empty, tosService), new StatusService(directoryDAO, registrationDAO, googleExt, dbRef), mockManagedGroupService, directoryDAO, registrationDAO, policyDAO, googleExt)
 
   }
 
   val tosConfig = config.as[TermsOfServiceConfig]("termsOfService")
 
-  def genSamRoutes(samDependencies: SamDependencies, uInfo: UserInfo)(implicit system: ActorSystem, materializer: Materializer): SamRoutes = new SamRoutes(samDependencies.resourceService, samDependencies.userService, samDependencies.statusService, samDependencies.managedGroupService, null, samDependencies.tosService.tosConfig, samDependencies.directoryDAO, samDependencies.policyEvaluatorService, samDependencies.tosService, LiquibaseConfig("", false))
+  def genSamRoutes(samDependencies: SamDependencies, uInfo: UserInfo)(implicit system: ActorSystem, materializer: Materializer): SamRoutes = new SamRoutes(samDependencies.resourceService, samDependencies.userService, samDependencies.statusService, samDependencies.managedGroupService, null, samDependencies.tosService.tosConfig, samDependencies.directoryDAO, samDependencies.registrationDAO, samDependencies.policyEvaluatorService, samDependencies.tosService, LiquibaseConfig("", false))
     with MockUserInfoDirectives
     with GoogleExtensionRoutes {
       override val cloudExtensions: CloudExtensions = samDependencies.cloudExtensions
@@ -186,7 +186,7 @@ object TestSupport extends TestSupport {
   }
 }
 
-final case class SamDependencies(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, tosService: TosService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, directoryDAO: MockDirectoryDAO, policyDao: AccessPolicyDAO, val cloudExtensions: CloudExtensions)
+final case class SamDependencies(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, tosService: TosService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, directoryDAO: MockDirectoryDAO, registrationDAO: MockRegistrationDAO, policyDao: AccessPolicyDAO, val cloudExtensions: CloudExtensions)
 
 object FakeGoogleFirestore extends GoogleFirestoreService[IO]{
   override def set(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -73,7 +73,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   def makeOtherUser(samRoutes: TestSamRoutes, userInfo: UserInfo = defaultNewUser) = new {
     runAndWait(samRoutes.userService.createUser(WorkbenchUser(userInfo.userId, defaultGoogleSubjectId, userInfo.userEmail, None), samRequestContext))
     val email = userInfo.userEmail
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao)
+    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
   }
 
   def setGroupMembers(samRoutes: TestSamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {
@@ -88,7 +88,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val theDude = UserInfo(OAuth2BearerToken("tokenDude"), WorkbenchUserId("ElDudarino"), WorkbenchEmail("ElDudarino@example.com"), 0)
     defaultRoutes.directoryDAO.createUser(WorkbenchUser(theDude.userId, None, theDude.userEmail, None), samRequestContext).unsafeRunSync()
-    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.mockDirectoryDao)
+    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.mockDirectoryDao, defaultRoutes.mockRegistrationDao)
 
     body(dudesRoutes)
   }
@@ -106,7 +106,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
     val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
 
     assertCreateGroup(samRoutes)
     assertGetGroup(samRoutes)
@@ -132,7 +132,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
     val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
     samRoutes.directoryDAO.createUser(WorkbenchUser(newGuy.userId, None, newGuyEmail, None), samRequestContext).unsafeRunSync()
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
 
 
     Get(s"/api/group/$groupId") ~> newGuyRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -66,7 +66,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   def makeOtherUser(samRoutes: SamRoutes, userInfo: UserInfo = defaultNewUser) = new {
     runAndWait(samRoutes.userService.createUser(WorkbenchUser(userInfo.userId, defaultGoogleSubjectId, userInfo.userEmail, None), samRequestContext))
     val email = userInfo.userEmail
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.directoryDAO)
+    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.directoryDAO, samRoutes.registrationDAO)
   }
 
   def setGroupMembers(samRoutes: SamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {
@@ -81,7 +81,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val theDude = UserInfo(OAuth2BearerToken("tokenDude"), WorkbenchUserId("ElDudarino"), WorkbenchEmail("ElDudarino@example.com"), 0)
     defaultRoutes.directoryDAO.createUser(WorkbenchUser(theDude.userId, None, theDude.userEmail, None), samRequestContext).unsafeRunSync()
-    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.directoryDAO)
+    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.directoryDAO, defaultRoutes.registrationDAO)
     body(dudesRoutes)
   }
 
@@ -96,7 +96,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, Generator.genResourceId.sample.get, Set.empty))
     val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
     val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.directoryDAO)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.directoryDAO, samRoutes.registrationDAO)
 
     assertCreateGroup(samRoutes = samRoutes)
     assertGetGroup(samRoutes = samRoutes)
@@ -122,7 +122,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
     val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
     samRoutes.directoryDAO.createUser(WorkbenchUser(newGuy.userId, None, newGuyEmail, None), samRequestContext).unsafeRunSync()
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao)
+    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
 
 
     Get(s"/api/groups/v1/$groupId") ~> newGuyRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -60,7 +60,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
     mockUserService.createUser(WorkbenchUser(defaultUserInfo.userId, defaultGoogleSubjectId, defaultUserInfo.userEmail, None), samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO)
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -59,7 +59,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     mockUserService.createUser(WorkbenchUser(defaultUserInfo.userId, genGoogleSubjectId(), defaultUserInfo.userEmail, None), samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO)
   }
 
   private val managedGroupResourceType = configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport.eqWorkbenchExceptionErr
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes.myExceptionHandler
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, MockDirectoryDAO, MockRegistrationDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, UserService}
 import org.scalatest.concurrent.ScalaFutures
@@ -24,9 +24,10 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.ExecutionContext
 
 class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesting with ScalatestRouteTest with ScalaFutures with MockitoSugar with TestSupport {
-  def directives(dirDAO: DirectoryDAO = new MockDirectoryDAO()): StandardUserInfoDirectives = new StandardUserInfoDirectives {
+  def directives(dirDAO: DirectoryDAO = new MockDirectoryDAO(), regDAO: RegistrationDAO = new MockRegistrationDAO()): StandardUserInfoDirectives = new StandardUserInfoDirectives {
     override implicit val executionContext: ExecutionContext = null
     override val directoryDAO: DirectoryDAO = dirDAO
+    override val registrationDAO: RegistrationDAO = regDAO
     override val cloudExtensions: CloudExtensions = null
     override val termsOfServiceConfig: TermsOfServiceConfig = null
     override val userService: UserService = null
@@ -36,10 +37,11 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll(minSuccessful(20)) {
       (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val uid = genWorkbenchUserId(System.currentTimeMillis())
         val oidcHeaders = OIDCHeaders(token, externalId, 10L, email, None)
         directoryDAO.createUser(WorkbenchUser(uid, externalId.left.toOption, email, externalId.toOption), samRequestContext).unsafeRunSync()
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).unsafeRunSync()
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
         res should be (UserInfo(token, uid, email, 10L))
     }
   }
@@ -48,26 +50,28 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     // note that pets can only have google subject ids, not azure b2c ids
     forAll(genServiceAccountSubjectId, genGoogleSubjectId, genOAuth2BearerToken, genPetEmail) {
       (serviceSubjectId: ServiceAccountSubjectId, googleSubjectId: GoogleSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
-      val directoryDAO = new MockDirectoryDAO()
-      val uid = genWorkbenchUserId(System.currentTimeMillis())
-      directoryDAO.createUser(WorkbenchUser(uid, Option(googleSubjectId), email, None), samRequestContext).unsafeRunSync()
-      directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
-      val oidcHeaders = OIDCHeaders(token, Left(GoogleSubjectId(serviceSubjectId.value)), 10L, email, None)
-      val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-      res should be (UserInfo(token, uid, email, 10L))
+        val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
+        val uid = genWorkbenchUserId(System.currentTimeMillis())
+        directoryDAO.createUser(WorkbenchUser(uid, Option(googleSubjectId), email, None), samRequestContext).unsafeRunSync()
+        directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
+        val oidcHeaders = OIDCHeaders(token, Left(GoogleSubjectId(serviceSubjectId.value)), 10L, email, None)
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
+        res should be (UserInfo(token, uid, email, 10L))
     }
   }
 
   it should "be able to get a UserInfo object for service account if it is a not PET" in {
     forAll(genServiceAccountSubjectId, genOAuth2BearerToken, genPetEmail) {
       (serviceSubjectId: ServiceAccountSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
-      val directoryDAO = new MockDirectoryDAO()
-      val gSid = GoogleSubjectId(serviceSubjectId.value)
-      val uid = genWorkbenchUserId(System.currentTimeMillis())
-      val oidcHeaders = OIDCHeaders(token, Left(gSid), 10L, email, None)
-      directoryDAO.createUser(WorkbenchUser(uid, Some(gSid), email, None), samRequestContext).unsafeRunSync()
-      val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-      res should be (UserInfo(token, uid, email, 10L))
+        val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
+        val gSid = GoogleSubjectId(serviceSubjectId.value)
+        val uid = genWorkbenchUserId(System.currentTimeMillis())
+        val oidcHeaders = OIDCHeaders(token, Left(gSid), 10L, email, None)
+        directoryDAO.createUser(WorkbenchUser(uid, Some(gSid), email, None), samRequestContext).unsafeRunSync()
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
+        res should be (UserInfo(token, uid, email, 10L))
     }
   }
 
@@ -75,8 +79,9 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll {
       (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val oidcHeaders = OIDCHeaders(token, externalId, 10L, email, None)
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
@@ -85,8 +90,9 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll(genOAuth2BearerToken, genPetEmail, genGoogleSubjectId){
       (token: OAuth2BearerToken, email: WorkbenchEmail, googleSubjectId: GoogleSubjectId) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val oidcHeaders = OIDCHeaders(token, Left(googleSubjectId), 10L, email, None)
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
@@ -95,11 +101,12 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll(genServiceAccountSubjectId, genOAuth2BearerToken, genNonPetEmail){
       (serviceSubjectId: ServiceAccountSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val gSid = GoogleSubjectId(serviceSubjectId.value)
         val oidcHeaders = OIDCHeaders(token, Left(gSid), 10L, email, None)
         val uid = genWorkbenchUserId(System.currentTimeMillis())
         directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
 
         Eq[WorkbenchExceptionWithErrorReport].eqv(res, new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $gSid is not a WorkbenchUser"))) shouldBe(true)
     }
@@ -109,11 +116,12 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll(genGoogleSubjectId, genAzureB2CId, genOAuth2BearerToken, genGoogleSubjectId, genPetEmail) {
       (googleSubjectId: GoogleSubjectId, azureB2CId: AzureB2CId, token: OAuth2BearerToken, otherGoogleSubjectId: GoogleSubjectId, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val uid = genWorkbenchUserId(System.currentTimeMillis())
         val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), 10L, email, Option(otherGoogleSubjectId))
         val workbenchUser = WorkbenchUser(uid, Option(googleSubjectId), email, None)
         directoryDAO.createUser(workbenchUser, samRequestContext).unsafeRunSync()
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
@@ -122,11 +130,12 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     forAll(genGoogleSubjectId, genAzureB2CId, genOAuth2BearerToken, genPetEmail) {
       (googleSubjectId: GoogleSubjectId, azureB2CId: AzureB2CId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
+        val registrationDAO = new MockRegistrationDAO()
         val uid = genWorkbenchUserId(System.currentTimeMillis())
         val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), 10L, email, Option(googleSubjectId))
         val workbenchUser = WorkbenchUser(uid, Option(googleSubjectId), email, None)
         directoryDAO.createUser(workbenchUser, samRequestContext).unsafeRunSync()
-        val res = getUserInfo(directoryDAO, oidcHeaders, samRequestContext).unsafeRunSync()
+        val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
         res should be (UserInfo(token, uid, email, 10L))
         directoryDAO.loadUser(uid, samRequestContext).unsafeRunSync() shouldBe Option(workbenchUser.copy(azureB2CId = Option(azureB2CId)))
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -61,7 +61,7 @@ class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, null, Map.empty, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val policyEvaluatorService = PolicyEvaluatorService(emailDomain, Map.empty, policyDAO, directoryDAO)
-    val samRoutes = new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), WorkbenchUserId(""), WorkbenchEmail(""), 0), directoryDAO)
+    val samRoutes = new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), WorkbenchUserId(""), WorkbenchEmail(""), 0), directoryDAO, registrationDAO)
 
     Get("/status") ~> samRoutes.route ~> check {
       responseAs[StatusCheckResponse].ok shouldEqual false

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -23,16 +23,18 @@ import scala.concurrent.ExecutionContext
 /**
   * Created by dvoet on 7/14/17.
   */
-class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService = null)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, SwaggerConfig("", ""), TermsOfServiceConfig(false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false)) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService = null)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, SwaggerConfig("", ""), TermsOfServiceConfig(false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false)) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes: server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
+  def mockRegistrationDao: RegistrationDAO = registrationDAO
 }
 
-class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, SwaggerConfig("", ""), TermsOfServiceConfig(true, 0, "app.terra.bio/#terms-of-service"), directoryDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false)) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, SwaggerConfig("", ""), TermsOfServiceConfig(true, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false)) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes: server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
+  def mockRegistrationDao: RegistrationDAO = registrationDAO
 }
 
 object TestSamRoutes {
@@ -96,6 +98,6 @@ object TestSamRoutes {
 
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, dbRef)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, tosService = mockTosService)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO, tosService = mockTosService)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -227,8 +227,8 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
 
     directoryDAO.createUser(WorkbenchUser(adminUserId, None, adminUserEmail, None), samRequestContext).unsafeRunSync()
 
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, cloudExtensions)
-    val adminRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), adminUserId, adminUserEmail, 0), directoryDAO, cloudExtensions)
+    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO, cloudExtensions)
+    val adminRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), adminUserId, adminUserEmail, 0), directoryDAO, registrationDAO, cloudExtensions)
     testCode(samRoutes, adminRoutes)
   }
 
@@ -236,7 +236,7 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
 
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO,
+    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO,
       workbenchUser = Option(WorkbenchUser(UserService.genWorkbenchUserId(System.currentTimeMillis()), TestSupport.genGoogleSubjectId(), defaultUserEmail, None)))
 
     testCode(samRoutes)
@@ -249,7 +249,7 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig.copy(enabled = true))
     tosService.createNewGroupIfNeeded()
 
-    val samRoutes = new TestSamTosEnabledRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, tosService), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO,
+    val samRoutes = new TestSamTosEnabledRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, tosService), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO,
       workbenchUser = Option(WorkbenchUser(UserService.genWorkbenchUserId(System.currentTimeMillis()), TestSupport.genGoogleSubjectId(), defaultUserEmail, None)), tosService = tosService)
 
     testCode(samRoutes)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -22,8 +22,8 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
 
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, NoExtensions)
-    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, NoExtensions)
+    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO, NoExtensions)
+    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, registrationDAO, NoExtensions)
     testCode(samRoutes, SARoutes)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -20,8 +20,8 @@ class UserRoutesV2Spec extends UserRoutesSpecHelper {
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
 
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, NoExtensions)
-    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO,registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, NoExtensions)
+    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO, NoExtensions)
+    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO,registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, registrationDAO, NoExtensions)
     testCode(samRoutes, SARoutes)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -288,14 +288,12 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
   override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext)
       : IO[Option[WorkbenchUser]] = IO.pure(users.values.find(_.azureB2CId.contains(userId)))
 
-  override def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Int] = IO {
-    val result = for {
+  override def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] = IO {
+    for {
       user <- users.get(userId)
     } yield {
       users += user.id -> user.copy(azureB2CId = Option(b2CId))
-      1
     }
-    result.getOrElse(0)
   }
 
   override def checkStatus(samRequestContext: SamRequestContext): Boolean = true

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockRegistrationDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockRegistrationDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.errorReportSource
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, GoogleSubjectId, PetServiceAccount, PetServiceAccountId, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchSubject, WorkbenchUser, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{AzureB2CId, ErrorReport, GoogleSubjectId, PetServiceAccount, PetServiceAccountId, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchSubject, WorkbenchUser, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.ConnectionType.ConnectionType
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -80,4 +80,12 @@ class MockRegistrationDAO extends RegistrationDAO {
   }
 
   override def checkStatus(samRequestContext: SamRequestContext): Boolean = true
+
+  override def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] = IO {
+    for {
+      user <- users.get(userId)
+    } yield {
+      users += user.id -> user.copy(azureB2CId = Option(b2CId))
+    }
+  }
 }


### PR DESCRIPTION
Tickets:
https://broadworkbench.atlassian.net/browse/TOAZ-11
https://broadworkbench.atlassian.net/browse/TOAZ-13

Friends with https://github.com/broadinstitute/firecloud-develop/pull/2690. This PR can go before the fc-develop PR, but B2C logins won't work until both are merged.

1. Support B2C login in Sam swagger. Used a similar approach to [TDR](https://github.com/DataBiosphere/jade-data-repo/compare/mod_oauth2_poc):
   * Specify a new `securityScheme` for B2C with `x-tokenName` specified
   * Live-edit the `swagger-ui-bundle.js` to honor the `x-tokenName` scheme
      * Would be nice if Swagger fixed this, maybe we could open a bug

2. Add a `azureB2CId` attribute to LDAP `workbenchPerson` (and support updating existing users). This is used by Apache for the enabled-users check (see https://github.com/broadinstitute/firecloud-develop/pull/2690).

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
