### PR TITLE
[TOAZ-84] Update b2c authorizationUrl to dev instance

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2548,7 +2548,9 @@ components:
       x-tokenName: id_token
       flows:
         implicit:
-          authorizationUrl: https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1A_SIGNUP_SIGNIN
+          # This points at the B2C dev environment. See https://broadworkbench.atlassian.net/browse/TOAZ-85
+          # to make this configurable across environments.
+          authorizationUrl: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1A_SIGNUP_SIGNIN
           scopes:
             openid: open id authorization
             email: email authorization

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -11,10 +11,6 @@ info:
 servers:
   - url: /
 security:
-  - googleoauth:
-      - openid
-      - email
-      - profile
   - b2coauth:
       - openid
       - email
@@ -2534,15 +2530,6 @@ components:
           description: true if the user is in their proxy group
       description: ""
   securitySchemes:
-    googleoauth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: https://accounts.google.com/o/oauth2/auth
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
     b2coauth:
       type: oauth2
       x-tokenName: id_token

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -11,6 +11,10 @@ info:
 servers:
   - url: /
 security:
+  - googleoauth:
+      - openid
+      - email
+      - profile
   - b2coauth:
       - openid
       - email
@@ -2530,6 +2534,15 @@ components:
           description: true if the user is in their proxy group
       description: ""
   securitySchemes:
+    googleoauth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://accounts.google.com/o/oauth2/auth
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization
     b2coauth:
       type: oauth2
       x-tokenName: id_token


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-84

Updates the B2C URL to the Terraformed dev instance (see https://github.com/broadinstitute/terraform-ap-deployments/pull/544).

Note B2C login depends on https://github.com/broadinstitute/firecloud-develop/pull/2825 and https://github.com/broadinstitute/terra-helmfile/pull/2471.


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
