### PR TITLE
[CA-1577] convert branch name to be dockertag-safe

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,7 +23,9 @@ set -e
 # Set default variables
 DOCKER_CMD=
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}  # default to current branch
-DOCKERTAG_SAFE_NAME=$(echo $BRANCH | sed -e 's/[^a-zA-Z0-9_.\-]/-/g' -e 's/^[.\-]*//g' | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
+REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
+REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
+DOCKERTAG_SAFE_NAME=$(echo $BRANCH | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
 DOCKERHUB_REGISTRY=${DOCKERHUB_REGISTRY:-broadinstitute/$PROJECT}
 DOCKERHUB_TESTS_REGISTRY=${DOCKERHUB_REGISTRY}-tests
 GCR_REGISTRY=""

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,6 +23,7 @@ set -e
 # Set default variables
 DOCKER_CMD=
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}  # default to current branch
+DOCKERTAG_SAFE_NAME=$(echo $BRANCH | sed -e 's/[^a-zA-Z0-9_.\-]/-/g' -e 's/^[.\-]*//g' | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
 DOCKERHUB_REGISTRY=${DOCKERHUB_REGISTRY:-broadinstitute/$PROJECT}
 DOCKERHUB_TESTS_REGISTRY=${DOCKERHUB_REGISTRY}-tests
 GCR_REGISTRY=""
@@ -133,13 +134,13 @@ function docker_cmd()
         if [ $DOCKER_CMD="push" ]; then
             echo "pushing ${DOCKERHUB_REGISTRY}:${HASH_TAG}..."
             docker push $DOCKERHUB_REGISTRY:${HASH_TAG}
-            docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $DOCKERHUB_REGISTRY:${BRANCH}
-            docker push $DOCKERHUB_REGISTRY:${BRANCH}
+            docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $DOCKERHUB_REGISTRY:${DOCKERTAG_SAFE_NAME}
+            docker push $DOCKERHUB_REGISTRY:${DOCKERTAG_SAFE_NAME}
 
             echo "pushing ${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}..."
             docker push $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG}
-            docker tag $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${BRANCH}
-            docker push $DOCKERHUB_TESTS_REGISTRY:${BRANCH}
+            docker tag $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
+            docker push $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
 
             if [[ -n $GCR_REGISTRY ]]; then
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}


### PR DESCRIPTION
Ticket: [CA-1577](https://broadworkbench.atlassian.net/browse/CA-1577)
<Put notes here to help reviewer understand this PR>

Docker tag names are based on the github branch name. Sometimes github branch names contain slashes (/) and this causes issues for the docker tag, due to the [docker tag name restrictions](https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.)


This PR should rerun tests after merging in:
* https://github.com/broadinstitute/firecloud-develop/pull/2878
* https://github.com/broadinstitute/firecloud-automated-testing/pull/150

---

Tested with all 3 changes in this test run and everything passed 🎉 : 
https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/63384/
https://fc-jenkins.dsp-techops.broadinstitute.org/job/swatomation-pipeline/63470/

---

Other approaches considered:
* Change Scala Steward's default branch name
  * this feature does not exist yet -- https://githubhot.com/repo/scala-steward-org/scala-steward/issues/2127
* Re-create the PRs with a new branch name without slashes (like in https://github.com/DataBiosphere/leonardo/blob/develop/.github/workflows/merge_scalasteward_prs.yml)
  * This would require creating another github action in each repo that has Scala Steward. Also, this doesn't allow us to use slashes in the branch name, which some devs would like.
* Add a new parameter for the sanitized image name and thread it through all of the jenkins jobs.
  * This might work but would require more changes (particularly to jenkins jobs) than the chosen approach.
* Move to GCR if it allows slashes in the tag name. Bonus: using GCR is preferred over using dockerhub.
  *  GCR still uses `docker` to tag images, so we can't get around the name restriction. https://cloud.google.com/container-registry/docs/pushing-and-pulling#tag


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
