### PR TITLE
[IA-3326] add Service Account User role to PET only

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -322,6 +322,7 @@ class GoogleExtensions(
               // See: https://broadworkbench.atlassian.net/browse/CA-1005
               googleDirectoryDAO.addServiceAccountToGroup(proxyEmail, sa)
             }))
+            _ <- IO.fromFuture(IO(googleIamDAO.addServiceAccountUserRoleForUser(project, sa.email, sa.email)))
           } yield sa
         // SA already exists in google, use it
         case Some(sa) => IO.pure(sa)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -326,6 +326,7 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
     when(googleIamDAO.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(ServiceAccountKey(ServiceAccountKeyId("foo"), ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(expectedJson).encode), None, None)))
     when(googleIamDAO.removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])).thenReturn(Future.successful(()))
     when(googleIamDAO.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(Seq.empty))
+    when(googleIamDAO.addServiceAccountUserRoleForUser(any[GoogleProject], any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
     (googleIamDAO, expectedJson)
   }
 


### PR DESCRIPTION
Tested in a fiab:

<img width="1295" alt="Screen Shot 2022-05-12 at 12 15 58 PM" src="https://user-images.githubusercontent.com/23626109/168121976-98171258-5900-44b6-b797-9f260704ece0.png">


Worked with devops to give the dev and QA sam service account the `roles/iam.serviceAccountAdmin` role to be able to update a service account (it only had permission to create service accounts before). Here's the terraform PR to do that: https://github.com/broadinstitute/terraform-ap-deployments/pull/646
Once this sam PR is merged, I plan on terraforming higher envs to give the sam SA that same role


**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
