### PR TITLE
POL-228 stop calling opendj on user info calls

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -18,42 +18,43 @@ import scala.io.Source
 class TosService (val directoryDao: DirectoryDAO, val registrationDao: RegistrationDAO, val appsDomain: String, val tosConfig: TermsOfServiceConfig)(implicit val executionContext: ExecutionContext) extends LazyLogging {
   val termsOfServiceFile = "termsOfService.md"
 
-  def resetTermsOfServiceGroupsIfNeeded(): IO[Option[BasicWorkbenchGroup]] = {
+  def resetTermsOfServiceGroupsIfNeeded(): IO[Option[WorkbenchGroupName]] = {
     if(tosConfig.enabled) {
-      getTosGroup().flatMap {
+      getTosGroupName().flatMap {
         case None =>
-          logger.info(s"creating new ToS group ${getGroupName()}")
-          val groupEmail = WorkbenchEmail(s"GROUP_${getGroupName(tosConfig.version)}@$appsDomain")
-          directoryDao.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(getGroupName(tosConfig.version)), Set.empty, groupEmail), None, SamRequestContext(None)).flatMap { createdGroup =>
-            if(tosConfig.version > 0) registrationDao.disableAllHumanIdentities(SamRequestContext(None)).map { _ => Option(createdGroup)} //special clause for v0 ToS, which will be enforced via a migration (see WOR-118)
-            else IO.pure(Option(createdGroup))
+          logger.info(s"creating new ToS group ${getGroupNameString()}")
+          val groupEmail = WorkbenchEmail(s"GROUP_${getGroupNameString(tosConfig.version)}@$appsDomain")
+          directoryDao.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(getGroupNameString(tosConfig.version)), Set.empty, groupEmail), None, SamRequestContext(None)).flatMap { createdGroup =>
+            if(tosConfig.version > 0) registrationDao.disableAllHumanIdentities(SamRequestContext(None)).map { _ => Option(createdGroup.id)} //special clause for v0 ToS, which will be enforced via a migration (see WOR-118)
+            else IO.pure(Option(createdGroup.id))
           }
-        case group => IO.pure(group)
+        case groupName => IO.pure(groupName)
       }
     } else IO.none
   }
 
-  def getGroupName(currentVersion:Int = tosConfig.version): String = {
+  def getGroupNameString(currentVersion:Int = tosConfig.version): String = {
     s"tos_accepted_${currentVersion}"
   }
 
-  def getTosGroup(): IO[Option[BasicWorkbenchGroup]] = {
-    directoryDao.loadGroup(WorkbenchGroupName(getGroupName()), SamRequestContext(None))
+  def getTosGroupName(): IO[Option[WorkbenchGroupName]] = {
+    val groupName = WorkbenchGroupName(getGroupNameString())
+    directoryDao.loadGroupEmail(groupName, SamRequestContext(None)).map(_.map(_ => groupName))
   }
 
   def acceptTosStatus(user: WorkbenchSubject): IO[Option[Boolean]] =
     if (tosConfig.enabled) {
       resetTermsOfServiceGroupsIfNeeded().flatMap {
-        case Some(group) => directoryDao.addGroupMember(group.id, user, SamRequestContext(None)).map(Option(_))
-        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupName()} failed to create.")))
+        case Some(groupName) => directoryDao.addGroupMember(groupName, user, SamRequestContext(None)).map(Option(_))
+        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupNameString()} failed to create.")))
       }
     } else IO.pure(None)
 
   def rejectTosStatus(user: WorkbenchSubject): IO[Option[Boolean]] =
     if (tosConfig.enabled) {
       resetTermsOfServiceGroupsIfNeeded().flatMap {
-        case Some(group) => directoryDao.removeGroupMember(group.id, user, SamRequestContext(None)).map(Option(_))
-        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupName()} failed to create.")))
+        case Some(groupName) => directoryDao.removeGroupMember(groupName, user, SamRequestContext(None)).map(Option(_))
+        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupNameString()} failed to create.")))
       }
     } else IO.pure(None)
 
