### PR TITLE
refactor UserInfo and WorkbenchUser to SamUser

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -82,8 +82,8 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
     }
   }
 
-  private def handleListGroups(userInfo: UserInfo, samRequestContext: SamRequestContext) =
-    complete(managedGroupService.listGroups(userInfo.userId, samRequestContext).map(StatusCodes.OK -> _))
+  private def handleListGroups(userInfo: SamUser, samRequestContext: SamRequestContext) =
+    complete(managedGroupService.listGroups(userInfo.id, samRequestContext).map(StatusCodes.OK -> _))
 
   private def handleGetGroup(resourceId: ResourceId, samRequestContext: SamRequestContext): Route =
     complete(managedGroupService.loadManagedGroup(resourceId, samRequestContext).flatMap {
@@ -91,21 +91,21 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
         case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "group not found")))
       })
 
-  private def handleCreateGroup(resourceId: ResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
+  private def handleCreateGroup(resourceId: ResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
     complete(managedGroupService.createManagedGroup(resourceId, userInfo, samRequestContext = samRequestContext).map(_ => StatusCodes.Created))
 
-  private def handleDeleteGroup(managedGroup: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.delete, userInfo.userId, samRequestContext) {
+  private def handleDeleteGroup(managedGroup: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.delete, userInfo.id, samRequestContext) {
       complete(managedGroupService.deleteManagedGroup(managedGroup.resourceId, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), userInfo.userId, samRequestContext) {
+  private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), userInfo.id, samRequestContext) {
       complete(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName, samRequestContext).map(StatusCodes.OK -> _))
     }
 
-  private def handleOverwriteEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.userId, samRequestContext) {
+  private def handleOverwriteEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
       entity(as[Set[WorkbenchEmail]]) { members =>
         complete(managedGroupService.overwritePolicyMemberEmails(managedGroup.resourceId, accessPolicyName, members, samRequestContext).map(_ => StatusCodes.Created))
       }
@@ -115,9 +115,9 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
       managedGroup: FullyQualifiedResourceId,
       accessPolicyName: ManagedGroupPolicyName,
       email: String,
-      userInfo: UserInfo,
+      userInfo: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.userId, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
       withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
         complete(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext).map(_ => StatusCodes.NoContent))
       }
@@ -127,25 +127,25 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
       managedGroup: FullyQualifiedResourceId,
       accessPolicyName: ManagedGroupPolicyName,
       email: String,
-      userInfo: UserInfo,
+      userInfo: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.userId, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
       withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
         complete(managedGroupService.removeSubjectFromPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }
 
