### PR TITLE
DR-2418 Add read_dataset to snapshot_creator role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1034,7 +1034,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
       }
       snapshot_creator = {
-        roleActions = ["read_data", "read_policies", "link_snapshot"]
+        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
       }
       admin = {
         roleActions = ["share_policy::steward", "read_policies", "alter_policies"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2418

Our documentation specifically states that `snapshot_creator`s should be able to read datasets. However, the `snapshot_creator` role did not have the `read_dataset` action!

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
