### PR TITLE
POL-237 terms of service first class

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -18,4 +18,5 @@
     <include file="changesets/20201123_flat_group_membership.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211010_azure_b2c_id.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220328_idx_serp_source_policy_id.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220511_tos_version.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
@@ -11,4 +11,10 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet logicalFilePath="dummy" author="dvoet" id="migrate_tos">
+        <sql>
+            update sam_user set accepted_tos_version = '0' where id in
+            (select gmf.member_user_id from sam_group_member_flat gmf join sam_group g on g.id = gmf.group_id where g.name = 'tos_accepted_0' and gmf.member_user_id is not null)
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="dvoet" id="add_tos_version">
+        <addColumn tableName="sam_user">
+            <column name="accepted_tos_version" type="VARCHAR(40)">
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -32,7 +32,6 @@ import org.broadinstitute.dsde.workbench.sam.google._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.DelegatePool
 import org.broadinstitute.dsde.workbench.util2.ExecutionContexts
 
@@ -76,8 +75,6 @@ object Boot extends IOApp with LazyLogging {
         _ <- dependencies.samApplication.resourceService.initResourceTypes().onError {
           case t: Throwable => IO(logger.error("FATAL - failure starting http server", t)) *> IO.raiseError(t)
         }
-
-        _ <- dependencies.samApplication.tosService.resetTermsOfServiceGroupsIfNeeded(SamRequestContext(None))
 
         _ <- dependencies.policyEvaluatorService.initPolicy()
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -30,7 +30,8 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
         user <- getSamUser(directoryDAO, registrationDAO, oidcHeaders, samRequestContext)
         tosStatusAcceptable <- tosService.isTermsOfServiceStatusAcceptable(user.id, samRequestContext)
       } yield {
-        val permittedToAccessTerra = tosStatusAcceptable && user.enabled
+        // service account users do not need to accept ToS
+        val permittedToAccessTerra = (tosStatusAcceptable || SAdomain.matches(user.email.value)) && user.enabled
         if (permittedToAccessTerra) {
           user
         } else {
@@ -59,7 +60,8 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
       googleSubjectId,
       oidcHeaders.email,
       azureB2CId,
-      false)
+      false,
+      None)
   }
 
   /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardUserInfoDirectives.scala
@@ -28,10 +28,10 @@ trait StandardUserInfoDirectives extends UserInfoDirectives with LazyLogging wit
     onSuccess {
       val requireActiveUserIO = for {
         user <- getSamUser(directoryDAO, registrationDAO, oidcHeaders, samRequestContext)
-        tosStatusAcceptable <- tosService.isTermsOfServiceStatusAcceptable(user.id, samRequestContext)
       } yield {
         // service account users do not need to accept ToS
-        val permittedToAccessTerra = (tosStatusAcceptable || SAdomain.matches(user.email.value)) && user.enabled
+        val tosStatusAcceptable = tosService.isTermsOfServiceStatusAcceptable(user) || SAdomain.matches(user.email.value)
+        val permittedToAccessTerra = tosStatusAcceptable && user.enabled
         if (permittedToAccessTerra) {
           user
         } else {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -139,7 +139,7 @@ object AppConfig {
     TermsOfServiceConfig(
       config.getBoolean("enabled"),
       config.getBoolean("isGracePeriodEnabled"),
-      config.getInt("version"),
+      config.getString("version"),
       config.getString("url")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/TermsOfServiceConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/TermsOfServiceConfig.scala
@@ -8,4 +8,4 @@ package org.broadinstitute.dsde.workbench.sam.config
   * @param url The url to the Terra Terms of Service. Used for validation and will be displayed to user in error messages
   */
 
-case class TermsOfServiceConfig(enabled: Boolean, isGracePeriodEnabled: Boolean, version: Int, url: String)
+case class TermsOfServiceConfig(enabled: Boolean, isGracePeriodEnabled: Boolean, version: String, url: String)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -61,4 +61,7 @@ trait DirectoryDAO extends RegistrationDAO {
   def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]]
   def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit]
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit]
+
+  def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
+  def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
@@ -9,7 +9,9 @@ final case class UserRecord(id: WorkbenchUserId,
                             email: WorkbenchEmail,
                             googleSubjectId: Option[GoogleSubjectId],
                             enabled: Boolean,
-                            azureB2cId: Option[AzureB2CId])
+                            azureB2cId: Option[AzureB2CId],
+                            acceptedTosVersion: Option[String]
+                           )
 
 object UserTable extends SQLSyntaxSupportWithDefaultSamDB[UserRecord] {
   override def tableName: String = "SAM_USER"
@@ -20,12 +22,13 @@ object UserTable extends SQLSyntaxSupportWithDefaultSamDB[UserRecord] {
     rs.get(e.email),
     rs.stringOpt(e.googleSubjectId).map(GoogleSubjectId),
     rs.get(e.enabled),
-    rs.stringOpt(e.azureB2cId).map(AzureB2CId)
+    rs.stringOpt(e.azureB2cId).map(AzureB2CId),
+    rs.stringOpt(e.acceptedTosVersion)
   )
 
   def apply(o: SyntaxProvider[UserRecord])(rs: WrappedResultSet): UserRecord = apply(o.resultName)(rs)
 
   def unmarshalUserRecord(userRecord: UserRecord): SamUser = {
-    SamUser(userRecord.id, userRecord.googleSubjectId, userRecord.email, userRecord.azureB2cId, userRecord.enabled)
+    SamUser(userRecord.id, userRecord.googleSubjectId, userRecord.email, userRecord.azureB2cId, userRecord.enabled, userRecord.acceptedTosVersion)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -113,7 +113,7 @@ class GoogleExtensions(
           case Some(_) =>
             IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"subjectId $googleSubjectId is not a SamUser")))
           case None =>
-            val newUser = SamUser(genWorkbenchUserId(System.currentTimeMillis()), Option(googleSubjectId), googleServicesConfig.serviceAccountClientEmail, None, false)
+            val newUser = SamUser(genWorkbenchUserId(System.currentTimeMillis()), Option(googleSubjectId), googleServicesConfig.serviceAccountClientEmail, None, false, None)
             IO.fromFuture(IO(samApplication.userService.createUser(newUser, samRequestContext))).map(_ => newUser)
         }
       }
