### PR TITLE
DR-2406 Fix typo in dataset steward definition

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1025,7 +1025,7 @@ resourceTypes = {
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy:snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
       }
       custodian = {
         roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/DR-2406)

This should allow setting the snapshot creator role as a steward (currently we get a "You may not perform any of [ALTER_POLICIES, SHARE_POLICY::SNAPSHOT_CREATOR] on dataset/..." error)


---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
