### PR TITLE
[QA-1759] Pragmatic fix for v1 billing project creation failure in tests

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle2V = "0.23-7ddf186"
-  val workbenchServiceTestV = "1.0-01c83001-SNAP"
+  val workbenchServiceTestV = "1.0-d4fe49a1-SNAP"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle2V = "0.23-7ddf186"
-  val workbenchServiceTestV = "0.21-258d483"
+  val workbenchServiceTestV = "1.0-01c83001-SNAP"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle2V = "0.23-7ddf186"
-  val workbenchServiceTestV = "1.0-d4fe49a1-SNAP"
+  val workbenchServiceTestV = "1.0-93a9c2b"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SamApiSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.test.api
 
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
@@ -12,11 +11,10 @@ import org.broadinstitute.dsde.workbench.dao.Google.{googleDirectoryDAO, googleI
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.service.Sam.sendRequest
 import org.broadinstitute.dsde.workbench.service.SamModel._
+import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
 import org.broadinstitute.dsde.workbench.service.util.Tags
-import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.test.SamConfig
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
@@ -34,7 +32,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
   val gcsConfig = SamConfig.GCS
 
   def registerAsNewUser(email: WorkbenchEmail)(implicit authToken: AuthToken): Unit = {
-    val newUserProfile = Orchestration.profile.BasicProfile (
+    val newUserProfile = Orchestration.profile.BasicProfile(
       firstName = "Generic",
       lastName = "Testerson",
       title = "User",
@@ -73,7 +71,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
           user.userInfo
         }
         case None => {
-          logger.info (s"User ${tempUser.email} does not yet exist! Registering user.")
+          logger.info(s"User ${tempUser.email} does not yet exist! Registering user.")
           Sam.user.registerSelf()(tempAuthToken)
           Sam.user.status()(tempAuthToken).get.userInfo
         }
@@ -109,7 +107,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
     "should return terms of services with no auth token" in {
       val req = HttpRequest(GET, Sam.url + s"tos/text")
-      val response = sendRequest(req)
+      val response = Sam.sendRequest(req)
 
       val textFuture = Unmarshal(response.entity).to[String]
 
@@ -177,13 +175,13 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       val expectedProxyEmail1 = s"$userId1@${gcsConfig.appsDomain}"
 
-      proxyGroup1_1.value should endWith (expectedProxyEmail1)
-      proxyGroup1_2.value should endWith (expectedProxyEmail1)
+      proxyGroup1_1.value should endWith(expectedProxyEmail1)
+      proxyGroup1_2.value should endWith(expectedProxyEmail1)
 
       val expectedProxyEmail2 = s"$userId2@${gcsConfig.appsDomain}"
 
-      proxyGroup2_1.value should endWith (expectedProxyEmail2)
-      proxyGroup2_2.value should endWith (expectedProxyEmail2)
+      proxyGroup2_1.value should endWith(expectedProxyEmail2)
+      proxyGroup2_2.value should endWith(expectedProxyEmail2)
     }
 
     "should retrieve a user's proxy group from a pet service account email as any user" in {
@@ -207,7 +205,6 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
         proxyGroup_2.value should endWith(expectedProxyEmail)
       }
     }
-
 
     "should furnish a new service account key and cache it for further retrievals" in {
       val user = UserPool.chooseStudent
@@ -278,7 +275,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         // get my pet's email
-        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
+        val petEmail1 = Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
 
         val scopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
 
@@ -288,6 +285,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
         // convert string token to an AuthToken
         val petAuthToken = new AuthToken {
           override def buildCredential() = ???
+
           override lazy val value = petToken
         }
 
@@ -334,7 +332,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       withCleanBillingProject(UserPool.chooseProjectOwner, List(user.email)) { project =>
         // get my pet's email
-        val petEmail1 =  Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
+        val petEmail1 = Sam.user.petServiceAccountEmail(project)(user.makeAuthToken())
 
         val scopes = Set("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
 
@@ -344,6 +342,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
         // convert string token to an AuthToken
         val petAuthToken = new AuthToken {
           override def buildCredential() = ???
+
           override lazy val value = petToken
         }
 
@@ -366,6 +365,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       // convert string token to an AuthToken
       val petAuthToken = new AuthToken {
         override def buildCredential() = ???
+
         override lazy val value = petToken
       }
 
@@ -382,7 +382,8 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       val adminPolicyName = "admin"
       val Seq(user1: Credentials, user2: Credentials, user3: Credentials) = UserPool.chooseStudents(3)
       val user1AuthToken = user1.makeAuthToken()
-      val Seq(user1Proxy: WorkbenchEmail, user2Proxy: WorkbenchEmail, user3Proxy: WorkbenchEmail) = Seq(user1, user2, user3).map(user => Sam.user.proxyGroup(user.email)(user1AuthToken))
+      val Seq(user1Proxy: WorkbenchEmail, user2Proxy: WorkbenchEmail, user3Proxy: WorkbenchEmail) =
+        Seq(user1, user2, user3).map(user => Sam.user.proxyGroup(user.email)(user1AuthToken))
 
       Sam.user.createGroup(managedGroupId)(user1AuthToken)
       register cleanUp Sam.user.deleteGroup(managedGroupId)(user1AuthToken)
@@ -395,38 +396,50 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       // The admin policy should contain only the user that created the group
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(user1Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       // Change the membership of the admin policy to include users 1 and 2
       Sam.user.setPolicyMembers(managedGroupId, adminPolicyName, Set(user1.email, user2.email))(user1AuthToken)
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(user1Proxy.value, user2Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       // Add user 3 to the admin policy
       Sam.user.addUserToPolicy(managedGroupId, adminPolicyName, user3.email)(user1AuthToken)
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(user1Proxy.value, user2Proxy.value, user3Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       // Remove user 2 from the admin policy
       Sam.user.removeUserFromPolicy(managedGroupId, adminPolicyName, user2.email)(user1AuthToken)
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(policyEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(user1Proxy.value, user3Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
     }
 
     "should only synchronize the intersection group for policies constrained by auth domains" taggedAs Tags.ExcludeInAlpha in {
       val authDomainId = UUID.randomUUID.toString
       val Seq(inPolicyUser: Credentials, inAuthDomainUser: Credentials, inBothUser: Credentials) = UserPool.chooseStudents(3)
       val inBothUserAuthToken = inBothUser.makeAuthToken()
-      val Seq(inAuthDomainUserProxy: WorkbenchEmail, inBothUserProxy: WorkbenchEmail) = Seq(inAuthDomainUser, inBothUser).map {
-        user => Sam.user.proxyGroup(user.email)(inBothUserAuthToken)
+      val Seq(inAuthDomainUserProxy: WorkbenchEmail, inBothUserProxy: WorkbenchEmail) = Seq(inAuthDomainUser, inBothUser).map { user =>
+        Sam.user.proxyGroup(user.email)(inBothUserAuthToken)
       }
 
       // Create group that will act as auth domain
@@ -442,15 +455,21 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       assert(authDomainAdminEmail.size == 1)
 
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(authDomainAdminEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(authDomainAdminEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(inBothUserProxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       Sam.user.setPolicyMembers(authDomainId, "admin", Set(inAuthDomainUser.email, inBothUser.email))(inBothUserAuthToken)
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(authDomainAdminEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(authDomainAdminEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(inBothUserProxy.value, inAuthDomainUserProxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       val resourceTypeName = "workspace"
       val resourceId = UUID.randomUUID.toString
@@ -472,16 +491,19 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       // Google should only know about the user that is in both the auth domain group and the constrained policy
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(resourceOwnerEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(resourceOwnerEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(inBothUserProxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
     }
 
     "should only synchronize all policy members for constrainable policies without auth domains" taggedAs Tags.ExcludeInAlpha in {
       val Seq(policyUser: Credentials, policyUser1: Credentials, policyUser2: Credentials) = UserPool.chooseStudents(3)
       val policyUser2Token = policyUser2.makeAuthToken()
-      val Seq(policyUser1Proxy: WorkbenchEmail, policyUser2Proxy: WorkbenchEmail) = Seq(policyUser1, policyUser2).map {
-        user => Sam.user.proxyGroup(user.email)(policyUser2Token)
+      val Seq(policyUser1Proxy: WorkbenchEmail, policyUser2Proxy: WorkbenchEmail) = Seq(policyUser1, policyUser2).map { user =>
+        Sam.user.proxyGroup(user.email)(policyUser2Token)
       }
 
       val resourceTypeName = "workspace"
@@ -504,9 +526,12 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
       // Google should only know about the user that is in both the auth domain group and the constrained policy
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(resourceOwnerEmail.head), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(resourceOwnerEmail.head), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(policyUser1Proxy.value, policyUser2Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
     }
 
     "should synchronize the all users group for public policies" taggedAs Tags.ExcludeInAlpha in {
@@ -528,17 +553,23 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
       val adminNotifierPolicy = policies.filter(_.policyName equals adminNotifierPolicyName).last
 
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(adminPolicy.email), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(adminPolicy.email), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(user1Proxy.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
 
       Sam.user.syncResourcePolicy(resourceTypeName, resourceId, adminNotifierPolicyName)(user1AuthToken)
       Sam.user.makeResourcePolicyPublic(resourceTypeName, resourceId, adminNotifierPolicyName, true)(user1AuthToken)
 
       awaitAssert(
-        Await.result(googleDirectoryDAO.listGroupMembers(adminNotifierPolicy.email), 5.minutes)
+        Await
+          .result(googleDirectoryDAO.listGroupMembers(adminNotifierPolicy.email), 5.minutes)
           .getOrElse(Set.empty) should contain theSameElementsAs Set(allUsersGroupEmail.value),
-        5.minutes, 5.seconds)
+        5.minutes,
+        5.seconds
+      )
     }
 
     "should not allow pet creation in a project that belongs to an external org" in {

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/Generators.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/Generators.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.test
+package org.broadinstitute.dsde.workbench.sam
 
 import org.broadinstitute.dsde.workbench.google2.{CollectionName, Document}
 import org.broadinstitute.dsde.workbench.google2.util.LockPath

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/SamConfig.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/SamConfig.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.test
+package org.broadinstitute.dsde.workbench.sam
 
 import org.broadinstitute.dsde.workbench.config.CommonConfig
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.test.api
+package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpMethods.GET
@@ -11,11 +11,11 @@ import org.broadinstitute.dsde.workbench.dao.Google.{googleDirectoryDAO, googleI
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountName}
+import org.broadinstitute.dsde.workbench.sam.SamConfig
 import org.broadinstitute.dsde.workbench.service.SamModel._
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
 import org.broadinstitute.dsde.workbench.service.util.Tags
-import org.broadinstitute.dsde.workbench.test.SamConfig
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
@@ -120,14 +120,11 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
     "should give pets the same access as their owners" in {
       val anyUser: Credentials = UserPool.chooseAnyUser
       val userAuthToken: AuthToken = anyUser.makeAuthToken()
-
       val owner: Credentials = UserPool.chooseProjectOwner
 
       // set auth tokens explicitly to control which credentials are used
-
       val userStatus = Sam.user.status()(userAuthToken).get
 
-      // user a brand new billing project to ensure known state for pet (not present)
       withCleanBillingProject(owner, userEmails = List(anyUser.email)) { projectName =>
         val petAccountEmail = Sam.user.petServiceAccountEmail(projectName)(userAuthToken)
         petAccountEmail.value should not be userStatus.userInfo.userEmail
@@ -135,9 +132,7 @@ class SamApiSpec extends AnyFreeSpec with BillingFixtures with Matchers with Sca
 
         // first call should create pet.  confirm that a second call to create/retrieve gives the same results
         Sam.user.petServiceAccountEmail(projectName)(userAuthToken) shouldBe petAccountEmail
-
         val petAuthToken = ServiceAccountAuthTokenFromJson(Sam.user.petServiceAccountKey(projectName)(userAuthToken))
-
         Sam.user.status()(petAuthToken) shouldBe Some(userStatus)
 
         // who is my pet -> who is my user's pet -> it's me

--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
@@ -1,22 +1,19 @@
-package org.broadinstitute.dsde.workbench.test.util
+package org.broadinstitute.dsde.workbench.sam.util
 
-import java.util.concurrent.TimeUnit
-import cats.implicits._
-import cats.effect.{Clock, IO}
 import cats.effect.unsafe.implicits.global
+import cats.effect.{Clock, IO}
+import cats.implicits._
 import cats.kernel.Eq
-import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.GoogleFirestoreInterpreter
 import org.broadinstitute.dsde.workbench.google2.util.{DistributedLock, DistributedLockConfig, FailToObtainLock}
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
-import org.broadinstitute.dsde.workbench.test.Generators.genLockPath
-import org.broadinstitute.dsde.workbench.test.SamConfig.GCS
-import java.util.concurrent.TimeUnit
-import scala.jdk.CollectionConverters._
-import scala.concurrent.duration._
-import scala.concurrent.duration.FiniteDuration
+import org.broadinstitute.dsde.workbench.sam.Generators.genLockPath
+import org.broadinstitute.dsde.workbench.sam.SamConfig.GCS
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 class DistributedLockSpec extends AsyncFlatSpec with Matchers {
 


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/QA-1759
Bypass problematic deployment manager code for creating v1 billing
projects. Use GPAlloc instead. What could possibly go wrong?

The package path of the tests was also wrong and has been for quite a while. I'm not sure if this is intentional but the linter was giving me sad req squiggles so I fixed it + re-optimised imports.

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