-  private def handleRequestAccess(managedGroup: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.notifyAdmins, userInfo.userId, samRequestContext) {
-      complete(managedGroupService.requestAccess(managedGroup.resourceId, userInfo.userId, samRequestContext).map(_ => StatusCodes.NoContent))
+  private def handleRequestAccess(managedGroup: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.notifyAdmins, userInfo.id, samRequestContext) {
+      complete(managedGroupService.requestAccess(managedGroup.resourceId, userInfo.id, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
   private def handleSetAccessInstructions(
       managedGroup: FullyQualifiedResourceId,
       accessInstructions: ManagedGroupAccessInstructions,
-      userInfo: UserInfo,
+      userInfo: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.setAccessInstructions, userInfo.userId, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.setAccessInstructions, userInfo.id, samRequestContext) {
       complete(managedGroupService.setAccessInstructions(managedGroup.resourceId, accessInstructions.value, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -27,7 +27,7 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
   val managedGroupService: ManagedGroupService
 
   def groupRoutes: server.Route = withSamRequestContext { samRequestContext =>
-    requireUserInfo(samRequestContext) { userInfo =>
+    requireActiveUser(samRequestContext) { samUser =>
       (pathPrefix("groups" / "v1") | pathPrefix("group")) {
         pathPrefix(Segment) { groupId =>
           val managedGroup = FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, ResourceId(groupId))
@@ -36,18 +36,18 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
             get {
               handleGetGroup(managedGroup.resourceId, samRequestContext)
             } ~ post {
-              handleCreateGroup(managedGroup.resourceId, userInfo, samRequestContext)
+              handleCreateGroup(managedGroup.resourceId, samUser, samRequestContext)
             } ~ delete {
-              handleDeleteGroup(managedGroup, userInfo, samRequestContext)
+              handleDeleteGroup(managedGroup, samUser, samRequestContext)
             }
           } ~ pathPrefix("requestAccess") {
             post {
-              handleRequestAccess(managedGroup, userInfo, samRequestContext)
+              handleRequestAccess(managedGroup, samUser, samRequestContext)
             }
           } ~ path("accessInstructions") {
             put {
               entity(as[ManagedGroupAccessInstructions]) { accessInstructions =>
-                handleSetAccessInstructions(managedGroup, accessInstructions, userInfo, samRequestContext)
+                handleSetAccessInstructions(managedGroup, accessInstructions, samUser, samRequestContext)
               }
             } ~ get {
               handleGetAccessInstructions(managedGroup, samRequestContext)
@@ -57,16 +57,16 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
 
             pathEndOrSingleSlash {
               get {
-                handleListEmails(managedGroup, accessPolicyName, userInfo, samRequestContext)
+                handleListEmails(managedGroup, accessPolicyName, samUser, samRequestContext)
               } ~ put {
-                handleOverwriteEmails(managedGroup, accessPolicyName, userInfo, samRequestContext)
+                handleOverwriteEmails(managedGroup, accessPolicyName, samUser, samRequestContext)
               }
             } ~ pathPrefix(Segment) { email =>
               pathEndOrSingleSlash {
                 put {
-                  handleAddEmailToPolicy(managedGroup, accessPolicyName, email, userInfo, samRequestContext)
+                  handleAddEmailToPolicy(managedGroup, accessPolicyName, email, samUser, samRequestContext)
                 } ~ delete {
-                  handleDeleteEmailFromPolicy(managedGroup, accessPolicyName, email, userInfo, samRequestContext)
+                  handleDeleteEmailFromPolicy(managedGroup, accessPolicyName, email, samUser, samRequestContext)
                 }
               }
             }
@@ -75,15 +75,15 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
       } ~ (pathPrefix("groups" / "v1") | pathPrefix("groups")) {
         pathEndOrSingleSlash {
           get {
-            handleListGroups(userInfo, samRequestContext)
+            handleListGroups(samUser, samRequestContext)
           }
         }
       }
     }
   }
 
-  private def handleListGroups(userInfo: SamUser, samRequestContext: SamRequestContext) =
-    complete(managedGroupService.listGroups(userInfo.id, samRequestContext).map(StatusCodes.OK -> _))
+  private def handleListGroups(samUser: SamUser, samRequestContext: SamRequestContext) =
+    complete(managedGroupService.listGroups(samUser.id, samRequestContext).map(StatusCodes.OK -> _))
 
   private def handleGetGroup(resourceId: ResourceId, samRequestContext: SamRequestContext): Route =
     complete(managedGroupService.loadManagedGroup(resourceId, samRequestContext).flatMap {
@@ -91,21 +91,21 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
         case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "group not found")))
       })
 
-  private def handleCreateGroup(resourceId: ResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
-    complete(managedGroupService.createManagedGroup(resourceId, userInfo, samRequestContext = samRequestContext).map(_ => StatusCodes.Created))
+  private def handleCreateGroup(resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    complete(managedGroupService.createManagedGroup(resourceId, samUser, samRequestContext = samRequestContext).map(_ => StatusCodes.Created))
 
-  private def handleDeleteGroup(managedGroup: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.delete, userInfo.id, samRequestContext) {
+  private def handleDeleteGroup(managedGroup: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.delete, samUser.id, samRequestContext) {
       complete(managedGroupService.deleteManagedGroup(managedGroup.resourceId, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), userInfo.id, samRequestContext) {
+  private def handleListEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.readPolicy(accessPolicyName), samUser.id, samRequestContext) {
       complete(managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, accessPolicyName, samRequestContext).map(StatusCodes.OK -> _))
     }
 
-  private def handleOverwriteEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
+  private def handleOverwriteEmails(managedGroup: FullyQualifiedResourceId, accessPolicyName: ManagedGroupPolicyName, samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), samUser.id, samRequestContext) {
       entity(as[Set[WorkbenchEmail]]) { members =>
         complete(managedGroupService.overwritePolicyMemberEmails(managedGroup.resourceId, accessPolicyName, members, samRequestContext).map(_ => StatusCodes.Created))
       }
@@ -115,9 +115,9 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
       managedGroup: FullyQualifiedResourceId,
       accessPolicyName: ManagedGroupPolicyName,
       email: String,
-      userInfo: SamUser,
+      samUser: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), samUser.id, samRequestContext) {
       withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
         complete(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext).map(_ => StatusCodes.NoContent))
       }
@@ -127,25 +127,25 @@ trait ManagedGroupRoutes extends UserInfoDirectives with SecurityDirectives with
       managedGroup: FullyQualifiedResourceId,
       accessPolicyName: ManagedGroupPolicyName,
       email: String,
-      userInfo: SamUser,
+      samUser: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), userInfo.id, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), samUser.id, samRequestContext) {
       withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
         complete(managedGroupService.removeSubjectFromPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }
 
-  private def handleRequestAccess(managedGroup: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.notifyAdmins, userInfo.id, samRequestContext) {
-      complete(managedGroupService.requestAccess(managedGroup.resourceId, userInfo.id, samRequestContext).map(_ => StatusCodes.NoContent))
+  private def handleRequestAccess(managedGroup: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    requireAction(managedGroup, SamResourceActions.notifyAdmins, samUser.id, samRequestContext) {
+      complete(managedGroupService.requestAccess(managedGroup.resourceId, samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
   private def handleSetAccessInstructions(
       managedGroup: FullyQualifiedResourceId,
       accessInstructions: ManagedGroupAccessInstructions,
-      userInfo: SamUser,
+      samUser: SamUser,
       samRequestContext: SamRequestContext): Route =
-    requireAction(managedGroup, SamResourceActions.setAccessInstructions, userInfo.id, samRequestContext) {
+    requireAction(managedGroup, SamResourceActions.setAccessInstructions, samUser.id, samRequestContext) {
       complete(managedGroupService.setAccessInstructions(managedGroup.resourceId, accessInstructions.value, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -38,7 +38,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
 
   def resourceRoutes: server.Route =
     (pathPrefix("config" / "v1" / "resourceTypes") | pathPrefix("resourceTypes")) {
-        requireUserInfo(SamRequestContext(None)) { userInfo => // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods ; these in particular are unpublished APIs
+        requireActiveUser(SamRequestContext(None)) { samUser => // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods ; these in particular are unpublished APIs
           pathEndOrSingleSlash {
             get {
               complete(resourceService.getResourceTypes().map(typeMap => StatusCodes.OK -> typeMap.values.toSet))
@@ -48,53 +48,53 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     } ~
     (pathPrefix("resources" / "v1") | pathPrefix("resource")) {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo(samRequestContext) { userInfo =>
+        requireActiveUser(samRequestContext) { samUser =>
           pathPrefix(Segment) { resourceTypeName =>
             withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
               pathEndOrSingleSlash {
-                getUserPoliciesForResourceType(resourceType, userInfo, samRequestContext) ~
-                  postResource(resourceType, userInfo, samRequestContext)
+                getUserPoliciesForResourceType(resourceType, samUser, samRequestContext) ~
+                  postResource(resourceType, samUser, samRequestContext)
               } ~ pathPrefix(Segment) { resourceId =>
                 val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
 
                 pathEndOrSingleSlash {
-                  deleteResource(resource, userInfo, samRequestContext) ~
-                    postDefaultResource(resourceType, resource, userInfo, samRequestContext)
+                  deleteResource(resource, samUser, samRequestContext) ~
+                    postDefaultResource(resourceType, resource, samUser, samRequestContext)
                 } ~ pathPrefix("action") {
                   pathPrefix(Segment) { action =>
                     pathEndOrSingleSlash {
-                      getActionPermissionForUser(resource, userInfo, action, samRequestContext)
+                      getActionPermissionForUser(resource, samUser, action, samRequestContext)
                     } ~ pathPrefix("userEmail") {
                       pathPrefix(Segment) { userEmail =>
                         pathEndOrSingleSlash {
-                          getActionPermissionForUserEmail(resource, userInfo, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
+                          getActionPermissionForUserEmail(resource, samUser, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
                         }
                       }
                     }
                   }
                 } ~ pathPrefix("authDomain") {
                   pathEndOrSingleSlash {
-                    getResourceAuthDomain(resource, userInfo, samRequestContext)
+                    getResourceAuthDomain(resource, samUser, samRequestContext)
                   }
                 } ~ pathPrefix("policies") {
                   pathEndOrSingleSlash {
-                    getResourcePolicies(resource, userInfo, samRequestContext)
+                    getResourcePolicies(resource, samUser, samRequestContext)
                   } ~ pathPrefix(Segment) { policyName =>
                     val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
 
                     pathEndOrSingleSlash {
-                      getPolicy(policyId, userInfo, samRequestContext) ~
-                        putPolicyOverwrite(resourceType, policyId, userInfo, samRequestContext)
+                      getPolicy(policyId, samUser, samRequestContext) ~
+                        putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext)
                     } ~ pathPrefix("memberEmails") {
                       pathEndOrSingleSlash {
-                        putPolicyMembershipOverwrite(policyId, userInfo, samRequestContext)
+                        putPolicyMembershipOverwrite(policyId, samUser, samRequestContext)
                       } ~ pathPrefix(Segment) { email =>
                         withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
                           pathEndOrSingleSlash {
                             requireOneOfAction(
                               resource,
                               Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)),
-                              userInfo.id,
+                              samUser.id,
                               samRequestContext) {
                               putUserInPolicy(policyId, subject, samRequestContext) ~
                                 deleteUserFromPolicy(policyId, subject, samRequestContext)
@@ -104,22 +104,22 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                       }
                     } ~ pathPrefix("public") {
                       pathEndOrSingleSlash {
-                        getPublicFlag(policyId, userInfo, samRequestContext) ~
-                          putPublicFlag(policyId, userInfo, samRequestContext)
+                        getPublicFlag(policyId, samUser, samRequestContext) ~
+                          putPublicFlag(policyId, samUser, samRequestContext)
                       }
                     }
                   }
                 } ~ pathPrefix("roles") {
                   pathEndOrSingleSlash {
-                    getUserResourceRoles(resource, userInfo, samRequestContext)
+                    getUserResourceRoles(resource, samUser, samRequestContext)
                   }
                 } ~ pathPrefix("actions") {
                   pathEndOrSingleSlash {
-                    listActionsForUser(resource, userInfo, samRequestContext)
+                    listActionsForUser(resource, samUser, samRequestContext)
                   }
                 } ~ pathPrefix("allUsers") {
                   pathEndOrSingleSlash {
-                    getAllResourceUsers(resource, userInfo, samRequestContext)
+                    getAllResourceUsers(resource, samUser, samRequestContext)
                   }
                 }
               }
@@ -129,29 +129,29 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     } ~ pathPrefix("resources" / "v2") {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo(samRequestContext) { userInfo =>
+        requireActiveUser(samRequestContext) { samUser =>
           pathPrefix(Segment) { resourceTypeName =>
             withResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
               pathEndOrSingleSlash {
-                getUserResourcesOfType(resourceType, userInfo, samRequestContext) ~
-                postResource(resourceType, userInfo, samRequestContext)
+                getUserResourcesOfType(resourceType, samUser, samRequestContext) ~
+                postResource(resourceType, samUser, samRequestContext)
               } ~
               pathPrefix(Segment) { resourceId =>
                 val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
 
                 pathEndOrSingleSlash {
-                  deleteResource(resource, userInfo, samRequestContext) ~
-                  postDefaultResource(resourceType, resource, userInfo, samRequestContext)
+                  deleteResource(resource, samUser, samRequestContext) ~
+                  postDefaultResource(resourceType, resource, samUser, samRequestContext)
                 } ~
                 pathPrefix("action") {
                   pathPrefix(Segment) { action =>
                     pathEndOrSingleSlash {
-                      getActionPermissionForUser(resource, userInfo, action, samRequestContext)
+                      getActionPermissionForUser(resource, samUser, action, samRequestContext)
                     } ~
                     pathPrefix("userEmail") {
                       pathPrefix(Segment) { userEmail =>
                         pathEndOrSingleSlash {
-                          getActionPermissionForUserEmail(resource, userInfo, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
+                          getActionPermissionForUserEmail(resource, samUser, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
                         }
                       }
                     }
@@ -159,51 +159,51 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                 } ~
                 pathPrefix("authDomain") {
                   pathEndOrSingleSlash {
-                    getResourceAuthDomain(resource, userInfo, samRequestContext)
+                    getResourceAuthDomain(resource, samUser, samRequestContext)
                   }
                 } ~
                 pathPrefix("roles") {
                     pathEndOrSingleSlash {
-                      getUserResourceRoles(resource, userInfo, samRequestContext)
+                      getUserResourceRoles(resource, samUser, samRequestContext)
                     }
                 } ~
                 pathPrefix("actions") {
                   pathEndOrSingleSlash {
-                    listActionsForUser(resource, userInfo, samRequestContext)
+                    listActionsForUser(resource, samUser, samRequestContext)
                   }
                 } ~
                 pathPrefix("allUsers") {
                   pathEndOrSingleSlash {
-                    getAllResourceUsers(resource, userInfo, samRequestContext)
+                    getAllResourceUsers(resource, samUser, samRequestContext)
                   }
                 } ~
                 pathPrefix("parent") {
                   pathEndOrSingleSlash {
-                    getResourceParent(resource, userInfo, samRequestContext) ~
-                    setResourceParent(resource, userInfo, samRequestContext) ~
-                    deleteResourceParent(resource, userInfo, samRequestContext)
+                    getResourceParent(resource, samUser, samRequestContext) ~
+                    setResourceParent(resource, samUser, samRequestContext) ~
+                    deleteResourceParent(resource, samUser, samRequestContext)
                   }
                 } ~
                 pathPrefix("children") {
                   pathEndOrSingleSlash {
-                    getResourceChildren(resource, userInfo, samRequestContext)
+                    getResourceChildren(resource, samUser, samRequestContext)
                   }
                 } ~
                 pathPrefix ("policies") {
                   pathEndOrSingleSlash {
-                    getResourcePolicies(resource, userInfo, samRequestContext)
+                    getResourcePolicies(resource, samUser, samRequestContext)
                   } ~ pathPrefix(Segment) { policyName =>
                     val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
 
                     pathEndOrSingleSlash {
-                      getPolicy(policyId, userInfo, samRequestContext) ~
-                        putPolicyOverwrite(resourceType, policyId, userInfo, samRequestContext) ~
-                        deletePolicy(policyId, userInfo, samRequestContext)
+                      getPolicy(policyId, samUser, samRequestContext) ~
+                        putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext) ~
+                        deletePolicy(policyId, samUser, samRequestContext)
                     } ~
                     pathPrefix("memberEmails") {
-                      requireActionsForSharePolicy(policyId, userInfo, samRequestContext) {
+                      requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
                         pathEndOrSingleSlash {
-                          putPolicyMembershipOverwrite(policyId, userInfo, samRequestContext)
+                          putPolicyMembershipOverwrite(policyId, samUser, samRequestContext)
                         } ~
                         pathPrefix(Segment) { email =>
                           withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
@@ -217,8 +217,8 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                     } ~
                     pathPrefix("public") {
                       pathEndOrSingleSlash {
-                        getPublicFlag(policyId, userInfo, samRequestContext) ~
-                        putPublicFlag(policyId, userInfo, samRequestContext)
+                        getPublicFlag(policyId, samUser, samRequestContext) ~
+                        putPublicFlag(policyId, samUser, samRequestContext)
                       }
                     }
                   }
@@ -234,26 +234,26 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   // see https://github.com/scala/bug/issues/7934
   object Deprecated { @deprecated("remove as part of CA-1783", "") class Corral { def listUserAccessPolicies = policyEvaluatorService.listUserAccessPolicies _ }; object Corral extends Corral }
 
-  def getUserPoliciesForResourceType(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getUserPoliciesForResourceType(resourceType: ResourceType, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(Deprecated.Corral.listUserAccessPolicies(resourceType.name, userInfo.id, samRequestContext))
+      complete(Deprecated.Corral.listUserAccessPolicies(resourceType.name, samUser.id, samRequestContext))
     }
 
-  def getUserResourcesOfType(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getUserResourcesOfType(resourceType: ResourceType, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(policyEvaluatorService.listUserResources(resourceType.name, userInfo.id, samRequestContext))
+      complete(policyEvaluatorService.listUserResources(resourceType.name, samUser.id, samRequestContext))
     }
 
-  def postResource(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def postResource(resourceType: ResourceType, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     post {
       entity(as[CreateResourceRequest]) { createResourceRequest =>
-        requireCreateWithOptionalParent(createResourceRequest.parent, resourceType, userInfo.id, samRequestContext) {
+        requireCreateWithOptionalParent(createResourceRequest.parent, resourceType, samUser.id, samRequestContext) {
           if (resourceType.reuseIds && resourceType.isAuthDomainConstrainable) {
             throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow both authorization domains and id reuse"))
           }
 
           def resourceMaker(samRequestContext: SamRequestContext): IO[ToResponseMarshallable] = resourceService
-            .createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, createResourceRequest.parent, userInfo.id, samRequestContext)
+            .createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, createResourceRequest.parent, samUser.id, samRequestContext)
             .map { r =>
               if (createResourceRequest.returnResource.contains(true)) {
                 StatusCodes.Created -> CreateResourceResponse(r.resourceTypeName, r.resourceId, r.authDomain, r.accessPolicies.map(ap => CreateResourcePolicyResponse(ap.id, ap.email)))
@@ -267,25 +267,25 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def deleteResource(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def deleteResource(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
       // Note that this does not require remove_child on the parent if it exists. remove_child is meant to prevent
       // users from removing a child only to add it to a different parent and thus circumvent any permissions
       // a parent may be enforcing. Deleting a child does not allow this situation.
-      requireAction(resource, SamResourceActions.delete, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.delete, samUser.id, samRequestContext) {
         complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }
 
-  def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     post {
-      complete(resourceService.createResource(resourceType, resource.resourceId, userInfo, samRequestContext).map(_ => StatusCodes.NoContent))
+      complete(resourceService.createResource(resourceType, resource.resourceId, samUser, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  def getActionPermissionForUser(resource: FullyQualifiedResourceId, userInfo: SamUser, action: String, samRequestContext: SamRequestContext): server.Route =
+  def getActionPermissionForUser(resource: FullyQualifiedResourceId, samUser: SamUser, action: String, samRequestContext: SamRequestContext): server.Route =
     get {
       complete {
-        policyEvaluatorService.hasPermission(resource, ResourceAction(action), userInfo.id, samRequestContext).map { hasPermission =>
+        policyEvaluatorService.hasPermission(resource, ResourceAction(action), samUser.id, samRequestContext).map { hasPermission =>
           StatusCodes.OK -> JsBoolean(hasPermission)
         }
       }
@@ -296,9 +296,9 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     *
     * <p> The caller should have readPolicies, OR testAnyActionAccess or testActionAccess::{action} to make this call.
     */
-  def getActionPermissionForUserEmail(resource: FullyQualifiedResourceId, userInfo: SamUser, action: ResourceAction, userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): server.Route =
+  def getActionPermissionForUserEmail(resource: FullyQualifiedResourceId, samUser: SamUser, action: ResourceAction, userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.testAnyActionAccess, SamResourceActions.testActionAccess(action)), userInfo.id, samRequestContext) {
+      requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.testAnyActionAccess, SamResourceActions.testActionAccess(action)), samUser.id, samRequestContext) {
         complete {
           policyEvaluatorService.hasPermissionByUserEmail(resource, action, userEmail, samRequestContext).map { hasPermission =>
             StatusCodes.OK -> JsBoolean(hasPermission)
@@ -307,34 +307,34 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def listActionsForUser(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def listActionsForUser(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(policyEvaluatorService.listUserResourceActions(resource, userInfo.id, samRequestContext = samRequestContext).map { actions =>
+      complete(policyEvaluatorService.listUserResourceActions(resource, samUser.id, samRequestContext = samRequestContext).map { actions =>
         StatusCodes.OK -> actions
       })
     }
 
-  def getResourceAuthDomain(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readAuthDomain, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.readAuthDomain, samUser.id, samRequestContext) {
         complete(resourceService.loadResourceAuthDomain(resource, samRequestContext).map { response =>
           StatusCodes.OK -> response
         })
       }
     }
 
-  def getResourcePolicies(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getResourcePolicies(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readPolicies, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.readPolicies, samUser.id, samRequestContext) {
         complete(resourceService.listResourcePolicies(resource, samRequestContext).map { response =>
           StatusCodes.OK -> response.toSet
         })
       }
     }
 
-  def getPolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getPolicy(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
         complete(resourceService.loadResourcePolicy(policyId, samRequestContext).map {
           case Some(response) => StatusCodes.OK -> response
           case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found"))
@@ -342,23 +342,23 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def putPolicyOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def putPolicyOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireAction(policyId.resource, SamResourceActions.alterPolicies, userInfo.id, samRequestContext) {
+      requireAction(policyId.resource, SamResourceActions.alterPolicies, samUser.id, samRequestContext) {
         entity(as[AccessPolicyMembership]) { membershipUpdate =>
           complete(resourceService.overwritePolicy(resourceType, policyId.accessPolicyName, policyId.resource, membershipUpdate, samRequestContext).map(_ => StatusCodes.Created))
         }
       }
     }
 
-  private def requireActionsForSharePolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext)(sharePolicy: server.Route): server.Route =
-    requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+  private def requireActionsForSharePolicy(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext)(sharePolicy: server.Route): server.Route =
+    requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
       sharePolicy
     }
 
-  def putPolicyMembershipOverwrite(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def putPolicyMembershipOverwrite(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchEmail]]) { membersList =>
           complete(
             resourceService.overwritePolicyMembers(policyId, membersList, samRequestContext).map(_ => StatusCodes.NoContent))
@@ -376,20 +376,20 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       complete(resourceService.removeSubjectFromPolicy(policyId, subject, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  def getPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getPublicFlag(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
         complete(resourceService.isPublic(policyId, samRequestContext))
       }
     }
 
-  def putPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def putPublicFlag(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
         requireOneOfAction(
           FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(policyId.resource.resourceTypeName.value)),
           Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(policyId.accessPolicyName)),
-          userInfo.id,
+          samUser.id,
           samRequestContext
         ) {
           entity(as[Boolean]) { isPublic =>
@@ -399,27 +399,27 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def getUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getUserResourceRoles(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
       complete {
-        resourceService.listUserResourceRoles(resource, userInfo, samRequestContext).map { roles =>
+        resourceService.listUserResourceRoles(resource, samUser, samRequestContext).map { roles =>
           StatusCodes.OK -> roles
         }
       }
     }
 
-  def getAllResourceUsers(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getAllResourceUsers(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readPolicies, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.readPolicies, samUser.id, samRequestContext) {
         complete(resourceService.listAllFlattenedResourceUsers(resource, samRequestContext).map { allUsers =>
           StatusCodes.OK -> allUsers
         })
       }
     }
 
-  def getResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getResourceParent(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.getParent, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.getParent, samUser.id, samRequestContext) {
         complete(resourceService.getResourceParent(resource, samRequestContext).map {
           case Some(response) => StatusCodes.OK -> response
           case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource parent not found"))
@@ -427,12 +427,12 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def setResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def setResourceParent(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
       entity(as[FullyQualifiedResourceId]) { newResourceParent =>
-        requireAction(resource, SamResourceActions.setParent, userInfo.id, samRequestContext) {
-          requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.id, samRequestContext) {
-            requireParentAction(resource, Option(newResourceParent), SamResourceActions.addChild, userInfo.id, samRequestContext) {
+        requireAction(resource, SamResourceActions.setParent, samUser.id, samRequestContext) {
+          requireParentAction(resource, None, SamResourceActions.removeChild, samUser.id, samRequestContext) {
+            requireParentAction(resource, Option(newResourceParent), SamResourceActions.addChild, samUser.id, samRequestContext) {
               complete(resourceService.setResourceParent(resource, newResourceParent, samRequestContext).map(_ => StatusCodes.NoContent))
             }
           }
@@ -440,10 +440,10 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def deleteResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def deleteResourceParent(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
-      requireAction(resource, SamResourceActions.setParent, userInfo.id, samRequestContext) {
-        requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.setParent, samUser.id, samRequestContext) {
+        requireParentAction(resource, None, SamResourceActions.removeChild, samUser.id, samRequestContext) {
           complete(resourceService.deleteResourceParent(resource, samRequestContext).map { parentDeleted =>
             if (parentDeleted) {
               StatusCodes.NoContent
@@ -455,16 +455,16 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def getResourceChildren(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def getResourceChildren(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.listChildren, userInfo.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.listChildren, samUser.id, samRequestContext) {
         complete(resourceService.listResourceChildren(resource, samRequestContext).map(children => StatusCodes.OK -> children))
       }
     }
 
-  def deletePolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
+  def deletePolicy(policyId: FullyQualifiedPolicyId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyId.accessPolicyName)), samUser.id, samRequestContext) {
         complete(resourceService.deletePolicy(policyId, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -94,7 +94,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
                             requireOneOfAction(
                               resource,
                               Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)),
-                              userInfo.userId,
+                              userInfo.id,
                               samRequestContext) {
                               putUserInPolicy(policyId, subject, samRequestContext) ~
                                 deleteUserFromPolicy(policyId, subject, samRequestContext)
@@ -234,26 +234,26 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
   // see https://github.com/scala/bug/issues/7934
   object Deprecated { @deprecated("remove as part of CA-1783", "") class Corral { def listUserAccessPolicies = policyEvaluatorService.listUserAccessPolicies _ }; object Corral extends Corral }
 
-  def getUserPoliciesForResourceType(resourceType: ResourceType, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getUserPoliciesForResourceType(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(Deprecated.Corral.listUserAccessPolicies(resourceType.name, userInfo.userId, samRequestContext))
+      complete(Deprecated.Corral.listUserAccessPolicies(resourceType.name, userInfo.id, samRequestContext))
     }
 
-  def getUserResourcesOfType(resourceType: ResourceType, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getUserResourcesOfType(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(policyEvaluatorService.listUserResources(resourceType.name, userInfo.userId, samRequestContext))
+      complete(policyEvaluatorService.listUserResources(resourceType.name, userInfo.id, samRequestContext))
     }
 
-  def postResource(resourceType: ResourceType, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def postResource(resourceType: ResourceType, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     post {
       entity(as[CreateResourceRequest]) { createResourceRequest =>
-        requireCreateWithOptionalParent(createResourceRequest.parent, resourceType, userInfo.userId, samRequestContext) {
+        requireCreateWithOptionalParent(createResourceRequest.parent, resourceType, userInfo.id, samRequestContext) {
           if (resourceType.reuseIds && resourceType.isAuthDomainConstrainable) {
             throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "this api may not be used for resource types that allow both authorization domains and id reuse"))
           }
 
           def resourceMaker(samRequestContext: SamRequestContext): IO[ToResponseMarshallable] = resourceService
-            .createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, createResourceRequest.parent, userInfo.userId, samRequestContext)
+            .createResource(resourceType, createResourceRequest.resourceId, createResourceRequest.policies, createResourceRequest.authDomain, createResourceRequest.parent, userInfo.id, samRequestContext)
             .map { r =>
               if (createResourceRequest.returnResource.contains(true)) {
                 StatusCodes.Created -> CreateResourceResponse(r.resourceTypeName, r.resourceId, r.authDomain, r.accessPolicies.map(ap => CreateResourcePolicyResponse(ap.id, ap.email)))
@@ -267,25 +267,25 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def deleteResource(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def deleteResource(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
       // Note that this does not require remove_child on the parent if it exists. remove_child is meant to prevent
       // users from removing a child only to add it to a different parent and thus circumvent any permissions
       // a parent may be enforcing. Deleting a child does not allow this situation.
-      requireAction(resource, SamResourceActions.delete, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.delete, userInfo.id, samRequestContext) {
         complete(resourceService.deleteResource(resource, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }
 
-  def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def postDefaultResource(resourceType: ResourceType, resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     post {
       complete(resourceService.createResource(resourceType, resource.resourceId, userInfo, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  def getActionPermissionForUser(resource: FullyQualifiedResourceId, userInfo: UserInfo, action: String, samRequestContext: SamRequestContext): server.Route =
+  def getActionPermissionForUser(resource: FullyQualifiedResourceId, userInfo: SamUser, action: String, samRequestContext: SamRequestContext): server.Route =
     get {
       complete {
-        policyEvaluatorService.hasPermission(resource, ResourceAction(action), userInfo.userId, samRequestContext).map { hasPermission =>
+        policyEvaluatorService.hasPermission(resource, ResourceAction(action), userInfo.id, samRequestContext).map { hasPermission =>
           StatusCodes.OK -> JsBoolean(hasPermission)
         }
       }
@@ -296,9 +296,9 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
     *
     * <p> The caller should have readPolicies, OR testAnyActionAccess or testActionAccess::{action} to make this call.
     */
-  def getActionPermissionForUserEmail(resource: FullyQualifiedResourceId, userInfo: UserInfo, action: ResourceAction, userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): server.Route =
+  def getActionPermissionForUserEmail(resource: FullyQualifiedResourceId, userInfo: SamUser, action: ResourceAction, userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.testAnyActionAccess, SamResourceActions.testActionAccess(action)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(resource, Set(SamResourceActions.readPolicies, SamResourceActions.testAnyActionAccess, SamResourceActions.testActionAccess(action)), userInfo.id, samRequestContext) {
         complete {
           policyEvaluatorService.hasPermissionByUserEmail(resource, action, userEmail, samRequestContext).map { hasPermission =>
             StatusCodes.OK -> JsBoolean(hasPermission)
@@ -307,34 +307,34 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def listActionsForUser(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def listActionsForUser(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      complete(policyEvaluatorService.listUserResourceActions(resource, userInfo.userId, samRequestContext = samRequestContext).map { actions =>
+      complete(policyEvaluatorService.listUserResourceActions(resource, userInfo.id, samRequestContext = samRequestContext).map { actions =>
         StatusCodes.OK -> actions
       })
     }
 
-  def getResourceAuthDomain(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getResourceAuthDomain(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readAuthDomain, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.readAuthDomain, userInfo.id, samRequestContext) {
         complete(resourceService.loadResourceAuthDomain(resource, samRequestContext).map { response =>
           StatusCodes.OK -> response
         })
       }
     }
 
-  def getResourcePolicies(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getResourcePolicies(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readPolicies, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.readPolicies, userInfo.id, samRequestContext) {
         complete(resourceService.listResourcePolicies(resource, samRequestContext).map { response =>
           StatusCodes.OK -> response.toSet
         })
       }
     }
 
-  def getPolicy(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getPolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
         complete(resourceService.loadResourcePolicy(policyId, samRequestContext).map {
           case Some(response) => StatusCodes.OK -> response
           case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found"))
@@ -342,23 +342,23 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def putPolicyOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def putPolicyOverwrite(resourceType: ResourceType, policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireAction(policyId.resource, SamResourceActions.alterPolicies, userInfo.userId, samRequestContext) {
+      requireAction(policyId.resource, SamResourceActions.alterPolicies, userInfo.id, samRequestContext) {
         entity(as[AccessPolicyMembership]) { membershipUpdate =>
           complete(resourceService.overwritePolicy(resourceType, policyId.accessPolicyName, policyId.resource, membershipUpdate, samRequestContext).map(_ => StatusCodes.Created))
         }
       }
     }
 
-  private def requireActionsForSharePolicy(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext)(sharePolicy: server.Route): server.Route =
-    requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+  private def requireActionsForSharePolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext)(sharePolicy: server.Route): server.Route =
+    requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
       sharePolicy
     }
 
-  def putPolicyMembershipOverwrite(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def putPolicyMembershipOverwrite(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
         entity(as[Set[WorkbenchEmail]]) { membersList =>
           complete(
             resourceService.overwritePolicyMembers(policyId, membersList, samRequestContext).map(_ => StatusCodes.NoContent))
@@ -376,20 +376,20 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       complete(resourceService.removeSubjectFromPolicy(policyId, subject, samRequestContext).map(_ => StatusCodes.NoContent))
     }
 
-  def getPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
         complete(resourceService.isPublic(policyId, samRequestContext))
       }
     }
 
-  def putPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def putPublicFlag(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
         requireOneOfAction(
           FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(policyId.resource.resourceTypeName.value)),
           Set(SamResourceActions.setPublic, SamResourceActions.setPublicPolicy(policyId.accessPolicyName)),
-          userInfo.userId,
+          userInfo.id,
           samRequestContext
         ) {
           entity(as[Boolean]) { isPublic =>
@@ -399,7 +399,7 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def getUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
       complete {
         resourceService.listUserResourceRoles(resource, userInfo, samRequestContext).map { roles =>
@@ -408,18 +408,18 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def getAllResourceUsers(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getAllResourceUsers(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.readPolicies, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.readPolicies, userInfo.id, samRequestContext) {
         complete(resourceService.listAllFlattenedResourceUsers(resource, samRequestContext).map { allUsers =>
           StatusCodes.OK -> allUsers
         })
       }
     }
 
-  def getResourceParent(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.getParent, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.getParent, userInfo.id, samRequestContext) {
         complete(resourceService.getResourceParent(resource, samRequestContext).map {
           case Some(response) => StatusCodes.OK -> response
           case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource parent not found"))
@@ -427,12 +427,12 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def setResourceParent(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def setResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
       entity(as[FullyQualifiedResourceId]) { newResourceParent =>
-        requireAction(resource, SamResourceActions.setParent, userInfo.userId, samRequestContext) {
-          requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.userId, samRequestContext) {
-            requireParentAction(resource, Option(newResourceParent), SamResourceActions.addChild, userInfo.userId, samRequestContext) {
+        requireAction(resource, SamResourceActions.setParent, userInfo.id, samRequestContext) {
+          requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.id, samRequestContext) {
+            requireParentAction(resource, Option(newResourceParent), SamResourceActions.addChild, userInfo.id, samRequestContext) {
               complete(resourceService.setResourceParent(resource, newResourceParent, samRequestContext).map(_ => StatusCodes.NoContent))
             }
           }
@@ -440,10 +440,10 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def deleteResourceParent(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def deleteResourceParent(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
-      requireAction(resource, SamResourceActions.setParent, userInfo.userId, samRequestContext) {
-        requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.setParent, userInfo.id, samRequestContext) {
+        requireParentAction(resource, None, SamResourceActions.removeChild, userInfo.id, samRequestContext) {
           complete(resourceService.deleteResourceParent(resource, samRequestContext).map { parentDeleted =>
             if (parentDeleted) {
               StatusCodes.NoContent
@@ -455,16 +455,16 @@ trait ResourceRoutes extends UserInfoDirectives with SecurityDirectives with Sam
       }
     }
 
-  def getResourceChildren(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def getResourceChildren(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     get {
-      requireAction(resource, SamResourceActions.listChildren, userInfo.userId, samRequestContext) {
+      requireAction(resource, SamResourceActions.listChildren, userInfo.id, samRequestContext) {
         complete(resourceService.listResourceChildren(resource, samRequestContext).map(children => StatusCodes.OK -> children))
       }
     }
 
-  def deletePolicy(policyId: FullyQualifiedPolicyId, userInfo: UserInfo, samRequestContext: SamRequestContext): server.Route =
+  def deletePolicy(policyId: FullyQualifiedPolicyId, userInfo: SamUser, samRequestContext: SamRequestContext): server.Route =
     delete {
-      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyId.accessPolicyName)), userInfo.userId, samRequestContext) {
+      requireOneOfAction(policyId.resource, Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyId.accessPolicyName)), userInfo.id, samRequestContext) {
         complete(resourceService.deletePolicy(policyId, samRequestContext).map(_ => StatusCodes.NoContent))
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -23,24 +24,25 @@ import scala.util.matching.Regex
 trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
 
-  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo] = requireOidcHeaders.flatMap { oidcHeaders =>
+  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
       getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeToFuture()
     }
   }
 
-  def requireCreateUser(samRequestContext: SamRequestContext): Directive1[WorkbenchUser] = requireOidcHeaders.map(buildWorkbenchUser)
+  def requireCreateUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.map(buildWorkbenchUser)
 
-  private def buildWorkbenchUser(oidcHeaders: OIDCHeaders): WorkbenchUser = {
+  private def buildWorkbenchUser(oidcHeaders: OIDCHeaders): SamUser = {
     // google id can either be in the external id or google id from azure headers, favor the external id as the source
     val googleSubjectId = (oidcHeaders.externalId.left.toOption ++ oidcHeaders.googleSubjectIdFromAzure).headOption
     val azureB2CId = oidcHeaders.externalId.toOption // .right is missing (compared to .left above) since Either is Right biased
 
-    WorkbenchUser(
+    SamUser(
       genWorkbenchUserId(System.currentTimeMillis()),
       googleSubjectId,
       oidcHeaders.email,
-      azureB2CId)
+      azureB2CId,
+      false)
   }
 
   /**
@@ -49,22 +51,8 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
   private def requireOidcHeaders: Directive1[OIDCHeaders] = {
     (headerValueByName(accessTokenHeader).as(OAuth2BearerToken) &
       externalIdFromHeaders &
-      expiresInFromHeader &
       headerValueByName(emailHeader).as(WorkbenchEmail) &
       optionalHeaderValueByName(googleIdFromAzureHeader).map(_.map(GoogleSubjectId))).as(OIDCHeaders)
-  }
-
-  private def expiresInFromHeader: Directive1[Long] = {
-    // gets expiresInHeader as a string and converts it to Long raising an exception if it can't
-    optionalHeaderValueByName(expiresInHeader).flatMap {
-      case Some(expiresInString) =>
-        Try(expiresInString.toLong).fold(
-          t => failWith(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"expiresIn $expiresInString can't be converted to Long", t))).toDirective,
-          expiresInLong => provide(expiresInLong)
-        )
-
-      case None => provide(0)
-    }
   }
 
   private def externalIdFromHeaders: Directive1[Either[GoogleSubjectId, AzureB2CId]] = headerValueByName(userIdHeader).map { idString =>
@@ -78,25 +66,24 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
 object StandardUserInfoDirectives {
   val SAdomain: Regex = "(\\S+@\\S+\\.iam\\.gserviceaccount\\.com$)".r
   val accessTokenHeader = "OIDC_access_token"
-  val expiresInHeader = "OIDC_CLAIM_expires_in"
   val emailHeader = "OIDC_CLAIM_email"
   val userIdHeader = "OIDC_CLAIM_user_id"
   val googleIdFromAzureHeader = "OAUTH2_CLAIM_google_id"
 
-  def getUserInfo(directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, oidcHeaders: OIDCHeaders, samRequestContext: SamRequestContext): IO[UserInfo] = {
+  def getUserInfo(directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, oidcHeaders: OIDCHeaders, samRequestContext: SamRequestContext): IO[SamUser] = {
     oidcHeaders match {
-      case OIDCHeaders(_, Left(googleSubjectId), _, saEmail@WorkbenchEmail(SAdomain(_)), _) =>
+      case OIDCHeaders(_, Left(googleSubjectId), saEmail@WorkbenchEmail(SAdomain(_)), _) =>
         // If it's a PET account, we treat it as its owner
         directoryDAO.getUserFromPetServiceAccount(ServiceAccountSubjectId(googleSubjectId.value), samRequestContext).flatMap {
-          case Some(pet) => IO.pure(UserInfo(oidcHeaders.token, pet.id, pet.email, oidcHeaders.expiresIn))
-          case None => lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext).map(uid => UserInfo(oidcHeaders.token, uid, saEmail, oidcHeaders.expiresIn))
+          case Some(petsOwner) => IO.pure(petsOwner)
+          case None => lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext)
         }
 
-      case OIDCHeaders(_, Left(googleSubjectId), _, _, _) =>
-        lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext).map(uid => UserInfo(oidcHeaders.token, uid, oidcHeaders.email, oidcHeaders.expiresIn))
+      case OIDCHeaders(_, Left(googleSubjectId), _, _) =>
+        lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext)
 
-      case OIDCHeaders(_, Right(azureB2CId), _, _, _) =>
-        loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, registrationDAO, samRequestContext).map(user => UserInfo(oidcHeaders.token, user.id, oidcHeaders.email, oidcHeaders.expiresIn))
+      case OIDCHeaders(_, Right(azureB2CId), _, _) =>
+        loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, registrationDAO, samRequestContext)
     }
   }
 
@@ -126,17 +113,19 @@ object StandardUserInfoDirectives {
     }
   }
 
-  private def lookUpByGoogleSubjectId(googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[WorkbenchUserId] =
+  private def lookUpByGoogleSubjectId(googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] =
     for {
-      subject <- directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
-      userInfo <- subject match {
-        case Some(uid: WorkbenchUserId) => IO.pure(uid)
-        case Some(_) =>
-          IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $googleSubjectId is not a WorkbenchUser")))
-        case None =>
-          IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Google Id $googleSubjectId not found in sam")))
+      maybeSamUser <- directoryDAO.loadUserByGoogleSubjectId(googleSubjectId, samRequestContext)
+      samUser <- maybeSamUser match {
+        case Some(samUser) => IO.pure(samUser)
+        case None => directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext).flatMap {
+          case Some(_) =>
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $googleSubjectId is not a WorkbenchUser")))
+          case None =>
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Google Id $googleSubjectId not found in sam")))
+        }
       }
-    } yield userInfo
+    } yield samUser
 }
 
-final case class OIDCHeaders(token: OAuth2BearerToken, externalId: Either[GoogleSubjectId, AzureB2CId], expiresIn: Long, email: WorkbenchEmail, googleSubjectIdFromAzure: Option[GoogleSubjectId])
+final case class OIDCHeaders(token: OAuth2BearerToken, externalId: Either[GoogleSubjectId, AzureB2CId], email: WorkbenchEmail, googleSubjectIdFromAzure: Option[GoogleSubjectId])

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -24,7 +24,7 @@ import scala.util.matching.Regex
 trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
 
-  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
+  def requireActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
       getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeToFuture()
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.sam.api.RejectionHandlers.{MethodDisabl
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.TermsOfServiceAcceptance
+import org.broadinstitute.dsde.workbench.sam.model.{SamUser, TermsOfServiceAcceptance}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 
@@ -24,13 +24,13 @@ trait UserInfoDirectives {
   val cloudExtensions: CloudExtensions
   val termsOfServiceConfig: TermsOfServiceConfig
 
-  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo]
+  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser]
 
-  def requireCreateUser(samRequestContext: SamRequestContext): Directive1[WorkbenchUser]
+  def requireCreateUser(samRequestContext: SamRequestContext): Directive1[SamUser]
 
-  def asWorkbenchAdmin(userInfo: UserInfo): Directive0 =
+  def asWorkbenchAdmin(userInfo: SamUser): Directive0 =
     Directives.mapInnerRoute { r =>
-      onSuccess(cloudExtensions.isWorkbenchAdmin(userInfo.userEmail)) { isAdmin =>
+      onSuccess(cloudExtensions.isWorkbenchAdmin(userInfo.email)) { isAdmin =>
         if (!isAdmin) Directives.failWith(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "You must be an admin.")))
         else r
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserInfoDirectives.scala
@@ -24,13 +24,13 @@ trait UserInfoDirectives {
   val cloudExtensions: CloudExtensions
   val termsOfServiceConfig: TermsOfServiceConfig
 
-  def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser]
+  def requireActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser]
 
   def requireCreateUser(samRequestContext: SamRequestContext): Directive1[SamUser]
 
-  def asWorkbenchAdmin(userInfo: SamUser): Directive0 =
+  def asWorkbenchAdmin(samUser: SamUser): Directive0 =
     Directives.mapInnerRoute { r =>
-      onSuccess(cloudExtensions.isWorkbenchAdmin(userInfo.email)) { isAdmin =>
+      onSuccess(cloudExtensions.isWorkbenchAdmin(samUser.email)) { isAdmin =>
         if (!isAdmin) Directives.failWith(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "You must be an admin.")))
         else r
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -10,7 +10,6 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.UserService
-import org.broadinstitute.dsde.workbench.sam.service.UserService.genWorkbenchUserId
 import spray.json.JsBoolean
 
 import scala.concurrent.ExecutionContext
@@ -52,7 +51,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
               get {
                 parameter("userDetailsOnly".?) { userDetailsOnly =>
                   complete {
-                    userService.getUserStatus(user.userId, userDetailsOnly.exists(_.equalsIgnoreCase("true")), samRequestContext).map { statusOption =>
+                    userService.getUserStatus(user.id, userDetailsOnly.exists(_.equalsIgnoreCase("true")), samRequestContext).map { statusOption =>
                       statusOption
                         .map { status =>
                           StatusCodes.OK -> Option(status)
@@ -71,7 +70,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 get {
                   requireUserInfo(samRequestContext) { userInfo =>
                     complete {
-                      userService.getTermsOfServiceStatus(userInfo.userId, samRequestContext).map { statusOption =>
+                      userService.getTermsOfServiceStatus(userInfo.id, samRequestContext).map { statusOption =>
                         statusOption
                           .map { status =>
                             StatusCodes.OK -> Option(JsBoolean(status))
@@ -88,7 +87,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 requireUserInfo(samRequestContext) { userInfo =>
                   withTermsOfServiceAcceptance {
                     complete {
-                      userService.acceptTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
+                      userService.acceptTermsOfService(userInfo.id, samRequestContext).map { statusOption =>
                         statusOption
                           .map { status =>
                             StatusCodes.OK -> Option(status)
@@ -102,7 +101,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
               delete {
                 requireUserInfo(samRequestContext) { userInfo =>
                   complete {
-                    userService.rejectTermsOfService(userInfo.userId, samRequestContext).map { statusOption =>
+                    userService.rejectTermsOfService(userInfo.id, samRequestContext).map { statusOption =>
                       statusOption
                         .map { status =>
                           StatusCodes.OK -> Option(status)
@@ -132,7 +131,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
               path("info") {
                 get {
                   complete {
-                    userService.getUserStatusInfo(user.userId, samRequestContext).map { statusOption =>
+                    userService.getUserStatusInfo(user.id, samRequestContext).map { statusOption =>
                       statusOption
                         .map { status =>
                           StatusCodes.OK -> Option(status)
@@ -145,7 +144,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 path("diagnostics") {
                   get {
                     complete {
-                      userService.getUserStatusDiagnostics(user.userId, samRequestContext).map { statusOption =>
+                      userService.getUserStatusDiagnostics(user.id, samRequestContext).map { statusOption =>
                         statusOption
                           .map { status =>
                             StatusCodes.OK -> Option(status)
@@ -182,7 +181,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                   pathEnd {
                     delete {
                       complete {
-                        userService.deleteUser(WorkbenchUserId(userId), userInfo, samRequestContext).map(_ => StatusCodes.OK)
+                        userService.deleteUser(WorkbenchUserId(userId), samRequestContext).map(_ => StatusCodes.OK)
                       }
                     } ~
                       get {
@@ -267,7 +266,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 path(Segment) { inviteeEmail =>
                   complete {
                     userService
-                      .inviteUser(InviteUser(genWorkbenchUserId(System.currentTimeMillis()), WorkbenchEmail(inviteeEmail.trim)), samRequestContext)
+                      .inviteUser(WorkbenchEmail(inviteeEmail.trim), samRequestContext)
                       .map(userStatus => StatusCodes.Created -> userStatus)
                   }
                 }
@@ -278,5 +277,3 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
     }
   }
 }
-
-final case class InviteUser(inviteeId: WorkbenchUserId, inviteeEmail: WorkbenchEmail)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -47,7 +47,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
               }
             }
           } ~ withSamRequestContext { samRequestContext =>
-            (changeForbiddenToNotFound & requireUserInfo(samRequestContext)) { user =>
+            (changeForbiddenToNotFound & requireActiveUser(samRequestContext)) { user =>
               get {
                 parameter("userDetailsOnly".?) { userDetailsOnly =>
                   complete {
@@ -68,9 +68,9 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
             pathPrefix("status") {
               pathEndOrSingleSlash {
                 get {
-                  requireUserInfo(samRequestContext) { userInfo =>
+                  requireActiveUser(samRequestContext) { samUser =>
                     complete {
-                      userService.getTermsOfServiceStatus(userInfo.id, samRequestContext).map { statusOption =>
+                      userService.getTermsOfServiceStatus(samUser.id, samRequestContext).map { statusOption =>
                         statusOption
                           .map { status =>
                             StatusCodes.OK -> Option(JsBoolean(status))
@@ -84,10 +84,10 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
             } ~
             pathEndOrSingleSlash {
               post {
-                requireUserInfo(samRequestContext) { userInfo =>
+                requireActiveUser(samRequestContext) { samUser =>
                   withTermsOfServiceAcceptance {
                     complete {
-                      userService.acceptTermsOfService(userInfo.id, samRequestContext).map { statusOption =>
+                      userService.acceptTermsOfService(samUser.id, samRequestContext).map { statusOption =>
                         statusOption
                           .map { status =>
                             StatusCodes.OK -> Option(status)
@@ -99,9 +99,9 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
                 }
               } ~
               delete {
-                requireUserInfo(samRequestContext) { userInfo =>
+                requireActiveUser(samRequestContext) { samUser =>
                   complete {
-                    userService.rejectTermsOfService(userInfo.id, samRequestContext).map { statusOption =>
+                    userService.rejectTermsOfService(samUser.id, samRequestContext).map { statusOption =>
                       statusOption
                         .map { status =>
                           StatusCodes.OK -> Option(status)
@@ -127,7 +127,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
               }
             }
           } ~ withSamRequestContext { samRequestContext =>
-            (changeForbiddenToNotFound & requireUserInfo(samRequestContext)) { user =>
+            (changeForbiddenToNotFound & requireActiveUser(samRequestContext)) { user =>
               path("info") {
                 get {
                   complete {
@@ -163,8 +163,8 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
   def adminUserRoutes: server.Route =
     pathPrefix("admin") {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo(samRequestContext) { userInfo =>
-          asWorkbenchAdmin(userInfo) {
+        requireActiveUser(samRequestContext) { samUser =>
+          asWorkbenchAdmin(samUser) {
             pathPrefix("user") {
               path("email" / Segment) { email =>
                 complete {
@@ -247,7 +247,7 @@ trait UserRoutes extends UserInfoDirectives with SamRequestContextDirectives {
   val apiUserRoutes: server.Route = pathPrefix("users") {
     pathPrefix("v1") {
       withSamRequestContext { samRequestContext =>
-        requireUserInfo(samRequestContext) { userInfo =>
+        requireActiveUser(samRequestContext) { samUser =>
           get {
             path(Segment) { email =>
               pathEnd {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -64,7 +64,7 @@ trait AccessPolicyDAO {
 
   def listUserResourceRoles(resourceId: FullyQualifiedResourceId, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceRoleName]]
 
-  def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[WorkbenchUser]]
+  def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[SamUser]]
 
   def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean, samRequestContext: SamRequestContext): IO[Unit]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.workbench.sam.dataAccess
 
 import java.util.Date
-
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUser}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 /**
@@ -36,9 +35,10 @@ trait DirectoryDAO extends RegistrationDAO {
   def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
   def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]]
 
-  def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser]
-  def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
-  def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
+  def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser]
+  def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+  def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+  def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
   def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
 
 
@@ -52,7 +52,7 @@ trait DirectoryDAO extends RegistrationDAO {
   def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
   def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean]
 
-  def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
+  def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
   def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount]
   def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Option[PetServiceAccount]]
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 import cats.effect.Temporal
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 
 // use ExecutionContexts.blockingThreadPool for blockingEc
 class LdapRegistrationDAO(
@@ -45,7 +46,7 @@ class LdapRegistrationDAO(
 
   override def getConnectionType(): ConnectionType = ConnectionType.LDAP
 
-  override def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser] = {
+  override def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] = {
     val attrs = List(
       new Attribute(Attr.email, user.email.value),
       new Attribute(Attr.sn, user.id.value),
@@ -63,7 +64,7 @@ class LdapRegistrationDAO(
     } *> IO.pure(user)
   }
 
-  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]] = executeLdap(IO(loadUserInternal(userId)), "loadUser", samRequestContext)
+  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = executeLdap(IO(loadUserInternal(userId)), "loadUser", samRequestContext)
 
   def loadUserInternal(userId: WorkbenchUserId) =
     Option(ldapConnectionPool.getEntry(userDn(userId))) flatMap { results =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1330,7 +1330,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
     })
   }
 
-  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[WorkbenchUser]] = {
+  override def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[SamUser]] = {
     val f = GroupMemberFlatTable.syntax("f")
     val u = UserTable.syntax("u")
     val p = PolicyTable.syntax("p")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/RegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/RegistrationDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.ConnectionType.ConnectionType
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 /**
@@ -13,8 +14,8 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
   */
 trait RegistrationDAO {
   def getConnectionType(): ConnectionType
-  def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser]
-  def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]]
+  def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser]
+  def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
   def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
   def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
   def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import scalikejdbc._
 
 final case class UserRecord(id: WorkbenchUserId,
@@ -24,7 +25,7 @@ object UserTable extends SQLSyntaxSupportWithDefaultSamDB[UserRecord] {
 
   def apply(o: SyntaxProvider[UserRecord])(rs: WrappedResultSet): UserRecord = apply(o.resultName)(rs)
 
-  def unmarshalUserRecord(userRecord: UserRecord): WorkbenchUser = {
-    WorkbenchUser(userRecord.id, userRecord.googleSubjectId, userRecord.email, userRecord.azureB2cId)
+  def unmarshalUserRecord(userRecord: UserRecord): SamUser = {
+    SamUser(userRecord.id, userRecord.googleSubjectId, userRecord.email, userRecord.azureB2cId, userRecord.enabled)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUser}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SamModelDirectives, SamRequestContextDirectives, SecurityDirectives, UserInfoDirectives, ioMarshaller}
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -31,7 +31,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
               requireAction(
                 FullyQualifiedResourceId(CloudExtensions.resourceTypeName, GoogleExtensions.resourceId),
                 GoogleExtensions.getPetPrivateKeyAction,
-                userInfo.userId,
+                userInfo.id,
                 samRequestContext) {
                 complete {
                   import spray.json._
@@ -52,7 +52,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                     complete {
                       import spray.json._
                       googleExtensions
-                        .getArbitraryPetServiceAccountKey(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), samRequestContext)
+                        .getArbitraryPetServiceAccountKey(userInfo, samRequestContext)
                         .map(key => StatusCodes.OK -> key.parseJson)
                     }
                   }
@@ -63,7 +63,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                     post {
                       entity(as[Set[String]]) { scopes =>
                         complete {
-                          googleExtensions.getArbitraryPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), scopes, samRequestContext).map { token =>
+                          googleExtensions.getArbitraryPetServiceAccountToken(userInfo, scopes, samRequestContext).map { token =>
                             StatusCodes.OK -> JsString(token)
                           }
                         }
@@ -76,14 +76,14 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                     requireOneOfActionIfParentIsWorkspace(
                       FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
                       Set(SamResourceActions.createPet),
-                      userInfo.userId,
+                      userInfo.id,
                       samRequestContext) {
                       get {
                         complete {
                           import spray.json._
                           // parse json to ensure it is json and tells akka http the right content-type
                           googleExtensions
-                            .getPetServiceAccountKey(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), samRequestContext)
+                            .getPetServiceAccountKey(userInfo, GoogleProject(project), samRequestContext)
                             .map { key =>
                               StatusCodes.OK -> key.parseJson
                             }
@@ -94,7 +94,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                         delete {
                           complete {
                             googleExtensions
-                              .removePetServiceAccountKey(userInfo.userId, GoogleProject(project), ServiceAccountKeyId(keyId), samRequestContext)
+                              .removePetServiceAccountKey(userInfo.id, GoogleProject(project), ServiceAccountKeyId(keyId), samRequestContext)
                               .map(_ => StatusCodes.NoContent)
                           }
                         }
@@ -104,13 +104,13 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                       requireOneOfActionIfParentIsWorkspace(
                         FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
                         Set(SamResourceActions.createPet),
-                        userInfo.userId,
+                        userInfo.id,
                         samRequestContext) {
                         post {
                           entity(as[Set[String]]) { scopes =>
                             complete {
                               googleExtensions
-                                .getPetServiceAccountToken(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), scopes, samRequestContext)
+                                .getPetServiceAccountToken(userInfo, GoogleProject(project), scopes, samRequestContext)
                                 .map { token =>
                                   StatusCodes.OK -> JsString(token)
                                 }
@@ -123,11 +123,11 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                       requireOneOfActionIfParentIsWorkspace(
                         FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
                         Set(SamResourceActions.createPet),
-                        userInfo.userId,
+                        userInfo.id,
                         samRequestContext) {
                         get {
                           complete {
-                            googleExtensions.createUserPetServiceAccount(WorkbenchUser(userInfo.userId, None, userInfo.userEmail, None), GoogleProject(project), samRequestContext).map {
+                            googleExtensions.createUserPetServiceAccount(userInfo, GoogleProject(project), samRequestContext).map {
                               petSA =>
                                 StatusCodes.OK -> petSA.serviceAccount.email
                             }
@@ -136,7 +136,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with UserInfoDirectives with
                       } ~
                         delete { // NOTE: This endpoint is not visible in Swagger
                           complete {
-                            googleExtensions.deleteUserPetServiceAccount(userInfo.userId, GoogleProject(project), samRequestContext).map(_ => StatusCodes.NoContent)
+                            googleExtensions.deleteUserPetServiceAccount(userInfo.id, GoogleProject(project), samRequestContext).map(_ => StatusCodes.NoContent)
                           }
                         }
                     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream
 import java.util.Date
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Clock, IO}
 import cats.implicits._
@@ -105,28 +104,19 @@ class GoogleExtensions(
     val samRequestContext = SamRequestContext(None) // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods
     val extensionResourceType =
       resourceTypes.getOrElse(CloudExtensions.resourceTypeName, throw new Exception(s"${CloudExtensions.resourceTypeName} resource type not found"))
-    val ownerGoogleSubjectId = GoogleSubjectId(googleServicesConfig.serviceAccountClientId)
+    val googleSubjectId = GoogleSubjectId(googleServicesConfig.serviceAccountClientId)
     for {
-      user <- directoryDAO.loadSubjectFromGoogleSubjectId(ownerGoogleSubjectId, samRequestContext)
-
-      subject <- directoryDAO.loadSubjectFromGoogleSubjectId(GoogleSubjectId(googleServicesConfig.serviceAccountClientId), samRequestContext)
-      serviceAccountUserInfo <- subject match {
-        case Some(uid: WorkbenchUserId) => IO.pure(UserInfo(OAuth2BearerToken(""), uid, googleServicesConfig.serviceAccountClientEmail, 0))
-        case Some(_) =>
-          IO.raiseError(
-            new WorkbenchExceptionWithErrorReport(
-              ErrorReport(StatusCodes.Conflict, s"subjectId in configuration ${googleServicesConfig.serviceAccountClientId} is not a valid user")))
-        case None => IO.pure(UserInfo(OAuth2BearerToken(""), genWorkbenchUserId(System.currentTimeMillis()), googleServicesConfig.serviceAccountClientEmail, 0))
+      maybeSamUser <- directoryDAO.loadUserByGoogleSubjectId(googleSubjectId, samRequestContext)
+      samUser <- maybeSamUser match {
+        case Some(samUser) => IO.pure(samUser)
+        case None => directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext).flatMap {
+          case Some(_) =>
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $googleSubjectId is not a SamUser")))
+          case None =>
+            val newUser = SamUser(genWorkbenchUserId(System.currentTimeMillis()), Option(googleSubjectId), googleServicesConfig.serviceAccountClientEmail, None, false)
+            IO.fromFuture(IO(samApplication.userService.createUser(newUser, samRequestContext))).map(_ => newUser)
+        }
       }
-      _ <- IO.fromFuture(
-        IO(
-          samApplication.userService.createUser(WorkbenchUser(
-            serviceAccountUserInfo.userId,
-            Option(GoogleSubjectId(googleServicesConfig.serviceAccountClientId)),
-            serviceAccountUserInfo.userEmail,
-            None), samRequestContext) recover {
-            case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) =>
-          }))
 
       _ <- googleKms.createKeyRing(googleServicesConfig.googleKms.project,
         googleServicesConfig.googleKms.location,
@@ -149,7 +139,7 @@ class GoogleExtensions(
 
       _ <- samApplication.resourceService.createResourceType(extensionResourceType, samRequestContext)
 
-      _ <- samApplication.resourceService.createResource(extensionResourceType, GoogleExtensions.resourceId, serviceAccountUserInfo, samRequestContext) handleErrorWith {
+      _ <- samApplication.resourceService.createResource(extensionResourceType, GoogleExtensions.resourceId, samUser, samRequestContext) handleErrorWith {
         case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) => IO.unit
       }
       _ <- googleKeyCache.onBoot()
@@ -240,7 +230,7 @@ class GoogleExtensions(
     googleGroupSyncPubSubDAO.publishMessages(googleServicesConfig.groupSyncPubSubConfig.topic, messages)
   }
 
-  override def onUserCreate(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] = {
+  override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = {
     val proxyEmail = toProxyFromUser(user.id)
     for {
       _ <- googleDirectoryDAO.createGroup(user.email.value, proxyEmail, Option(googleDirectoryDAO.lockedDownGroupSettings)) recover {
@@ -252,7 +242,7 @@ class GoogleExtensions(
     } yield ()
   }
 
-  override def getUserStatus(user: WorkbenchUser): Future[Boolean] =
+  override def getUserStatus(user: SamUser): Future[Boolean] =
     getUserProxy(user.id).flatMap {
       case Some(proxyEmail) => googleDirectoryDAO.isGroupMember(proxyEmail, WorkbenchEmail(user.email.value))
       case None => Future.successful(false)
@@ -269,7 +259,7 @@ class GoogleExtensions(
       }
     } yield a
 
-  override def onUserEnable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] =
+  override def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] =
     for {
       _ <- withProxyEmail(user.id) { proxyEmail =>
         googleDirectoryDAO.addMemberToGroup(proxyEmail, WorkbenchEmail(user.email.value))
@@ -277,7 +267,7 @@ class GoogleExtensions(
       _ <- forAllPets(user.id, samRequestContext)({ (petServiceAccount: PetServiceAccount) => enablePetServiceAccount(petServiceAccount, samRequestContext) })
     } yield ()
 
-  override def onUserDisable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] =
+  override def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] =
     for {
       _ <- forAllPets(user.id, samRequestContext)({ (petServiceAccount: PetServiceAccount) => disablePetServiceAccount(petServiceAccount, samRequestContext) })
       _ <- withProxyEmail(user.id) { proxyEmail =>
@@ -303,7 +293,7 @@ class GoogleExtensions(
       }
     } yield deletedSomething
 
-  def createUserPetServiceAccount(user: WorkbenchUser, project: GoogleProject, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
+  def createUserPetServiceAccount(user: SamUser, project: GoogleProject, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
     val (petSaName, petSaDisplayName) = toPetSAFromUser(user)
     // The normal situation is that the pet either exists in both ldap and google or neither.
     // Sometimes, especially in tests, the pet may be removed from ldap, but not google or the other way around.
@@ -383,31 +373,31 @@ class GoogleExtensions(
     for {
       subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
       key <- subject match {
-        case Some(userId: WorkbenchUserId) => getPetServiceAccountKey(WorkbenchUser(userId, None, userEmail, None), project, samRequestContext).map(Option(_))
+        case Some(userId: WorkbenchUserId) => getPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), project, samRequestContext).map(Option(_))
         case _ => IO.pure(None)
       }
     } yield key
 
-  def getPetServiceAccountKey(user: WorkbenchUser, project: GoogleProject, samRequestContext: SamRequestContext): IO[String] =
+  def getPetServiceAccountKey(user: SamUser, project: GoogleProject, samRequestContext: SamRequestContext): IO[String] =
     for {
       pet <- createUserPetServiceAccount(user, project, samRequestContext)
       key <- googleKeyCache.getKey(pet)
     } yield key
 
-  def getPetServiceAccountToken(user: WorkbenchUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
+  def getPetServiceAccountToken(user: SamUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
     getPetServiceAccountKey(user, project, samRequestContext).unsafeToFuture().flatMap { key =>
       getAccessTokenUsingJson(key, scopes)
     }
 
-  def getArbitraryPetServiceAccountKey(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[String] =
+  def getArbitraryPetServiceAccountKey(user: SamUser, samRequestContext: SamRequestContext): Future[String] =
     getDefaultServiceAccountForShellProject(user, samRequestContext)
 
-  def getArbitraryPetServiceAccountToken(user: WorkbenchUser, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
+  def getArbitraryPetServiceAccountToken(user: SamUser, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
     getArbitraryPetServiceAccountKey(user, samRequestContext).flatMap { key =>
       getAccessTokenUsingJson(key, scopes)
     }
 
-  private def getDefaultServiceAccountForShellProject(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[String] = {
+  private def getDefaultServiceAccountForShellProject(user: SamUser, samRequestContext: SamRequestContext): Future[String] = {
     val projectName = s"fc-${googleServicesConfig.environment.substring(0, Math.min(googleServicesConfig.environment.length(), 5))}-${user.id.value}" //max 30 characters. subject ID is 21
     for {
       creationOperationId <- googleProjectDAO.createProject(projectName, googleServicesConfig.terraGoogleOrgNumber, GoogleResourceTypes.Organization).map(opId => Option(opId)) recover {
@@ -505,7 +495,7 @@ class GoogleExtensions(
   def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     directoryDAO.getSynchronizedEmail(groupId, samRequestContext)
 
-  private[google] def toPetSAFromUser(user: WorkbenchUser): (ServiceAccountName, ServiceAccountDisplayName) = {
+  private[google] def toPetSAFromUser(user: SamUser): (ServiceAccountName, ServiceAccountDisplayName) = {
     /*
      * Service account IDs must be:
      * 1. between 6 and 30 characters

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -242,6 +242,16 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 
+final case class SamUser(id: WorkbenchUserId,
+                         googleSubjectId: Option[GoogleSubjectId],
+                         email: WorkbenchEmail,
+                         azureB2CId: Option[AzureB2CId],
+//                         acceptedToS: Option[Boolean], // None means ToS acceptance not required (disabled or grace period)
+                         enabled: Boolean) {
+//  val permittedToAccessTerra = acceptedToS.getOrElse(true) && enabled
+  def toUserIdInfo = UserIdInfo(id, email, googleSubjectId)
+}
+
 object SamLenses {
   val resourceIdentityAccessPolicy = AccessPolicy.id composeLens FullyQualifiedPolicyId.resource
   val resourceTypeNameInAccessPolicy = resourceIdentityAccessPolicy composeLens FullyQualifiedResourceId.resourceTypeName

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.sam.api.ExtensionRoutes
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, ResourceTypeName, SamUser}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
@@ -34,13 +34,13 @@ trait CloudExtensions {
 
   def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit]
 
-  def onUserCreate(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
 
-  def getUserStatus(user: WorkbenchUser): Future[Boolean]
+  def getUserStatus(user: SamUser): Future[Boolean]
 
-  def onUserEnable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
 
-  def onUserDisable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
 
   def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit]
 
@@ -73,13 +73,13 @@ trait NoExtensions extends CloudExtensions {
 
   override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] = Future.successful(())
 
-  override def onUserCreate(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
 
-  override def getUserStatus(user: WorkbenchUser): Future[Boolean] = Future.successful(true)
+  override def getUserStatus(user: SamUser): Future[Boolean] = Future.successful(true)
 
-  override def onUserEnable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
 
-  override def onUserDisable(user: WorkbenchUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
 
   override def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -32,11 +32,11 @@ class ManagedGroupService(
       ManagedGroupService.managedGroupTypeName,
       throw new WorkbenchException(s"resource type ${ManagedGroupService.managedGroupTypeName.value} not found"))
 
-  def createManagedGroup(groupId: ResourceId, userInfo: SamUser, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[Resource] = {
+  def createManagedGroup(groupId: ResourceId, samUser: SamUser, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[Resource] = {
     def adminRole = managedGroupType.ownerRoleName
 
     val memberPolicy = ManagedGroupService.memberPolicyName -> AccessPolicyMembership(Set.empty, Set.empty, Set(ManagedGroupService.memberRoleName), None, None)
-    val adminPolicy = ManagedGroupService.adminPolicyName -> AccessPolicyMembership(Set(userInfo.email), Set.empty, Set(adminRole), None, None)
+    val adminPolicy = ManagedGroupService.adminPolicyName -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(adminRole), None, None)
     val adminNotificationPolicy = ManagedGroupService.adminNotifierPolicyName -> AccessPolicyMembership(
       Set.empty,
       Set.empty,
@@ -46,7 +46,7 @@ class ManagedGroupService(
 
     validateGroupName(groupId.value)
     for {
-      managedGroup <- resourceService.createResource(managedGroupType, groupId, Map(adminPolicy, memberPolicy, adminNotificationPolicy), Set.empty, None, userInfo.id, samRequestContext)
+      managedGroup <- resourceService.createResource(managedGroupType, groupId, Map(adminPolicy, memberPolicy, adminNotificationPolicy), Set.empty, None, samUser.id, samRequestContext)
       policies <- accessPolicyDAO.listAccessPolicies(managedGroup.fullyQualifiedId, samRequestContext)
       workbenchGroup <- createAggregateGroup(managedGroup, policies.toSet, accessInstructionsOpt, samRequestContext)
       _ <- IO.fromFuture(IO(cloudExtensions.publishGroup(workbenchGroup.id)))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -76,20 +76,20 @@ class ResourceService(
 
   /**
     * Create a resource with default policies. The default policies contain 1 policy with the same name as the
-    * owner role for the resourceType, has the owner role, membership contains only userInfo
+    * owner role for the resourceType, has the owner role, membership contains only samUser
     *
     * @param resourceType
     * @param resourceId
-    * @param userInfo
+    * @param samUser
     * @return
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): IO[Resource] = {
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Resource] = {
     val ownerRole = resourceType.roles
       .find(_.roleName == resourceType.ownerRoleName)
       .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
     val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.email), Set.empty, Set(ownerRole.roleName), None, None))
-    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, userInfo.id, samRequestContext)
+      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None))
+    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
   }
 
   /**
@@ -264,8 +264,8 @@ class ResourceService(
         } yield ()
     }
 
-  def listUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
-    accessPolicyDAO.listUserResourceRoles(resource, userInfo.id, samRequestContext).unsafeToFuture()
+  def listUserResourceRoles(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
+    accessPolicyDAO.listUserResourceRoles(resource, samUser.id, samRequestContext).unsafeToFuture()
 
   /**
     * Overwrites an existing policy (keyed by resourceType/resourceId/policyName), saves a new one if it doesn't exist yet

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -83,13 +83,13 @@ class ResourceService(
     * @param userInfo
     * @return
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): IO[Resource] = {
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): IO[Resource] = {
     val ownerRole = resourceType.roles
       .find(_.roleName == resourceType.ownerRoleName)
       .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
     val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.userEmail), Set.empty, Set(ownerRole.roleName), None, None))
-    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, userInfo.userId, samRequestContext)
+      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(userInfo.email), Set.empty, Set(ownerRole.roleName), None, None))
+    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, userInfo.id, samRequestContext)
   }
 
   /**
@@ -264,8 +264,8 @@ class ResourceService(
         } yield ()
     }
 
-  def listUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: UserInfo, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
-    accessPolicyDAO.listUserResourceRoles(resource, userInfo.userId, samRequestContext).unsafeToFuture()
+  def listUserResourceRoles(resource: FullyQualifiedResourceId, userInfo: SamUser, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
+    accessPolicyDAO.listUserResourceRoles(resource, userInfo.id, samRequestContext).unsafeToFuture()
 
   /**
     * Overwrites an existing policy (keyed by resourceType/resourceId/policyName), saves a new one if it doesn't exist yet
@@ -530,7 +530,7 @@ class ResourceService(
       members <- accessPolicies.toList.parTraverse(accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id, samRequestContext))
       workbenchUsers = members.flatten.toSet
     } yield {
-      workbenchUsers.map(user => UserIdInfo(user.id, user.email, user.googleSubjectId))
+      workbenchUsers.map(_.toUserIdInfo)
     }
 
   @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.kernel.Async
 import com.unboundid.ldap.sdk._
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO.Attr
 import org.broadinstitute.dsde.workbench.sam.util.OpenCensusIOUtils.traceIOWithContext
 
@@ -35,11 +36,11 @@ trait LdapSupport {
   }.getOrElse(Set.empty)
 
 
-  protected def unmarshalUser(results: Entry): Either[String, WorkbenchUser] =
+  protected def unmarshalUser(results: Entry): Either[String, SamUser] =
     for {
       uid <- getAttribute(results, Attr.uid).toRight(s"${Attr.uid} attribute missing")
       email <- getAttribute(results, Attr.email).toRight(s"${Attr.email} attribute missing")
-    } yield WorkbenchUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email), None)
+    } yield SamUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email), None, false)
 
   /**
     * Executes ldap query.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -68,10 +68,10 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
-  def makeOtherUser(samRoutes: TestSamRoutes, userInfo: SamUser = defaultNewUser) = new {
-    runAndWait(samRoutes.userService.createUser(userInfo, samRequestContext))
-    val email = userInfo.email
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
+  def makeOtherUser(samRoutes: TestSamRoutes, samUser: SamUser = defaultNewUser) = new {
+    runAndWait(samRoutes.userService.createUser(samUser, samRequestContext))
+    val email = samUser.email
+    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, samUser, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
   }
 
   def setGroupMembers(samRoutes: TestSamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -3,7 +3,6 @@ package api
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.Materializer
@@ -41,7 +40,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   private val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
   private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
   private val groupId = "foo"
-  private val defaultNewUser = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), WorkbenchEmail("newGuy@organization.org"), 0)
+  private val defaultNewUser = Generator.genWorkbenchUserGoogle.sample.get
   private def defaultGoogleSubjectId = Option(GoogleSubjectId(genRandom(System.currentTimeMillis())))
 
   def assertGroupDoesNotExist(samRoutes: TestSamRoutes, groupId: String = groupId): Unit = {
@@ -69,9 +68,9 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
-  def makeOtherUser(samRoutes: TestSamRoutes, userInfo: UserInfo = defaultNewUser) = new {
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(userInfo.userId, defaultGoogleSubjectId, userInfo.userEmail, None), samRequestContext))
-    val email = userInfo.userEmail
+  def makeOtherUser(samRoutes: TestSamRoutes, userInfo: SamUser = defaultNewUser) = new {
+    runAndWait(samRoutes.userService.createUser(userInfo, samRequestContext))
+    val email = userInfo.email
     val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
   }
 
@@ -85,8 +84,8 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     assertCreateGroup(defaultRoutes)
     assertGetGroup(defaultRoutes)
 
-    val theDude = UserInfo(OAuth2BearerToken("tokenDude"), WorkbenchUserId("ElDudarino"), WorkbenchEmail("ElDudarino@example.com"), 0)
-    defaultRoutes.directoryDAO.createUser(WorkbenchUser(theDude.userId, None, theDude.userEmail, None), samRequestContext).unsafeRunSync()
+    val theDude = Generator.genWorkbenchUserGoogle.sample.get
+    defaultRoutes.directoryDAO.createUser(theDude, samRequestContext).unsafeRunSync()
     val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.mockDirectoryDao, defaultRoutes.mockRegistrationDao)
 
     body(dudesRoutes)
@@ -102,17 +101,15 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   it should "respond with 200 if the requesting user is in the member policy for the group" in {
     val samRoutes = TestSamRoutes(resourceTypes)
 
-
-    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
-    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
+    val newGuy = Generator.genWorkbenchUserGoogle.sample.get
     val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
 
     assertCreateGroup(samRoutes)
     assertGetGroup(samRoutes)
 
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(newGuy.userId, defaultGoogleSubjectId, newGuy.userEmail, None), samRequestContext))
+    runAndWait(samRoutes.userService.createUser(newGuy, samRequestContext))
 
-    setGroupMembers(samRoutes, Set(newGuyEmail), expectedStatus = StatusCodes.Created)
+    setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 
     assertGetGroup(newGuyRoutes)
   }
@@ -128,9 +125,8 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     assertCreateGroup(samRoutes)
 
-    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
-    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
-    samRoutes.directoryDAO.createUser(WorkbenchUser(newGuy.userId, None, newGuyEmail, None), samRequestContext).unsafeRunSync()
+    val newGuy = Generator.genWorkbenchUserGoogle.sample.get
+    samRoutes.directoryDAO.createUser(newGuy, samRequestContext).unsafeRunSync()
     val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, samRoutes.mockRegistrationDao)
 
 
@@ -319,7 +315,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Get(s"/api/group/$groupId/admin") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[String] should include (TestSamRoutes.defaultUserInfo.userEmail.value)
+      responseAs[String] should include (TestSamRoutes.defaultUserInfo.email.value)
     }
   }
 
@@ -399,10 +395,9 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   it should "fail with 404 when the group does not exist" in {
     val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, ResourceId("foo"), Set.empty))
 
-    val newGuyEmail = WorkbenchEmail("newGuy@organization.org")
-    val newGuy = UserInfo(OAuth2BearerToken("newToken"), WorkbenchUserId("NewGuy"), newGuyEmail, 0)
+    val newGuy = Generator.genWorkbenchUserGoogle.sample.get
 
-    val members = Set(newGuyEmail)
+    val members = Set(newGuy.email)
     Put(s"/api/group/$groupId/admin", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
@@ -440,8 +435,8 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     assertCreateGroup(samRoutes)
 
-    val defaultUserInfo = samRoutes.userInfo
-    Put(s"/api/group/$groupId/admin/${defaultUserInfo.userEmail}") ~> samRoutes.route ~> check {
+    val defaultUserInfo = samRoutes.user
+    Put(s"/api/group/$groupId/admin/${defaultUserInfo.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -489,7 +484,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val newGuy = makeOtherUser(samRoutes)
 
 
-    Put(s"/api/group/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> newGuy.routes.route ~> check {
+    Put(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> newGuy.routes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -500,7 +495,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     assertCreateGroup(samRoutes)
 
-    Delete(s"/api/group/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+    Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -512,14 +507,14 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     assertCreateGroup(samRoutes)
 
-    Delete(s"/api/group/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+    Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "respond with 404 when the group does not exist" in {
     val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, ResourceId("foo"), Set.empty))
-    Delete(s"/api/group/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+    Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -529,7 +524,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     assertCreateGroup(samRoutes)
 
-    Delete(s"/api/group/$groupId/people/${samRoutes.userInfo.userEmail}") ~> samRoutes.route ~> check {
+    Delete(s"/api/group/$groupId/people/${samRoutes.user.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -542,7 +537,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val newGuy = makeOtherUser(samRoutes)
 
 
-    Delete(s"/api/group/$groupId/admin/${samRoutes.userInfo.userEmail}") ~> newGuy.routes.route ~> check {
+    Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> newGuy.routes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -62,10 +62,10 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   }
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
-  def makeOtherUser(samRoutes: SamRoutes, userInfo: SamUser = defaultNewUser) = new {
-    runAndWait(samRoutes.userService.createUser(userInfo, samRequestContext))
-    val email = userInfo.email
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, userInfo, samRoutes.directoryDAO, samRoutes.registrationDAO)
+  def makeOtherUser(samRoutes: SamRoutes, samUser: SamUser = defaultNewUser) = new {
+    runAndWait(samRoutes.userService.createUser(samUser, samRequestContext))
+    val email = samUser.email
+    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, samUser, samRoutes.directoryDAO, samRoutes.registrationDAO)
   }
 
   def setGroupMembers(samRoutes: SamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
@@ -2,19 +2,19 @@ package org.broadinstitute.dsde.workbench.sam
 package api
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import cats.effect.unsafe.implicits.global
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, UserInfo, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUser, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 /**
   * Created by dvoet on 6/7/17.
   */
 trait MockUserInfoDirectives extends UserInfoDirectives {
-  val userInfo: UserInfo
-  val workbenchUser: Option[WorkbenchUser] = None
+  val user: SamUser
+  val workbenchUser: Option[SamUser] = None
 
   val petSAdomain = "\\S+@\\S+\\.iam\\.gserviceaccount\\.com".r
 
@@ -22,20 +22,20 @@ trait MockUserInfoDirectives extends UserInfoDirectives {
     petSAdomain.pattern.matcher(email).matches
   }
 
-  override def requireUserInfo(samRequestContext: SamRequestContext): Directive1[UserInfo] = onSuccess {
-    directoryDAO.loadSubjectFromEmail(userInfo.userEmail, samRequestContext).map { maybeUser =>
+  override def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser] = onSuccess {
+    directoryDAO.loadSubjectFromEmail(user.email, samRequestContext).map { maybeUser =>
       maybeUser.map { _ =>
-        if (isPetSA(userInfo.userEmail.value)) {
-          UserInfo(OAuth2BearerToken(""), WorkbenchUserId("newuser"), WorkbenchEmail("newuser@new.com"), userInfo.tokenExpiresIn)
+        if (isPetSA(user.email.value)) {
+          user.copy(id = WorkbenchUserId("newuser"), email = WorkbenchEmail("newuser@new.com"))
         } else {
-          userInfo
+          user
         }
         // forbidden status code matches what the StandardUserInfoDirectives does when user is not found
       }.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "user not found")))
     }.unsafeToFuture()
   }
 
-  override def requireCreateUser(samRequestContext: SamRequestContext): Directive1[WorkbenchUser] = workbenchUser match {
+  override def requireCreateUser(samRequestContext: SamRequestContext): Directive1[SamUser] = workbenchUser match {
     case None => failWith(new Exception("workbenchUser not specified"))
     case Some(u) => provide(u)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockUserInfoDirectives.scala
@@ -22,7 +22,7 @@ trait MockUserInfoDirectives extends UserInfoDirectives {
     petSAdomain.pattern.matcher(email).matches
   }
 
-  override def requireUserInfo(samRequestContext: SamRequestContext): Directive1[SamUser] = onSuccess {
+  override def requireActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = onSuccess {
     directoryDAO.loadSubjectFromEmail(user.email, samRequestContext).map { maybeUser =>
       maybeUser.map { _ =>
         if (isPetSA(user.email.value)) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -42,7 +42,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val testActionAccess = ResourceActionPattern("test_action_access::.+", "", false)
   }
 
-  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: SamUser = defaultUserInfo) = {
+  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], samUser: SamUser = defaultUserInfo) = {
     val directoryDAO = new MockDirectoryDAO()
     val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val registrationDAO = new MockRegistrationDAO()
@@ -56,7 +56,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
     mockUserService.createUser(defaultUserInfo, samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, samUser, directoryDAO, registrationDAO)
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -3,7 +3,6 @@ package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
@@ -25,15 +24,13 @@ import spray.json.{JsBoolean, JsValue}
   */
 class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
-  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
-  def defaultGoogleSubjectId = Generator.genGoogleSubjectId.sample
+  val defaultUserInfo = TestSamRoutes.defaultUserInfo
 
-  private val config = TestSupport.config
   private val resourceTypes = TestSupport.appConfig.resourceTypes
   private val resourceTypeMap = resourceTypes.map(rt => rt.name -> rt).toMap
   private val managedGroupResourceType = resourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
-  private val defaultTestUser = WorkbenchUser(WorkbenchUserId("testuser"), defaultGoogleSubjectId, WorkbenchEmail("testuser@foo.com"), None)
+  private val defaultTestUser = Generator.genWorkbenchUserGoogle.sample.get
 
   private object SamResourceActionPatterns {
     val readPolicies = ResourceActionPattern("read_policies", "", false)
@@ -45,7 +42,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val testActionAccess = ResourceActionPattern("test_action_access::.+", "", false)
   }
 
-  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo) = {
+  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: SamUser = defaultUserInfo) = {
     val directoryDAO = new MockDirectoryDAO()
     val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val registrationDAO = new MockRegistrationDAO()
@@ -57,7 +54,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
-    mockUserService.createUser(WorkbenchUser(defaultUserInfo.userId, defaultGoogleSubjectId, defaultUserInfo.userEmail, None), samRequestContext)
+    mockUserService.createUser(defaultUserInfo, samRequestContext)
 
     new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO)
   }
@@ -195,7 +192,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -216,7 +213,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, defaultUserInfo, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -231,7 +228,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
@@ -256,7 +253,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
     // Group is never persisted
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
@@ -269,12 +266,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     resourceType.isAuthDomainConstrainable shouldEqual true
 
     val authDomainId = ResourceId("myAuthDomain")
-    val otherUser = UserInfo(OAuth2BearerToken("magicString"), WorkbenchUserId("bugsBunny"), WorkbenchEmail("bugsford_bunnington@example.com"), 0)
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(otherUser.userId, defaultGoogleSubjectId, otherUser.userEmail, None), samRequestContext))
+    val otherUser = Generator.genWorkbenchUserGoogle.sample.get
+    runAndWait(samRoutes.userService.createUser(otherUser, samRequestContext))
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, otherUser, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
@@ -319,7 +316,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/policies/{policyName}" should "200 on existing policy of a resource with read_policies" in {
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
@@ -340,8 +337,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   private def responsePayloadClue(str: String): String = s" -> Here is the response payload: $str"
 
   private def createUserResourcePolicy(members: AccessPolicyMembership, resourceType: ResourceType, samRoutes: TestSamRoutes, resourceId: ResourceId, policyName: AccessPolicyName): Unit = {
-    val user = WorkbenchUser(samRoutes.userInfo.userId, defaultGoogleSubjectId, samRoutes.userInfo.userEmail, None)
-    findOrCreateUser(user, samRoutes.userService)
+    findOrCreateUser(samRoutes.user, samRoutes.userService)
 
     Post(s"/api/resource/${resourceType.name}/${resourceId.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent withClue responsePayloadClue(responseAs[String])
@@ -353,7 +349,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     }
   }
 
-  private def findOrCreateUser(user: WorkbenchUser, userService: UserService): UserStatus = {
+  private def findOrCreateUser(user: SamUser, userService: UserService): UserStatus = {
     runAndWait(userService.getUserStatus(user.id, samRequestContext = samRequestContext)) match {
       case Some(userStatus) => userStatus
       case None => runAndWait(userService.createUser(user, samRequestContext))
@@ -361,7 +357,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "200 on existing policy of a resource with read_policy" in {
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
     val policyName = AccessPolicyName("bar")
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
@@ -380,7 +376,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "404 on non existing policy of a resource" in {
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
@@ -398,7 +394,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "403 on existing policy of a resource without read policies" in {
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set.empty, Set.empty)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
@@ -569,7 +565,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
     policyDao.createResource(Resource(ResourceTypeName("rt"), ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
@@ -628,7 +624,7 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType), Resource(resourceType.name, ResourceId("foo"), Set.empty))
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
     //Create the resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -695,8 +691,9 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
 
     samRoutes.resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(WorkbenchUserId(""), defaultGoogleSubjectId, WorkbenchEmail("user2@example.com"), None), samRequestContext))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user2"), WorkbenchEmail("user2@example.com"), 0), samRequestContext))
+    val user = Generator.genWorkbenchUserGoogle.sample.get
+    runAndWait(samRoutes.userService.createUser(user, samRequestContext))
+    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), user, samRequestContext))
 
     //Verify resource exists by checking for conflict on recreate
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -788,13 +785,13 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
+    val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(testUser.userId, defaultGoogleSubjectId, testUser.userEmail, None), samRequestContext))
+    runAndWait(samRoutes.userService.createUser(testUser, samRequestContext))
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
-    Put(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.userEmail}") ~> samRoutes.route ~> check {
+    Put(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -866,16 +863,16 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
     val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    val testUser = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("testuser"), WorkbenchEmail("testuser@foo.com"), 0)
+    val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
-    runAndWait(samRoutes.userService.createUser(WorkbenchUser(testUser.userId, defaultGoogleSubjectId, testUser.userEmail, None), samRequestContext))
+    runAndWait(samRoutes.userService.createUser(testUser, samRequestContext))
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
     runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.userId, samRequestContext))
+        FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id, samRequestContext))
 
-    Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.userEmail}") ~> samRoutes.route ~> check {
+    Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -42,7 +42,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   )
 
   private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType] = Map(defaultResourceType.name -> defaultResourceType),
-                              userInfo: SamUser = defaultUserInfo): SamRoutes = {
+                              samUser: SamUser = defaultUserInfo): SamRoutes = {
     val directoryDAO = new MockDirectoryDAO()
     val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val registrationDAO = new MockRegistrationDAO()
@@ -57,9 +57,9 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
-    mockUserService.createUser(userInfo, samRequestContext)
+    mockUserService.createUser(samUser, samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, samUser, directoryDAO, registrationDAO)
   }
 
   private val managedGroupResourceType = configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -144,14 +144,14 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     val headers = createRequiredHeaders(externalId, email, accessToken)
     val user = services.directoryDAO.createUser(SamUser(genWorkbenchUserId(System.currentTimeMillis()), externalId.left.toOption, email = email, azureB2CId = externalId.toOption, false), samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.requireUserInfo(samRequestContext)(x => complete(x.toString))} ~> check {
+      handleExceptions(myExceptionHandler){services.requireActiveUser(samRequestContext)(x => complete(x.toString))} ~> check {
       status shouldBe StatusCodes.OK
       responseAs[String] shouldEqual user.toString
     }
   }
 
   it should "fail if required headers are missing" in {
-    Get("/") ~> handleExceptions(myExceptionHandler){directives().requireUserInfo(samRequestContext)(x => complete(x.toString))} ~> check {
+    Get("/") ~> handleExceptions(myExceptionHandler){directives().requireActiveUser(samRequestContext)(x => complete(x.toString))} ~> check {
       rejection shouldBe MissingHeaderRejection(accessTokenHeader)
     }
   }
@@ -163,7 +163,7 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     val existingUser = services.directoryDAO.createUser(googleUser, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler) {
-        services.requireUserInfo(samRequestContext)(x => complete(x.toString))
+        services.requireActiveUser(samRequestContext)(x => complete(x.toString))
       } ~> check {
       status shouldBe StatusCodes.OK
       val exptectedUser = existingUser.copy(azureB2CId = Option(azureB2CId))
@@ -178,7 +178,7 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     val headers = createRequiredHeaders(Right(azureUser.azureB2CId.get), azureUser.email, accessToken, Option(googleSubjectId))
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler) {
-        services.requireUserInfo(samRequestContext)(x => complete(x.toString))
+        services.requireActiveUser(samRequestContext)(x => complete(x.toString))
       } ~> check {
       status shouldBe StatusCodes.OK
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectivesSpec.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.workbench.sam.api.SamRoutes.myExceptionHandler
 import org.broadinstitute.dsde.workbench.sam.api.StandardUserInfoDirectives._
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, MockDirectoryDAO, MockRegistrationDAO, RegistrationDAO}
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, UserService}
 import org.scalatest.concurrent.ScalaFutures
@@ -39,40 +40,38 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
       (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val uid = genWorkbenchUserId(System.currentTimeMillis())
-        val oidcHeaders = OIDCHeaders(token, externalId, 10L, email, None)
-        directoryDAO.createUser(WorkbenchUser(uid, externalId.left.toOption, email, externalId.toOption), samRequestContext).unsafeRunSync()
+        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(googleSubjectId = externalId.left.toOption, azureB2CId = externalId.toOption)
+        val oidcHeaders = OIDCHeaders(token, externalId, email, None)
+        directoryDAO.createUser(user, samRequestContext).unsafeRunSync()
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-        res should be (UserInfo(token, uid, email, 10L))
+        res should be (user)
     }
   }
 
   it should "be able to get a UserInfo object for service account if it is a PET" in {
     // note that pets can only have google subject ids, not azure b2c ids
-    forAll(genServiceAccountSubjectId, genGoogleSubjectId, genOAuth2BearerToken, genPetEmail) {
-      (serviceSubjectId: ServiceAccountSubjectId, googleSubjectId: GoogleSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+    forAll(genServiceAccountSubjectId, genWorkbenchUserGoogle, genOAuth2BearerToken, genServiceAccountEmail) {
+      (serviceSubjectId: ServiceAccountSubjectId, user: SamUser, token: OAuth2BearerToken, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val uid = genWorkbenchUserId(System.currentTimeMillis())
-        directoryDAO.createUser(WorkbenchUser(uid, Option(googleSubjectId), email, None), samRequestContext).unsafeRunSync()
-        directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
-        val oidcHeaders = OIDCHeaders(token, Left(GoogleSubjectId(serviceSubjectId.value)), 10L, email, None)
+        directoryDAO.createUser(user, samRequestContext).unsafeRunSync()
+        directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(user.id, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
+        val oidcHeaders = OIDCHeaders(token, Left(GoogleSubjectId(serviceSubjectId.value)), email, None)
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-        res should be (UserInfo(token, uid, email, 10L))
+        res should be (user)
     }
   }
 
   it should "be able to get a UserInfo object for service account if it is a not PET" in {
-    forAll(genServiceAccountSubjectId, genOAuth2BearerToken, genPetEmail) {
-      (serviceSubjectId: ServiceAccountSubjectId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+    forAll(genWorkbenchUserServiceAccount, genOAuth2BearerToken) {
+      (serviceAccountUser: SamUser, token: OAuth2BearerToken) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val gSid = GoogleSubjectId(serviceSubjectId.value)
         val uid = genWorkbenchUserId(System.currentTimeMillis())
-        val oidcHeaders = OIDCHeaders(token, Left(gSid), 10L, email, None)
-        directoryDAO.createUser(WorkbenchUser(uid, Some(gSid), email, None), samRequestContext).unsafeRunSync()
+        val oidcHeaders = OIDCHeaders(token, Left(serviceAccountUser.googleSubjectId.get), serviceAccountUser.email, None)
+        directoryDAO.createUser(serviceAccountUser, samRequestContext).unsafeRunSync()
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-        res should be (UserInfo(token, uid, email, 10L))
+        res should be (serviceAccountUser)
     }
   }
 
@@ -81,18 +80,18 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
       (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val oidcHeaders = OIDCHeaders(token, externalId, 10L, email, None)
+        val oidcHeaders = OIDCHeaders(token, externalId, email, None)
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
 
   it should "fail if PET account is not found" in {
-    forAll(genOAuth2BearerToken, genPetEmail, genGoogleSubjectId){
+    forAll(genOAuth2BearerToken, genServiceAccountEmail, genGoogleSubjectId){
       (token: OAuth2BearerToken, email: WorkbenchEmail, googleSubjectId: GoogleSubjectId) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val oidcHeaders = OIDCHeaders(token, Left(googleSubjectId), 10L, email, None)
+        val oidcHeaders = OIDCHeaders(token, Left(googleSubjectId), email, None)
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
@@ -104,7 +103,7 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
         val gSid = GoogleSubjectId(serviceSubjectId.value)
-        val oidcHeaders = OIDCHeaders(token, Left(gSid), 10L, email, None)
+        val oidcHeaders = OIDCHeaders(token, Left(gSid), email, None)
         val uid = genWorkbenchUserId(System.currentTimeMillis())
         directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(uid, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
@@ -114,54 +113,40 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
   }
 
   it should "fail if azureB2CId does not exist and google subject id is not for current user" in {
-    forAll(genGoogleSubjectId, genAzureB2CId, genOAuth2BearerToken, genGoogleSubjectId, genPetEmail) {
-      (googleSubjectId: GoogleSubjectId, azureB2CId: AzureB2CId, token: OAuth2BearerToken, otherGoogleSubjectId: GoogleSubjectId, email: WorkbenchEmail) =>
+    forAll(genWorkbenchUserGoogle, genAzureB2CId, genOAuth2BearerToken, genGoogleSubjectId, genServiceAccountEmail) {
+      (googleUser: SamUser, azureB2CId: AzureB2CId, token: OAuth2BearerToken, otherGoogleSubjectId: GoogleSubjectId, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val uid = genWorkbenchUserId(System.currentTimeMillis())
-        val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), 10L, email, Option(otherGoogleSubjectId))
-        val workbenchUser = WorkbenchUser(uid, Option(googleSubjectId), email, None)
-        directoryDAO.createUser(workbenchUser, samRequestContext).unsafeRunSync()
+        val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), email, Option(otherGoogleSubjectId))
+        directoryDAO.createUser(googleUser, samRequestContext).unsafeRunSync()
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).attempt.unsafeRunSync().swap.toOption.get.asInstanceOf[WorkbenchExceptionWithErrorReport]
         res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
 
   it should "update existing user with azureB2CId" in {
-    forAll(genGoogleSubjectId, genAzureB2CId, genOAuth2BearerToken, genPetEmail) {
-      (googleSubjectId: GoogleSubjectId, azureB2CId: AzureB2CId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
+    forAll(genWorkbenchUserGoogle, genAzureB2CId, genOAuth2BearerToken, genServiceAccountEmail) {
+      (workbenchUser: SamUser, azureB2CId: AzureB2CId, token: OAuth2BearerToken, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
         val registrationDAO = new MockRegistrationDAO()
-        val uid = genWorkbenchUserId(System.currentTimeMillis())
-        val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), 10L, email, Option(googleSubjectId))
-        val workbenchUser = WorkbenchUser(uid, Option(googleSubjectId), email, None)
+        val oidcHeaders = OIDCHeaders(token, Right(azureB2CId), email, workbenchUser.googleSubjectId)
         directoryDAO.createUser(workbenchUser, samRequestContext).unsafeRunSync()
         val res = getUserInfo(directoryDAO, registrationDAO, oidcHeaders, samRequestContext).unsafeRunSync()
-        res should be (UserInfo(token, uid, email, 10L))
-        directoryDAO.loadUser(uid, samRequestContext).unsafeRunSync() shouldBe Option(workbenchUser.copy(azureB2CId = Option(azureB2CId)))
-    }
-  }
-
-  "requireUserInfo" should "fail if expiresIn is in illegal format" in {
-    forAll(genUserInfoHeadersWithInvalidExpiresIn) {
-      headers: List[RawHeader] =>
-        Get("/").withHeaders(headers) ~> handleExceptions(myExceptionHandler){directives().requireUserInfo(samRequestContext)(x => complete(x.toString))} ~> check {
-          val res = responseAs[String]
-          status shouldBe StatusCodes.BadRequest
-          responseAs[String].contains(s"expiresIn ${headers.find(_.name == expiresInHeader).get.value} can't be converted to Long") shouldBe(true)
-        }
+        val expectedUser = workbenchUser.copy(azureB2CId = Option(azureB2CId))
+        res should be (expectedUser)
+        directoryDAO.loadUser(workbenchUser.id, samRequestContext).unsafeRunSync() shouldBe Option(expectedUser)
     }
   }
 
   it should "accept request with oidc headers" in forAll(genExternalId, genNonPetEmail, genOAuth2BearerToken, minSuccessful(20)) { (externalId, email, accessToken) =>
     val services = directives()
     val expiresIn = System.currentTimeMillis() + 1000
-    val headers = createRequiredHeaders(externalId, email, accessToken, expiresInString = expiresIn.toString)
-    val user = services.directoryDAO.createUser(WorkbenchUser(genWorkbenchUserId(System.currentTimeMillis()), externalId.left.toOption, email = email, azureB2CId = externalId.toOption), samRequestContext).unsafeRunSync()
+    val headers = createRequiredHeaders(externalId, email, accessToken)
+    val user = services.directoryDAO.createUser(SamUser(genWorkbenchUserId(System.currentTimeMillis()), externalId.left.toOption, email = email, azureB2CId = externalId.toOption, false), samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler){services.requireUserInfo(samRequestContext)(x => complete(x.toString))} ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual UserInfo(accessToken, user.id, user.email, expiresIn).toString
+      responseAs[String] shouldEqual user.toString
     }
   }
 
@@ -171,25 +156,26 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     }
   }
 
-  it should "populate google id if google id from azure matches existing user" in forAll(genAzureB2CId, genNonPetEmail, genOAuth2BearerToken, genGoogleSubjectId) { (azureB2CId, email, accessToken, googleSubjectId) =>
+  it should "populate google id if google id from azure matches existing user" in forAll(genAzureB2CId, genWorkbenchUserGoogle, genOAuth2BearerToken) { (azureB2CId, googleUser, accessToken) =>
     val services = directives(new MockDirectoryDAO())
     val expiresIn = System.currentTimeMillis() + 1000
-    val headers = createRequiredHeaders(Right(azureB2CId), email, accessToken, Option(googleSubjectId), expiresInString = expiresIn.toString)
-    val existingUser = services.directoryDAO.createUser(WorkbenchUser(genWorkbenchUserId(System.currentTimeMillis()), Option(googleSubjectId), email, None), samRequestContext).unsafeRunSync()
+    val headers = createRequiredHeaders(Right(azureB2CId), googleUser.email, accessToken, googleUser.googleSubjectId)
+    val existingUser = services.directoryDAO.createUser(googleUser, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler) {
         services.requireUserInfo(samRequestContext)(x => complete(x.toString))
       } ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual UserInfo(accessToken, existingUser.id, existingUser.email, expiresIn).toString
-      services.directoryDAO.loadUser(existingUser.id, samRequestContext).unsafeRunSync() shouldEqual Some(existingUser.copy(azureB2CId = Option(azureB2CId)))
+      val exptectedUser = existingUser.copy(azureB2CId = Option(azureB2CId))
+      responseAs[String] shouldEqual exptectedUser.toString
+      services.directoryDAO.loadUser(existingUser.id, samRequestContext).unsafeRunSync() shouldEqual Some(exptectedUser)
     }
   }
 
-  it should "pass if google id from azure does not exist" in forAll(genAzureB2CId, genNonPetEmail, genOAuth2BearerToken, genGoogleSubjectId) { (azureB2CId, email, accessToken, googleSubjectId) =>
+  it should "pass if google id from azure does not exist" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken, genGoogleSubjectId) { (azureUser, accessToken, googleSubjectId) =>
     val services = directives(new MockDirectoryDAO())
-    services.directoryDAO.createUser(WorkbenchUser(genWorkbenchUserId(System.currentTimeMillis()), None, email, Option(azureB2CId)), samRequestContext).unsafeRunSync()
-    val headers = createRequiredHeaders(Right(azureB2CId), email, accessToken, Option(googleSubjectId))
+    services.directoryDAO.createUser(azureUser, samRequestContext).unsafeRunSync()
+    val headers = createRequiredHeaders(Right(azureUser.azureB2CId.get), azureUser.email, accessToken, Option(googleSubjectId))
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler) {
         services.requireUserInfo(samRequestContext)(x => complete(x.toString))
@@ -202,9 +188,9 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     val services = directives()
     val headers = createRequiredHeaders(externalId, email, accessToken)
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.requireCreateUser(samRequestContext)(x => complete(x.copy(id = WorkbenchUserId("")).toString))} ~> check {
+      handleExceptions(myExceptionHandler){services.requireCreateUser(samRequestContext)(user => complete(user.copy(id = WorkbenchUserId("")).toString))} ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual WorkbenchUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption).toString
+      responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption, false).toString
     }
   }
 
@@ -216,7 +202,7 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
         services.requireCreateUser(samRequestContext)(x => complete(x.copy(id = WorkbenchUserId("")).toString))
       } ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual WorkbenchUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId)).toString
+      responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId), false).toString
     }
   }
 
@@ -226,12 +212,11 @@ class StandardUserInfoDirectivesSpec extends AnyFlatSpec with PropertyBasedTesti
     }
   }
 
-  private def createRequiredHeaders(externalId: Either[GoogleSubjectId, AzureB2CId], email: WorkbenchEmail, accessToken: OAuth2BearerToken, googleIdFromAzure: Option[GoogleSubjectId] = None, expiresInString: String = (System.currentTimeMillis() + 1000).toString): List[RawHeader] = {
+  private def createRequiredHeaders(externalId: Either[GoogleSubjectId, AzureB2CId], email: WorkbenchEmail, accessToken: OAuth2BearerToken, googleIdFromAzure: Option[GoogleSubjectId] = None) = {
     List(
       RawHeader(emailHeader, email.value),
       RawHeader(userIdHeader, externalId.fold(_.value, _.value)),
       RawHeader(accessTokenHeader, accessToken.token),
-      RawHeader(expiresInHeader, expiresInString)
     ) ++ googleIdFromAzure.map(gid => RawHeader(googleIdFromAzureHeader, gid.value))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -2,11 +2,9 @@ package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{LdapRegistrationDAO, MockAccessPolicyDAO, MockDirectoryDAO}
@@ -61,7 +59,7 @@ class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, null, Map.empty, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val policyEvaluatorService = PolicyEvaluatorService(emailDomain, Map.empty, policyDAO, directoryDAO)
-    val samRoutes = new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, UserInfo(OAuth2BearerToken(""), WorkbenchUserId(""), WorkbenchEmail(""), 0), directoryDAO, registrationDAO)
+    val samRoutes = new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, Generator.genWorkbenchUserGoogle.sample.get, directoryDAO, registrationDAO)
 
     Get("/status") ~> samRoutes.route ~> check {
       responseAs[StatusCheckResponse].ok shouldEqual false

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -1,15 +1,13 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives.reject
 import akka.stream.Materializer
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
-import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{googleServicesConfig, samRequestContext}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
@@ -22,14 +20,14 @@ import scala.concurrent.ExecutionContext
 /**
   * Created by dvoet on 7/14/17.
   */
-class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService = null)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[SamUser] = None, tosService: TosService = null)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
   extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes: server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
   def mockRegistrationDao: RegistrationDAO = registrationDAO
 }
 
-class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val userInfo: UserInfo, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[WorkbenchUser] = None, tosService: TosService)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[SamUser] = None, tosService: TosService)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
   extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes: server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
@@ -37,7 +35,7 @@ class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorS
 }
 
 object TestSamRoutes {
-  val defaultUserInfo = UserInfo(OAuth2BearerToken("accessToken"), WorkbenchUserId("user1"), WorkbenchEmail("user1@example.com"), 0)
+  val defaultUserInfo = Generator.genWorkbenchUserGoogle.sample.get
 
   object SamResourceActionPatterns {
     val readPolicies = ResourceActionPattern("read_policies", "", false)
@@ -73,7 +71,7 @@ object TestSamRoutes {
     ResourceRoleName("owner")
   )
 
-  def apply(resourceTypes: Map[ResourceTypeName, ResourceType], userInfo: UserInfo = defaultUserInfo, policyAccessDAO: Option[AccessPolicyDAO] = None, maybeDirectoryDAO: Option[MockDirectoryDAO] = None)(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext) = {
+  def apply(resourceTypes: Map[ResourceTypeName, ResourceType], user: SamUser = defaultUserInfo, policyAccessDAO: Option[AccessPolicyDAO] = None, maybeDirectoryDAO: Option[MockDirectoryDAO] = None)(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext) = {
     val dbRef = TestSupport.dbRef
     val resourceTypesWithAdmin = resourceTypes + (resourceTypeAdmin.name -> resourceTypeAdmin)
     // need to make sure MockDirectoryDAO and MockAccessPolicyDAO share the same groups
@@ -88,13 +86,13 @@ object TestSamRoutes {
     val mockUserService = new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
     val mockTosService = new TosService(directoryDAO,registrationDAO, emailDomain, TestSupport.tosConfig)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypesWithAdmin, policyDAO, directoryDAO, NoExtensions, emailDomain)
-    TestSupport.runAndWait(mockUserService.createUser(WorkbenchUser(userInfo.userId, TestSupport.genGoogleSubjectId(), userInfo.userEmail, None), samRequestContext))
+    TestSupport.runAndWait(mockUserService.createUser(user, samRequestContext))
     val allUsersGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext))
     TestSupport.runAndWait(googleDirectoryDAO.createGroup(allUsersGroup.id.toString, allUsersGroup.email))
     mockResourceService.initResourceTypes(samRequestContext).unsafeRunSync()
 
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, NoExtensions, dbRef)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, userInfo, directoryDAO, registrationDAO, tosService = mockTosService)
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, user, directoryDAO, registrationDAO, tosService = mockTosService)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -4,7 +4,6 @@ package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockDirectoryDAO, MockRegistrationDAO}
@@ -20,8 +19,8 @@ class UserRoutesV2Spec extends UserRoutesSpecHelper {
     val directoryDAO = new MockDirectoryDAO()
     val registrationDAO = new MockRegistrationDAO()
 
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), defaultUserId, defaultUserEmail, 0), directoryDAO, registrationDAO, NoExtensions)
-    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO,registrationDAO, NoExtensions, TestSupport.dbRef), null, UserInfo(OAuth2BearerToken(""), petSAUserId, petSAEmail, 0), directoryDAO, registrationDAO, NoExtensions)
+    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO, registrationDAO, NoExtensions, TestSupport.dbRef), null, defaultUser, directoryDAO, registrationDAO, NoExtensions)
+    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)), new StatusService(directoryDAO,registrationDAO, NoExtensions, TestSupport.dbRef), null, petSAUser, directoryDAO, registrationDAO, NoExtensions)
     testCode(samRoutes, SARoutes)
   }
 
@@ -44,7 +43,7 @@ class UserRoutesV2Spec extends UserRoutesSpecHelper {
     Get("/register/user/v2/self/info") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
-    val (user, samDep, routes) = createTestUser(googSubjectId = Some(googleSubjectId))
+    val (user, samDep, routes) = createTestUser()
     Get("/register/user/v2/self/info") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[UserStatusInfo] shouldEqual UserStatusInfo(user.id.value, user.email.value, true, true)
@@ -56,7 +55,7 @@ class UserRoutesV2Spec extends UserRoutesSpecHelper {
     Get("/register/user/v2/self/diagnostics") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
-    val (user, samDep, routes) = createTestUser(googSubjectId = Some(googleSubjectId), tosEnabled = true, tosAccepted = true)
+    val (user, samDep, routes) = createTestUser(tosEnabled = true, tosAccepted = true)
 
     Get("/register/user/v2/self/diagnostics") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAOSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.unsafe.implicits.global
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool, LDAPException}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.config.DirectoryConfig
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
@@ -38,8 +38,7 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
 
 
   "LdapGroupDirectoryDAO"  should "create, read, delete users" in {
-    val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"), None)
+    val user = Generator.genWorkbenchUserGoogle.sample.get
 
     assertResult(None) {
       dao.loadUser(user.id, samRequestContext).unsafeRunSync()
@@ -61,12 +60,11 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "create, load, delete pet service accounts" in {
-    val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"), None)
+    val user = Generator.genWorkbenchUserGoogle.sample.get
     val serviceAccountUniqueId = ServiceAccountSubjectId(UUID.randomUUID().toString)
     val serviceAccount = ServiceAccount(serviceAccountUniqueId, WorkbenchEmail("foo@bar.com"), ServiceAccountDisplayName(""))
     val project = GoogleProject("testproject")
-    val petServiceAccount = PetServiceAccount(PetServiceAccountId(userId, project), serviceAccount)
+    val petServiceAccount = PetServiceAccount(PetServiceAccountId(user.id, project), serviceAccount)
 
     assertResult(user) {
       dao.createUser(user, samRequestContext).unsafeRunSync()
@@ -92,8 +90,7 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "succeed if the user has been created" in {
-    val userId = WorkbenchUserId(UUID.randomUUID().toString)
-    val user = WorkbenchUser(userId, None, WorkbenchEmail("foo@bar.com"), None)
+    val user = Generator.genWorkbenchUserGoogle.sample.get
 
     assertResult(None) {
       dao.loadUser(user.id, samRequestContext).unsafeRunSync()
@@ -109,7 +106,7 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "disable users when deleting them" in {
-    val user = WorkbenchUser(WorkbenchUserId(UUID.randomUUID().toString), None, WorkbenchEmail("foo@bar.com"), None)
+    val user = Generator.genWorkbenchUserGoogle.sample.get
 
     assertResult(user) {
       dao.createUser(user, samRequestContext).unsafeRunSync()
@@ -133,7 +130,7 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "throw an exception when trying to overwrite an existing googleSubjectId" in {
-    val user = WorkbenchUser(WorkbenchUserId(UUID.randomUUID().toString), Some(GoogleSubjectId("existingGoogleSubjectId")), WorkbenchEmail("foo@bar.com"), None)
+    val user = Generator.genWorkbenchUserGoogle.sample.get
 
     assertResult(user) {
       dao.createUser(user, samRequestContext).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -182,12 +182,12 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
 
   // current implementation returns only the WorkbenchUserIds in this policy. it does not fully mock the behavior of LdapAccessPolicyDAO.
   // this function previously just returned an empty set and this is sufficient for the test I'm using it in (as of 10/25/18), so good enough for now
-  override def listFlattenedPolicyMembers(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[WorkbenchUser]] = IO {
+  override def listFlattenedPolicyMembers(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[SamUser]] = IO {
     val members = policies.collect {
       case (`policyIdentity`, policy: AccessPolicy) => policy.members
     }
     members.flatten.collect {
-      case u: WorkbenchUserId => WorkbenchUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None)
+      case u: WorkbenchUserId => SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false)
     }.toSet
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockRegistrationDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockRegistrationDAO.scala
@@ -2,8 +2,9 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.errorReportSource
-import org.broadinstitute.dsde.workbench.model.{AzureB2CId, ErrorReport, GoogleSubjectId, PetServiceAccount, PetServiceAccountId, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchSubject, WorkbenchUser, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{AzureB2CId, ErrorReport, GoogleSubjectId, PetServiceAccount, PetServiceAccountId, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchSubject, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.ConnectionType.ConnectionType
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import scala.collection.concurrent.TrieMap
@@ -12,7 +13,7 @@ import scala.collection.mutable
 class MockRegistrationDAO extends RegistrationDAO {
   private val enabledUsers: mutable.Map[WorkbenchSubject, Unit] = new TrieMap()
 
-  private val users: mutable.Map[WorkbenchUserId, WorkbenchUser] = new TrieMap()
+  private val users: mutable.Map[WorkbenchUserId, SamUser] = new TrieMap()
   private val usersWithEmails: mutable.Map[WorkbenchEmail, WorkbenchUserId] = new TrieMap()
   private val usersWithGoogleSubjectIds: mutable.Map[GoogleSubjectId, WorkbenchSubject] = new TrieMap()
 
@@ -21,7 +22,7 @@ class MockRegistrationDAO extends RegistrationDAO {
 
   override def getConnectionType(): ConnectionType = ConnectionType.LDAP
 
-  override def createUser(user: WorkbenchUser, samRequestContext: SamRequestContext): IO[WorkbenchUser] =
+  override def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] =
     if (users.keySet.contains(user.id)) {
       IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"user ${user.id} already exists")))
     } else {
@@ -34,7 +35,7 @@ class MockRegistrationDAO extends RegistrationDAO {
 
   override def createEnabledUsersGroup(samRequestContext: SamRequestContext): IO[Unit] = IO.unit //the enabledUsers group is instantiated with this mock class, so no-op here
 
-  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUser]] = IO {
+  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = IO {
     users.get(userId)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -41,7 +41,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
 
   "GET /api/google/v1/user/proxyGroup/{email}" should "return a user's proxy group" in {
     val (user, _, routes) = createTestUser()
-    Get(s"/api/google/v1/user/proxyGroup/$defaultUserEmail") ~> routes.route ~> check {
+    Get(s"/api/google/v1/user/proxyGroup/${user.email}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
       response shouldBe WorkbenchEmail(s"PROXY_${user.id}@${googleServicesConfig.appsDomain}")
@@ -184,13 +184,13 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   "GET /api/google/v1/petServiceAccount/{project}/{userEmail}" should "200 with a key" in {
     val (defaultUserInfo, samRoutes, expectedJson) = setupPetSATest()
 
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty, None)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty, None)
     Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
 
     // create a pet service account key
-    Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.userEmail.value}") ~> samRoutes.route ~> check {
+    Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.email.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
       response shouldEqual(expectedJson)
@@ -200,7 +200,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   it should "404 when user does not exist" in {
     val (defaultUserInfo, samRoutes, _) = setupPetSATest()
 
-    val members = AccessPolicyMembership(Set(defaultUserInfo.userEmail), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty, None)
+    val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(GoogleExtensions.getPetPrivateKeyAction), Set.empty, None)
     Put(s"/api/resource/${CloudExtensions.resourceTypeName.value}/${GoogleExtensions.resourceId.value}/policies/foo", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -84,9 +84,9 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     resource
   }
 
-  private def makeGroup(groupName: String, managedGroupService: ManagedGroupService, userInfo: SamUser = dummyUser) = {
+  private def makeGroup(groupName: String, managedGroupService: ManagedGroupService, samUser: SamUser = dummyUser) = {
     makeResourceType(managedGroupResourceType)
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), userInfo, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), samUser, samRequestContext = samRequestContext))
   }
 
   before {
@@ -311,7 +311,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(adminUser.email)
   }
 
-  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: SamUser): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, userInfo, samRequestContext))
+  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, samUser, samRequestContext))
 
   "ManagedGroupService listGroups" should "return the list of groups that passed user belongs to" in {
     // Setup multiple managed groups owned by different users.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -3,11 +3,10 @@ package org.broadinstitute.dsde.workbench.sam.service
 import java.net.URI
 import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.unsafe.implicits.{global => globalEc}
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -52,7 +51,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   private val resourceService = new ResourceService(resourceTypeMap, policyEvaluatorService, policyDAO, dirDAO, NoExtensions, testDomain)
   private val managedGroupService = new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, policyDAO, dirDAO, NoExtensions, testDomain)
 
-  val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
+  val dummyUser = Generator.genWorkbenchUserBoth.sample.get
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -80,19 +79,19 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
 
     assertPoliciesOnResource(resource.fullyQualifiedId, expectedPolicies = LazyList(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName))
 
-    dirDAO.listFlattenedGroupMembers(WorkbenchGroupName(groupId), samRequestContext).unsafeRunSync() should contain theSameElementsAs(Set(dummyUserInfo.userId))
+    dirDAO.listFlattenedGroupMembers(WorkbenchGroupName(groupId), samRequestContext).unsafeRunSync() should contain theSameElementsAs(Set(dummyUser.id))
 
     resource
   }
 
-  private def makeGroup(groupName: String, managedGroupService: ManagedGroupService, userInfo: UserInfo = dummyUserInfo) = {
+  private def makeGroup(groupName: String, managedGroupService: ManagedGroupService, userInfo: SamUser = dummyUser) = {
     makeResourceType(managedGroupResourceType)
     runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), userInfo, samRequestContext = samRequestContext))
   }
 
   before {
     clearDatabase()
-    dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, TestSupport.genGoogleSubjectId(), dummyUserInfo.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(dummyUser, samRequestContext).unsafeRunSync()
   }
 
   protected def clearDatabase(): Unit = TestSupport.truncateAll
@@ -130,7 +129,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     val groupName = "uniqueName"
     assertMakeGroup(groupName)
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), dummyUserInfo, samRequestContext = samRequestContext))
+      runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext))
     }
     exception.getMessage should include ("A resource of this type and name already exists")
     managedGroupService.loadManagedGroup(resourceId, samRequestContext).unsafeRunSync() shouldEqual None
@@ -207,7 +206,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
 
   "ManagedGroupService listPolicyMemberEmails" should "return a list of email addresses for the groups admin policy" in {
     val managedGroup = assertMakeGroup()
-    managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(dummyUserInfo.userEmail)
+    managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(dummyUser.email)
     managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.memberPolicyName, samRequestContext).unsafeRunSync() shouldEqual Set.empty
   }
 
@@ -218,8 +217,8 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   "ManagedGroupService.overwritePolicyMemberEmails" should "permit overwriting the admin policy" in {
-    val dummyAdmin = WorkbenchUser(dummyUserInfo.userId, None, dummyUserInfo.userEmail, None)
-    val otherAdmin = WorkbenchUser(WorkbenchUserId("admin2"), None, WorkbenchEmail("admin2@foo.test"), None)
+    val dummyAdmin = dummyUser
+    val otherAdmin = Generator.genWorkbenchUserBoth.sample.get
     val someGroupEmail = WorkbenchEmail("someGroup@some.org")
     dirDAO.createUser(otherAdmin, samRequestContext).unsafeRunSync()
     val managedGroup = assertMakeGroup()
@@ -241,17 +240,16 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
 
   it should "throw an exception if any of the email addresses do not match an existing subject" in {
     val managedGroup = assertMakeGroup()
-    val badAdmin = WorkbenchUser(WorkbenchUserId("admin2"), None, WorkbenchEmail("admin2@foo.test"), None)
 
     intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(managedGroupService.overwritePolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, Set(badAdmin.email), samRequestContext))
+      runAndWait(managedGroupService.overwritePolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, Set(WorkbenchEmail("admin2@foo.test")), samRequestContext))
     }
   }
 
   it should "permit overwriting the member policy" in {
     val managedGroup = assertMakeGroup()
 
-    val someUser = WorkbenchUser(WorkbenchUserId("someUser"), None, WorkbenchEmail("someUser@foo.test"), None)
+    val someUser = Generator.genWorkbenchUserBoth.sample.get
     val someGroupEmail = WorkbenchEmail("someGroup@some.org")
     dirDAO.createUser(someUser, samRequestContext).unsafeRunSync()
     dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("someGroup"), Set.empty, someGroupEmail), samRequestContext = samRequestContext).unsafeRunSync()
@@ -265,13 +263,13 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   "ManagedGroupService addSubjectToPolicy" should "successfully add the subject to the existing policy for the group" in {
-    val adminUser = WorkbenchUser(dummyUserInfo.userId, None, dummyUserInfo.userEmail, None)
+    val adminUser = dummyUser
 
     val managedGroup = assertMakeGroup()
 
     managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(adminUser.email)
 
-    val someUser = WorkbenchUser(WorkbenchUserId("someUser"), None, WorkbenchEmail("someUser@foo.test"), None)
+    val someUser = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(someUser, samRequestContext).unsafeRunSync()
     runAndWait(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, ManagedGroupService.adminPolicyName, someUser.id, samRequestContext))
 
@@ -280,7 +278,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "succeed without changing if the email address is already in the policy" in {
-    val adminUser = WorkbenchUser(dummyUserInfo.userId, None, dummyUserInfo.userEmail, None)
+    val adminUser = dummyUser
 
     val managedGroup = assertMakeGroup()
 
@@ -290,7 +288,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   "ManagedGroupService removeSubjectFromPolicy" should "successfully remove the subject from the policy for the group" in {
-    val adminUser = WorkbenchUser(dummyUserInfo.userId, None, dummyUserInfo.userEmail, None)
+    val adminUser = dummyUser
 
     val managedGroup = assertMakeGroup()
 
@@ -302,7 +300,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
   }
 
   it should "not do anything if the subject is not a member of the policy" in {
-    val adminUser = WorkbenchUser(dummyUserInfo.userId, None, dummyUserInfo.userEmail, None)
+    val adminUser = dummyUser
 
     val managedGroup = assertMakeGroup()
 
@@ -313,7 +311,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     managedGroupService.listPolicyMemberEmails(managedGroup.resourceId, ManagedGroupService.adminPolicyName, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(adminUser.email)
   }
 
-  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: UserInfo): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, userInfo, samRequestContext))
+  private def makeResource(resourceType: ResourceType, resourceId: ResourceId, userInfo: SamUser): Resource = runAndWait(resourceService.createResource(resourceType, resourceId, userInfo, samRequestContext))
 
   "ManagedGroupService listGroups" should "return the list of groups that passed user belongs to" in {
     // Setup multiple managed groups owned by different users.
@@ -327,10 +325,10 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     val resService = new ResourceService(resTypes, policyEvaluatorService, policyDAO, dirDAO, NoExtensions, testDomain)
     val mgService = new ManagedGroupService(resService, policyEvaluatorService, resTypes, policyDAO, dirDAO, NoExtensions, testDomain)
 
-    val user1 = UserInfo(OAuth2BearerToken("token1"), WorkbenchUserId("userId1"), WorkbenchEmail("user1@company.com"), 0)
-    val user2 = UserInfo(OAuth2BearerToken("token2"), WorkbenchUserId("userId2"), WorkbenchEmail("user2@company.com"), 0)
-    dirDAO.createUser(WorkbenchUser(user1.userId, None, user1.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user2.userId, None, user2.userEmail, None), samRequestContext).unsafeRunSync()
+    val user1 = Generator.genWorkbenchUserBoth.sample.get
+    val user2 = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(user1, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user2, samRequestContext).unsafeRunSync()
 
     val user1Groups = Set("foo", "bar", "baz")
     val user2Groups = Set("qux", "quux")
@@ -340,13 +338,13 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     val user1Memberships = Set(user2Groups.head)
     val user2Memberships = Set(user1Groups.head)
 
-    user1Memberships.foreach(s => runAndWait(mgService.addSubjectToPolicy(ResourceId(s), ManagedGroupService.memberPolicyName, user1.userId, samRequestContext)))
-    user2Memberships.foreach(s => runAndWait(mgService.addSubjectToPolicy(ResourceId(s), ManagedGroupService.memberPolicyName, user2.userId, samRequestContext)))
+    user1Memberships.foreach(s => runAndWait(mgService.addSubjectToPolicy(ResourceId(s), ManagedGroupService.memberPolicyName, user1.id, samRequestContext)))
+    user2Memberships.foreach(s => runAndWait(mgService.addSubjectToPolicy(ResourceId(s), ManagedGroupService.memberPolicyName, user2.id, samRequestContext)))
 
     // let everyone notify admins
     (user1Groups ++ user2Groups).foreach { g =>
-      runAndWait(mgService.addSubjectToPolicy(ResourceId(g), ManagedGroupService.adminNotifierPolicyName, user1.userId, samRequestContext))
-      runAndWait(mgService.addSubjectToPolicy(ResourceId(g), ManagedGroupService.adminNotifierPolicyName, user2.userId, samRequestContext))
+      runAndWait(mgService.addSubjectToPolicy(ResourceId(g), ManagedGroupService.adminNotifierPolicyName, user1.id, samRequestContext))
+      runAndWait(mgService.addSubjectToPolicy(ResourceId(g), ManagedGroupService.adminNotifierPolicyName, user2.id, samRequestContext))
     }
 
     val user1Resources = Set("quuz", "corge")
@@ -358,12 +356,12 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     val user1ExpectedAdmin = user1Groups.map(s => ManagedGroupMembershipEntry(ResourceId(s), ManagedGroupService.adminRoleName, WorkbenchEmail(s"$s@example.com")))
     val user1ExpectedMember = user1Memberships.map(s => ManagedGroupMembershipEntry(ResourceId(s), ManagedGroupService.memberRoleName, WorkbenchEmail(s"$s@example.com")))
     val user1ExpectedGroups = user1ExpectedAdmin ++ user1ExpectedMember
-    mgService.listGroups(user1.userId, samRequestContext).unsafeRunSync() should contain theSameElementsAs user1ExpectedGroups
+    mgService.listGroups(user1.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs user1ExpectedGroups
 
     val user2ExpectedAdmin = user2Groups.map(s => ManagedGroupMembershipEntry(ResourceId(s), ManagedGroupService.adminRoleName, WorkbenchEmail(s"$s@example.com")))
     val user2ExpectedMember = user2Memberships.map(s => ManagedGroupMembershipEntry(ResourceId(s), ManagedGroupService.memberRoleName, WorkbenchEmail(s"$s@example.com")))
     val user2ExpectedGroups = user2ExpectedAdmin ++ user2ExpectedMember
-    mgService.listGroups(user2.userId, samRequestContext).unsafeRunSync() should contain theSameElementsAs user2ExpectedGroups
+    mgService.listGroups(user2.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs user2ExpectedGroups
   }
 
   "ManagedGroupService getAccessInstructions" should "return access instructions when a group has them set" in {
@@ -400,7 +398,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     makeResourceType(managedGroupResourceType)
 
     val instructions = "Test Instructions"
-    val managedGroup = runAndWait(managedGroupService.createManagedGroup(ResourceId(resourceId.value), dummyUserInfo, Option(instructions), samRequestContext))
+    val managedGroup = runAndWait(managedGroupService.createManagedGroup(ResourceId(resourceId.value), dummyUser, Option(instructions), samRequestContext))
 
     managedGroupService.getAccessInstructions(managedGroup.resourceId, samRequestContext).unsafeRunSync().getOrElse(None) shouldEqual instructions
 
@@ -416,8 +414,8 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
 
     assertMakeGroup(groupId = resourceId.value, managedGroupService = testManagedGroupService)
 
-    val requester = dirDAO.createUser(WorkbenchUser(WorkbenchUserId("userId1"), Some(GoogleSubjectId("not the user id")), WorkbenchEmail("user1@company.com"), None), samRequestContext).unsafeRunSync()
-    val adminGoogleSubjectId = WorkbenchUserId(dirDAO.loadUser(dummyUserInfo.userId, samRequestContext).unsafeRunSync().flatMap(_.googleSubjectId).getOrElse(fail("could not find admin google subject id")).value)
+    val requester = dirDAO.createUser(Generator.genWorkbenchUserBoth.sample.get, samRequestContext).unsafeRunSync()
+    val adminGoogleSubjectId = WorkbenchUserId(dirDAO.loadUser(dummyUser.id, samRequestContext).unsafeRunSync().flatMap(_.googleSubjectId).getOrElse(fail("could not find admin google subject id")).value)
 
     val expectedNotificationMessages = Set(
       Notifications.GroupAccessRequestNotification(
@@ -436,7 +434,7 @@ class ManagedGroupServiceSpec extends AnyFlatSpec with Matchers with TestSupport
     assertMakeGroup(groupId = resourceId.value)
     managedGroupService.setAccessInstructions(resourceId, "instructions", samRequestContext).unsafeRunSync()
     val error = intercept[WorkbenchExceptionWithErrorReport] {
-      managedGroupService.requestAccess(resourceId, dummyUserInfo.userId, samRequestContext).unsafeRunSync()
+      managedGroupService.requestAccess(resourceId, dummyUser.id, samRequestContext).unsafeRunSync()
     }
     error.errorReport.statusCode should be(Some(StatusCodes.BadRequest))
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -2,14 +2,13 @@ package org.broadinstitute.dsde.workbench.sam.service
 
 import java.net.URI
 import java.util.UUID
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
 import cats.implicits._
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.Generator.{genPolicy, genResourceTypeNameExcludeManagedGroup, genUserInfo, _}
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.Generator._
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -34,8 +33,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     super.beforeEach()
   }
 
-  private[service] val dummyUserInfo =
-    UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
+  private[service] val dummyUser = Generator.genWorkbenchUserBoth.sample.get
 
   private[service] val defaultResourceTypeActions = Set(
     ResourceAction("alter_policies"),
@@ -83,7 +81,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     constrainableReaderRoleName
   )
   private[service] val constrainablePolicyMembership =
-    AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(constrainableViewAction), Set(constrainableReaderRoleName), None)
+    AccessPolicyMembership(Set(dummyUser.email), Set(constrainableViewAction), Set(constrainableReaderRoleName), None)
 
   private[service] val managedGroupResourceType = configResourceTypes.getOrElse(
     ResourceTypeName("managed-group"),
@@ -137,7 +135,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   def setup(): IO[Unit] = {
     for{
       _ <- clearDatabase()
-      _ <- dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, TestSupport.genGoogleSubjectId(), dummyUserInfo.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(dummyUser, samRequestContext)
     } yield ()
   }
 
@@ -145,10 +143,10 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
 
   private[service] def savePolicyMembers(policy: AccessPolicy) = {
     policy.members.toList.traverse {
-      case u: WorkbenchUserId => dirDAO.createUser(WorkbenchUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None), samRequestContext).recoverWith {
-        case _: WorkbenchException => IO.pure(WorkbenchUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None))
+      case u: WorkbenchUserId => dirDAO.createUser(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false), samRequestContext).recoverWith {
+        case _: WorkbenchException => IO.pure(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false))
       }
-      case g: WorkbenchGroupName => managedGroupService.createManagedGroup(ResourceId(g.value), dummyUserInfo, samRequestContext = samRequestContext).recoverWith {
+      case g: WorkbenchGroupName => managedGroupService.createManagedGroup(ResourceId(g.value), dummyUser, samRequestContext = samRequestContext).recoverWith {
         case _: WorkbenchException => IO.pure(Resource(defaultResourceType.name, ResourceId(g.value), Set.empty))
       }
       case _ => IO.unit
@@ -156,13 +154,13 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   "hasPermission" should "return true if given action is granted through membership in another policy" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val action = ResourceAction("weirdAction")
 
     val resource = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
 
     val samplePolicy = genPolicy.sample.get
-    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.id)(samplePolicy)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
 
     val resource2 = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
@@ -175,9 +173,9 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
 
     val res = for{
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
-      _ <- resource2.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
+      _ <- resource2.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- savePolicyMembers(policy2)
 
@@ -189,7 +187,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
       _ <- policyDAO.createPolicy(policy, samRequestContext)
       _ <- policyDAO.createPolicy(policy2, samRequestContext)
 
-      r <- service.policyEvaluatorService.hasPermission(policy2.id.resource, action, user.userId, samRequestContext)
+      r <- service.policyEvaluatorService.hasPermission(policy2.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe true
     }
@@ -198,23 +196,23 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return false if given action is not allowed for a user" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = genPolicy.sample.get
     val action = ResourceAction("weirdAction")
     val resource = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
-    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.id)(samplePolicy)
     val policyExcludeAction = AccessPolicy.actions.set(samplePolicy.actions - action)(policyWithUser)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyExcludeAction)
 
     val res = for{
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(defaultResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe false
     }
@@ -223,23 +221,23 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return false if user is not a member of the resource" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = genPolicy.sample.get
     val action = genResourceAction.sample.get
     val resource = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
-    val policyWithUser = AccessPolicy.members.set(samplePolicy.members - user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.set(samplePolicy.members - user.id)(samplePolicy)
     val policyExcludeAction = AccessPolicy.actions.set(samplePolicy.actions - action)(policyWithUser)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyExcludeAction)
 
     val res = for{
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(defaultResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe(false)
     }
@@ -248,22 +246,22 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return true if given action is allowed for a user and resource is not constrained by auth domains" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = genPolicy.sample.get
     val action = genResourceAction.sample.get
     val resource = genResource.sample.get.copy(authDomain = Set.empty, resourceTypeName = defaultResourceType.name)
-    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.id)(samplePolicy)
     val policyWithAction = AccessPolicy.actions.modify(_ + action)(policyWithUser)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithAction)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
       _ <- policyDAO.createResourceType(defaultResourceType, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- service.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe(true)
     }
@@ -272,23 +270,23 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return true if given action is allowed for a user, action is constrained by auth domains, user is a member of all required auth domains" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = constrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
-    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.id)(samplePolicy)
     val policyWithResource = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), user, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe(true)
     }
@@ -297,23 +295,23 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return true if given action is allowed for a user, action is constrained by auth domains, resource has no auth domain" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = constrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name, authDomain = Set.empty)
-    val policyWithUser = AccessPolicy.members.modify(_ + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + user.id)(samplePolicy)
     val policyWithResource = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe(true)
     }
@@ -322,7 +320,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return false if given action is NOT allowed for a user, action is constrained by auth domains, user is a member of required auth domains" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = constrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name, authDomain = Set(genWorkbenchGroupName.sample.get))
@@ -331,14 +329,14 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), user, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.userId, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, user.id, samRequestContext)
     } yield {
       r shouldBe(false)
     }
@@ -347,25 +345,25 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return false if given action is allowed for a user, action is constrained by auth domains, user is NOT a member of auth domain" in {
-    val user = genUserInfo.sample.get
-    val probeUser = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
+    val probeUser = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = constrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
-    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.id)(samplePolicy)
     val policyWithResource = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(probeUser.userId, TestSupport.genGoogleSubjectId(), probeUser.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- dirDAO.createUser(probeUser, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), user, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, probeUser.userId, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, probeUser.id, samRequestContext)
     } yield {
       r shouldBe(false)
     }
@@ -374,25 +372,25 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return true if given action is allowed for a user, action is NOT constrained by auth domains, user is not a member of auth domain" in {
-    val user = genUserInfo.sample.get
-    val probeUser = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
+    val probeUser = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = unconstrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
-    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.id)(samplePolicy)
     val policyWithResource = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(probeUser.userId, TestSupport.genGoogleSubjectId(), probeUser.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- dirDAO.createUser(probeUser, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), user, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, probeUser.userId, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermission(policy.id.resource, action, probeUser.id, samRequestContext)
     } yield {
       r shouldBe(true)
     }
@@ -401,25 +399,25 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   "hasPermissionByUserEmail" should "return true if given action is allowed for a user, action is NOT constrained by auth domains, user is not a member of auth domain" in {
-    val user = genUserInfo.sample.get
-    val probeUser = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
+    val probeUser = genWorkbenchUserBoth.sample.get
     val samplePolicy = SamLenses.resourceTypeNameInAccessPolicy.modify(_ => constrainableResourceType.name)(genPolicy.sample.get)
     val action = unconstrainableViewAction
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
-    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.modify(_ + probeUser.id)(samplePolicy)
     val policyWithResource = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyWithUser)
     val policy = AccessPolicy.actions.modify(_ + action)(policyWithResource).copy(roles = Set.empty)
 
     val res = for{
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(probeUser.userId, TestSupport.genGoogleSubjectId(), probeUser.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- dirDAO.createUser(probeUser, samRequestContext)
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
       _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), user, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(constrainableResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.hasPermissionByUserEmail(policy.id.resource, action, probeUser.userEmail, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.hasPermissionByUserEmail(policy.id.resource, action, probeUser.email, samRequestContext)
     } yield {
       r shouldBe(true)
     }
@@ -428,23 +426,23 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "return false if given action is not allowed for a user" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val samplePolicy = genPolicy.sample.get
     val action = ResourceAction("weirdAction")
     val resource = genResource.sample.get.copy(resourceTypeName = defaultResourceType.name)
-    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.userId)(samplePolicy)
+    val policyWithUser = AccessPolicy.members.set(samplePolicy.members + user.id)(samplePolicy)
     val policyExcludeAction = AccessPolicy.actions.set(samplePolicy.actions - action)(policyWithUser)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(policyExcludeAction)
 
     val res = for{
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(defaultResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
       _ <- policyDAO.createPolicy(policy, samRequestContext)
-      r <- service.policyEvaluatorService.hasPermissionByUserEmail(policy.id.resource, action, user.userEmail, samRequestContext)
+      r <- service.policyEvaluatorService.hasPermissionByUserEmail(policy.id.resource, action, user.email, samRequestContext)
     } yield {
       r shouldBe false
     }
@@ -462,7 +460,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
 
     val res = for{
       _ <- policyDAO.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       _ <- policyDAO.createResourceType(defaultResourceType, samRequestContext)
       _ <- policyDAO.createResource(resource, samRequestContext)
@@ -485,16 +483,16 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
       _ <- service.createResourceType(defaultResourceType, samRequestContext)
       _ <- service.createResourceType(otherResourceType, samRequestContext)
 
-      _ <- service.createResource(defaultResourceType, resource1.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(defaultResourceType, resource2.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(otherResourceType, resource3.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(otherResourceType, resource4.resourceId, dummyUserInfo, samRequestContext)
+      _ <- service.createResource(defaultResourceType, resource1.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(defaultResourceType, resource2.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(otherResourceType, resource3.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(otherResourceType, resource4.resourceId, dummyUser, samRequestContext)
 
-      _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("in-it"), resource1, AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("alter_policies")), Set.empty), samRequestContext)
+      _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("in-it"), resource1, AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("alter_policies")), Set.empty), samRequestContext)
       _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("not-in-it"), resource1, AccessPolicyMembership(Set.empty, Set(ResourceAction("non_owner_action")), Set.empty), samRequestContext)
-      _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("in-it"), resource3, AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("alter_policies")), Set.empty), samRequestContext)
+      _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("in-it"), resource3, AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("alter_policies")), Set.empty), samRequestContext)
       _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("not-in-it"), resource3, AccessPolicyMembership(Set.empty, Set(ResourceAction("non_owner_action")), Set.empty), samRequestContext)
-      r <- service.policyEvaluatorService.listUserResources(defaultResourceType.name, dummyUserInfo.userId, samRequestContext)
+      r <- service.policyEvaluatorService.listUserResources(defaultResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       r should contain theSameElementsAs Set(
         UserResourcesResponse(resource1.resourceId, RolesAndActions(Set(defaultResourceType.ownerRoleName), Set(ResourceAction("alter_policies"))), RolesAndActions.empty, RolesAndActions.empty, Set.empty, Set.empty),
@@ -513,10 +511,10 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)  // make sure managed groups in auth domain set are created. dummyUserInfo will be member of the created resourceId
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, dummyUserInfo.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       val expected = Set(UserResourcesResponse(resource.resourceId, RolesAndActions.fromPolicyMembership(constrainablePolicyMembership), RolesAndActions.empty, RolesAndActions.empty, Set.empty, Set.empty))
       r should contain theSameElementsAs expected
@@ -532,10 +530,10 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)  // make sure managed groups in auth domain set are created. dummyUserInfo will be member of the created resourceId
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, dummyUserInfo.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       val expected = Set(UserResourcesResponse(resource.resourceId, RolesAndActions.fromPolicyMembership(constrainablePolicyMembership), RolesAndActions.empty, RolesAndActions.empty, resource.authDomain, Set.empty))
       r should contain theSameElementsAs expected
@@ -545,7 +543,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
   }
 
   it should "list required authDomains and authDomains user is not a member of if constrainable" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(genPolicy.sample.get).copy(roles = Set.empty)
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
@@ -553,13 +551,13 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- constrainableService.createPolicy(policy.id, policy.members + user.userId, policy.roles, policy.actions, Set.empty, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, user.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- constrainableService.createPolicy(policy.id, policy.members + user.id, policy.roles, policy.actions, Set.empty, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserResources(constrainableResourceType.name, user.id, samRequestContext)
     } yield {
       val expected = Set(UserResourcesResponse(resource.resourceId, RolesAndActions.fromPolicy(policy), RolesAndActions.empty, RolesAndActions.empty, resource.authDomain, resource.authDomain))
       r should contain theSameElementsAs expected
@@ -581,16 +579,16 @@ class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
       _ <- service.createResourceType(defaultResourceType, samRequestContext)
       _ <- service.createResourceType(otherResourceType, samRequestContext)
 
-      _ <- service.createResource(defaultResourceType, resource1.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(defaultResourceType, resource2.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(otherResourceType, resource3.resourceId, dummyUserInfo, samRequestContext)
-      _ <- service.createResource(otherResourceType, resource4.resourceId, dummyUserInfo, samRequestContext)
+      _ <- service.createResource(defaultResourceType, resource1.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(defaultResourceType, resource2.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(otherResourceType, resource3.resourceId, dummyUser, samRequestContext)
+      _ <- service.createResource(otherResourceType, resource4.resourceId, dummyUser, samRequestContext)
 
-      _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("in-it"), resource1, AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
+      _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("in-it"), resource1, AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
       _ <- service.overwritePolicy(defaultResourceType, AccessPolicyName("not-in-it"), resource1, AccessPolicyMembership(Set.empty, Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
-      _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("in-it"), resource3, AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
+      _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("in-it"), resource3, AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
       _ <- service.overwritePolicy(otherResourceType, AccessPolicyName("not-in-it"), resource3, AccessPolicyMembership(Set.empty, Set(ResourceAction("alter_policies")), Set.empty, None), samRequestContext)
-      r <- service.policyEvaluatorService.listUserAccessPolicies(defaultResourceType.name, dummyUserInfo.userId, samRequestContext)
+      r <- service.policyEvaluatorService.listUserAccessPolicies(defaultResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       r should contain theSameElementsAs Set(
         UserPolicyResponse(resource1.resourceId, AccessPolicyName(defaultResourceType.ownerRoleName.value), Set.empty, Set.empty, false),
@@ -610,10 +608,10 @@ class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)  // make sure managed groups in auth domain set are created. dummyUserInfo will be member of the created resourceId
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUserInfo.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, Set.empty, Set.empty, false))
       r shouldBe(expected)
@@ -630,10 +628,10 @@ class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)  // make sure managed groups in auth domain set are created. dummyUserInfo will be member of the created resourceId
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUserInfo.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, dummyUser.id, samRequestContext)
     } yield {
       val expected = Set(UserPolicyResponse(resource.resourceId, viewPolicyName, resource.authDomain, Set.empty, false))
       r shouldBe(expected)
@@ -643,7 +641,7 @@ class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
   }
 
   it should "list required authDomains and authDomains user is not a member of if constrainable" in {
-    val user = genUserInfo.sample.get
+    val user = genWorkbenchUserBoth.sample.get
     val resource = genResource.sample.get.copy(resourceTypeName = constrainableResourceType.name)
     val policy = SamLenses.resourceIdentityAccessPolicy.set(resource.fullyQualifiedId)(genPolicy.sample.get).copy(roles = Set.empty)
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
@@ -651,13 +649,13 @@ class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
     val res = for{
       _ <- constrainableService.createResourceType(constrainableResourceType, samRequestContext)
       _ <- constrainableService.createResourceType(managedGroupResourceType, samRequestContext)
-      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUserInfo, samRequestContext = samRequestContext))
+      _ <- resource.authDomain.toList.traverse(a => managedGroupService.createManagedGroup(ResourceId(a.value), dummyUser, samRequestContext = samRequestContext))
       _ <- savePolicyMembers(policy)
       // create resource that dummyUserInfo is a member of for constrainableResourceType
-      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUserInfo.userId, samRequestContext)
-      _ <- dirDAO.createUser(WorkbenchUser(user.userId, TestSupport.genGoogleSubjectId(), user.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext)
-      _ <- constrainableService.createPolicy(policy.id, policy.members + user.userId, policy.roles, policy.actions, Set.empty, samRequestContext)
-      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, user.userId, samRequestContext)
+      _ <- constrainableService.createResource(constrainableResourceType, resource.resourceId, Map(viewPolicyName -> constrainablePolicyMembership), resource.authDomain, None, dummyUser.id, samRequestContext)
+      _ <- dirDAO.createUser(user, samRequestContext)
+      _ <- constrainableService.createPolicy(policy.id, policy.members + user.id, policy.roles, policy.actions, Set.empty, samRequestContext)
+      r <- constrainableService.policyEvaluatorService.listUserAccessPolicies(constrainableResourceType.name, user.id, samRequestContext)
     } yield {
       val expected = Set(UserPolicyResponse(resource.resourceId, policy.id.accessPolicyName, resource.authDomain, resource.authDomain, false))
       r shouldBe(expected)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.sam.service
 import java.net.URI
 import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
@@ -12,7 +11,7 @@ import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam
 import org.broadinstitute.dsde.workbench.sam.Generator._
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.resourceTypeReader
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -51,7 +50,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
   private val ownerRoleName = ResourceRoleName("owner")
 
-  private val dummyUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("userid"), WorkbenchEmail("user@company.com"), 0)
+  private val dummyUser = Generator.genWorkbenchUserBoth.sample.get
 
   private val defaultResourceTypeActions = Set(ResourceAction("alter_policies"), ResourceAction("delete"), ResourceAction("read_policies"), ResourceAction("view"), ResourceAction("non_owner_action"))
   private val defaultResourceTypeActionPatterns = Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.delete, SamResourceActionPatterns.readPolicies, ResourceActionPattern("view", "", false), ResourceActionPattern("non_owner_action", "", false))
@@ -77,7 +76,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     Set(ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)),
     constrainableReaderRoleName
   )
-  private val constrainablePolicyMembership = AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(constrainableViewAction), Set(constrainableReaderRoleName), None)
+  private val constrainablePolicyMembership = AccessPolicyMembership(Set(dummyUser.email), Set(constrainableViewAction), Set(constrainableReaderRoleName), None)
 
   private val managedGroupResourceType = realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
@@ -107,7 +106,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
   before {
     clearDatabase()
-    dirDAO.createUser(WorkbenchUser(dummyUserInfo.userId, TestSupport.genGoogleSubjectId(), dummyUserInfo.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(dummyUser, samRequestContext).unsafeRunSync()
   }
 
   protected def clearDatabase(): Unit = TestSupport.truncateAll
@@ -118,7 +117,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
   private def constructExpectedPolicies(resourceType: ResourceType, resource: FullyQualifiedResourceId) = {
     val role = resourceType.roles.find(_.roleName == resourceType.ownerRoleName).get
-    val initialMembers = if(role.roleName.equals(resourceType.ownerRoleName)) Set(dummyUserInfo.userId.asInstanceOf[WorkbenchSubject]) else Set[WorkbenchSubject]()
+    val initialMembers = if(role.roleName.equals(resourceType.ownerRoleName)) Set(dummyUser.id.asInstanceOf[WorkbenchSubject]) else Set[WorkbenchSubject]()
     val group = BasicWorkbenchGroup(WorkbenchGroupName(role.roleName.value), initialMembers, toEmail(resource.resourceTypeName.value, resource.resourceId.value, role.roleName.value))
     LazyList(AccessPolicy(
       FullyQualifiedPolicyId(resource, AccessPolicyName(role.roleName.value)), group.members, group.email, Set(role.roleName), Set.empty, Set.empty, public = false))
@@ -151,7 +150,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
 
-    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext))
 
     assertResult(constructExpectedPolicies(defaultResourceType, resource)) {
       policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync().map(_.copy(email=WorkbenchEmail("policy-randomuuid@example.com")))
@@ -171,7 +170,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
 
-    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext))
 
     val policyToUpdate = constructExpectedPolicies(defaultResourceType, resource).head.id
 
@@ -197,13 +196,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(constrainableResourceType.name, resourceName)
 
     constrainableService.createResourceType(constrainableResourceType, samRequestContext).unsafeRunSync()
-    val managedGroupResource = managedGroupService.createManagedGroup(ResourceId("ad"), dummyUserInfo, samRequestContext = samRequestContext).unsafeRunSync()
+    val managedGroupResource = managedGroupService.createManagedGroup(ResourceId("ad"), dummyUser, samRequestContext = samRequestContext).unsafeRunSync()
 
     val ownerRoleName = constrainableReaderRoleName
-    val policyMembership = AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(constrainableViewAction), Set(ownerRoleName), None)
+    val policyMembership = AccessPolicyMembership(Set(dummyUser.email), Set(constrainableViewAction), Set(ownerRoleName), None)
     val policyName = AccessPolicyName("foo")
 
-    val testResource = runAndWait(constrainableService.createResource(constrainableResourceType, resourceName, Map(policyName -> policyMembership), Set(WorkbenchGroupName(managedGroupResource.resourceId.value)), None, dummyUserInfo.userId, samRequestContext))
+    val testResource = runAndWait(constrainableService.createResource(constrainableResourceType, resourceName, Map(policyName -> policyMembership), Set(WorkbenchGroupName(managedGroupResource.resourceId.value)), None, dummyUser.id, samRequestContext))
 
     val policyToUpdate = FullyQualifiedPolicyId(testResource.fullyQualifiedId, policyName)
     constrainableService.isPublic(policyToUpdate, samRequestContext).unsafeRunSync() should equal(false)
@@ -221,44 +220,43 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resourceName2 = ResourceId("resource2")
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    service.createResource(defaultResourceType, resourceName1, dummyUserInfo, samRequestContext).unsafeRunSync()
+    service.createResource(defaultResourceType, resourceName1, dummyUser, samRequestContext).unsafeRunSync()
 
-    val policies2 = service.createResource(defaultResourceType, resourceName2, dummyUserInfo, samRequestContext).unsafeRunSync()
+    val policies2 = service.createResource(defaultResourceType, resourceName2, dummyUser, samRequestContext).unsafeRunSync()
 
     policyDAO.createPolicy(AccessPolicy(
-      FullyQualifiedPolicyId(policies2.fullyQualifiedId, AccessPolicyName(otherRoleName.value)), Set(dummyUserInfo.userId), WorkbenchEmail("a@b.c"), Set(otherRoleName), Set.empty, Set.empty, public = false), samRequestContext).unsafeRunSync()
+      FullyQualifiedPolicyId(policies2.fullyQualifiedId, AccessPolicyName(otherRoleName.value)), Set(dummyUser.id), WorkbenchEmail("a@b.c"), Set(otherRoleName), Set.empty, Set.empty, public = false), samRequestContext).unsafeRunSync()
 
     assertResult(defaultResourceType.roles.filter(_.roleName.equals(ownerRoleName)).head.actions) {
-      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), dummyUserInfo.userId, samRequestContext = samRequestContext).unsafeRunSync()
+      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), dummyUser.id, samRequestContext = samRequestContext).unsafeRunSync()
     }
 
     assertResult(defaultResourceTypeActions) {
-      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), dummyUserInfo.userId, samRequestContext = samRequestContext).unsafeRunSync()
+      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), dummyUser.id, samRequestContext = samRequestContext).unsafeRunSync()
     }
 
-    assert(!service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), ResourceAction("non_owner_action"), dummyUserInfo.userId, samRequestContext).unsafeRunSync())
-    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), ResourceAction("non_owner_action"), dummyUserInfo.userId, samRequestContext).unsafeRunSync())
-    assert(!service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, ResourceId("doesnotexist")), ResourceAction("view"), dummyUserInfo.userId, samRequestContext).unsafeRunSync())
+    assert(!service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), ResourceAction("non_owner_action"), dummyUser.id, samRequestContext).unsafeRunSync())
+    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), ResourceAction("non_owner_action"), dummyUser.id, samRequestContext).unsafeRunSync())
+    assert(!service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, ResourceId("doesnotexist")), ResourceAction("view"), dummyUser.id, samRequestContext).unsafeRunSync())
   }
 
   it should "list the user's actions for a resource with nested groups" in {
     val resourceName1 = ResourceId("resource1")
 
-    val user = dirDAO.createUser(WorkbenchUser(WorkbenchUserId("asdfawefawea"), None, WorkbenchEmail("asdfawefawea@foo.bar"), None), samRequestContext).unsafeRunSync()
+    val user = dirDAO.createUser(Generator.genWorkbenchUserBoth.sample.get, samRequestContext).unsafeRunSync()
     val group = BasicWorkbenchGroup(WorkbenchGroupName("g"), Set(user.id), WorkbenchEmail("foo@bar.com"))
     dirDAO.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    val resource = runAndWait(service.createResource(defaultResourceType, resourceName1, dummyUserInfo, samRequestContext))
+    val resource = runAndWait(service.createResource(defaultResourceType, resourceName1, dummyUser, samRequestContext))
     val nonOwnerAction = ResourceAction("non_owner_action")
     runAndWait(service.overwritePolicy(defaultResourceType, AccessPolicyName("new_policy"), resource.fullyQualifiedId, AccessPolicyMembership(Set(group.email), Set(nonOwnerAction), Set.empty, None), samRequestContext))
 
-    val userInfo = UserInfo(OAuth2BearerToken(""), user.id, user.email, 0)
     assertResult(Set(ResourceAction("non_owner_action"))) {
-      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), userInfo.userId, samRequestContext = samRequestContext).unsafeRunSync()
+      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), user.id, samRequestContext = samRequestContext).unsafeRunSync()
     }
 
-    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), nonOwnerAction, userInfo.userId, samRequestContext).unsafeRunSync())
+    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName1), nonOwnerAction, user.id, samRequestContext).unsafeRunSync())
   }
 
   it should "list public policies" in {
@@ -267,16 +265,16 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
 
-    val policies2 = runAndWait(service.createResource(defaultResourceType, resourceName2, dummyUserInfo, samRequestContext))
+    val policies2 = runAndWait(service.createResource(defaultResourceType, resourceName2, dummyUser, samRequestContext))
 
     policyDAO.createPolicy(AccessPolicy(
       FullyQualifiedPolicyId(policies2.fullyQualifiedId, AccessPolicyName(otherRoleName.value)), Set.empty, WorkbenchEmail("a@b.c"), Set(otherRoleName), Set.empty, Set.empty, public = true), samRequestContext).unsafeRunSync()
 
     assertResult(defaultResourceTypeActions) {
-      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), dummyUserInfo.userId, samRequestContext = samRequestContext).unsafeRunSync()
+      service.policyEvaluatorService.listUserResourceActions(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), dummyUser.id, samRequestContext = samRequestContext).unsafeRunSync()
     }
 
-    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), ResourceAction("non_owner_action"), dummyUserInfo.userId, samRequestContext).unsafeRunSync())
+    assert(service.policyEvaluatorService.hasPermission(FullyQualifiedResourceId(defaultResourceType.name, resourceName2), ResourceAction("non_owner_action"), dummyUser.id, samRequestContext).unsafeRunSync())
   }
 
   "createResource" should "detect conflict on create" in {
@@ -285,10 +283,10 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resourceName = ResourceId("resource")
 
     service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(resourceType, resourceName, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(resourceType, resourceName, dummyUser, samRequestContext))
 
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(resourceType, resourceName, dummyUserInfo, samRequestContext))
+      runAndWait(service.createResource(resourceType, resourceName, dummyUser, samRequestContext))
     }
 
     exception.errorReport.statusCode shouldEqual Option(StatusCodes.Conflict)
@@ -301,10 +299,10 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
 
-    val policyMembership = AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("view")), Set(ownerRoleName), Option(Set.empty))
+    val policyMembership = AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("view")), Set(ownerRoleName), Option(Set.empty))
     val policyName = AccessPolicyName("foo")
 
-    runAndWait(service.createResource(resourceType, resourceName, Map(policyName -> policyMembership), Set.empty, None, dummyUserInfo.userId, samRequestContext))
+    runAndWait(service.createResource(resourceType, resourceName, Map(policyName -> policyMembership), Set.empty, None, dummyUser.id, samRequestContext))
 
     val policies = service.listResourcePolicies(FullyQualifiedResourceId(resourceType.name, resourceName), samRequestContext).unsafeRunSync()
     assertResult(LazyList(AccessPolicyResponseEntry(policyName, policyMembership, WorkbenchEmail("")))) {
@@ -319,7 +317,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
 
     val validChars = ('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9') ++ Seq('.', '-', '_', '~', '%')
-    runAndWait(service.createResource(resourceType, ResourceId(validChars.mkString), dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(resourceType, ResourceId(validChars.mkString), dummyUser, samRequestContext))
   }
 
   it should "prevent invalid resource ids" in {
@@ -331,7 +329,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     for (char <- "!@#$^&*()+= <>/?'\"][{}\\|`") {
       withClue(s"expected character $char to be invalid") {
         val exception = intercept[WorkbenchExceptionWithErrorReport] {
-          runAndWait(service.createResource(resourceType, ResourceId(char.toString), dummyUserInfo, samRequestContext))
+          runAndWait(service.createResource(resourceType, ResourceId(char.toString), dummyUser, samRequestContext))
         }
 
         exception.errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
@@ -347,13 +345,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
 
     val exception1 = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(resourceType, resourceName, Map(AccessPolicyName("foo") -> AccessPolicyMembership(Set.empty, Set.empty, Set(ownerRoleName), None)), Set.empty, None, dummyUserInfo.userId, samRequestContext))
+      runAndWait(service.createResource(resourceType, resourceName, Map(AccessPolicyName("foo") -> AccessPolicyMembership(Set.empty, Set.empty, Set(ownerRoleName), None)), Set.empty, None, dummyUser.id, samRequestContext))
     }
 
     exception1.errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
 
     val exception2 = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(resourceType, resourceName, Map(AccessPolicyName("foo") -> AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set.empty, None)), Set.empty, None, dummyUserInfo.userId, samRequestContext))
+      runAndWait(service.createResource(resourceType, resourceName, Map(AccessPolicyName("foo") -> AccessPolicyMembership(Set(dummyUser.email), Set.empty, Set.empty, None)), Set.empty, None, dummyUser.id, samRequestContext))
     }
 
     exception2.errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
@@ -367,8 +365,8 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     val test = for {
       _ <- service.createResourceType(resourceType, samRequestContext)
-      parent <- service.createResource(resourceType, parentResourceName, dummyUserInfo, samRequestContext)
-      child <- service.createResource(resourceType, childResourceName, Map.empty, Set.empty, Option(parent.fullyQualifiedId), dummyUserInfo.userId, samRequestContext)
+      parent <- service.createResource(resourceType, parentResourceName, dummyUser, samRequestContext)
+      child <- service.createResource(resourceType, childResourceName, Map.empty, Set.empty, Option(parent.fullyQualifiedId), dummyUser.id, samRequestContext)
       actualParent <- policyDAO.getResourceParent(child.fullyQualifiedId, samRequestContext)
     } yield {
       actualParent shouldBe Option(parent.fullyQualifiedId)
@@ -387,7 +385,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     constrainableResourceType.isAuthDomainConstrainable shouldEqual true
     constrainableService.createResourceType(constrainableResourceType, samRequestContext).unsafeRunSync()
 
-    val resource = runAndWait(service.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), dummyUserInfo, samRequestContext))
+    val resource = runAndWait(service.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), dummyUser, samRequestContext))
     assertResourceExists(resource.fullyQualifiedId, constrainableResourceType, policyDAO)
   }
 
@@ -398,12 +396,12 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
     val managedGroupName = "fooGroup"
     val secondMGroupName = "barGroup"
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUserInfo, samRequestContext = samRequestContext))
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(secondMGroupName), dummyUserInfo, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUser, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(secondMGroupName), dummyUser, samRequestContext = samRequestContext))
 
     val authDomain = NonEmptyList.of(WorkbenchGroupName(managedGroupName), WorkbenchGroupName(secondMGroupName))
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain.toList.toSet, None, dummyUserInfo.userId, samRequestContext))
+    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain.toList.toSet, None, dummyUser.id, samRequestContext))
     val storedAuthDomain = constrainableService.loadResourceAuthDomain(resource.fullyQualifiedId, samRequestContext).unsafeRunSync()
 
     storedAuthDomain should contain theSameElementsAs authDomain.toList
@@ -415,13 +413,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
     val managedGroupName = "fooGroup"
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUserInfo, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUser, samRequestContext = samRequestContext))
     val nonExistentGroup = WorkbenchGroupName("aBadGroup")
 
     val authDomain = Set(WorkbenchGroupName(managedGroupName), nonExistentGroup)
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
     intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, None, dummyUserInfo.userId, samRequestContext))
+      runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, None, dummyUser.id, samRequestContext))
     }
   }
 
@@ -429,19 +427,19 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     constrainableResourceType.isAuthDomainConstrainable shouldEqual true
     constrainableService.createResourceType(constrainableResourceType, samRequestContext).unsafeRunSync()
 
-    val bender = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("Bender"), WorkbenchEmail("bender@planex.com"), 0)
-    dirDAO.createUser(WorkbenchUser(bender.userId, None, bender.userEmail, None), samRequestContext).unsafeRunSync()
+    val bender = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(bender, samRequestContext).unsafeRunSync()
 
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
     val managedGroupName1 = "firstGroup"
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName1), dummyUserInfo, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName1), dummyUser, samRequestContext = samRequestContext))
     val managedGroupName2 = "benderIsGreat"
     runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName2), bender, samRequestContext = samRequestContext))
 
     val authDomain = Set(WorkbenchGroupName(managedGroupName1), WorkbenchGroupName(managedGroupName2))
     val viewPolicyName = AccessPolicyName(constrainableReaderRoleName.value)
     intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, None, dummyUserInfo.userId, samRequestContext))
