### PR TITLE
[WOR-278] Improve ToS resilience

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -29,6 +29,11 @@ class TosService (val directoryDao: DirectoryDAO, val registrationDao: Registrat
             case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) => tosGroup
           }.flatMap { createdGroup =>
             if(tosConfig.version > 0) registrationDao.disableAllHumanIdentities(samRequestContext).handleError { e =>
+              // If this call has failed, then human users won't be disabled and they will not be forced to accept the
+              // new ToS version to use Terra which is a compliance issue. Ensuring that human users are disabled is
+              // challenging. Instead, we have set up log-based alerting to notify us of this issue so we can manually
+              // disable human users (https://broadworkbench.atlassian.net/browse/WOR-280). If you must modify this
+              // log message, please modify the alert as well.
               logger.error(s"Failed to disable all human identities when setting up ${getGroupNameString()}", e)
               throw e
             }.map { _ => Option(createdGroup.id)} //special clause for v0 ToS, which will be enforced via a migration (see WOR-118)


### PR DESCRIPTION
Ticket: [WOR-278](https://broadworkbench.atlassian.net/browse/WOR-278)
* tolerate race condition when creating ToS accepted group in Postgres
* log error when `registrationDAO.disableAllHumanIdentities` fails

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
