### PR TITLE
[CA-1103] Remove GPAlloc from Sam Automation Tests

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle2V = "0.23-7ddf186"
-  val workbenchServiceTestV = "0.21-258d483"
+  val workbenchServiceTestV = "1.0-be4e2333-SNAP"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 


### PR DESCRIPTION
R: https://broadworkbench.atlassian.net/browse/CA-1103
Update test code for changes to workbench-libs that removed support for
GPAlloc.

TODO: need to find a billing account to use for tests... Not sure if I can hard-code this or edit the config for leonardo tests to include this.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