+      runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId(UUID.randomUUID().toString), Map(viewPolicyName -> constrainablePolicyMembership), authDomain, None, dummyUser.id, samRequestContext))
     }
   }
 
@@ -458,14 +456,14 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
     val managedGroupName = "fooGroup"
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUserInfo, samRequestContext = samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), dummyUser, samRequestContext = samRequestContext))
 
-    val policyMembership = AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set(ResourceAction("view")), Set(ownerRoleName), None)
+    val policyMembership = AccessPolicyMembership(Set(dummyUser.email), Set(ResourceAction("view")), Set(ownerRoleName), None)
     val policyName = AccessPolicyName("foo")
 
     val authDomain = Set(WorkbenchGroupName(managedGroupName))
     intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(defaultResourceType, ResourceId(UUID.randomUUID().toString), Map(policyName -> policyMembership), authDomain, None, dummyUserInfo.userId, samRequestContext))
+      runAndWait(service.createResource(defaultResourceType, ResourceId(UUID.randomUUID().toString), Map(policyName -> policyMembership), authDomain, None, dummyUser.id, samRequestContext))
     }
   }
 
@@ -474,9 +472,9 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, resourceName)
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext))
 
-    val roles = runAndWait(service.listUserResourceRoles(resource, dummyUserInfo, samRequestContext))
+    val roles = runAndWait(service.listUserResourceRoles(resource, dummyUser, samRequestContext))
 
     roles shouldEqual Set(ownerRoleName)
   }