@@ -373,7 +373,7 @@ class GoogleExtensions(
     for {
       subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
       key <- subject match {
-        case Some(userId: WorkbenchUserId) => getPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), project, samRequestContext).map(Option(_))
+        case Some(userId: WorkbenchUserId) => getPetServiceAccountKey(SamUser(userId, None, userEmail, None, false, None), project, samRequestContext).map(Option(_))
         case _ => IO.pure(None)
       }
     } yield key

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -246,7 +246,8 @@ final case class SamUser(id: WorkbenchUserId,
                          googleSubjectId: Option[GoogleSubjectId],
                          email: WorkbenchEmail,
                          azureB2CId: Option[AzureB2CId],
-                         enabled: Boolean) {
+                         enabled: Boolean,
+                         acceptedTosVersion: Option[String]) {
   def toUserIdInfo = UserIdInfo(id, email, googleSubjectId)
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, Registrat
 import org.broadinstitute.dsde.workbench.sam.errorReportSource
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
 
 import scala.concurrent.ExecutionContext
 import java.io.{FileNotFoundException, IOException}
@@ -44,12 +45,8 @@ class TosService (val directoryDao: DirectoryDAO, val registrationDao: Registrat
     * If ToS disabled, return true
     * Otherwise return true if user has accepted ToS
     */
-  def isTermsOfServiceStatusAcceptable(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] = {
-    if (tosConfig.isGracePeriodEnabled) {
-      IO.pure(true)
-    } else {
-      getTosStatus(userId, samRequestContext).map(_.getOrElse(true))
-    }
+  def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean = {
+    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version)
   }
 
   /**

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -42,7 +42,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       _ <- UserService.validateEmailAddress(inviteeEmail, blockedEmailDomains)
       existingSubject <- directoryDAO.loadSubjectFromEmail(inviteeEmail, samRequestContext)
       createdUser <- existingSubject match {
-        case None => createUserInternal(SamUser(genWorkbenchUserId(System.currentTimeMillis()), None, inviteeEmail, None, false), samRequestContext)
+        case None => createUserInternal(SamUser(genWorkbenchUserId(System.currentTimeMillis()), None, inviteeEmail, None, false, None), samRequestContext)
         case Some(_) =>
           IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"email ${inviteeEmail} already exists")))
       }
@@ -63,7 +63,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           acceptInvitedUser(user, samRequestContext, uid)
 
         case None =>
-          createUserInternal(SamUser(user.id, user.googleSubjectId, user.email, user.azureB2CId, false), samRequestContext)
+          createUserInternal(user, samRequestContext)
 
         case Some(_) =>
           //We don't support inviting a group account or pet service account
@@ -92,8 +92,8 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
   private def validateNewWorkbenchUser(newWorkbenchUser: SamUser, samRequestContext: SamRequestContext): IO[Unit] = {
     for {
       existingUser <- newWorkbenchUser match {
-        case SamUser(_, Some(googleSubjectId), _, _, _) => directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
-        case SamUser(_, _, _, Some(azureB2CId), _) => directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext).map(_.map(_.id))
+        case SamUser(_, Some(googleSubjectId), _, _, _, _) => directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
+        case SamUser(_, _, _, Some(azureB2CId), _, _) => directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext).map(_.map(_.id))
         case _ => IO.raiseError(new WorkbenchException("cannot create user when neither google subject id nor azure b2c id exists"))
       }
 
@@ -142,8 +142,6 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
   def acceptTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] = {
     for {
       _ <- tosService.acceptTosStatus(userId, samRequestContext)
-      enabled <- directoryDAO.isEnabled(userId, samRequestContext)
-      _ <- if (enabled) registrationDAO.enableIdentity(userId, samRequestContext) else IO.none
       status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
     } yield status
   }
@@ -151,7 +149,6 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
   def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] = {
     for {
       _ <- tosService.rejectTosStatus(userId, samRequestContext)
-      _ <- registrationDAO.disableIdentity(userId, samRequestContext)
       status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
     } yield status
   }
@@ -224,7 +221,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
   private def enableUserInternal(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = {
     for {
       _ <- directoryDAO.enableIdentity(user.id, samRequestContext).unsafeToFuture()
-      _ <- enableIdentityIfTosAccepted(user, samRequestContext).unsafeToFuture()
+      _ <- registrationDAO.enableIdentity(user.id, samRequestContext).unsafeToFuture()
       _ <- cloudExtensions.onUserEnable(user, samRequestContext)
     } yield ()
   }
@@ -233,29 +230,6 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
 
   private def isServiceAccount(email: String) = {
     serviceAccountDomain.pattern.matcher(email).matches
-  }
-
-  private def enableIdentityIfTosAccepted(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = {
-    val gracePeriodEnabled = tosService.tosConfig.isGracePeriodEnabled
-    tosService.getTosStatus(user.id, samRequestContext)
-      .flatMap {
-        // If the user has accepted TOS, the grace period is enabled, or TOS is disabled, then enable the user in LDAP
-        // Additionally, if the user is an SA, it's also acceptable to enable them in LDAP
-        case Some(true) | None => {
-          logger.info(s"ToS requirement will not be bypassed for user ${user.id} / ${user.email}. termsOfService.enabled: ${tosService.tosConfig.enabled}, gracePeriod: ${gracePeriodEnabled}")
-          registrationDAO.enableIdentity(user.id, samRequestContext)
-        }
-        case _ =>
-          if(isServiceAccount(user.email.value) || gracePeriodEnabled) {
-            logger.info(s"Bypassing ToS requirement for user ${user.id} / ${user.email}. " +
-              s"gracePeriod: ${gracePeriodEnabled}, isServiceAccount: ${isServiceAccount(user.email.value)}")
-            registrationDAO.enableIdentity(user.id, samRequestContext)
-          }
-          else {
-            logger.info(s"ToS requirement will not be bypassed for user ${user.id} / ${user.email}. termsOfService.enabled: ${tosService.tosConfig.enabled}, gracePeriod: ${gracePeriodEnabled}")
-            IO.unit
-          }
-      }
   }
 
   def disableUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Option[UserStatus]] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -157,9 +157,9 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     directoryDAO.loadUser(userId, samRequestContext).flatMap {
       case Some(user) =>
         for {
-          tosStatus <- tosService.isTermsOfServiceStatusAcceptable(user.id, samRequestContext)
           adminEnabled <- directoryDAO.isEnabled(user.id, samRequestContext)
         } yield {
+          val tosStatus = tosService.isTermsOfServiceStatusAcceptable(user)
           Some(UserStatusInfo(user.id.value, user.email.value, tosStatus && adminEnabled, adminEnabled))
         }
       case None => IO.pure(None)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/LdapSupport.scala
@@ -40,7 +40,7 @@ trait LdapSupport {
     for {
       uid <- getAttribute(results, Attr.uid).toRight(s"${Attr.uid} attribute missing")
       email <- getAttribute(results, Attr.email).toRight(s"${Attr.email} attribute missing")
-    } yield SamUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email), None, false)
+    } yield SamUser(WorkbenchUserId(uid), getAttribute(results, Attr.googleSubjectId).map(GoogleSubjectId), WorkbenchEmail(email), None, false, None)
 
   /**
     * Executes ldap query.

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -32,26 +32,26 @@ object Generator {
     email <- genNonPetEmail
     googleSubjectId <- genGoogleSubjectId
     userId = genWorkbenchUserId(System.currentTimeMillis())
-  }yield SamUser(userId, Option(googleSubjectId), email, None, false)
+  }yield SamUser(userId, Option(googleSubjectId), email, None, false, None)
 
   val genWorkbenchUserServiceAccount = for{
     email <- genServiceAccountEmail
     googleSubjectId <- genGoogleSubjectId
     userId = genWorkbenchUserId(System.currentTimeMillis())
-  }yield SamUser(userId, Option(googleSubjectId), email, None, false)
+  }yield SamUser(userId, Option(googleSubjectId), email, None, false, None)
 
   val genWorkbenchUserAzure = for {
     email <- genNonPetEmail
     azureB2CId <- genAzureB2CId
     userId = genWorkbenchUserId(System.currentTimeMillis())
-  } yield SamUser(userId, None, email, Option(azureB2CId), false)
+  } yield SamUser(userId, None, email, Option(azureB2CId), false, None)
 
   val genWorkbenchUserBoth = for {
     email <- genNonPetEmail
     googleSubjectId <- genGoogleSubjectId
     azureB2CId <- genAzureB2CId
     userId = genWorkbenchUserId(System.currentTimeMillis())
-  } yield SamUser(userId, Option(googleSubjectId), email, Option(azureB2CId), false)
+  } yield SamUser(userId, Option(googleSubjectId), email, Option(azureB2CId), false, None)
 
   val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s${x.take(50)}")) //prepending `s` just so this won't be an empty string
   val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) //prepending `s` just so this won't be an empty string

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -22,14 +22,14 @@ import scala.concurrent.ExecutionContext
   * Created by dvoet on 7/14/17.
   */
 class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[SamUser] = None, tosService: TosService = null)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
   def mockRegistrationDao: RegistrationDAO = registrationDAO
 }
 
 class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val workbenchUser: Option[SamUser] = None, tosService: TosService)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, 0, "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration) with MockUserInfoDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
   def mockRegistrationDao: RegistrationDAO = registrationDAO

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -187,7 +187,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       case (`policyIdentity`, policy: AccessPolicy) => policy.members
     }
     members.flatten.collect {
-      case u: WorkbenchUserId => SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false)
+      case u: WorkbenchUserId => SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false, None)
     }.toSet
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -290,4 +290,30 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(users.values.find(_.googleSubjectId.contains(userId)))
+
+  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] = {
+    loadUser(userId, samRequestContext).map {
+      case None => false
+      case Some(user) =>
+        if (user.acceptedTosVersion.contains(tosVersion)) {
+          false
+        } else {
+          users.put(userId, user.copy(acceptedTosVersion = Option(tosVersion)))
+          true
+        }
+    }
+  }
+
+  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] = {
+    loadUser(userId, samRequestContext).map {
+      case None => false
+      case Some(user) =>
+        if (user.acceptedTosVersion.isEmpty) {
+          false
+        } else {
+          users.put(userId, user.copy(acceptedTosVersion = None))
+          true
+        }
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -143,8 +143,8 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
 
   private[service] def savePolicyMembers(policy: AccessPolicy) = {
     policy.members.toList.traverse {
-      case u: WorkbenchUserId => dirDAO.createUser(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false), samRequestContext).recoverWith {
-        case _: WorkbenchException => IO.pure(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false))
+      case u: WorkbenchUserId => dirDAO.createUser(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false, None), samRequestContext).recoverWith {
+        case _: WorkbenchException => IO.pure(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false, None))
       }
       case g: WorkbenchGroupName => managedGroupService.createManagedGroup(ResourceId(g.value), dummyUser, samRequestContext = samRequestContext).recoverWith {
         case _: WorkbenchException => IO.pure(Resource(defaultResourceType.name, ResourceId(g.value), Set.empty))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -1,28 +1,17 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
-import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
-import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, LdapRegistrationDAO, PostgresDirectoryDAO, RegistrationDAO}
+import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, LdapRegistrationDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.schema.JndiSchemaDAO
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.net.URI
-import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
-import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar.mock
-
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
 
-class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll with BeforeAndAfter {
+class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll with BeforeAndAfter with PropertyBasedTesting {
 
   private lazy val directoryConfig = TestSupport.appConfig.directoryConfig
   private lazy val schemaLockConfig = TestSupport.appConfig.schemaLockConfig
@@ -35,14 +24,10 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
   val defaultUser = Generator.genWorkbenchUserBoth.sample.get
   val serviceAccountUser = Generator.genWorkbenchUserServiceAccount.sample.get
 
-  private val tosServiceEnabledV0 = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = 0))
+  private val tosServiceEnabledV0 = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "0"))
   private val tosServiceEnabled = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true))
