### PR TITLE
member policy details [AJ-329]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2082,7 +2082,7 @@ components:
         memberPolicies:
           type: array
           items:
-            $ref: '#/components/schemas/PolicyIdAndEmail'
+            $ref: '#/components/schemas/PolicyIdentifiers'
         actions:
           type: array
           items:
@@ -2260,7 +2260,7 @@ components:
           description: The email address associated with the group
       description: specification of a managed group with an access policy and the
         email associated with the managed group
-    PolicyIdAndEmail:
+    PolicyIdentifiers:
       required:
         - policyName
         - policyEmail

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2079,6 +2079,10 @@ components:
           type: array
           items:
             type: string
+        memberPolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyIdAndEmail'
         actions:
           type: array
           items:
@@ -2256,6 +2260,26 @@ components:
           description: The email address associated with the group
       description: specification of a managed group with an access policy and the
         email associated with the managed group
+    PolicyIdAndEmail:
+      required:
+        - policyName
+        - policyEmail
+        - resourceTypeName
+        - resourceId
+      type: object
+      properties:
+        policyName:
+          type: string
+          description: The name of the policy
+        policyEmail:
+          type: string
+          description: The email of the policy
+        resourceTypeName:
+          type: string
+          description: The type of the resource
+        resourceId:
+          type: string
+          description: The id of the resource
     ResourceAndAccessPolicy:
       required:
         - accessPolicyName

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -101,7 +101,7 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
 
   private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
     requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), userInfo.userId, samRequestContext) {
-      complete(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName, samRequestContext).map(x => StatusCodes.OK -> x.toSet))
+      complete(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName, samRequestContext).map(StatusCodes.OK -> _))
     }
 
   private def handleOverwriteEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -34,6 +34,10 @@ trait AccessPolicyDAO {
 
   def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicy]]
 
+  def loadPolicyMembership(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]]
+
+  def listAccessPolicyMemberships(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]]
+
   def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[Unit]
 
   def overwritePolicy(newPolicy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -14,7 +14,6 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 trait DirectoryDAO extends RegistrationDAO {
   def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup]
   def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]]
-  def loadGroups(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[BasicWorkbenchGroup]]
   def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]]
   def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit]
@@ -35,13 +34,11 @@ trait DirectoryDAO extends RegistrationDAO {
 
   def loadSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]]
   def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
-  def loadSubjectEmails(subjects: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]]
   def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]]
 
   def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser]
   def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
   def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
-  def loadUsers(userIds: Set[WorkbenchUserId], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchUser]]
   def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
 
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1066,7 +1066,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
           left join ${PolicyActionTable as pa} on ${p.id} = ${pa.resourcePolicyId}
           left join ${ResourceActionTable as ra} on ${pa.resourceActionId} = ${ra.id}
           left join ${ResourceTypeTable as part} on ${ra.resourceTypeId} = ${part.id}