@@ -486,18 +484,18 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resourceType = ResourceType(ResourceTypeName(UUID.randomUUID().toString), Set(ResourceActionPattern("a1", "", false)), Set(ResourceRole(ownerRoleName, Set(ResourceAction("a1")))), ownerRoleName)
     val resourceName = ResourceId("resource")
 
-    val roles = runAndWait(service.listUserResourceRoles(FullyQualifiedResourceId(resourceType.name, resourceName), dummyUserInfo, samRequestContext))
+    val roles = runAndWait(service.listUserResourceRoles(FullyQualifiedResourceId(resourceType.name, resourceName), dummyUser, samRequestContext))
 
     roles shouldEqual Set.empty
 
-    dirDAO.deleteUser(dummyUserInfo.userId, samRequestContext).unsafeRunSync()
+    dirDAO.deleteUser(dummyUser.id, samRequestContext).unsafeRunSync()
   }
 
   "policyDao.listAccessPolicies" should "list policies for a newly created resource" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val policies = policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync().map(_.copy(email=WorkbenchEmail("policy-randomuuid@example.com")))
 
@@ -508,10 +506,10 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
     val ownerRole = defaultResourceType.roles.find(_.roleName == defaultResourceType.ownerRoleName).get
     val forcedEmail = WorkbenchEmail("policy-randomuuid@example.com")