-  private val tosServiceEnabledV2 = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = 2))
+  private val tosServiceEnabledV2 = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2"))
   private val tosServiceDisabled = new TosService(dirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = false))
-  private val userServiceTosEnabledV0 = new UserService(dirDAO, NoExtensions, regDAO, Seq.empty, tosServiceEnabledV0)
-  private val userServiceTosEnabled = new UserService(dirDAO, NoExtensions, regDAO, Seq.empty, tosServiceEnabled)
-  private val userServiceTosEnabledV2 = new UserService(dirDAO, NoExtensions, regDAO, Seq.empty, tosServiceEnabledV2)
-  private val userServiceTosDisabled = new UserService(dirDAO, NoExtensions, regDAO, Seq.empty, tosServiceDisabled)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -64,39 +49,7 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     TestSupport.truncateAll
   }
 
-  it should "generate the expected group name" in {
-    assert(tosServiceEnabled.getGroupName(0).value == "tos_accepted_0")
-    assert(tosServiceEnabled.getGroupName(10).value == "tos_accepted_10")
-  }
-
-  it should "create the group once" in {
-    assert(tosServiceEnabled.getTosGroupNameIfExists(samRequestContext).unsafeRunSync().isEmpty, "ToS Group should not exist at the start")
-    assert(tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync().isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
-    val maybeGroup = tosServiceEnabled.getTosGroupNameIfExists(samRequestContext).unsafeRunSync()
-    assert(maybeGroup.isDefined, "ToS Group should exist after above call")
-    assert(maybeGroup.get.value == "tos_accepted_0")
-    assert(tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync().isDefined, "resetTermsOfServiceGroupsIfNeeded() should return the same response when called again")
-  }
-
-  it should "tolerate the race condition where the ToS group is created after checking to see if it exists" in {
-    val mockDirDAO = mock[DirectoryDAO]
-    val tosService = new TosService(mockDirDAO, regDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = 0))
-
-    when(mockDirDAO.createGroup(any[BasicWorkbenchGroup], any[Option[String]], any[SamRequestContext]))
-      .thenReturn(IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "group already exists!")(ErrorReportSource("sam")))))
-    when(mockDirDAO.loadGroupEmail(any[WorkbenchGroupName], any[SamRequestContext])).thenReturn(IO(None))
-
-    assert(tosService.getTosGroupNameIfExists(samRequestContext).unsafeRunSync().isEmpty, "ToS Group should not exist at the start")
-    assert(tosService.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync().isDefined, "resetTermsOfServiceGroupsIfNeeded() should not fail if the group is created after it tries to load it")
-  }
-
-  it should "do nothing if ToS check is not enabled" in {
-    assert(tosServiceDisabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext) == IO.none)
-  }
-
-  it should "accept, get, and reject the ToS for a user" in {
-    val group = tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
+  "TosService" should "accept, get, and reject the ToS for a user" in {
     dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
     // accept and get ToS status
@@ -112,171 +65,15 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     assertResult(expected = false, s"getTosStatus(${defaultUser.id}) should have returned false")(actual = getTosStatusResultRejected.get)
   }
 
-  it should "empty the enabledUsers group in OpenDJ when the ToS version changes" in {
-    //Reset the ToS groups (this will empty the enabled-users group, but it should already be empty)
-    val group = tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
-
-    //Create the user in the system
-    Await.result(userServiceTosEnabled.createUser(defaultUser, samRequestContext), Duration.Inf)
-
-    //As the above user, accept the ToS
-    userServiceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    //Check if the user has accepted ToS
-    val isEnabledViaToS = dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledViaToS, "dirDAO.isEnabled (first check) should have returned true")
-
-    //Check if the user is enabled in LDAP
-    val isEnabledLdap = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledLdap, "regDAO.isEnabled (first check) should have returned true")
-
-    //Bump the ToS version and reset the ToS groups
-    val group2 = tosServiceEnabledV2.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group2.isDefined, "resetTermsOfServiceGroupsIfNeeded() should re-create the group")
-
-    //Ensure that the user is now disabled, because they haven't accepted the new ToS version
-    val isEnabledLdapV2 = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assertResult(expected = false, "regDAO.isEnabled (second check) should have returned false")(actual = isEnabledLdapV2)
-
-    //Lastly, let's make sure the user can get re-enabled when accepting the new ToS version
-    userServiceTosEnabledV2.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    //Ensure that the user is now disabled, because they haven't accepted the new ToS version
-    val isEnabledLdapV2PostAccept = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assertResult(expected = true, "regDAO.isEnabled (second check) should have returned false")(actual = isEnabledLdapV2PostAccept)
-
-    //Delete the user from the system
-    Await.result(userServiceTosEnabled.deleteUser(defaultUser.id, samRequestContext), Duration.Inf)
-  }
-
-  it should "not empty the enabledUsers group in OpenDJ when the ToS version remains the same" in {
-    //Reset the ToS groups (this will empty the enabled-users group, but it should already be empty)
-    val group = tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
-
-    //Create the user in the system
+  it should "accept new version of ToS" in {
     dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-    //Enable in Postgres
-    dirDAO.enableIdentity(defaultUser.id, samRequestContext).unsafeRunSync()
+    tosServiceEnabledV0.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(false)
+    tosServiceEnabledV0.acceptTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
+    tosServiceEnabledV0.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
 
-    //As the above user, accept the ToS
-    userServiceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    //Check if the user has accepted ToS
-    val isEnabledViaToS = dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledViaToS, "dirDAO.isEnabled (first check) should have returned true")
-
-    //Check if the user is enabled in LDAP
-    val isEnabledLdap = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledLdap, "regDAO.isEnabled (first check) should have returned true")
-
-    //Reset the ToS groups, which should be a no-op since the version remains the same
-    val group2 = tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-
-    //Ensure that the user is NOT disabled, because we haven't changed the ToS version
-    val isEnabledLdapPostReset = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assertResult(expected = true, "regDAO.isEnabled (second check) should have returned false")(actual = isEnabledLdapPostReset)
+    tosServiceEnabledV2.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(false)
+    tosServiceEnabledV2.acceptTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
+    tosServiceEnabledV2.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
   }
