### PR TITLE
[ca-1690] upgrade workbench-libs google2 to update bouncy castle 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val workbenchUtil2V   = "0.1-74c9fc2"
   val workbenchModelV  = "0.15-f9f0d4c"
   val workbenchGoogleV = "0.21-51d7fff"
-  val workbenchGoogle2V = "0.21-9d25534"
+  val workbenchGoogle2V = "0.21-bf66e61"
   val workbenchNotificationsV = "0.3-d74ff96"
   val monocleVersion = "2.0.3"
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-1690

upgrade workbench-libs google2 to update bouncy castle 

this does not upgrade to the latest version of workbench-libs google2, since that requires a cats migration and that will be handled separately.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