-    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(ownerRole.roleName), Option(Set.empty)), forcedEmail)
+    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUser.email), Set.empty, Set(ownerRole.roleName), Option(Set.empty)), forcedEmail)
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val policies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync().map(_.copy(email = forcedEmail))
     policies should contain theSameElementsAs Set(expectedPolicy)
@@ -521,10 +519,10 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
     val ownerRole = defaultResourceType.roles.find(_.roleName == defaultResourceType.ownerRoleName).get
     val forcedEmail = WorkbenchEmail("policy-randomuuid@example.com")
-    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUserInfo.userEmail), Set.empty, Set(ownerRole.roleName), Option(Set.empty)), forcedEmail)
+    val expectedPolicy = AccessPolicyResponseEntry(AccessPolicyName(ownerRole.roleName.value), AccessPolicyMembership(Set(dummyUser.email), Set.empty, Set(ownerRole.roleName), Option(Set.empty)), forcedEmail)
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val policies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync().map(_.copy(email = forcedEmail))
     policies should contain theSameElementsAs Set(expectedPolicy)
@@ -534,13 +532,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     // create a "side" resource; we will use its policy emails as members in the default resource
     val sideResource = FullyQualifiedResourceId(otherResourceType.name, ResourceId("side-resource"))
     service.createResourceType(otherResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(otherResourceType, sideResource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(otherResourceType, sideResource.resourceId, dummyUser, samRequestContext))
     val sidePolicies = service.listResourcePolicies(sideResource, samRequestContext).unsafeRunSync()
 
     // create the default resource
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     // add "side" policy emails to default resource
     sidePolicies.foreach { sidePolicy =>
@@ -569,7 +567,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val actualPolicies = service.listResourcePolicies(resource, samRequestContext).unsafeRunSync()
     actualPolicies.size shouldBe 1
@@ -582,7 +580,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(
@@ -654,7 +652,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(
@@ -728,7 +726,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(rt.name, ResourceId("my-resource"))
 
     service.createResourceType(rt, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(rt, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(rt, resource.resourceId, dummyUser, samRequestContext))
 
     val actions = Set(ResourceAction("foo-bang-bar"))
     val newPolicy = runAndWait(service.overwritePolicy(rt, AccessPolicyName("foo"), resource, AccessPolicyMembership(Set.empty, actions, Set.empty, None), samRequestContext))
@@ -746,7 +744,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("INVALID_ACTION")), Set.empty, public = false)
@@ -768,7 +766,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(rt.name, ResourceId("my-resource"))
 
     service.createResourceType(rt, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(rt, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(rt, resource.resourceId, dummyUser, samRequestContext))
 
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(service.overwritePolicy(rt, AccessPolicyName("foo"), resource, AccessPolicyMembership(Set.empty, Set(ResourceAction("foo--bar")), Set.empty, None), samRequestContext))
@@ -781,7 +779,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("foo")), group.members, group.email, Set(ResourceRoleName("INVALID_ROLE")), Set.empty, Set.empty, public = false)
@@ -801,7 +799,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("foo")), group.members, group.email, Set.empty, Set(ResourceAction("non_owner_action")), Set.empty, public = false)
@@ -821,7 +819,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set.empty, toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))
     val newPolicy = AccessPolicy(
@@ -842,7 +840,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     assert(policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync().nonEmpty)
 
@@ -857,11 +855,11 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     defaultResourceType.reuseIds shouldEqual false
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
     runAndWait(service.deleteResource(resource, samRequestContext))
 
     val err = intercept[WorkbenchExceptionWithErrorReport] {
-      runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+      runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
     }
     err.getMessage should include ("resource of this type and name already exists")
   }