-
-  it should "not remove Service Accounts from the enabledUsers group in OpenDJ when the ToS version changes" in {
-    //Reset the ToS groups (this will empty the enabled-users group, but it should already be empty)
-    val group = tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the group initially")
-
-    //Create the users in the system
-    Await.result(userServiceTosEnabled.createUser(defaultUser, samRequestContext), Duration.Inf)
-    Await.result(userServiceTosEnabled.createUser(serviceAccountUser, samRequestContext), Duration.Inf)
-
-    //As the above user, accept the ToS
-    userServiceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    //Check if the user has accepted ToS and is enabled in Postgres
-    val isEnabledViaToS = dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledViaToS, "dirDAO.isEnabled (first check) should have returned true [User]")
-
-    //Check if the SA is enabled
-    val isSAEnabledViaToS = dirDAO.isEnabled(serviceAccountUser.id, samRequestContext).unsafeRunSync()
-    assert(isSAEnabledViaToS, "dirDAO.isEnabled (first check) should have returned true [SA]")
-
-    //Check if the user is enabled in LDAP
-    val isEnabledLdap = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledLdap, "regDAO.isEnabled (first check) should have returned true [User]")
-
-    //Check if the SA is enabled in LDAP
-    val isSAEnabledLdap = regDAO.isEnabled(serviceAccountUser.id, samRequestContext).unsafeRunSync()
-    assert(isSAEnabledLdap, "regDAO.isEnabled (first check) should have returned true [SA]")
-
-    //Bump the ToS version and reset the ToS groups
-    val group2 = tosServiceEnabledV2.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group2.isDefined, "resetTermsOfServiceGroupsIfNeeded() should re-create the group")
-
-    //Ensure that the user is now disabled, because they haven't accepted the new ToS version
-    val isEnabledLdapV2 = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assertResult(expected = false, "regDAO.isEnabled (second check) should have returned false [User]")(actual = isEnabledLdapV2)
-
-    //Ensure that the SA is still enabled, because we don't disable SAs when the ToS version changes
-    val isSAEnabledLdapV2 = regDAO.isEnabled(serviceAccountUser.id, samRequestContext).unsafeRunSync()
-    assertResult(expected = true, "regDAO.isEnabled (second check) should have returned true [SA]")(actual = isSAEnabledLdapV2)
-  }
-
-  it should "not remove users from the enabledUsers group in OpenDJ when the ToS version is v0" in {
-    //Create the users in the system with ToS disabled. This simulates the rollout to production
-    Await.result(userServiceTosDisabled.createUser(defaultUser, samRequestContext), Duration.Inf)
-    Await.result(userServiceTosDisabled.createUser(serviceAccountUser, samRequestContext), Duration.Inf)
-
-    //Check if the user is enabled in LDAP
-    val isEnabledLdap = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledLdap, "regDAO.isEnabled (first check) should have returned true [User]")
-
-    //Check if the SA is enabled in LDAP
-    val isSAEnabledLdap = regDAO.isEnabled(serviceAccountUser.id, samRequestContext).unsafeRunSync()
-    assert(isSAEnabledLdap, "regDAO.isEnabled (first check) should have returned true [SA]")
-
-    //Reset the ToS groups (this shouldn't do anything to the enabledUsers group, which we'll assert elsewhere below)
-    val group = tosServiceEnabledV0.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the Postgres group initially")
-
-    //Check if the user is enabled in LDAP
-    val isEnabledLdapAfter = regDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    assert(isEnabledLdapAfter, "regDAO.isEnabled (second check) should have returned true [User]")
-
-    //Check if the SA is enabled in LDAP
-    val isSAEnabledLdapAfter = regDAO.isEnabled(serviceAccountUser.id, samRequestContext).unsafeRunSync()
-    assert(isSAEnabledLdapAfter, "regDAO.isEnabled (second check) should have returned true [SA]")
-  }
-
-  it should "throw when it fails to remove users from the enabledUsers group in OpenDJ" in {
-    val mockRegDAO = mock[RegistrationDAO]
-    val tosService = new TosService(dirDAO, mockRegDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = 1))
-
-    when(mockRegDAO.disableAllHumanIdentities(any[SamRequestContext]))
-      .thenReturn(IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport("Couldn't empty enabled-users")(ErrorReportSource("sam")))))
-
-    intercept [WorkbenchExceptionWithErrorReport] {
-      tosService.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    }
-  }
-
-  it should "should allow a user to accept ToS v0" in {
-    //Create the users in the system with ToS disabled. This simulates the rollout to production
-    Await.result(userServiceTosDisabled.createUser(defaultUser, samRequestContext), Duration.Inf)
-
-    //Reset the ToS groups
-    val group = tosServiceEnabledV0.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    assert(group.isDefined, "resetTermsOfServiceGroupsIfNeeded() should create the Postgres group initially")
-
-    //Check if the user has accepted ToS and is enabled in Postgres
-    val isEnabledViaToS = tosServiceEnabledV0.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync().get
-    assert(!isEnabledViaToS, "tosServiceEnabledV0.getTosStatus (first check) should have returned false [User]")
-
-    //As the above user, accept the ToS
-    userServiceTosEnabledV0.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    //Check if the user has accepted ToS and is enabled in Postgres
-    val isEnabledViaToSAfter = tosServiceEnabledV0.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync().get
-    assert(isEnabledViaToSAfter, "tosServiceEnabledV0.getTosStatus (second check) should have returned true [User]")
-  }
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.implicits.{global => globalEc}
 import com.unboundid.ldap.sdk.{LDAPConnection, LDAPConnectionPool}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.Generator.{arbNonPetEmail => _, _}
