### PR TITLE
allow users to actually accept the tos

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -62,20 +62,20 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 }
               }
             }
-          } ~ withSamRequestContext { samRequestContext =>
-            pathPrefix("termsofservice") {
-              pathEndOrSingleSlash {
-                post {
-                  requireUserInfo(samRequestContext) { userInfo =>
-                    withTermsOfServiceAcceptance {
-                      complete {
-                        userService.acceptTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
-                          statusOption
-                            .map { status =>
-                              StatusCodes.OK -> Option(status)
-                            }
-                            .getOrElse(StatusCodes.NotFound -> None)
-                        }
+          }
+        } ~ withSamRequestContext { samRequestContext =>
+          pathPrefix("termsofservice") {
+            pathEndOrSingleSlash {
+              post {
+                requireUserInfo(samRequestContext) { userInfo =>
+                  withTermsOfServiceAcceptance {
+                    complete {
+                      userService.acceptTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
+                        statusOption
+                          .map { status =>
+                            StatusCodes.OK -> Option(status)
+                          }
+                          .getOrElse(StatusCodes.NotFound -> None)
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -62,6 +62,26 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 }
               }
             }
+          } ~ withSamRequestContext { samRequestContext =>
+            pathPrefix("termsofservice") {
+              pathEndOrSingleSlash {
+                post {
+                  requireUserInfo(samRequestContext) { userInfo =>
+                    withTermsOfServiceAcceptance {
+                      complete {
+                        userService.acceptTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
+                          statusOption
+                            .map { status =>
+                              StatusCodes.OK -> Option(status)
+                            }
+                            .getOrElse(StatusCodes.NotFound -> None)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       } ~ pathPrefix("v2") {
@@ -198,23 +218,6 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
     pathPrefix("v1") {
       withSamRequestContext { samRequestContext =>
         requireUserInfo(samRequestContext) { userInfo =>
-          pathPrefix("tos" / "accept") {
-            pathEndOrSingleSlash {
-              post {
-                withTermsOfServiceAcceptance {
-                  complete {
-                    userService.acceptTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
-                      statusOption
-                        .map { status =>
-                          StatusCodes.OK -> Option(status)
-                        }
-                        .getOrElse(StatusCodes.NotFound -> None)
-                    }
-                  }
-                }
-              }
-            }
-          } ~
           get {
             path(Segment) { email =>
               pathEnd {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -200,7 +200,7 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
     }
 
     if (tosEnabled && tosAccepted) {
-      Post("/api/users/v1/tos/accept", TermsOfServiceAcceptance("app.terra.bio/#terms-of-service")) ~> routes.route ~> check {
+      Post("/register/user/v1/termsofservice", TermsOfServiceAcceptance("app.terra.bio/#terms-of-service")) ~> routes.route ~> check {
         status shouldEqual StatusCodes.OK
         val res = responseAs[UserStatus]
         res.userInfo.userEmail shouldBe userEmail

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -45,7 +45,7 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
     val (_, _, routes) = createTestUser(tosEnabled = true, tosAccepted = false)
     val tos = TermsOfServiceAcceptance("app.terra.bio/#terms-of-service")
 
-    Post("/api/users/v1/tos/accept", tos) ~> routes.route ~> check {
+    Post("/register/user/v1/tos/accept", tos) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val res = responseAs[UserStatus]
       res.userInfo.userSubjectId.value.length shouldBe 21
@@ -58,7 +58,7 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
     val (_, _, routes) = createTestUser(tosEnabled = true, tosAccepted = false)
 
     val tos = TermsOfServiceAcceptance("onemillionpats.com")
-    Post("/api/users/v1/tos/accept", tos) ~> routes.route ~> check {
+    Post("/register/user/v1/termsofservice", tos) ~> routes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
       responseAs[ErrorReport].message should startWith("You must accept the Terms of Service in order to register.")
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -45,7 +45,7 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper{
     val (_, _, routes) = createTestUser(tosEnabled = true, tosAccepted = false)
     val tos = TermsOfServiceAcceptance("app.terra.bio/#terms-of-service")
 
-    Post("/register/user/v1/tos/accept", tos) ~> routes.route ~> check {
+    Post("/register/user/v1/termsofservice", tos) ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val res = responseAs[UserStatus]
       res.userInfo.userSubjectId.value.length shouldBe 21


### PR DESCRIPTION
moves the ToS accept route from `/api/users/v1/tos/accept` to `/register/user/v1/termsofservice`

Endpoints under `/api` can only be called if the user is enabled, so this allows users to actually accept the ToS if they're ever disabled.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