@@ -875,13 +873,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
     val resource = FullyQualifiedResourceId(reusableResourceType.name, ResourceId("my-resource"))
 
-    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUser, samRequestContext))
     policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync() should not be empty
 
     runAndWait(localService.deleteResource(resource, samRequestContext))
     policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync() shouldBe empty
 
-    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(localService.createResource(reusableResourceType, resource.resourceId, dummyUser, samRequestContext))
     policyDAO.listAccessPolicies(resource, samRequestContext).unsafeRunSync() should not be empty
   }
 
@@ -891,10 +889,10 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val otherAuthDomainGroup = "barGroup"
     constrainableService.createResourceType(resourceType, samRequestContext).unsafeRunSync()
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
-    managedGroupService.createManagedGroup(ResourceId(authDomainGroupToDelete), dummyUserInfo, samRequestContext = samRequestContext).unsafeRunSync()
-    managedGroupService.createManagedGroup(ResourceId(otherAuthDomainGroup), dummyUserInfo, samRequestContext = samRequestContext).unsafeRunSync()
-    val resourceToDelete = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(authDomainGroupToDelete)), None, dummyUserInfo.userId, samRequestContext).unsafeRunSync()
-    val otherResource = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(otherAuthDomainGroup)), None, dummyUserInfo.userId, samRequestContext).unsafeRunSync()
+    managedGroupService.createManagedGroup(ResourceId(authDomainGroupToDelete), dummyUser, samRequestContext = samRequestContext).unsafeRunSync()
+    managedGroupService.createManagedGroup(ResourceId(otherAuthDomainGroup), dummyUser, samRequestContext = samRequestContext).unsafeRunSync()
+    val resourceToDelete = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(authDomainGroupToDelete)), None, dummyUser.id, samRequestContext).unsafeRunSync()
+    val otherResource = constrainableService.createResource(resourceType, ResourceId(UUID.randomUUID().toString), Map(AccessPolicyName(constrainableReaderRoleName.value) -> constrainablePolicyMembership), Set(WorkbenchGroupName(otherAuthDomainGroup)), None, dummyUser.id, samRequestContext).unsafeRunSync()
 
     runAndWait(constrainableService.deleteResource(resourceToDelete.fullyQualifiedId, samRequestContext))
     runAndWait(managedGroupService.deleteManagedGroup(ResourceId(authDomainGroupToDelete), samRequestContext))