-          where ${p.resourceId} = (${loadResourcePKSubQuery(resource.resourceTypeName)})
+          where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
           ${limitOnePolicyClause(limitOnePolicy, p)}"""
 
     listPoliciesQuery.map(rs =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1066,7 +1066,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
           left join ${PolicyActionTable as pa} on ${p.id} = ${pa.resourcePolicyId}
           left join ${ResourceActionTable as ra} on ${pa.resourceActionId} = ${ra.id}
           left join ${ResourceTypeTable as part} on ${ra.resourceTypeId} = ${part.id}
-          where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
+          where ${p.resourceId} = (${loadResourcePKSubQuery(resource.resourceTypeName)})
           ${limitOnePolicyClause(limitOnePolicy, p)}"""
 
     listPoliciesQuery.map(rs =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -731,6 +731,61 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
                values (${policyGroupName}, ${policy.email}, ${Instant.now()})""".updateAndReturnGeneratedKey().apply())
   }
 
+  private def directMemberUserEmailsQuery(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName]) = {
+    val u = UserTable.syntax("u")
+    val p = PolicyTable.syntax("p")
+    val gm = GroupMemberTable.syntax("gm")
+
+    samsql"""select ${p.result.name}, ${u.resultAll} from ${PolicyTable as p}
+        join ${GroupMemberTable as gm} on ${gm.groupId} = ${p.groupId}
+        join ${UserTable as u} on ${u.id} = ${gm.memberUserId}
+        where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
+        ${limitOnePolicyClause(limitOnePolicy, p)}"""
+      .map(rs => (rs.get[AccessPolicyName](p.resultName.name), UserTable(u)(rs)))
+  }
+
+  private def directMemberGroupEmailsQuery(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName]) = {
+    val g = GroupTable.syntax("g")
+    val p = PolicyTable.syntax("p")
+    val gm = GroupMemberTable.syntax("gm")
+    val op = PolicyTable.syntax("op")
+
+    samsql"""select ${p.result.name}, ${g.resultAll} from ${PolicyTable as p}
+        join ${GroupMemberTable as gm} on ${gm.groupId} = ${p.groupId}
+        join ${GroupTable as g} on ${g.id} = ${gm.memberGroupId}
+        where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
+        and not exists (select 1 from ${PolicyTable as op} where ${op.groupId} = ${g.id})
+        ${limitOnePolicyClause(limitOnePolicy, p)}"""
+      .map(rs => (rs.get[AccessPolicyName](p.resultName.name), GroupTable(g)(rs)))
+  }
+
+  private def limitOnePolicyClause(limitOnePolicy: Option[AccessPolicyName], p: QuerySQLSyntaxProvider[SQLSyntaxSupport[PolicyRecord], PolicyRecord]) = {
+    limitOnePolicy match {
+      case Some(policyName) => samsqls"and ${p.name} = ${policyName}"
+      case None => samsqls""
+    }
+  }
+
+  private def directMemberPolicyIdAndEmailsQuery(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName]) = {
+    val mp = PolicyTable.syntax("mp") // member policy
+    val mpr = ResourceTable.syntax("mpr") // member policy resource
+    val mprt = ResourceTypeTable.syntax("mprt") // member policy resource type
+    val mpg = GroupTable.syntax("mpg") // member policy group
+
+    val p = PolicyTable.syntax("p")
+    val gm = GroupMemberTable.syntax("gm")
+
+    samsql"""select ${p.result.name}, ${mp.result.name}, ${mpg.result.email}, ${mpr.result.name}, ${mprt.result.name} from ${PolicyTable as p}
+        join ${GroupMemberTable as gm} on ${gm.groupId} = ${p.groupId}
+        join ${PolicyTable as mp} on ${mp.groupId} = ${gm.memberGroupId}
+        join ${GroupTable as mpg} on ${mpg.id} = ${mp.groupId}
+        join ${ResourceTable as mpr} on ${mpr.id} = ${mp.resourceId}
+        join ${ResourceTypeTable as mprt} on ${mprt.id} = ${mpr.resourceTypeId}
+        where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
+        ${limitOnePolicyClause(limitOnePolicy, p)}"""
+      .map(rs => (rs.get[AccessPolicyName](p.resultName.name), PolicyIdAndEmail(rs.get[AccessPolicyName](mp.resultName.name), rs.get[WorkbenchEmail](mpg.resultName.email), rs.get[ResourceTypeName](mprt.resultName.name), rs.get[ResourceId](mpr.resultName.name))))
+  }
+
   // Policies and their roles and actions are set to cascade delete when the associated group is deleted
   override def deletePolicy(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Unit] = {
     val p = PolicyTable.syntax("p")
@@ -932,73 +987,132 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
 
   // Abstracts logic to load and unmarshal one or more policies, use to get full AccessPolicy objects from Postgres
   private def listPolicies(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName] = None, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicy]] = {
+    listPoliciesWithMembers(resource, limitOnePolicy, samRequestContext) { (policyInfos, memberGroupsByPolicy, memberUsersByPolicy, memberPoliciesByPolicy) =>
+      policyInfos.map { case (policyInfo, resultsByPolicy) =>
+        val (policyRoles, policyActions, policyDescendantPermissions) = unmarshalPolicyPermissions(resultsByPolicy)
+
+        val memberGroups = memberGroupsByPolicy(policyInfo.name).map(_.name).toSet[WorkbenchSubject]
+        val memberUsers = memberUsersByPolicy(policyInfo.name).map(_.id).toSet[WorkbenchSubject]
+        val memberPolicies = memberPoliciesByPolicy(policyInfo.name).map(p => FullyQualifiedPolicyId(FullyQualifiedResourceId(p.resourceTypeName, p.resourceId), p.policyName)).toSet[WorkbenchSubject]
+
+        val policyId = FullyQualifiedPolicyId(FullyQualifiedResourceId(policyInfo.resourceTypeName, policyInfo.resourceId), policyInfo.name)
+        AccessPolicy(policyId, memberUsers ++ memberGroups ++ memberPolicies, policyInfo.email, policyRoles, policyActions, policyDescendantPermissions, policyInfo.public)
+      }.to(LazyList)
+    }
+  }
+
+  /**
+    * Utility function that performs the required queries to list all policies for a resource or a load a single
+    * policy including all actions, roles and members
+    * @param resource resource to list policies for
+    * @param limitOnePolicy name of policy if loading a single
+    * @param samRequestContext
+    * @param unmarshaller function that takes the results of the queries and returns a list of the desired object.
+    *                     The first map keyed by the basic policy info and has values for roles and actions
+    *                     The other maps are keyed by the policy name and have values for
+    *                     member groups, users and policies in that order. These maps also have a default value
+    *                     of List.empty so no need to worry about missing values.
+    * @tparam T the return type
+    * @return
+    */
+  private def listPoliciesWithMembers[T](resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName], samRequestContext: SamRequestContext)
+                                        (unmarshaller: (
+                                          Map[PolicyInfo, List[(RoleResult, ActionResult)]],
+                                          Map[AccessPolicyName, List[GroupRecord]],
+                                          Map[AccessPolicyName, List[UserRecord]],
+                                          Map[AccessPolicyName, List[PolicyIdAndEmail]]) => LazyList[T]): IO[LazyList[T]] = {
+    readOnlyTransaction("listPoliciesWithMembers", samRequestContext)({ implicit session =>
+      // query to get policies and all associated roles and actions
+      val policyInfos = groupByFirstInPair(policyInfoQuery(resource, limitOnePolicy).list().apply())
+
+      // queries to get all members, there are 3 kinds, groups, users and policies
+      val memberGroupsByPolicy = groupByFirstInPair(directMemberGroupEmailsQuery(resource, limitOnePolicy).list().apply()).withDefault(_ => List.empty)
+      val memberUsersByPolicy = groupByFirstInPair(directMemberUserEmailsQuery(resource, limitOnePolicy).list().apply()).withDefault(_ => List.empty)
+      val memberPoliciesByPolicy = groupByFirstInPair(directMemberPolicyIdAndEmailsQuery(resource, limitOnePolicy).list().apply()).withDefault(_ => List.empty)
+
+      // convert query results to desired output
+      unmarshaller(policyInfos, memberGroupsByPolicy, memberUsersByPolicy, memberPoliciesByPolicy)
+    })
+  }
+
+  /**
+    * Takes a list of pairs and returns a map grouped by the first element with values of lists of the second
+    * @param list pairs to group by first element
+    * @tparam X type of first element in pair
+    * @tparam Y type of second element in pair
+    * @return map grouped by first element
+    */
+  private def groupByFirstInPair[X, Y](list: List[(X, Y)]): Map[X, List[Y]] = {
+    list.groupBy(_._1).map { case (key, pairs) => key -> pairs.map(_._2) }
+  }
+
+  private def policyInfoQuery(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName]) = {
     val g = GroupTable.syntax("g")
-    val r = ResourceTable.syntax("r")
-    val rt = ResourceTypeTable.syntax("rt")
-    val gm = GroupMemberTable.syntax("gm")
-    val sg = GroupTable.syntax("sg")
     val p = PolicyTable.syntax("p")
-    val sp = PolicyTable.syntax("sp")
-    val sr = ResourceTable.syntax("sr")
-    val srt = ResourceTypeTable.syntax("srt")
     val pr = PolicyRoleTable.syntax("pr")
     val rr = ResourceRoleTable.syntax("rr")
     val pa = PolicyActionTable.syntax("pa")
     val ra = ResourceActionTable.syntax("ra")
-    val prrt = ResourceTypeTable.syntax("prrt")
-    val part = ResourceTypeTable.syntax("part")
-
-    val limitOnePolicyClause: SQLSyntax = limitOnePolicy match {
-      case Some(policyName) => samsqls"and ${p.name} = ${policyName}"
-      case None => samsqls""
-    }
+    val prrt = ResourceTypeTable.syntax("prrt") // policy role resource type
+    val part = ResourceTypeTable.syntax("part") // policy action resource type
 
     val listPoliciesQuery =
-      samsql"""select ${p.result.name}, ${r.result.name}, ${rt.result.name}, ${g.result.email}, ${p.result.public}, ${gm.result.memberUserId}, ${sg.result.name}, ${sp.result.name}, ${sr.result.name}, ${srt.result.name}, ${prrt.result.name}, ${rr.result.role}, ${pr.result.descendantsOnly}, ${part.result.name}, ${ra.result.action}, ${pa.result.descendantsOnly}
+      samsql"""select ${p.result.name}, ${g.result.email}, ${p.result.public}, ${prrt.result.name}, ${rr.result.role}, ${pr.result.descendantsOnly}, ${part.result.name}, ${ra.result.action}, ${pa.result.descendantsOnly}
           from ${GroupTable as g}
           join ${PolicyTable as p} on ${g.id} = ${p.groupId}
-          join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
-          join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
-          left join ${GroupMemberTable as gm} on ${g.id} = ${gm.groupId}
-          left join ${GroupTable as sg} on ${gm.memberGroupId} = ${sg.id}
-          left join ${PolicyTable as sp} on ${sg.id} = ${sp.groupId}
-          left join ${ResourceTable as sr} on ${sp.resourceId} = ${sr.id}
-          left join ${ResourceTypeTable as srt} on ${sr.resourceTypeId} = ${srt.id}
           left join ${PolicyRoleTable as pr} on ${p.id} = ${pr.resourcePolicyId}
           left join ${ResourceRoleTable as rr} on ${pr.resourceRoleId} = ${rr.id}
           left join ${ResourceTypeTable as prrt} on ${rr.resourceTypeId} = ${prrt.id}
           left join ${PolicyActionTable as pa} on ${p.id} = ${pa.resourcePolicyId}
           left join ${ResourceActionTable as ra} on ${pa.resourceActionId} = ${ra.id}
           left join ${ResourceTypeTable as part} on ${ra.resourceTypeId} = ${part.id}
-          where ${r.name} = ${resource.resourceId}
-          and ${rt.name} = ${resource.resourceTypeName}
-          ${limitOnePolicyClause}"""
+          where ${p.resourceId} = (${loadResourcePKSubQuery(resource)})
+          ${limitOnePolicyClause(limitOnePolicy, p)}"""
 
-    readOnlyTransaction("listPolicies", samRequestContext)({ implicit session =>
-      val results = listPoliciesQuery.map(rs => (PolicyInfo(rs.get[AccessPolicyName](p.resultName.name), rs.get[ResourceId](r.resultName.name), rs.get[ResourceTypeName](rt.resultName.name), rs.get[WorkbenchEmail](g.resultName.email), rs.boolean(p.resultName.public)),
-        MemberResult(rs.stringOpt(gm.resultName.memberUserId).map(WorkbenchUserId), rs.stringOpt(sg.resultName.name).map(WorkbenchGroupName), rs.stringOpt(sp.resultName.name).map(AccessPolicyName(_)), rs.stringOpt(sr.resultName.name).map(ResourceId(_)), rs.stringOpt(srt.resultName.name).map(ResourceTypeName(_))),
-        (RoleResult(rs.stringOpt(prrt.resultName.name).map(ResourceTypeName(_)), rs.stringOpt(rr.resultName.role).map(ResourceRoleName(_)), rs.booleanOpt(pr.resultName.descendantsOnly)),
-          ActionResult(rs.stringOpt(part.resultName.name).map(ResourceTypeName(_)), rs.stringOpt(ra.resultName.action).map(ResourceAction(_)), rs.booleanOpt(pa.resultName.descendantsOnly)))))
-        .list().apply().groupBy(_._1)
-
-      results.map { case (policyInfo, resultsByPolicy) =>
-        val (_, memberResults, permissionsResults) = resultsByPolicy.unzip3
-
-        val policyMembers = unmarshalPolicyMembers(memberResults)
-
-        val (policyRoles, policyActions, policyDescendantPermissions) = unmarshalPolicyPermissions(permissionsResults)
-
-        AccessPolicy(FullyQualifiedPolicyId(FullyQualifiedResourceId(policyInfo.resourceTypeName, policyInfo.resourceId), policyInfo.name), policyMembers, policyInfo.email, policyRoles, policyActions, policyDescendantPermissions, policyInfo.public)
-      }.to(LazyList)
-    })
+    listPoliciesQuery.map(rs =>
+      (
+        PolicyInfo(
+          rs.get[AccessPolicyName](p.resultName.name),
+          resource.resourceId,
+          resource.resourceTypeName,
+          rs.get[WorkbenchEmail](g.resultName.email),
+          rs.boolean(p.resultName.public)),
+        (
+          RoleResult(
+            rs.stringOpt(prrt.resultName.name).map(ResourceTypeName(_)),
+            rs.stringOpt(rr.resultName.role).map(ResourceRoleName(_)),
+            rs.booleanOpt(pr.resultName.descendantsOnly)),
+          ActionResult(
+            rs.stringOpt(part.resultName.name).map(ResourceTypeName(_)),
+            rs.stringOpt(ra.resultName.action).map(ResourceAction(_)),
+            rs.booleanOpt(pa.resultName.descendantsOnly))
+        )
+      )
+    )
   }
 
-  private def unmarshalPolicyMembers(memberResults: List[MemberResult]): Set[WorkbenchSubject] = {
-    memberResults.collect {
-      case MemberResult(Some(userId), None, None, None, None) => userId
-      case MemberResult(None, Some(groupName), None, None, None) => groupName
-      case MemberResult(None, Some(_), Some(policyName), Some(resourceName), Some(resourceTypeName)) => FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceName), policyName)
-    }.toSet
+  override def loadPolicyMembership(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] = {
+    listPoliciesMemberships(policyId.resource, Option(policyId.accessPolicyName), samRequestContext).map(_.headOption.map(_.membership))
+  }
+
+  override def listAccessPolicyMemberships(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]] = {
+    listPoliciesMemberships(resource, None, samRequestContext)
+  }
+
+  // a variant of listPolicies but returns a structure that contains member emails and nested policy information instead of subject ids
+  private def listPoliciesMemberships(resource: FullyQualifiedResourceId, limitOnePolicy: Option[AccessPolicyName] = None, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]] = {
+    listPoliciesWithMembers(resource, limitOnePolicy, samRequestContext) { (policyInfos, memberGroupsByPolicy, memberUsersByPolicy, memberPoliciesByPolicy) =>
+      policyInfos.map { case (policyInfo, resultsByPolicy) =>
+        val (policyRoles, policyActions, policyDescendantPermissions) = unmarshalPolicyPermissions(resultsByPolicy)
+
+        // policies have extra information, users and groups are just emails
+        val memberGroups = memberGroupsByPolicy(policyInfo.name).map(_.email)
+        val memberUsers = memberUsersByPolicy(policyInfo.name).map(_.email)
+        val memberPolicies = memberPoliciesByPolicy(policyInfo.name).toSet
+
+        AccessPolicyWithMembership(policyInfo.name, AccessPolicyMembership(memberPolicies.map(_.policyEmail) ++ memberUsers ++ memberGroups, policyActions, policyRoles, Option(policyDescendantPermissions), Option(memberPolicies)), policyInfo.email)
+      }.to(LazyList)
+    }
   }
 
   private def unmarshalPolicyPermissions(permissionsResults: List[(RoleResult, ActionResult)]): (Set[ResourceRoleName], Set[ResourceAction], Set[AccessPolicyDescendantPermissions]) = {
@@ -1483,7 +1597,6 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
 }
 
 private final case class PolicyInfo(name: AccessPolicyName, resourceId: ResourceId, resourceTypeName: ResourceTypeName, email: WorkbenchEmail, public: Boolean)
-private final case class MemberResult(userId: Option[WorkbenchUserId], groupName: Option[WorkbenchGroupName], policyName: Option[AccessPolicyName], resourceId: Option[ResourceId], resourceTypeName: Option[ResourceTypeName])
 private final case class RoleResult(resourceTypeName: Option[ResourceTypeName], role: Option[ResourceRoleName], descendantsOnly: Option[Boolean])
 private final case class ActionResult(resourceTypeName: Option[ResourceTypeName], action: Option[ResourceAction], descendantsOnly: Option[Boolean])
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -107,51 +107,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     }
   }
 
-  override def loadGroups(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[BasicWorkbenchGroup]] = {
-    if (groupNames.isEmpty) {
-      IO.pure(LazyList.empty)
-    } else {
-      for {
-        results <- readOnlyTransaction("loadGroups", samRequestContext)({ implicit session =>
-          val g = GroupTable.syntax("g")
-          val sg = GroupTable.syntax("sg")
-          val gm = GroupMemberTable.syntax("gm")
-          val p = PolicyTable.syntax("p")
-          val r = ResourceTable.syntax("r")
-          val rt = ResourceTypeTable.syntax("rt")
-
-          samsql"""select ${g.result.name}, ${g.result.email}, ${gm.result.memberUserId}, ${sg.result.name}, ${p.result.name}, ${r.result.name}, ${rt.result.name}
-                    from ${GroupTable as g}
-                    left join ${GroupMemberTable as gm} on ${g.id} = ${gm.groupId}
-                    left join ${GroupTable as sg} on ${gm.memberGroupId} = ${sg.id}
-                    left join ${PolicyTable as p} on ${p.groupId} = ${sg.id}
-                    left join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
-                    left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
-                    where ${g.name} in (${groupNames})"""
-            .map { rs =>
-              (rs.get[WorkbenchGroupName](g.resultName.name),
-                rs.get[WorkbenchEmail](g.resultName.email),
-                rs.stringOpt(gm.resultName.memberUserId).map(WorkbenchUserId),
-                rs.stringOpt(sg.resultName.name).map(WorkbenchGroupName),
-                rs.stringOpt(p.resultName.name).map(AccessPolicyName(_)),
-                rs.stringOpt(r.resultName.name).map(ResourceId(_)),
-                rs.stringOpt(rt.resultName.name).map(ResourceTypeName(_)))
-            }.list().apply()
-        })
-      } yield {
-        results.groupBy(result => (result._1, result._2)).map { case ((groupName, email), results) =>
-          val members: Set[WorkbenchSubject] = results.collect {
-              case (_, _, Some(userId), None, None, None, None) => userId
-              case (_, _, None, Some(subGroupName), None, None, None) => subGroupName
-              case (_, _, None, Some(_), Some(policyName), Some(resourceName), Some(resourceTypeName)) => FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceName), policyName)
-          }.toSet
-
-          BasicWorkbenchGroup(groupName, members, email)
-        }
-      }.to(LazyList)
-    }
-  }
-
   override def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
     batchLoadGroupEmail(Set(groupName), samRequestContext).map(_.toMap.get(groupName))
   }
@@ -345,22 +300,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     }
   }
 
-  // NOTE: This implementation is a copy/paste of the implementation from LdapDirectoryDAO.  The question was raised
-  // whether this should also handle Pets and Policies.  At this time, we don't know if it should, but for backwards
-  // compatibility with LdapDirectoryDAO, we're going to use the same implementation for now.
-  override def loadSubjectEmails(subjects: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
-    val userSubjects = subjects collect { case userId: WorkbenchUserId => userId }
-    val groupSubjects = subjects collect { case groupName: WorkbenchGroupName => groupName }
-
-    val users = loadUsers(userSubjects, samRequestContext)
-    val groups = loadGroups(groupSubjects, samRequestContext)
-
-    for {
-      userEmails <- users.map(_.map(_.email))
-      groupEmails <- groups.map(_.map(_.email))
-    } yield userEmails ++ groupEmails
-  }
-
   override def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] = {
     readOnlyTransaction("loadSubjectFromGoogleSubjectId", samRequestContext)({ implicit session =>
       val u = UserTable.syntax
@@ -436,18 +375,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         ()
       }
     })
-  }
-
-  override def loadUsers(userIds: Set[WorkbenchUserId], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchUser]] = {
-    if(userIds.nonEmpty) {
-      readOnlyTransaction("loadUsers", samRequestContext)({ implicit session =>
-        val userTable = UserTable.syntax
-
-        val loadUsersQuery = samsql"select ${userTable.resultAll} from ${UserTable as userTable} where ${userTable.id} in (${userIds})"
-        loadUsersQuery.map(UserTable(userTable))
-          .list().apply().map(UserTable.unmarshalUserRecord).to(LazyList)
-      })
-    } else IO.pure(LazyList.empty)
   }
 
   // Not worrying about cascading deletion of user's pet SAs because LDAP doesn't delete user's pet SAs automatically

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -624,6 +624,11 @@ case class GoogleExtensionsInitializer(cloudExtensions: GoogleExtensions, google
       )
     )
 
-    cloudExtensions.onBoot(samApplication)
+    for {
+      _ <- googleGroupSynchronizer.init()
+      onBootResult <- cloudExtensions.onBoot(samApplication)
+    } yield {
+      onBootResult
+    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -40,6 +40,10 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
                               googleExtensions: GoogleExtensions,
                               resourceTypes: Map[ResourceTypeName, ResourceType])(implicit executionContext: ExecutionContext)
   extends LazyLogging with FutureSupport {
+
+  def init(): IO[Set[ResourceTypeName]] =
+    accessPolicyDAO.upsertResourceTypes(resourceTypes.values.toSet, SamRequestContext(None))
+
   def synchronizeGroupMembers(groupId: WorkbenchGroupIdentity, visitedGroups: Set[WorkbenchGroupIdentity] = Set.empty[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): Future[Map[WorkbenchEmail, Seq[SyncReportItem]]] = {
     def toSyncReportItem(operation: String, email: String, result: Try[Unit]) =
       SyncReportItem(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -44,7 +44,7 @@ object SamJsonSupport {
 
   implicit val AccessPolicyDescendantPermissionsFormat = jsonFormat3(AccessPolicyDescendantPermissions.apply)
 
-  implicit val PolicyIdAndEmailFormat = jsonFormat4(PolicyIdAndEmail.apply)
+  implicit val PolicyIdentifiersFormat = jsonFormat4(PolicyIdentifiers.apply)
 
   implicit val AccessPolicyMembershipFormat = jsonFormat5(AccessPolicyMembership.apply)
 
@@ -192,7 +192,7 @@ object RolesAndActions {
 @Lenses final case class FullyQualifiedPolicyId(resource: FullyQualifiedResourceId, accessPolicyName: AccessPolicyName) extends WorkbenchGroupIdentity {
   override def toString: String = s"${accessPolicyName.value}.${resource.resourceId.value}.${resource.resourceTypeName.value}"
 }
-@Lenses final case class PolicyIdAndEmail(policyName: AccessPolicyName, policyEmail: WorkbenchEmail, resourceTypeName: ResourceTypeName, resourceId: ResourceId)
+@Lenses final case class PolicyIdentifiers(policyName: AccessPolicyName, policyEmail: WorkbenchEmail, resourceTypeName: ResourceTypeName, resourceId: ResourceId)
 @Lenses case class AccessPolicyName(value: String) extends ValueObject
 @Lenses final case class CreateResourceRequest(
                                                 resourceId: ResourceId,
@@ -221,7 +221,7 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
                                                 actions: Set[ResourceAction],
                                                 roles: Set[ResourceRoleName],
                                                 descendantPermissions: Option[Set[AccessPolicyDescendantPermissions]] = Option(Set.empty),
-                                                memberPolicies: Option[Set[PolicyIdAndEmail]] = Option(Set.empty)) {
+                                                memberPolicies: Option[Set[PolicyIdentifiers]] = Option(Set.empty)) {
   def getDescendantPermissions: Set[AccessPolicyDescendantPermissions] = descendantPermissions.getOrElse(Set.empty)
 }
 // AccessPolicyWithMembership is practically the same as AccessPolicyResponseEntry but the latter is used in api responses

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -44,7 +44,9 @@ object SamJsonSupport {
 
   implicit val AccessPolicyDescendantPermissionsFormat = jsonFormat3(AccessPolicyDescendantPermissions.apply)
 
-  implicit val AccessPolicyMembershipFormat = jsonFormat4(AccessPolicyMembership.apply)
+  implicit val PolicyIdAndEmailFormat = jsonFormat4(PolicyIdAndEmail.apply)
+
+  implicit val AccessPolicyMembershipFormat = jsonFormat5(AccessPolicyMembership.apply)
 
   implicit val AccessPolicyResponseEntryFormat = jsonFormat3(AccessPolicyResponseEntry.apply)
 
@@ -55,8 +57,6 @@ object SamJsonSupport {
   implicit val UserResourcesResponseFormat = jsonFormat6(UserResourcesResponse.apply)
 
   implicit val PolicyIdentityFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
-
-  implicit val PolicyIdAndEmailFormat = jsonFormat4(PolicyIdAndEmail.apply)
 
   implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
 
@@ -220,7 +220,8 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
 @Lenses final case class AccessPolicyMembership(memberEmails: Set[WorkbenchEmail],
                                                 actions: Set[ResourceAction],
                                                 roles: Set[ResourceRoleName],
-                                                descendantPermissions: Option[Set[AccessPolicyDescendantPermissions]] = Option(Set.empty)) {
+                                                descendantPermissions: Option[Set[AccessPolicyDescendantPermissions]] = Option(Set.empty),
+                                                memberPolicies: Option[Set[PolicyIdAndEmail]] = Option(Set.empty)) {
   def getDescendantPermissions: Set[AccessPolicyDescendantPermissions] = descendantPermissions.getOrElse(Set.empty)
 }
 @Lenses final case class AccessPolicyResponseEntry(policyName: AccessPolicyName, policy: AccessPolicyMembership, email: WorkbenchEmail)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -217,6 +217,8 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
     extends WorkbenchGroup
 
 @Lenses final case class AccessPolicyDescendantPermissions(resourceType: ResourceTypeName, actions: Set[ResourceAction], roles: Set[ResourceRoleName])
+// AccessPolicyMembership.memberPolicies is logically read-only; at some point in the future it could be lazy-loaded
+// (via extra queries) based on the contents of memberEmails.
 @Lenses final case class AccessPolicyMembership(memberEmails: Set[WorkbenchEmail],
                                                 actions: Set[ResourceAction],
                                                 roles: Set[ResourceRoleName],

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -224,6 +224,9 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
                                                 memberPolicies: Option[Set[PolicyIdAndEmail]] = Option(Set.empty)) {
   def getDescendantPermissions: Set[AccessPolicyDescendantPermissions] = descendantPermissions.getOrElse(Set.empty)
 }
+// AccessPolicyWithMembership is practically the same as AccessPolicyResponseEntry but the latter is used in api responses
+// and the former is used at the DAO level so it seems better to keep them separate
+@Lenses final case class AccessPolicyWithMembership(policyName: AccessPolicyName, membership: AccessPolicyMembership, email: WorkbenchEmail)
 @Lenses final case class AccessPolicyResponseEntry(policyName: AccessPolicyName, policy: AccessPolicyMembership, email: WorkbenchEmail)
 
 // Access Policy with no membership info to improve efficiency for calls that care about only the roles and actions of a policy, not the membership

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -56,6 +56,8 @@ object SamJsonSupport {
 
   implicit val PolicyIdentityFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
 
+  implicit val PolicyIdAndEmailFormat = jsonFormat4(PolicyIdAndEmail.apply)
+
   implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
 
   implicit val ManagedGroupAccessInstructionsFormat = ValueObjectFormat(ManagedGroupAccessInstructions.apply)
@@ -190,6 +192,7 @@ object RolesAndActions {
 @Lenses final case class FullyQualifiedPolicyId(resource: FullyQualifiedResourceId, accessPolicyName: AccessPolicyName) extends WorkbenchGroupIdentity {
   override def toString: String = s"${accessPolicyName.value}.${resource.resourceId.value}.${resource.resourceTypeName.value}"
 }
+@Lenses final case class PolicyIdAndEmail(policyName: AccessPolicyName, policyEmail: WorkbenchEmail, resourceTypeName: ResourceTypeName, resourceId: ResourceId)
 @Lenses case class AccessPolicyName(value: String) extends ValueObject
 @Lenses final case class CreateResourceRequest(
                                                 resourceId: ResourceId,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -120,11 +120,11 @@ class ManagedGroupService(
       }
     }
 
-  def listPolicyMemberEmails(resourceId: ResourceId, policyName: ManagedGroupPolicyName, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
+  def listPolicyMemberEmails(resourceId: ResourceId, policyName: ManagedGroupPolicyName, samRequestContext: SamRequestContext): IO[Set[WorkbenchEmail]] = {
     val policyIdentity =
       FullyQualifiedPolicyId(FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, resourceId), policyName)
-    accessPolicyDAO.loadPolicy(policyIdentity, samRequestContext) flatMap {
-      case Some(policy) => directoryDAO.loadSubjectEmails(policy.members, samRequestContext)
+    resourceService.loadResourcePolicy(policyIdentity, samRequestContext) flatMap {
+      case Some(policy) => IO.pure(policy.memberEmails)
       case None =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Group or policy could not be found: $policyIdentity")))
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -35,12 +35,13 @@ class ManagedGroupService(
   def createManagedGroup(groupId: ResourceId, userInfo: UserInfo, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[Resource] = {
     def adminRole = managedGroupType.ownerRoleName
 
-    val memberPolicy = ManagedGroupService.memberPolicyName -> AccessPolicyMembership(Set.empty, Set.empty, Set(ManagedGroupService.memberRoleName), None)
-    val adminPolicy = ManagedGroupService.adminPolicyName -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(adminRole), None)
+    val memberPolicy = ManagedGroupService.memberPolicyName -> AccessPolicyMembership(Set.empty, Set.empty, Set(ManagedGroupService.memberRoleName), None, None)
+    val adminPolicy = ManagedGroupService.adminPolicyName -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(adminRole), None, None)
     val adminNotificationPolicy = ManagedGroupService.adminNotifierPolicyName -> AccessPolicyMembership(
       Set.empty,
       Set.empty,
       Set(ManagedGroupService.adminNotifierRoleName),
+      None,
       None)
 
     validateGroupName(groupId.value)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -88,7 +88,7 @@ class ResourceService(
       .find(_.roleName == resourceType.ownerRoleName)
       .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
     val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(ownerRole.roleName), None))
+      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(ownerRole.roleName), None, None))
     createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, userInfo.userId, samRequestContext)
   }
 
@@ -488,7 +488,8 @@ class ResourceService(
         userEmails.toSet[WorkbenchUser].map(_.email) ++ groupEmails.map(_.email) ++ policiesAndEmails.flatMap(_.map(_.policyEmail)),
         policy.actions,
         policy.roles,
-        Option(policy.descendantPermissions))
+        Option(policy.descendantPermissions),
+        Option(policiesAndEmails.flatten.toSet))
   }
 
   def listResourcePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyResponseEntry]] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -467,45 +467,15 @@ class ResourceService(
     maybeFireNotification.map(_ => groupChanged)
   }
 
-  private[service] def loadAccessPolicyWithEmails(policy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicyMembership] = {
-    val users = policy.members.collect { case userId: WorkbenchUserId => userId }
-    val groups = policy.members.collect { case groupName: WorkbenchGroupName => groupName }
-    val policyMembers = policy.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
-
-    for {
-      userEmails <- directoryDAO.loadUsers(users, samRequestContext)
-      groupEmails <- directoryDAO.loadGroups(groups, samRequestContext)
-      policiesAndEmails <- policyMembers.toList.parTraverse { (resourceAndPolicyName: FullyQualifiedPolicyId) =>
-        accessPolicyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).map { accessPolicyOption =>
-          accessPolicyOption.map { accessPolicy =>
-            PolicyIdAndEmail(resourceAndPolicyName.accessPolicyName, accessPolicy.email,
-              resourceAndPolicyName.resource.resourceTypeName, resourceAndPolicyName.resource.resourceId)
-          }
-        }
-      }
-    } yield
-      AccessPolicyMembership(
-        userEmails.toSet[WorkbenchUser].map(_.email) ++ groupEmails.map(_.email) ++ policiesAndEmails.flatMap(_.map(_.policyEmail)),
-        policy.actions,
-        policy.roles,
-        Option(policy.descendantPermissions),
-        Option(policiesAndEmails.flatten.toSet))
-  }
-
   def listResourcePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyResponseEntry]] =
-    accessPolicyDAO.listAccessPolicies(resource, samRequestContext).flatMap { policies =>
-      policies.parTraverse { policy =>
-        loadAccessPolicyWithEmails(policy, samRequestContext).map { membership =>
-          AccessPolicyResponseEntry(policy.id.accessPolicyName, membership, policy.email)
-        }
+    accessPolicyDAO.listAccessPolicyMemberships(resource, samRequestContext).map { policiesWithMembership =>
+      policiesWithMembership.map { policyWithMembership =>
+        AccessPolicyResponseEntry(policyWithMembership.policyName, policyWithMembership.membership, policyWithMembership.email)
       }
     }
 
   def loadResourcePolicy(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] =
-    for {
-      policy <- accessPolicyDAO.loadPolicy(policyIdentity, samRequestContext)
-      res <- policy.traverse(p => loadAccessPolicyWithEmails(p, samRequestContext))
-    } yield res
+    accessPolicyDAO.loadPolicyMembership(policyIdentity, samRequestContext)
 
   private def makeValidatablePolicies(policies: Map[AccessPolicyName, AccessPolicyMembership], samRequestContext: SamRequestContext): IO[Set[ValidatableAccessPolicy]] =
     policies.toList.traverse {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -89,7 +89,7 @@ object TestSupport extends TestSupport {
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
     val googleIamDAO = googIamDAO.getOrElse(new MockGoogleIamDAO())
-    val policyDAO = policyAccessDAO.getOrElse(new MockAccessPolicyDAO(resourceTypes))
+    val policyDAO = policyAccessDAO.getOrElse(new MockAccessPolicyDAO(resourceTypes, directoryDAO))
     val notificationPubSubDAO = new MockGooglePubSubDAO()
     val googleGroupSyncPubSubDAO = new MockGooglePubSubDAO()
     val googleDisableUsersPubSubDAO = new MockGooglePubSubDAO()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
 import org.broadinstitute.dsde.workbench.sam.api.ManagedGroupRoutesSpec._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
@@ -22,7 +22,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
 
@@ -605,9 +604,9 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 
   it should "fail with 404 when the group does not exist" in {
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceTypes, groups)
-    val samRoutes = TestSamRoutes(resourceTypes, policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
+    val samRoutes = TestSamRoutes(resourceTypes, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(Resource(ManagedGroupService.managedGroupTypeName, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
 
@@ -715,9 +714,9 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
 object ManagedGroupRoutesSpec{
   def createSamRoutesWithResource(resourceTypeMap: Map[ResourceTypeName, ResourceType], resource: Resource)(implicit system: ActorSystem, materializer: Materializer, ec: ExecutionContext): TestSamRoutes ={
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceTypeMap, groups)
-    val samRoutes = TestSamRoutes(resourceTypeMap, policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceTypeMap, directoryDAO)
+    val samRoutes = TestSamRoutes(resourceTypeMap, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(resource, samRequestContext).unsafeRunSync()
     samRoutes

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -20,8 +20,6 @@ import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
-import scala.collection.concurrent.TrieMap
-
 /**
   * Created by dvoet on 6/7/17.
   */
@@ -48,8 +46,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo) = {
-    val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes)
     val directoryDAO = new MockDirectoryDAO()
+    val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val registrationDAO = new MockRegistrationDAO()
 
     val emailDomain = "example.com"
@@ -567,11 +565,11 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceTypes, groups)
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
     policyDao.createResource(Resource(ResourceTypeName("rt"), ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
@@ -627,11 +625,10 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "404 when listing policies for a resource when user can't see the resource" in {
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType), Resource(resourceType.name, ResourceId("foo"), Set.empty))
-
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceTypes, groups)
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
     //Create the resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{genGoogleSubjectId, _}
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.SamResourceActionPatterns
-import org.broadinstitute.dsde.workbench.sam.dataAccess.MockAccessPolicyDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -20,7 +20,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 
-import scala.collection.concurrent.TrieMap
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -594,13 +593,13 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
   it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceType, groups)
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceType, directoryDAO)
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
     //Create a resource
@@ -655,13 +654,13 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
   it should "404 when listing policies for a resource when user can't see the resource" in {
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    val groups = TrieMap.empty[WorkbenchGroupIdentity, WorkbenchGroup]
-    val policyDao = new MockAccessPolicyDAO(resourceType, groups)
+    val directoryDAO = new MockDirectoryDAO()
+    val policyDao = new MockAccessPolicyDAO(resourceType, directoryDAO)
+    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), policies = Some(groups))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     //Create the resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -44,8 +44,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType] = Map(defaultResourceType.name -> defaultResourceType),
                               userInfo: UserInfo = defaultUserInfo): SamRoutes = {
-    val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes)
     val directoryDAO = new MockDirectoryDAO()
+    val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val registrationDAO = new MockRegistrationDAO()
     val emailDomain = "example.com"
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -53,7 +53,7 @@ class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     connectionPool.close()
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new LdapRegistrationDAO(connectionPool, directoryConfig, TestSupport.blockingEc)
-    val policyDAO = new MockAccessPolicyDAO()
+    val policyDAO = new MockAccessPolicyDAO(directoryDAO)
 
     val emailDomain = "example.com"
     val mockResourceService = new ResourceService(Map.empty, null, policyDAO, directoryDAO, NoExtensions, emailDomain)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -15,32 +15,25 @@ import scala.collection.mutable
 /**
   * Created by dvoet on 7/17/17.
   */
-class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeName, ResourceType], private val policies: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()) extends AccessPolicyDAO {
-  def this(resourceTypes: Map[ResourceTypeName, ResourceType], policies: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup]) = {
-    this(new TrieMap[ResourceTypeName, ResourceType]() ++ resourceTypes, policies)
+class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeName, ResourceType], private val directoryDAO: MockDirectoryDAO) extends AccessPolicyDAO {
+  def this(resourceTypes: Map[ResourceTypeName, ResourceType], directoryDAO: MockDirectoryDAO) = {
+    this(new TrieMap[ResourceTypeName, ResourceType]() ++ resourceTypes, directoryDAO)
   }
 
-  def this(resourceTypes: Iterable[ResourceType], policies: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup]) = {
-    this(new TrieMap[ResourceTypeName, ResourceType] ++ resourceTypes.map(rt => rt.name -> rt).toMap, policies)
+  def this(resourceTypes: Iterable[ResourceType], directoryDAO: MockDirectoryDAO) = {
+    this(new TrieMap[ResourceTypeName, ResourceType] ++ resourceTypes.map(rt => rt.name -> rt).toMap, directoryDAO)
   }
 
-  def this(resourceType: ResourceType, policies: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup]) = {
-    this(Map(resourceType.name -> resourceType), policies)
+  def this(resourceType: ResourceType, directoryDAO: MockDirectoryDAO) = {
+    this(Map(resourceType.name -> resourceType), directoryDAO)
   }
 
-  def this(resourceTypes: Map[ResourceTypeName, ResourceType]) = {
-    this(new TrieMap[ResourceTypeName, ResourceType]() ++ resourceTypes)
-  }
-
-  def this(resourceTypes: Iterable[ResourceType]) = {
-    this(new TrieMap[ResourceTypeName, ResourceType] ++ resourceTypes.map(rt => rt.name -> rt).toMap)
-  }
-
-  def this() = {
-    this(Map.empty[ResourceTypeName, ResourceType])
+  def this(directoryDAO: MockDirectoryDAO) = {
+    this(Map.empty[ResourceTypeName, ResourceType], directoryDAO)
   }
 
   val resources = new TrieMap[FullyQualifiedResourceId, Resource]()
+  val policies = directoryDAO.groups
 
   override def upsertResourceTypes(resourceTypesToInit: Set[ResourceType], samRequestContext: SamRequestContext): IO[Set[ResourceTypeName]] = {
     for {
@@ -249,5 +242,49 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
     }
 
     aggregateByResource(forEachPolicy)
+  }
+
+  private def loadDirectMemberUserEmails(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
+    val userIds = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
+      policyGroup.members.collect { case userId: WorkbenchUserId => userId }
+    }.to(LazyList)
+
+    userIds.traverse { directoryDAO.loadUser(_, samRequestContext) }.map(_.flatMap(_.map(_.email)))
+  }
+
+  private def loadDirectMemberGroupEmails(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
+    val groupNames = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
+      policyGroup.members.collect { case groupName: WorkbenchGroupName => groupName }
+    }.to(LazyList)
+
+    groupNames.traverse { directoryDAO.loadGroup(_, samRequestContext) }.map(_.flatMap(_.map(_.email)))
+  }
+
+  private def loadDirectMemberPolicyIdAndEmails(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[PolicyIdAndEmail]] = {
+    val policyIds = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
+      policyGroup.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
+    }.to(LazyList)
+
+    policyIds.traverse { loadPolicy(_, samRequestContext) }.map(_.flatMap(_.map(p => PolicyIdAndEmail(p.id.accessPolicyName, p.email, p.id.resource.resourceTypeName, p.id.resource.resourceId))))
+  }
+
+  override def loadPolicyMembership(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] = {
+    listAccessPolicyMemberships(policyId.resource, samRequestContext).map { policyMemberships =>
+      policyMemberships.find(_.policyName == policyId.accessPolicyName).map(_.membership)
+    }
+  }
+
+  override def listAccessPolicyMemberships(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]] = {
+    listAccessPolicies(resource, samRequestContext).flatMap { policies =>
+      policies.traverse { policy =>
+        for {
+          users <- loadDirectMemberUserEmails(policy.id, samRequestContext)
+          groups <- loadDirectMemberGroupEmails(policy.id, samRequestContext)
+          subPolicies <- loadDirectMemberPolicyIdAndEmails(policy.id, samRequestContext)
+        } yield {
+          AccessPolicyWithMembership(policy.id.accessPolicyName, AccessPolicyMembership(users.toSet ++ groups ++ subPolicies.map(_.policyEmail), policy.actions, policy.roles, Option(policy.descendantPermissions), Option(subPolicies.toSet)), policy.email)
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
@@ -15,8 +15,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.net.URI
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.language.reflectiveCalls
 
@@ -41,7 +39,6 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   def sharedFixtures = new {
-    val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()
     val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
     val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
     val resourceActions: Set[ResourceAction] = Set(ResourceAction("delete"), SamResourceActions.notifyAdmins) union policyActions
@@ -73,9 +70,9 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
 
   def mockServicesFixture = new {
     val shared = sharedFixtures
-    val mockDirectoryDAO = new MockDirectoryDAO(shared.groups)
+    val mockDirectoryDAO = new MockDirectoryDAO()
     val mockRegistrationDAO = new MockDirectoryDAO()
-    val mockPolicyDAO = new MockAccessPolicyDAO(shared.resourceTypes, shared.groups)
+    val mockPolicyDAO = new MockAccessPolicyDAO(shared.resourceTypes, mockDirectoryDAO)
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(mockDirectoryDAO, samRequestContext))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, mockPolicyDAO, mockDirectoryDAO)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable
 /**
   * Created by mbemis on 6/23/17.
   */
-class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()) extends DirectoryDAO {
+class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap()) extends DirectoryDAO {
   private val groupSynchronizedDates: mutable.Map[WorkbenchGroupIdentity, Date] = new TrieMap()
   private val users: mutable.Map[WorkbenchUserId, WorkbenchUser] = new TrieMap()
   private val userAttributes: mutable.Map[WorkbenchUserId, mutable.Map[String, Any]] = new TrieMap()
@@ -47,10 +47,6 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
 
   override def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]] = IO {
     groups.get(groupName).map(_.asInstanceOf[BasicWorkbenchGroup])
-  }
-
-  override def loadGroups(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[BasicWorkbenchGroup]] = IO {
-    groups.view.filterKeys(groupNames.map(_.asInstanceOf[WorkbenchGroupIdentity])).values.map(_.asInstanceOf[BasicWorkbenchGroup]).to(LazyList)
   }
 
   override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] = {
@@ -105,10 +101,6 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
 
   override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]] = IO {
     users.get(userId)
-  }
-
-  override def loadUsers(userIds: Set[WorkbenchUserId], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchUser]] = IO {
-    users.view.filterKeys(userIds).values.to(LazyList)
   }
 
   override def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = IO {
@@ -210,10 +202,6 @@ class MockDirectoryDAO(private val groups: mutable.Map[WorkbenchGroupIdentity, W
       case id: PetServiceAccountId => petServiceAccountsByUser.get(id).map(_.serviceAccount.email)
     }
   }
-
-  override def loadSubjectEmails(subjects: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = subjects.to(LazyList).parTraverse { subject =>
-      loadSubjectEmail(subject, samRequestContext).map(_.get)
-    }
 
   override def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]] = {
     IO.pure(groupSynchronizedDates.get(groupId))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -1527,7 +1527,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createPolicy(reader, samRequestContext).unsafeRunSync()
 
         val ownerPolicyWithMembership = AccessPolicyWithMembership(owner.id.accessPolicyName, AccessPolicyMembership(Set(defaultUser.email, defaultGroup.email), owner.actions, owner.roles, Option(owner.descendantPermissions), Option(Set.empty)), owner.email)
-        val readerPolicyWithMembership = AccessPolicyWithMembership(reader.id.accessPolicyName, AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdAndEmail(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId)))), reader.email)
+        val readerPolicyWithMembership = AccessPolicyWithMembership(reader.id.accessPolicyName, AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId)))), reader.email)
 
         dao.listAccessPolicyMemberships(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should contain theSameElementsAs LazyList(ownerPolicyWithMembership, readerPolicyWithMembership)
       }
@@ -1548,7 +1548,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createPolicy(reader, samRequestContext).unsafeRunSync()
 
         val ownerPolicyMembership = AccessPolicyMembership(Set(defaultUser.email, defaultGroup.email), owner.actions, owner.roles, Option(owner.descendantPermissions), Option(Set.empty))
-        val readerPolicyMembership = AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdAndEmail(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId))))
+        val readerPolicyMembership = AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId))))
 
         dao.loadPolicyMembership(reader.id, samRequestContext).unsafeRunSync() shouldBe Option(readerPolicyMembership)
         dao.loadPolicyMembership(owner.id, samRequestContext).unsafeRunSync() shouldBe Option(ownerPolicyMembership)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -176,38 +176,6 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
     }
 
-    "loadGroups" - {
-      "load multiple groups" in {
-        val group1 = BasicWorkbenchGroup(WorkbenchGroupName("group1"), Set.empty, WorkbenchEmail("group1@foo.com"))
-        val group2 = BasicWorkbenchGroup(WorkbenchGroupName("group2"), Set.empty, WorkbenchEmail("group2@foo.com"))
-
-        dao.createGroup(group1, samRequestContext = samRequestContext).unsafeRunSync()
-        dao.createGroup(group2, samRequestContext = samRequestContext).unsafeRunSync()
-
-        dao.loadGroups(Set(group1.id, group2.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(group1, group2)
-      }
-
-      "handle loading nonexistent groups" in {
-        val group1 = BasicWorkbenchGroup(WorkbenchGroupName("group1"), Set.empty, WorkbenchEmail("group1@foo.com"))
-        val group2 = BasicWorkbenchGroup(WorkbenchGroupName("group2"), Set.empty, WorkbenchEmail("group2@foo.com"))
-
-        dao.createGroup(group1, samRequestContext = samRequestContext).unsafeRunSync()
-        dao.createGroup(group2, samRequestContext = samRequestContext).unsafeRunSync()
-
-        dao.loadGroups(Set(group1.id, group2.id, WorkbenchGroupName("fakeGroup")), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(group1, group2)
-      }
-
-      "should return member policies" in {
-        val group = BasicWorkbenchGroup(WorkbenchGroupName("group"), Set(defaultPolicy.id), WorkbenchEmail("group@example.com"))
-        policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-        policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
-        policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
-        dao.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
-
-        dao.loadGroups(Set(group.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(group)
-      }
-    }
-
     "addGroupMember" - {
       "add groups to other groups" in {
         val subGroup = emptyWorkbenchGroup("subGroup")
@@ -470,18 +438,6 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.createPolicy(parentPolicy, samRequestContext).unsafeRunSync()
 
         dao.listUsersGroups(defaultUser.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(subPolicy.id, parentPolicy.id)
-      }
-    }
-
-    "loadUsers" - {
-      "load multiple users at once" in {
-        val user1 = defaultUser
-        val user2 = WorkbenchUser(WorkbenchUserId("testUser2"), Option(GoogleSubjectId("testGoogleSubjectId2")), WorkbenchEmail("user2@test.com"), None)
-
-        dao.createUser(user1, samRequestContext).unsafeRunSync() shouldEqual user1
-        dao.createUser(user2, samRequestContext).unsafeRunSync() shouldEqual user2
-
-        dao.loadUsers(Set(user1.id, user2.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(user1, user2)
       }
     }
 
@@ -1110,29 +1066,6 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         dao.loadSubjectFromGoogleSubjectId(GoogleSubjectId(defaultPetSA.serviceAccount.subjectId.value), samRequestContext).unsafeRunSync() shouldBe Some(defaultPetSA.id)
       }
-    }
-
-    "loadSubjectEmails" - {
-      "two emails that don't exist" in {
-        dao.loadSubjectEmails(Set(defaultUser.id, defaultGroupName), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set.empty
-      }
-
-      "two emails that do exist" in {
-        val secondUser = WorkbenchUser(WorkbenchUserId("secondUser"), Option(GoogleSubjectId("testGoogleSubject2")), WorkbenchEmail("secondUser@foo.com"), None)
-
-        dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
-        dao.createUser(secondUser, samRequestContext).unsafeRunSync()
-
-        dao.loadSubjectEmails(Set(defaultUser.id, secondUser.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(defaultUser.email, secondUser.email)
-      }
-
-      "two emails of different types that do exist" in {
-        dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
-        dao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
-
-        dao.loadSubjectEmails(Set(defaultUser.id, defaultGroupName), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(defaultUser.email, defaultGroup.email)
-      }
-
     }
 
     "loadSubjectEmail" - {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -518,8 +518,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   }
 
   it should "create google extension resource on boot" in {
-    val mockAccessPolicyDAO = new MockAccessPolicyDAO()
     val mockDirectoryDAO = new MockDirectoryDAO
+    val mockAccessPolicyDAO = new MockAccessPolicyDAO(mockDirectoryDAO)
     val mockRegistrationDAO = new MockRegistrationDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGoogleKeyCachePubSubDAO = new MockGooglePubSubDAO

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -208,7 +208,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   "ManagedGroupService listPolicyMemberEmails" should "return a list of email addresses for the groups admin policy" in {
     val managedGroup = assertMakeGroup()
     managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(dummyUserInfo.userEmail)
-    managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.memberPolicyName, samRequestContext).unsafeRunSync() shouldEqual LazyList.empty
+    managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.memberPolicyName, samRequestContext).unsafeRunSync() shouldEqual Set.empty
   }
 
   it should "throw an exception if the group does not exist" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -530,6 +530,56 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     policies should contain theSameElementsAs Set(expectedPolicy)
   }
 
+  it should "include memberPolicies in the policy list where applicable" in {
+    // create a "side" resource; we will use its policy emails as members in the default resource
+    val sideResource = FullyQualifiedResourceId(otherResourceType.name, ResourceId("side-resource"))
+    service.createResourceType(otherResourceType, samRequestContext).unsafeRunSync()
+    runAndWait(service.createResource(otherResourceType, sideResource.resourceId, dummyUserInfo, samRequestContext))
+    val sidePolicies = service.listResourcePolicies(sideResource, samRequestContext).unsafeRunSync()
+
+    // create the default resource
+    val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
+    service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+
+    // add "side" policy emails to default resource
+    sidePolicies.foreach { sidePolicy =>
+      dirDAO.loadSubjectFromEmail(sidePolicy.email, samRequestContext).unsafeRunSync().map { subj =>
+        service.addSubjectToPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName(defaultResourceType.ownerRoleName.value)), subj, samRequestContext).unsafeRunSync()
+      }
+    }
+
+    val actualPolicies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync()
+    actualPolicies.size shouldBe 1
+    val ownerPolicy = actualPolicies.head
+    ownerPolicy.policy.memberPolicies shouldBe defined
+    val actualMemberPolicies = ownerPolicy.policy.memberPolicies.get
+
+    val expectedMemberPolicies = sidePolicies.map { p =>
+      PolicyIdAndEmail(p.policyName, p.email, sideResource.resourceTypeName, sideResource.resourceId)
+    }
+
+    actualMemberPolicies shouldBe expectedMemberPolicies.toSet
+
+    // all memberPolicies emails should also be in the memberEmails array
+    expectedMemberPolicies.foreach { p =>
+      ownerPolicy.policy.memberEmails should contain (p.policyEmail)
+    }
+  }
+
+  it should "not include memberPolicies in the policy list if no member is a policy" in {
+    val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
+
+    service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+
+    val actualPolicies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync()
+    actualPolicies.size shouldBe 1
+    // expect an empty set
+    actualPolicies.head.policy.memberPolicies shouldBe defined
+    actualPolicies.head.policy.memberPolicies.get shouldBe empty
+  }
+
   "overwritePolicy" should "succeed with a valid request" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -556,7 +556,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val actualMemberPolicies = ownerPolicy.policy.memberPolicies.get
 
     val expectedMemberPolicies = sidePolicies.map { p =>
-      PolicyIdAndEmail(p.policyName, p.email, sideResource.resourceTypeName, sideResource.resourceId)
+      PolicyIdentifiers(p.policyName, p.email, sideResource.resourceTypeName, sideResource.resourceId)
     }
 
     actualMemberPolicies shouldBe expectedMemberPolicies.toSet

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1351,9 +1351,9 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
       newPolicy <- policyDAO.createPolicy(AccessPolicy(
         FullyQualifiedPolicyId(res2.fullyQualifiedId, AccessPolicyName("foo")), Set(testGroup.id, dummyUserInfo.userId, FullyQualifiedPolicyId(res1.fullyQualifiedId, testPolicy.policyName)), WorkbenchEmail("a@b.c"), Set.empty, Set.empty, Set.empty, public = false), samRequestContext)
 
-      membership <- service.loadAccessPolicyWithEmails(newPolicy, samRequestContext)
+      membership <- policyDAO.loadPolicyMembership(newPolicy.id, samRequestContext)
     } yield {
-      membership.memberEmails should contain theSameElementsAs Set(
+      membership.value.memberEmails should contain theSameElementsAs Set(
         testGroup.email,
         dummyUserInfo.userEmail,
         testPolicy.email

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -552,14 +552,12 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val actualPolicies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync()
     actualPolicies.size shouldBe 1
     val ownerPolicy = actualPolicies.head
-    ownerPolicy.policy.memberPolicies shouldBe defined
-    val actualMemberPolicies = ownerPolicy.policy.memberPolicies.get
 
     val expectedMemberPolicies = sidePolicies.map { p =>
       PolicyIdentifiers(p.policyName, p.email, sideResource.resourceTypeName, sideResource.resourceId)
     }
 
-    actualMemberPolicies shouldBe expectedMemberPolicies.toSet
+    ownerPolicy.policy.memberPolicies.value shouldBe expectedMemberPolicies.toSet
 
     // all memberPolicies emails should also be in the memberEmails array
     expectedMemberPolicies.foreach { p =>


### PR DESCRIPTION
Ticket: [AJ-329](https://broadworkbench.atlassian.net/browse/AJ-329) / [CA-1825](https://broadworkbench.atlassian.net/browse/CA-1825)

See also #635.

This is an additive change to the `listResourcePoliciesV2` and `getPolicyV2` APIs, adding a new `memberPolicies` key to the response payload. If a policy contains members who are themselves policy groups, the resource type, resource id, policy name, and policy email address for each of those members will be detailed inside `memberPolicies` .

The use case for this is  in workspace->TDR snapshot permission syncing; we accomplish this by adding the workspace's reader/writer/owner/project-owner policy groups into the snapshot's reader policy. But, this is confusing to anyone who is looking at the list of snapshot readers - they see mysterious "users" like `policy-4e03e2b1-20bd-464b-970a-d77b8618d905@dev.test.firecloud.org`. By including the resource type/id and policy name, it is easier to translate that mysterious email address into "workspace 123 readers".

**Examples**

_TDR snapshot, containing some workspace policy emails:_
```json
[
  {
    "email": "policy-11abdf35-89b2-49d1-b632-d52c5ada3b13@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [
        "davidan.dev@gmail.com",
        "schaluva.dev@gmail.com"
      ],
      "memberPolicies": [],
      "roles": [
        "steward"
      ]
    },
    "policyName": "steward"
  },
  {
    "email": "policy-d38f16ab-ccca-4343-bb30-863da9f0f69d@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "discoverer"
      ]
    },
    "policyName": "discoverer"
  },
  {
    "email": "policy-42f21190-9e19-410f-a97d-eed040226513@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ],
      "memberPolicies": [],
      "roles": [
        "admin"
      ]
    },
    "policyName": "admin"
  },
  {
    "email": "policy-102e4387-a701-49f7-bf0d-c569251ac9e4@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [
        "policy-ee019c35-c9a5-4dd2-806c-d40b07d8041c@dev.test.firecloud.org",
        "policy-6858f84f-c13a-4039-9b34-ad1ab859b021@dev.test.firecloud.org",
        "policy-d9f48029-c4ee-40ff-9eac-9c8cd4d43a5f@dev.test.firecloud.org",
        "policy-f1ef089d-9421-44a5-9fd2-2f57153a9659@dev.test.firecloud.org"
      ],
      "memberPolicies": [
        {
          "policyEmail": "policy-ee019c35-c9a5-4dd2-806c-d40b07d8041c@dev.test.firecloud.org",
          "policyName": "owner",
          "resourceId": "63b61154-a5f1-445a-9277-e0d09777db29",
          "resourceTypeName": "workspace"
        },
        {
          "policyEmail": "policy-6858f84f-c13a-4039-9b34-ad1ab859b021@dev.test.firecloud.org",
          "policyName": "project-owner",
          "resourceId": "63b61154-a5f1-445a-9277-e0d09777db29",
          "resourceTypeName": "workspace"
        },
        {
          "policyEmail": "policy-d9f48029-c4ee-40ff-9eac-9c8cd4d43a5f@dev.test.firecloud.org",
          "policyName": "reader",
          "resourceId": "63b61154-a5f1-445a-9277-e0d09777db29",
          "resourceTypeName": "workspace"
        },
        {
          "policyEmail": "policy-f1ef089d-9421-44a5-9fd2-2f57153a9659@dev.test.firecloud.org",
          "policyName": "writer",
          "resourceId": "63b61154-a5f1-445a-9277-e0d09777db29",
          "resourceTypeName": "workspace"
        }
      ],
      "roles": [
        "reader"
      ]
    },
    "policyName": "reader"
  }
]
```

_typical workspace; note the project-owner policy:_
```json
[
  {
    "email": "policy-ee019c35-c9a5-4dd2-806c-d40b07d8041c@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [
        "davidan.dev@gmail.com"
      ],
      "memberPolicies": [],
      "roles": [
        "owner"
      ]
    },
    "policyName": "owner"
  },
  {
    "email": "policy-6858f84f-c13a-4039-9b34-ad1ab859b021@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [
        "policy-fabb88ae-48d2-440e-953d-13fb1157e51d@dev.test.firecloud.org"
      ],
      "memberPolicies": [
        {
          "policyEmail": "policy-fabb88ae-48d2-440e-953d-13fb1157e51d@dev.test.firecloud.org",
          "policyName": "owner",
          "resourceId": "davidan-bp-3",
          "resourceTypeName": "billing-project"
        }
      ],
      "roles": [
        "project-owner",
        "owner"
      ]
    },
    "policyName": "project-owner"
  },
  {
    "email": "policy-4a3b0e2b-6684-432d-8f0c-b1e61265debe@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "can-compute"
      ]
    },
    "policyName": "can-compute"
  },
  {
    "email": "policy-8dacb6a8-28de-4643-9a67-6f3eeb744169@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "can-catalog"
      ]
    },
    "policyName": "can-catalog"
  },
  {
    "email": "policy-d9f48029-c4ee-40ff-9eac-9c8cd4d43a5f@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "reader"
      ]
    },
    "policyName": "reader"
  },
  {
    "email": "policy-f1ef089d-9421-44a5-9fd2-2f57153a9659@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "writer"
      ]
    },
    "policyName": "writer"
  },
  {
    "email": "policy-efbaec46-1242-4b6b-914d-96899f9639f3@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "share-writer"
      ]
    },
    "policyName": "share-writer"
  },
  {
    "email": "policy-d2c8edfd-15f3-4000-9770-1f52b545bd37@dev.test.firecloud.org",
    "policy": {
      "actions": [],
      "descendantPermissions": [],
      "memberEmails": [],
      "memberPolicies": [],
      "roles": [
        "share-reader"
      ]
    },
    "policyName": "share-reader"
  }
]
```



---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
