### PR TITLE
Fix typos in group policy error message

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -230,7 +230,7 @@ object ManagedGroupService {
       case `adminNotifierValue` => ManagedGroupService.adminNotifierPolicyName
       case _ =>
         throw new WorkbenchExceptionWithErrorReport(
-          ErrorReport(StatusCodes.NotFound, "Policy name for managed groups must be one of: [\"admins\", \"members\"]"))
+          ErrorReport(StatusCodes.NotFound, s"Policy name for managed groups must be one of: ['$adminValue', '$memberValue']"))
     }
 
   def getRoleName(roleName: String): MangedGroupRoleName =


### PR DESCRIPTION
Redo of #570. Appears Jenkins doesn't like `/` in branch name