### PR TITLE
[WOR-70] add read_spend_report action to billing-project owner role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -652,6 +652,9 @@ resourceTypes = {
       read_spend_report_configuration = {
         description = "read the spend report config (i.e. the BigQuery dataset for spend reports) for this billing-project"
       }
+      read_spend_report = {
+        description = "read spend report which contains data pulled from BigQuery dataset for this billing-project"
+      }
       add_child = {
         description = "add children, e.g. google-project"
       }
@@ -665,7 +668,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "list_children", "remove_child", "add_child"]
+        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child"]
         descendantRoles = {
           google-project = ["owner"]
         }


### PR DESCRIPTION
Ticket: [WOR-70](https://broadworkbench.atlassian.net/browse/WOR-70)
Only billing project owners will be allowed to generate spend reports for their billing projects. We could use an existing action to decide whether a user should be able to do this, but why not just create a specific action?

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