@@ -919,8 +917,8 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val parentResource = FullyQualifiedResourceId(resourceType.name, ResourceId("my-resource-parent"))
     val childResource = FullyQualifiedResourceId(resourceType.name, ResourceId("my-resource-child"))
     service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(resourceType, parentResource.resourceId, dummyUserInfo, samRequestContext))
-    runAndWait(service.createResource(resourceType, childResource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(resourceType, parentResource.resourceId, dummyUser, samRequestContext))
+    runAndWait(service.createResource(resourceType, childResource.resourceId, dummyUser, samRequestContext))
     runAndWait(service.setResourceParent(childResource, parentResource, samRequestContext))
 
     runAndWait(service.createPolicy(FullyQualifiedPolicyId(parentResource, AccessPolicyName("reader")), Set.empty, Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, defaultResourceTypeActions, Set.empty)), samRequestContext))
@@ -938,8 +936,8 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-parent"))
     val childResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource-child"))
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, parentResource.resourceId, dummyUserInfo, samRequestContext))
-    runAndWait(service.createResource(defaultResourceType, childResource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, parentResource.resourceId, dummyUser, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, childResource.resourceId, dummyUser, samRequestContext))
     runAndWait(service.setResourceParent(childResource, parentResource, samRequestContext))
 
     assert(policyDAO.listAccessPolicies(parentResource, samRequestContext).unsafeRunSync().nonEmpty)
