### PR TITLE
[DC-243] Add Data Catalog admin role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -869,6 +869,29 @@ resourceTypes = {
     }
     reuseIds = false
   }
+  catalog = {
+    actionPatterns = {
+      "create_metadata" = {
+        description = "Can create catalog metadata"
+      },
+      "read_metadata" = {
+        description = "Can read catalog metadata"
+      },
+      "update_metadata" = {
+        description = "Can update catalog metadata"
+      },
+      "delete_metadata" = {
+        description = "Can delete catalog metadata"
+      }
+    }
+    ownerRoleName = "admin"
+    roles = {
+      admin = {
+        roleActions = ["create_metadata", "read_metadata", "update_metadata", "delete_metadata"]
+      }
+    }
+    reuseIds = true
+  }
   datarepo = {
     actionPatterns = {
       create_dataset = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -874,20 +874,20 @@ resourceTypes = {
       "create_metadata" = {
         description = "Can create catalog metadata"
       },
-      "read_metadata" = {
+      "read_any_metadata" = {
         description = "Can read catalog metadata"
       },
-      "update_metadata" = {
+      "update_any_metadata" = {
         description = "Can update catalog metadata"
       },
-      "delete_metadata" = {
+      "delete_any_metadata" = {
         description = "Can delete catalog metadata"
       }
     }
     ownerRoleName = "admin"
     roles = {
       admin = {
-        roleActions = ["create_metadata", "read_metadata", "update_metadata", "delete_metadata"]
+        roleActions = ["create_metadata", "read_any_metadata", "update_any_metadata", "delete_any_metadata"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: [DC-243](https://broadworkbench.atlassian.net/browse/DC-243)

In the Data Catalog, if user has access to a dataset in a storage system (such as the Data Repo) they can create/read/update/delete an entry in the catalog. This PR adds an admin role so that catalog team members can perform these actions for users if needed.

---
**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