-import org.broadinstitute.dsde.workbench.sam.TestSupport.{googleServicesConfig, tosConfig}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, LdapRegistrationDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -50,11 +50,7 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
   var service: UserService = _
   var tos: TosService = _
   var serviceTosEnabled: UserService = _
-  var serviceTosEnabledGracePeriodDisabled: UserService = _
-  var serviceTosEnabledGracePeriodEnabled: UserService = _
   var tosServiceEnabled: TosService = _
-  var tosServiceEnabledGracePeriodDisabled: TosService = _
-  var tosServiceEnabledGracePeriodEnabled: TosService = _
   var googleExtensions: GoogleExtensions = _
   val blockedDomain = "blocked.domain.com"
 
@@ -78,15 +74,8 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
 
     tos = new TosService(dirDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
     service = new UserService(dirDAO, googleExtensions, registrationDAO, Seq(blockedDomain), tos)
-
-    runAndWait(registrationDAO.createEnabledUsersGroup(samRequestContext).unsafeToFuture())
-
     tosServiceEnabled = new TosService(dirDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig.copy(enabled = true))
-    tosServiceEnabledGracePeriodEnabled = new TosService(dirDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig.copy(enabled = true, isGracePeriodEnabled = true))
-    tosServiceEnabledGracePeriodDisabled = new TosService(dirDAO, registrationDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig.copy(enabled = true, isGracePeriodEnabled = false))
     serviceTosEnabled = new UserService(dirDAO, googleExtensions, registrationDAO, Seq(blockedDomain), tosServiceEnabled)
-    serviceTosEnabledGracePeriodEnabled = new UserService(dirDAO, googleExtensions, registrationDAO, Seq(blockedDomain), tosServiceEnabledGracePeriodEnabled)
-    serviceTosEnabledGracePeriodDisabled = new UserService(dirDAO, googleExtensions, registrationDAO, Seq(blockedDomain), tosServiceEnabledGracePeriodDisabled)
   }
 
   protected def clearDatabase(): Unit = {
@@ -118,37 +107,10 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     }.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
   }
 