@@ -957,13 +955,13 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
   }
 
   "validatePolicy" should "succeed with a correct policy" in {
-    val emailToMaybeSubject = Map(dummyUserInfo.userEmail -> Option(dummyUserInfo.userId.asInstanceOf[WorkbenchSubject]))
+    val emailToMaybeSubject = Map(dummyUser.email -> Option(dummyUser.id.asInstanceOf[WorkbenchSubject]))
     val policy = service.ValidatableAccessPolicy(AccessPolicyName("a"), emailToMaybeSubject, Set(ownerRoleName), Set(ResourceAction("alter_policies")), Set())
     runAndWait(service.validatePolicy(defaultResourceType, policy)) shouldBe empty
   }
 
   "validatePolicy" should "fail with an incorrect policy" in {
-    val emailToMaybeSubject = Map(dummyUserInfo.userEmail -> Option(dummyUserInfo.userId.asInstanceOf[WorkbenchSubject]))
+    val emailToMaybeSubject = Map(dummyUser.email -> Option(dummyUser.id.asInstanceOf[WorkbenchSubject]))
     val policy = service.ValidatableAccessPolicy(AccessPolicyName("a"), emailToMaybeSubject, Set(ResourceRoleName("bad_name")), Set(ResourceAction("bad_action")), Set())
     val maybeErrorReport = runAndWait(service.validatePolicy(defaultResourceType, policy))
     maybeErrorReport.value.message should include("invalid policy")
@@ -993,29 +991,29 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
   "add/remove SubjectToPolicy" should "add/remove subject and tolerate prior (non)existence" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("my-resource"))
     val policyName = AccessPolicyName(defaultResourceType.ownerRoleName.value)
-    val otherUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("otheruserid"), WorkbenchEmail("otheruser@company.com"), 0)
+    val otherUser = Generator.genWorkbenchUserBoth.sample.get
 
-    dirDAO.createUser(WorkbenchUser(otherUserInfo.userId, None, otherUserInfo.userEmail, None), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(otherUser, samRequestContext).unsafeRunSync()
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
     // assert baseline
-    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUserInfo.userId, samRequestContext).unsafeRunSync() shouldBe empty
+    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUser.id, samRequestContext).unsafeRunSync() shouldBe empty
 
-    runAndWait(service.addSubjectToPolicy(FullyQualifiedPolicyId(resource, policyName), otherUserInfo.userId, samRequestContext))
-    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUserInfo.userId, samRequestContext).unsafeRunSync() should contain theSameElementsAs
+    runAndWait(service.addSubjectToPolicy(FullyQualifiedPolicyId(resource, policyName), otherUser.id, samRequestContext))
+    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUser.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs
       Set(UserResourcesResponse(resource.resourceId, RolesAndActions.fromRoles(Set(defaultResourceType.ownerRoleName)), RolesAndActions.empty, RolesAndActions.empty, Set.empty, Set.empty))
 
     // add a second time to make sure no exception is thrown
-    runAndWait(service.addSubjectToPolicy(FullyQualifiedPolicyId(resource, policyName), otherUserInfo.userId, samRequestContext))
+    runAndWait(service.addSubjectToPolicy(FullyQualifiedPolicyId(resource, policyName), otherUser.id, samRequestContext))
 
 
-    runAndWait(service.removeSubjectFromPolicy(FullyQualifiedPolicyId(resource, policyName), otherUserInfo.userId, samRequestContext))
-    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUserInfo.userId, samRequestContext).unsafeRunSync() shouldBe empty
+    runAndWait(service.removeSubjectFromPolicy(FullyQualifiedPolicyId(resource, policyName), otherUser.id, samRequestContext))
+    service.policyEvaluatorService.listUserResources(defaultResourceType.name, otherUser.id, samRequestContext).unsafeRunSync() shouldBe empty
 
     // remove a second time to make sure no exception is thrown
-    runAndWait(service.removeSubjectFromPolicy(FullyQualifiedPolicyId(resource, policyName), otherUserInfo.userId, samRequestContext))
+    runAndWait(service.removeSubjectFromPolicy(FullyQualifiedPolicyId(resource, policyName), otherUser.id, samRequestContext))
   }
 
   "addSubjectToPolicy" should "call CloudExtensions.onGroupUpdate when member added" in {
@@ -1123,16 +1121,16 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     policy.map(_.copy(email = WorkbenchEmail(""))) should equal(Some(AccessPolicy(resourceAndPolicyName, Set.empty, WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false)))
 
     // add a user to the policy and verify
-    policyDAO.overwritePolicy(policy.get.copy(members = Set(dummyUserInfo.userId)), samRequestContext).unsafeRunSync()
+    policyDAO.overwritePolicy(policy.get.copy(members = Set(dummyUser.id)), samRequestContext).unsafeRunSync()
     val policy2 = policyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).unsafeRunSync()
-    policy2.map(_.copy(email = WorkbenchEmail(""))) should equal(Some(AccessPolicy(resourceAndPolicyName, Set(dummyUserInfo.userId), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false)))
+    policy2.map(_.copy(email = WorkbenchEmail(""))) should equal(Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false)))
 
     // call it again to ensure it does not fail
     service.initResourceTypes().unsafeRunSync()
 
     // verify the policy has not changed
     val policy3 = policyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).unsafeRunSync()
-    policy3.map(_.copy(email = WorkbenchEmail(""))) should equal(Some(AccessPolicy(resourceAndPolicyName, Set(dummyUserInfo.userId), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false)))
+    policy3.map(_.copy(email = WorkbenchEmail(""))) should equal(Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false)))
   }
 
   it should "fail if resourceTypeAdmin not defined" in {
@@ -1158,16 +1156,16 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val init = service.initResourceTypes().unsafeRunSync()
     init should contain theSameElementsAs(Set(adminResType, parentResourceType, childResourceType))
 
-    val parentResource = runAndWait(service.createResource(parentResourceType, parentResourceId.resourceId, dummyUserInfo, samRequestContext))
-    val childResource = runAndWait(service.createResource(childResourceType, childResourceId.resourceId, dummyUserInfo, samRequestContext))
+    val parentResource = runAndWait(service.createResource(parentResourceType, parentResourceId.resourceId, dummyUser, samRequestContext))
+    val childResource = runAndWait(service.createResource(childResourceType, childResourceId.resourceId, dummyUser, samRequestContext))
     runAndWait(service.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext))
 
-    val user1 = UserIdInfo(WorkbenchUserId("user1"), WorkbenchEmail("user1@fake.com"), None)
-    dirDAO.createUser(WorkbenchUser(user1.userSubjectId, None, user1.userEmail, None), samRequestContext).unsafeRunSync()
+    val user1 = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(user1, samRequestContext).unsafeRunSync()
 
-    runAndWait(service.addSubjectToPolicy(parentOwnerPolicy, user1.userSubjectId, samRequestContext))
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
-    runAndWait(policyEvaluatorService.hasPermission(parentResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
+    runAndWait(service.addSubjectToPolicy(parentOwnerPolicy, user1.id, samRequestContext))
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(parentResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
 
 
     val overriddenParentResourceType = parentResourceType.copy(roles = Set(
@@ -1178,8 +1176,8 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val newInit = newService.initResourceTypes().unsafeRunSync()
     newInit should contain theSameElementsAs(Set(adminResType, overriddenParentResourceType, childResourceType))
 
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe false
-    runAndWait(policyEvaluatorService.hasPermission(parentResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe false
+    runAndWait(policyEvaluatorService.hasPermission(parentResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
   }
 
   it should "update effective resource tables if descendant permissions are added" in {
@@ -1201,23 +1199,23 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     newInit should contain theSameElementsAs(Set(adminResType, overriddenParentResourceType, childResourceType))
 
 
-    val parentResource = runAndWait(newService.createResource(parentResourceType, parentResourceId.resourceId, dummyUserInfo, samRequestContext))
-    val childResource = runAndWait(newService.createResource(childResourceType, childResourceId.resourceId, dummyUserInfo, samRequestContext))
+    val parentResource = runAndWait(newService.createResource(parentResourceType, parentResourceId.resourceId, dummyUser, samRequestContext))
+    val childResource = runAndWait(newService.createResource(childResourceType, childResourceId.resourceId, dummyUser, samRequestContext))
 
-    val user1 = UserIdInfo(WorkbenchUserId("user1"), WorkbenchEmail("user1@fake.com"), None)
-    dirDAO.createUser(WorkbenchUser(user1.userSubjectId, None, user1.userEmail, None), samRequestContext).unsafeRunSync()
+    val user1 = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(user1, samRequestContext).unsafeRunSync()
 
     runAndWait(newService.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext))
-    runAndWait(newService.addSubjectToPolicy(parentOwnerPolicy, user1.userSubjectId, samRequestContext))
+    runAndWait(newService.addSubjectToPolicy(parentOwnerPolicy, user1.id, samRequestContext))
 
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe false
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe false
 
     val service = new ResourceService(Map(adminResType.name -> adminResType, parentResourceType.name -> parentResourceType, childResourceType.name -> childResourceType), policyEvaluatorService, policyDAO, dirDAO, NoExtensions, emailDomain)
 
     val init = service.initResourceTypes().unsafeRunSync()
     init should contain theSameElementsAs(Set(adminResType, parentResourceType, childResourceType))
 
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
   }
 
   it should "leave other effective resource relationships intact if descendant permissions are added" in {
@@ -1237,20 +1235,20 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val init = service.initResourceTypes().unsafeRunSync()
     init should contain theSameElementsAs(Set(adminResType, parentResourceType, childResourceType, otherParentResourceType))
 
-    val parentResource = runAndWait(service.createResource(parentResourceType, parentResourceId.resourceId, dummyUserInfo, samRequestContext))
-    val childResource = runAndWait(service.createResource(childResourceType, childResourceId.resourceId, dummyUserInfo, samRequestContext))
-    val otherParentResource = runAndWait(service.createResource(otherParentResourceType, otherParentResourceId.resourceId, dummyUserInfo, samRequestContext))
-    val otherChildResource = runAndWait(service.createResource(childResourceType, otherChildResourceId.resourceId, dummyUserInfo, samRequestContext))
+    val parentResource = runAndWait(service.createResource(parentResourceType, parentResourceId.resourceId, dummyUser, samRequestContext))
+    val childResource = runAndWait(service.createResource(childResourceType, childResourceId.resourceId, dummyUser, samRequestContext))
+    val otherParentResource = runAndWait(service.createResource(otherParentResourceType, otherParentResourceId.resourceId, dummyUser, samRequestContext))
+    val otherChildResource = runAndWait(service.createResource(childResourceType, otherChildResourceId.resourceId, dummyUser, samRequestContext))
     runAndWait(service.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext))
     runAndWait(service.setResourceParent(otherChildResource.fullyQualifiedId, otherParentResource.fullyQualifiedId, samRequestContext))
 
-    val user1 = UserIdInfo(WorkbenchUserId("user1"), WorkbenchEmail("user1@fake.com"), None)
-    dirDAO.createUser(WorkbenchUser(user1.userSubjectId, None, user1.userEmail, None), samRequestContext).unsafeRunSync()
+    val user1 = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(user1, samRequestContext).unsafeRunSync()
 
-    runAndWait(service.addSubjectToPolicy(otherParentOwnerPolicy, user1.userSubjectId, samRequestContext))
-    runAndWait(policyEvaluatorService.hasPermission(otherChildResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
-    runAndWait(policyEvaluatorService.hasPermission(otherParentResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe false
+    runAndWait(service.addSubjectToPolicy(otherParentOwnerPolicy, user1.id, samRequestContext))
+    runAndWait(policyEvaluatorService.hasPermission(otherChildResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(otherParentResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe false
 
 
     val overriddenParentResourceType = parentResourceType.copy(roles = Set(
@@ -1261,78 +1259,78 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     val newInit = newService.initResourceTypes().unsafeRunSync()
     newInit should contain theSameElementsAs(Set(adminResType, overriddenParentResourceType, childResourceType, otherParentResourceType))
 
-    runAndWait(policyEvaluatorService.hasPermission(otherChildResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
-    runAndWait(policyEvaluatorService.hasPermission(otherParentResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe true
-    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.userSubjectId, samRequestContext)) shouldBe false
+    runAndWait(policyEvaluatorService.hasPermission(otherChildResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(otherParentResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe true
+    runAndWait(policyEvaluatorService.hasPermission(childResource.fullyQualifiedId, ResourceAction("view"), user1.id, samRequestContext)) shouldBe false
   }
 
   "listAllFlattenedResourceUsers" should "return a flattened list of all of the users in any of a resource's policies" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId(UUID.randomUUID().toString))
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUserInfo, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, dummyUser, samRequestContext))
 
-    val dummyUserIdInfo = dirDAO.loadUser(dummyUserInfo.userId, samRequestContext).unsafeRunSync().map { user => UserIdInfo(user.id, user.email, user.googleSubjectId) }.get
-    val user1 = UserIdInfo(WorkbenchUserId("user1"), WorkbenchEmail("user1@fake.com"), None)
-    val user2 = UserIdInfo(WorkbenchUserId("user2"), WorkbenchEmail("user2@fake.com"), None)
-    val user3 = UserIdInfo(WorkbenchUserId("user3"), WorkbenchEmail("user3@fake.com"), None)
-    val user4 = UserIdInfo(WorkbenchUserId("user4"), WorkbenchEmail("user4@fake.com"), None)
-    val user5 = UserIdInfo(WorkbenchUserId("user5"), WorkbenchEmail("user5@fake.com"), None)
-    val user6 = UserIdInfo(WorkbenchUserId("user6"), WorkbenchEmail("user6@fake.com"), None)
+    val dummyUserIdInfo = dirDAO.loadUser(dummyUser.id, samRequestContext).unsafeRunSync().map { user => UserIdInfo(user.id, user.email, user.googleSubjectId) }.get
+    val user1 = Generator.genWorkbenchUserBoth.sample.get
+    val user2 = Generator.genWorkbenchUserBoth.sample.get
+    val user3 = Generator.genWorkbenchUserBoth.sample.get
+    val user4 = Generator.genWorkbenchUserBoth.sample.get
+    val user5 = Generator.genWorkbenchUserBoth.sample.get
+    val user6 = Generator.genWorkbenchUserBoth.sample.get
 
-    dirDAO.createUser(WorkbenchUser(user1.userSubjectId, None, user1.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user2.userSubjectId, None, user2.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user3.userSubjectId, None, user3.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user4.userSubjectId, None, user4.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user5.userSubjectId, None, user5.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user6.userSubjectId, None, user6.userEmail, None), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user1, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user2, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user3, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user4, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user5, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user6, samRequestContext).unsafeRunSync()
 
     val ownerPolicy = FullyQualifiedPolicyId(resource, AccessPolicyName("owner"))
-    runAndWait(service.addSubjectToPolicy(ownerPolicy, user1.userSubjectId, samRequestContext))
-    runAndWait(service.addSubjectToPolicy(ownerPolicy, user2.userSubjectId, samRequestContext))
+    runAndWait(service.addSubjectToPolicy(ownerPolicy, user1.id, samRequestContext))
+    runAndWait(service.addSubjectToPolicy(ownerPolicy, user2.id, samRequestContext))
 
-    val group1 = BasicWorkbenchGroup(WorkbenchGroupName("group1"), Set(user3.userSubjectId, user4.userSubjectId), WorkbenchEmail("group1@fake.com"))
-    val subGroup = BasicWorkbenchGroup(WorkbenchGroupName("subGroup"), Set(user6.userSubjectId), WorkbenchEmail("subgroup@fake.com"))
-    val group2 = BasicWorkbenchGroup(WorkbenchGroupName("group2"), Set(user5.userSubjectId, subGroup.id), WorkbenchEmail("group2@fake.com"))
+    val group1 = BasicWorkbenchGroup(WorkbenchGroupName("group1"), Set(user3.id, user4.id), WorkbenchEmail("group1@fake.com"))
+    val subGroup = BasicWorkbenchGroup(WorkbenchGroupName("subGroup"), Set(user6.id), WorkbenchEmail("subgroup@fake.com"))
+    val group2 = BasicWorkbenchGroup(WorkbenchGroupName("group2"), Set(user5.id, subGroup.id), WorkbenchEmail("group2@fake.com"))
 
     dirDAO.createGroup(group1, samRequestContext = samRequestContext).unsafeRunSync()
     dirDAO.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
     dirDAO.createGroup(group2, samRequestContext = samRequestContext).unsafeRunSync()
     runAndWait(service.createPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("reader")), Set(group1.id, group2.id), Set.empty, Set.empty, Set.empty, samRequestContext))
 
-    service.listAllFlattenedResourceUsers(resource, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(dummyUserIdInfo, user1, user2, user3, user4, user5, user6)
+    service.listAllFlattenedResourceUsers(resource, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(dummyUserIdInfo, user1.toUserIdInfo, user2.toUserIdInfo, user3.toUserIdInfo, user4.toUserIdInfo, user5.toUserIdInfo, user6.toUserIdInfo)
   }
 
   it should "return a flattened list of all of the users in any of a resource's policies even if the users are in a managed group" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId(UUID.randomUUID().toString))
     val managedGroupName = "foo"
-    val resourceOwnerUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("user1"), WorkbenchEmail("user1@company.com"), 0)
-    val managedGroupOwnerUserInfo = UserInfo(OAuth2BearerToken("token"), WorkbenchUserId("user2"), WorkbenchEmail("user2@company.com"), 0)
+    val resourceOwnerUser = Generator.genWorkbenchUserBoth.sample.get
+    val managedGroupOwnerUser = Generator.genWorkbenchUserBoth.sample.get
 
-    dirDAO.createUser(WorkbenchUser(resourceOwnerUserInfo.userId, TestSupport.genGoogleSubjectId(), resourceOwnerUserInfo.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(managedGroupOwnerUserInfo.userId, TestSupport.genGoogleSubjectId(), managedGroupOwnerUserInfo.userEmail, Some(TestSupport.genAzureB2CId())), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(resourceOwnerUser, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(managedGroupOwnerUser, samRequestContext).unsafeRunSync()
 
-    val resourceOwner = dirDAO.loadUser(resourceOwnerUserInfo.userId, samRequestContext).unsafeRunSync().map { user => UserIdInfo(user.id, user.email, user.googleSubjectId) }.get
-    val managedGroupOwner = dirDAO.loadUser(managedGroupOwnerUserInfo.userId, samRequestContext).unsafeRunSync().map { user => UserIdInfo(user.id, user.email, user.googleSubjectId) }.get
+    val resourceOwner = dirDAO.loadUser(resourceOwnerUser.id, samRequestContext).unsafeRunSync().map(_.toUserIdInfo).get
+    val managedGroupOwner = dirDAO.loadUser(managedGroupOwnerUser.id, samRequestContext).unsafeRunSync().map(_.toUserIdInfo).get
 
-    val directPolicyMember = UserIdInfo(WorkbenchUserId("directMember"), WorkbenchEmail("directMember@fake.com"), None)
-    val user3 = UserIdInfo(WorkbenchUserId("user3"), WorkbenchEmail("user3@fake.com"), None)
-    val user4 = UserIdInfo(WorkbenchUserId("user4"), WorkbenchEmail("user4@fake.com"), None)
+    val directPolicyMember = Generator.genWorkbenchUserBoth.sample.get
+    val user3 = Generator.genWorkbenchUserBoth.sample.get
+    val user4 = Generator.genWorkbenchUserBoth.sample.get
 
-    dirDAO.createUser(WorkbenchUser(directPolicyMember.userSubjectId, None, directPolicyMember.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user3.userSubjectId, None, user3.userEmail, None), samRequestContext).unsafeRunSync()
-    dirDAO.createUser(WorkbenchUser(user4.userSubjectId, None, user4.userEmail, None), samRequestContext).unsafeRunSync()
+    dirDAO.createUser(directPolicyMember, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user3, samRequestContext).unsafeRunSync()
+    dirDAO.createUser(user4, samRequestContext).unsafeRunSync()
 
     service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
     service.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
-    runAndWait(service.createResource(defaultResourceType, resource.resourceId, resourceOwnerUserInfo, samRequestContext))
-    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), managedGroupOwnerUserInfo, samRequestContext = samRequestContext))
-    runAndWait(service.createPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("can-catalog")), Set(directPolicyMember.userSubjectId, WorkbenchGroupName(managedGroupName)), Set(ResourceRoleName("other")), Set.empty, Set.empty, samRequestContext))
+    runAndWait(service.createResource(defaultResourceType, resource.resourceId, resourceOwnerUser, samRequestContext))
+    runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupName), managedGroupOwnerUser, samRequestContext = samRequestContext))
+    runAndWait(service.createPolicy(FullyQualifiedPolicyId(resource, AccessPolicyName("can-catalog")), Set(directPolicyMember.id, WorkbenchGroupName(managedGroupName)), Set(ResourceRoleName("other")), Set.empty, Set.empty, samRequestContext))
 
-    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupName), ManagedGroupService.memberPolicyName, user3.userSubjectId, samRequestContext))
-    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupName), ManagedGroupService.memberPolicyName, user4.userSubjectId, samRequestContext))
+    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupName), ManagedGroupService.memberPolicyName, user3.id, samRequestContext))
+    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupName), ManagedGroupService.memberPolicyName, user4.id, samRequestContext))
 
-    service.listAllFlattenedResourceUsers(resource, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(resourceOwner, managedGroupOwner, directPolicyMember, user3, user4)
+    service.listAllFlattenedResourceUsers(resource, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(resourceOwner, managedGroupOwner, directPolicyMember.toUserIdInfo, user3.toUserIdInfo, user4.toUserIdInfo)
   }
 
   "loadAccessPolicyWithEmails" should "get emails for users, groups and policies" in {
@@ -1341,19 +1339,19 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
 
       testGroup <- dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("mygroup"), Set.empty, WorkbenchEmail("group@a.com")), samRequestContext = samRequestContext)
 
-      res1 <- service.createResource(defaultResourceType, ResourceId("resource1"), dummyUserInfo, samRequestContext)
+      res1 <- service.createResource(defaultResourceType, ResourceId("resource1"), dummyUser, samRequestContext)
       testPolicy <- service.listResourcePolicies(res1.fullyQualifiedId, samRequestContext).map(_.head)
 
-      res2 <- service.createResource(defaultResourceType, ResourceId("resource2"), dummyUserInfo, samRequestContext)
+      res2 <- service.createResource(defaultResourceType, ResourceId("resource2"), dummyUser, samRequestContext)
 
       newPolicy <- policyDAO.createPolicy(AccessPolicy(
-        FullyQualifiedPolicyId(res2.fullyQualifiedId, AccessPolicyName("foo")), Set(testGroup.id, dummyUserInfo.userId, FullyQualifiedPolicyId(res1.fullyQualifiedId, testPolicy.policyName)), WorkbenchEmail("a@b.c"), Set.empty, Set.empty, Set.empty, public = false), samRequestContext)
+        FullyQualifiedPolicyId(res2.fullyQualifiedId, AccessPolicyName("foo")), Set(testGroup.id, dummyUser.id, FullyQualifiedPolicyId(res1.fullyQualifiedId, testPolicy.policyName)), WorkbenchEmail("a@b.c"), Set.empty, Set.empty, Set.empty, public = false), samRequestContext)
 
       membership <- policyDAO.loadPolicyMembership(newPolicy.id, samRequestContext)
     } yield {
       membership.value.memberEmails should contain theSameElementsAs Set(
         testGroup.email,
-        dummyUserInfo.userEmail,
+        dummyUser.email,
         testPolicy.email
       )
     }
@@ -1371,9 +1369,9 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
       _ <- service.createResourceType(constrainableResourceType, samRequestContext)
       _ <- service.createResourceType(managedGroupResourceType, samRequestContext)
 
-      _ <- managedGroupService.createManagedGroup(ResourceId("authDomain"), dummyUserInfo, samRequestContext = samRequestContext)
-      childResource <- service.createResource(constrainableResourceType, ResourceId("child"), childAccessPolicies, Set(WorkbenchGroupName("authDomain")), None, dummyUserInfo.userId, samRequestContext)
-      parentResource <- service.createResource(constrainableResourceType, ResourceId("parent"), dummyUserInfo, samRequestContext)
+      _ <- managedGroupService.createManagedGroup(ResourceId("authDomain"), dummyUser, samRequestContext = samRequestContext)
+      childResource <- service.createResource(constrainableResourceType, ResourceId("child"), childAccessPolicies, Set(WorkbenchGroupName("authDomain")), None, dummyUser.id, samRequestContext)
+      parentResource <- service.createResource(constrainableResourceType, ResourceId("parent"), dummyUser, samRequestContext)
       _ <- service.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext)
     } yield ()
 
@@ -1387,7 +1385,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
   "deletePolicy" should "delete the policy" in {
     val testResult = for {
       _ <- service.createResourceType(defaultResourceType, samRequestContext)
-      resource <- service.createResource(defaultResourceType, ResourceId("resource"), dummyUserInfo, samRequestContext)
+      resource <- service.createResource(defaultResourceType, ResourceId("resource"), dummyUser, samRequestContext)
 
       policyId = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/POL-235
This is the first step to handling the enabled user check in Sam. I want to handle the check in the `requireUserInfo` directive which already loads the user. The problem is that the `WorkbenchUser` does not include the `enabled` field. Adding it means changing workbench-libs which makes me want to jump out the window. And `WorkbenchUser` is not even exposed outside of Sam so why is it in a shared lib? So I made `SamUser`. The next problem is that most of the contents of `SamUser` is dropped on the floor when returning a `UserInfo` object. The special fields in `UserInfo` (access token and expiration) are not even used in Sam. So return `SamUser` instead. The rest is updating tests to excise all uses of `UserInfo` and `WorkbenchUser`. Also centralize construction of `SamUser`s in the Generator functions.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