@@ -65,9 +66,9 @@ class TosService (val directoryDao: DirectoryDAO, val registrationDao: Registrat
     */
   def getTosStatus(user: WorkbenchSubject): IO[Option[Boolean]] = {
     if (tosConfig.enabled) {
-      getTosGroup().flatMap {
-        case Some(group) => directoryDao.isGroupMember(group.id, user, SamRequestContext(None)).map(Option(_))
-        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupName()} not found.")))
+      getTosGroupName().flatMap {
+        case Some(groupName) => directoryDao.isGroupMember(groupName, user, SamRequestContext(None)).map(Option(_))
+        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Terms of Service group ${getGroupNameString()} not found.")))
       }
     } else IO.none
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -172,9 +172,9 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     directoryDAO.loadUser(userId, samRequestContext).flatMap {
       case Some(user) =>
         for {
-          ldapStatus <- registrationDAO.isEnabled(user.id, samRequestContext)
+          tosStatus <- getTermsOfServiceStatus(user.id, samRequestContext)
           adminEnabled <- directoryDAO.isEnabled(user.id, samRequestContext)
-        } yield Some(UserStatusInfo(user.id.value, user.email.value, ldapStatus, adminEnabled))
+        } yield Some(UserStatusInfo(user.id.value, user.email.value, tosStatus.getOrElse(true) && adminEnabled, adminEnabled))
       case None => IO.pure(None)
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -71,17 +71,16 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
   }
 
   it should "generate the expected group name" in {
-    assert(tosServiceEnabled.getGroupName(0) == "tos_accepted_0")
-    assert(tosServiceEnabled.getGroupName(10) == "tos_accepted_10")
+    assert(tosServiceEnabled.getGroupNameString(0) == "tos_accepted_0")
+    assert(tosServiceEnabled.getGroupNameString(10) == "tos_accepted_10")
   }
 
   it should "create the group once" in {
-    assert(tosServiceEnabled.getTosGroup().unsafeRunSync().isEmpty, "ToS Group should not exist at the start")
+    assert(tosServiceEnabled.getTosGroupName().unsafeRunSync().isEmpty, "ToS Group should not exist at the start")
     assert(tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded().unsafeRunSync().isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
-    val maybeGroup = tosServiceEnabled.getTosGroup().unsafeRunSync()
+    val maybeGroup = tosServiceEnabled.getTosGroupName().unsafeRunSync()
     assert(maybeGroup.isDefined, "ToS Group should exist after above call")
-    assert(maybeGroup.get.id.value == "tos_accepted_0")
-    assert(maybeGroup.get.email.value == "GROUP_tos_accepted_0@example.com")
+    assert(maybeGroup.get.value == "tos_accepted_0")
     assert(tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded().unsafeRunSync().isDefined, "resetTermsOfServiceGroupsIfNeeded() should return the same response when called again")
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -131,12 +131,12 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded().unsafeRunSync()
     serviceTosEnabled.createUser(defaultUser, samRequestContext).futureValue
     val userGroups = dirDAO.listUsersGroups(defaultUserId, samRequestContext).unsafeRunSync()
-    userGroups shouldNot contain (WorkbenchGroupName(tos.getGroupName(TestSupport.tosConfig.version)))
+    userGroups shouldNot contain (WorkbenchGroupName(tos.getGroupNameString(TestSupport.tosConfig.version)))
     userGroups should have size 1
 
     serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
     val newUserGroups = dirDAO.listUsersGroups(defaultUserId, samRequestContext).unsafeRunSync()
-    newUserGroups should contain (WorkbenchGroupName(tos.getGroupName(TestSupport.tosConfig.version)))
+    newUserGroups should contain (WorkbenchGroupName(tos.getGroupNameString(TestSupport.tosConfig.version)))
     newUserGroups should have size 2
   }
 
@@ -279,7 +279,7 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     dirDAO.isEnabled(defaultUserId, samRequestContext).unsafeRunSync() shouldBe true
 
     // User should only be enabled in ToS if they accepted latest ToS
-    val tosGroup = WorkbenchGroupName(newTos.getGroupName())
+    val tosGroup = WorkbenchGroupName(newTos.getGroupNameString())
     val userGroups = dirDAO.listUsersGroups(defaultUserId, samRequestContext).unsafeRunSync()
     userGroups.contains(tosGroup) shouldEqual userAcceptsNewTos
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/POL-228

In `/register/user/v2/self/info`, instead of calling opendj to see if the user is in the enabled users group, return true if the user has accepted TOS and their record is enabled.

Also use a more efficient query in TOS service to check if the TOS group exists in postgres.

And some renames

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