-  it should "create and add a user to ToS group" in {
-    tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
+  it should "acceptTermsOfService" in {
     serviceTosEnabled.createUser(defaultUser, samRequestContext).futureValue
-    val userGroups = dirDAO.listUsersGroups(defaultUser.id, samRequestContext).unsafeRunSync()
-    userGroups shouldNot contain (tos.getGroupName(TestSupport.tosConfig.version))
-    userGroups should have size 1
-
-    serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-    val newUserGroups = dirDAO.listUsersGroups(defaultUser.id, samRequestContext).unsafeRunSync()
-    newUserGroups should contain (tos.getGroupName(TestSupport.tosConfig.version))
-    newUserGroups should have size 2
-  }
-
-  it should "not add user to ToS when tos is not enabled" in {
-    service.createUser(defaultUser, samRequestContext).futureValue
-    val userGroups = dirDAO.listUsersGroups(defaultUser.id, samRequestContext).unsafeRunSync()
-    userGroups should have size 1
-  }
-
-  it should "enable a user immediately if ToS is enabled and the grace period is enabled" in {
-    tosServiceEnabledGracePeriodEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    serviceTosEnabledGracePeriodEnabled.createUser(defaultUser, samRequestContext).futureValue
-    val isEnabled = registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    isEnabled shouldBe true
-  }
-
-  it should "not enable a user immediately if ToS is enabled and the grace period is disabled" in {
-    tosServiceEnabledGracePeriodDisabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    serviceTosEnabledGracePeriodDisabled.createUser(defaultUser, samRequestContext).futureValue
-    val isEnabled = registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync()
-    isEnabled shouldBe false
+    val status = serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
+    status shouldBe Option(UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("tosAccepted" -> true, "google" -> true, "ldap" -> true, "allUsersGroup" -> true, "adminEnabled" -> true)))
   }
 
   it should "get user status" in {
@@ -215,66 +177,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe false
   }
 
-  it should "enable a user in LDAP if they accept the latest Terms of Service" in {
-    createNewEnabledUser()
-    updateTosVersionThenEnableUser(userAcceptsNewTos = true)
-
-    // User should be enabled in LDAP
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-  }
-
-  it should "not enable a user in LDAP when they don't accept the latest Terms of Service" in {
-    createNewEnabledUser()
-    updateTosVersionThenEnableUser()
-
-    // User should not be enabled in LDAP
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe false
-  }
-
-  it should "enable a user in LDAP when TOS is disabled" in {
-    createNewEnabledUser()
-    updateTosVersionThenEnableUser(tosEnabled = false)
-
-    // User should be enabled in LDAP
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-  }
-
-  private def createNewEnabledUser(): Unit = {
-    // create a user
-    tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-    val newUser = serviceTosEnabled.createUser(defaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> false, "adminEnabled" -> true))
-    serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeToFuture().futureValue
-
-    // it should be enabled
-    dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-  }
-
-  private def updateTosVersionThenEnableUser(tosEnabled: Boolean = true, userAcceptsNewTos: Boolean = false): Unit = {
-    // update the terms of service version
-    val newTosConfig = tosConfig.copy(enabled = tosEnabled, version = tosConfig.version + 1)
-    val newTos = new TosService(dirDAO, registrationDAO, googleServicesConfig.appsDomain, newTosConfig)
-    val userServiceWithNewTos =  new UserService(dirDAO, googleExtensions, registrationDAO, Seq(blockedDomain), newTos)
-    newTos.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-
-    if (userAcceptsNewTos) {
-      userServiceWithNewTos.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeToFuture().futureValue
-    }
-
-    // disable the user and re-enable the user
-    userServiceWithNewTos.disableUser(defaultUser.id, samRequestContext).futureValue
-    userServiceWithNewTos.enableUser(defaultUser.id, samRequestContext).futureValue
-
-    // User should be enabled in SAM
-    dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-
-    // User should only be enabled in ToS if they accepted latest ToS
-    val tosGroup = newTos.getGroupName()
-    val userGroups = dirDAO.listUsersGroups(defaultUser.id, samRequestContext).unsafeRunSync()
-    userGroups.contains(tosGroup) shouldEqual userAcceptsNewTos
-  }
-
   it should "delete a user" in {
     // create a user
     val newUser = service.createUser(defaultUser, samRequestContext).futureValue
@@ -286,44 +188,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     // check
     dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe None
     registrationDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe None
-  }
-
-  it should "accept the tos and reject the tos" in {
-    tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-
-    // create a user
-    val newUser = serviceTosEnabled.createUser(defaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> false, "adminEnabled" -> true))
-
-    serviceTosEnabled.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    val status = serviceTosEnabled.getUserStatus(defaultUser.id, samRequestContext = samRequestContext).futureValue
-    status shouldBe Some(UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)))
-
-    serviceTosEnabled.rejectTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-    val rejectedStatus = serviceTosEnabled.getUserStatus(defaultUser.id, samRequestContext = samRequestContext).futureValue
-    rejectedStatus shouldBe Some(UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> false, "adminEnabled" -> true)))
-  }
-
-  it should "not accept the tos for users when the terms of service is not enabled" in {
-    // create a user
-    val newUser = service.createUser(defaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
-
-    service.acceptTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
-
-    val status = service.getUserStatus(defaultUser.id, samRequestContext = samRequestContext).futureValue
-    status shouldBe Some(UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)))
-
-  }
-
-  it should "immediately enable an SA when registering, without accepting the ToS" in {
-    val serviceAccountUser = genWorkbenchUserServiceAccount.sample.get
-
-    tosServiceEnabled.resetTermsOfServiceGroupsIfNeeded(samRequestContext).unsafeRunSync()
-
-    val newSA = serviceTosEnabled.createUser(serviceAccountUser, samRequestContext).futureValue
-    newSA shouldBe UserStatus(UserStatusDetails(serviceAccountUser.id, serviceAccountUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> false, "adminEnabled" -> true))
   }
 
   it should "generate unique identifier properly" in {
@@ -454,7 +318,7 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     val userId = dirDAO.loadSubjectFromEmail(userEmail, samRequestContext).unsafeRunSync().value.asInstanceOf[WorkbenchUserId]
     val res = dirDAO.loadUser(userId, samRequestContext).unsafeRunSync()
     val registrationRes = registrationDAO.loadUser(userId, samRequestContext).unsafeRunSync()
-    res shouldBe Some(SamUser(userId, None, userEmail, None, false))
+    res shouldBe Some(SamUser(userId, None, userEmail, None, false, None))
     registrationRes shouldEqual res
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/POL-237
This PR removes all the code that tried to make terms of service work with ldap. That hit a big road block anyway because of caching at the apache proxy layer. This also stops modeling ToS acceptance as a group within Sam and instead tracks the last version accepted by a user in the sam_user table. This makes it even easier to determine if a user has met all the criteria to make Terra api calls - now it requires only 1 database round trip.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
