### PR TITLE
implement audit logging

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -38,13 +38,11 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
 
   def resourceRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     (pathPrefix("config" / "v1" / "resourceTypes") | pathPrefix("resourceTypes")) {
-        withActiveUser(SamRequestContext(None)) { samUser => // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods ; these in particular are unpublished APIs
-          pathEndOrSingleSlash {
-            get {
-              complete(resourceService.getResourceTypes().map(typeMap => StatusCodes.OK -> typeMap.values.toSet))
-            }
-          }
+      pathEndOrSingleSlash {
+        get {
+          complete(resourceService.getResourceTypes().map(typeMap => StatusCodes.OK -> typeMap.values.toSet))
         }
+      }
     } ~
     (pathPrefix("resources" / "v1") | pathPrefix("resource")) {
       pathPrefix(Segment) { resourceTypeName =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -60,11 +60,12 @@ abstract class SamRoutes(
           pathPrefix("api") {
             // IMPORTANT - all routes under /api must have an active user
             withActiveUser(samRequestContext) { samUser =>
-              resourceRoutes(samUser, samRequestContext) ~
-                adminUserRoutes(samUser, samRequestContext) ~
-                extensionRoutes(samUser, samRequestContext) ~
-                groupRoutes(samUser, samRequestContext) ~
-                apiUserRoutes(samUser, samRequestContext)
+              val samRequestContextWithUser = samRequestContext.copy(samUser = Option(samUser))
+              resourceRoutes(samUser, samRequestContextWithUser) ~
+                adminUserRoutes(samUser, samRequestContextWithUser) ~
+                extensionRoutes(samUser, samRequestContextWithUser) ~
+                groupRoutes(samUser, samRequestContextWithUser) ~
+                apiUserRoutes(samUser, samRequestContextWithUser)
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/AuditLogger.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/AuditLogger.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.workbench.sam.audit
+
+import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
+import net.logstash.logback.argument.StructuredArguments
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import spray.json.{JsonWriter, enrichAny}
+import SamAuditModelJsonSupport.AuditInfoFormat
+
+object AuditLogger extends LazyLogging {
+  def logAuditEventIO[T <: AuditEvent : JsonWriter](samRequestContext: SamRequestContext, auditEvents: T*): IO[Unit] = {
+    IO(auditEvents.foreach(logAuditEvent(_, samRequestContext)))
+  }
+
+  def logAuditEvent[T <: AuditEvent : JsonWriter](auditEvent: T, samRequestContext: SamRequestContext): Unit = {
+    logger.whenInfoEnabled {
+      logger.info("auditEvent",
+        StructuredArguments.raw("eventDetails", auditEvent.toJson.compactPrint),
+        StructuredArguments.raw("auditInfo", samRequestContext.createAuditInfo.toJson.compactPrint))
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/AuditLogger.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/AuditLogger.scala
@@ -14,7 +14,7 @@ object AuditLogger extends LazyLogging {
 
   def logAuditEvent[T <: AuditEvent : JsonWriter](auditEvent: T, samRequestContext: SamRequestContext): Unit = {
     logger.whenInfoEnabled {
-      logger.info("auditEvent",
+      logger.info(auditEvent.eventType.toString,
         StructuredArguments.raw("eventDetails", auditEvent.toJson.compactPrint),
         StructuredArguments.raw("auditInfo", samRequestContext.createAuditInfo.toJson.compactPrint))
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
@@ -1,0 +1,122 @@
+package org.broadinstitute.dsde.workbench.sam.audit
+
+import org.broadinstitute.dsde.workbench.model.{WorkbenchException, WorkbenchGroupName, WorkbenchSubject, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedPolicyId, FullyQualifiedResourceId, ResourceAction, ResourceRoleName, ResourceTypeName}
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, RootJsonFormat, SerializationException}
+
+import java.net.InetAddress
+import java.time.Instant
+
+sealed trait AuditEvent
+
+final case class AuditInfo(userId: Option[WorkbenchUserId], timestamp: Instant, clientIp: Option[InetAddress])
+
+final case class ResourceChange(parent: Option[FullyQualifiedResourceId])
+
+sealed trait ResourceEventType
+case object ResourceCreated extends ResourceEventType
+case object ResourceUpdated extends ResourceEventType
+case object ResourceDeleted extends ResourceEventType
+
+final case class ResourceEvent(eventType: ResourceEventType,
+                               resource: FullyQualifiedResourceId,
+                               added: Option[ResourceChange] = None,
+                               removed: Option[ResourceChange] = None) extends AuditEvent
+
+case class AccessChange(member: WorkbenchSubject,
+                        roles: Option[Iterable[ResourceRoleName]],
+                        actions: Option[Iterable[ResourceAction]],
+                        descendantRoles: Option[Map[ResourceTypeName, Iterable[ResourceRoleName]]],
+                        descendantActions: Option[Map[ResourceTypeName, Iterable[ResourceAction]]])
+
+sealed trait AccessChangeEventType
+case object AccessAdded extends AccessChangeEventType
+case object AccessRemoved extends AccessChangeEventType
+
+final case class AccessChangeEvent(eventType: AccessChangeEventType,
+                                   resource: FullyQualifiedResourceId,
+                                   changeDetails: Set[AccessChange]) extends AuditEvent
+
+object SamAuditModelJsonSupport {
+  import DefaultJsonProtocol._
+  import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+  import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
+  import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+
+  implicit object InetAddressFormat extends RootJsonFormat[InetAddress] {
+    def write(ip: InetAddress) = JsString(ip.getHostAddress)
+
+    def read(value: JsValue): InetAddress = value match {
+      case JsString(str) => InetAddress.getByAddress(str.getBytes)
+      case _             => throw new WorkbenchException(s"Unable to unmarshal InetAddress from $value")
+    }
+  }
+
+  implicit val AuditInfoFormat = jsonFormat3(AuditInfo)
+
+  implicit val ResourceChangeFormat = jsonFormat1(ResourceChange)
+  implicit val ResourceEventTypeFormat = new RootJsonFormat[ResourceEventType] {
+    def read(obj: JsValue): ResourceEventType = obj match {
+      case JsString("ResourceCreated") => ResourceCreated
+      case JsString("ResourceUpdated") => ResourceUpdated
+      case JsString("ResourceDeleted") => ResourceDeleted
+      case _                           => throw new DeserializationException(s"could not deserialize ResourceEventType: $obj")
+    }
+
+    def write(obj: ResourceEventType): JsValue = JsString(obj.getClass.getSimpleName.split("\\$")(0))
+  }
+
+  implicit val ResourceEventFormat = jsonFormat4(ResourceEvent)
+
+  implicit val WorkbenchSubjectFormat = new RootJsonFormat[WorkbenchSubject] {
+    val MEMBER_TYPE_FIELD = "memberType"
+    val USER_TYPE = "user"
+    val GROUP_TYPE = "group"
+    val POLICY_TYPE = "policy"
+    val USER_ID_FIELD = "userId"
+    val GROUP_NAME_FIELD = "groupName"
+    val POLICY_ID_FIELD = "policyId"
+
+    override def read(json: JsValue): WorkbenchSubject = {
+      json match {
+        case JsObject(fields) =>
+          val maybeSubject: Option[WorkbenchSubject] = fields.get(MEMBER_TYPE_FIELD) match {
+            case Some(JsString(USER_TYPE)) => fields.get(USER_ID_FIELD).map(WorkbenchUserIdFormat.read)
+            case Some(JsString(GROUP_TYPE)) => fields.get(GROUP_NAME_FIELD).map(WorkbenchGroupNameFormat.read)
+            case Some(JsString(POLICY_TYPE)) => fields.get(POLICY_ID_FIELD).map(FullyQualifiedPolicyIdFormat.read)
+            case _ => None
+          }
+          maybeSubject.getOrElse(throw new DeserializationException(s"could not deserialize WorkbenchSubject: $json"))
+
+        case _ =>
+          throw new DeserializationException(s"could not deserialize WorkbenchSubject: $json")
+      }
+    }
+
+    override def write(obj: WorkbenchSubject): JsValue = {
+      obj match {
+        case user: WorkbenchUserId =>
+          JsObject(Map(MEMBER_TYPE_FIELD -> JsString(USER_TYPE), USER_ID_FIELD -> WorkbenchUserIdFormat.write(user)))
+        case groupName: WorkbenchGroupName =>
+          JsObject(Map(MEMBER_TYPE_FIELD -> JsString(GROUP_TYPE), GROUP_NAME_FIELD -> WorkbenchGroupNameFormat.write(groupName)))
+        case policyId: FullyQualifiedPolicyId =>
+          JsObject(Map(MEMBER_TYPE_FIELD -> JsString(POLICY_TYPE), POLICY_ID_FIELD -> FullyQualifiedPolicyIdFormat.write(policyId)))
+
+        case _ => throw new SerializationException(s"could not serialize WorkbenchSubject: $obj")
+      }
+    }
+  }
+
+  implicit val AccessChangeFormat = jsonFormat5(AccessChange)
+  implicit val AccessChangeEventTypeFormat = new RootJsonFormat[AccessChangeEventType] {
+    def read(obj: JsValue): AccessChangeEventType = obj match {
+      case JsString("AccessAdded") => AccessAdded
+      case JsString("AccessRemoved") => AccessRemoved
+      case _                         => throw new DeserializationException(s"could not deserialize AccessChangeEventType: $obj")
+    }
+
+    def write(obj: AccessChangeEventType): JsValue = JsString(obj.getClass.getSimpleName.split("\\$")(0))
+  }
+
+  implicit val PolicyEventFormat = jsonFormat3(AccessChangeEvent)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
@@ -9,8 +9,6 @@ import java.net.InetAddress
 sealed trait AuditEventType
 sealed trait AuditEvent {
   val eventType: AuditEventType
-
-  override def toString: String = getClass.getSimpleName.split("\\$")(0)
 }
 
 final case class AuditInfo(userId: Option[WorkbenchUserId], clientIp: Option[InetAddress])

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
@@ -19,8 +19,8 @@ final case class ResourceChange(parent: FullyQualifiedResourceId)
 
 sealed trait ResourceEventType extends AuditEventType
 case object ResourceCreated extends ResourceEventType
-case object ParentUpdated extends ResourceEventType
-case object ParentRemoved extends ResourceEventType
+case object ResourceParentUpdated extends ResourceEventType
+case object ResourceParentRemoved extends ResourceEventType
 case object ResourceDeleted extends ResourceEventType
 
 final case class ResourceEvent(eventType: ResourceEventType,
@@ -61,8 +61,8 @@ object SamAuditModelJsonSupport {
   implicit val ResourceEventTypeFormat = new RootJsonFormat[ResourceEventType] {
     def read(obj: JsValue): ResourceEventType = obj match {
       case JsString("ResourceCreated") => ResourceCreated
-      case JsString("ParentUpdated") => ParentUpdated
-      case JsString("ParentRemoved") => ParentRemoved
+      case JsString("ResourceParentUpdated") => ResourceParentUpdated
+      case JsString("ResourceParentRemoved") => ResourceParentRemoved
       case JsString("ResourceDeleted") => ResourceDeleted
       case _                           => throw new DeserializationException(s"could not deserialize ResourceEventType: $obj")
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
@@ -5,11 +5,10 @@ import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedPolicyId, Full
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, RootJsonFormat, SerializationException}
 
 import java.net.InetAddress
-import java.time.Instant
 
 sealed trait AuditEvent
 
-final case class AuditInfo(userId: Option[WorkbenchUserId], timestamp: Instant, clientIp: Option[InetAddress])
+final case class AuditInfo(userId: Option[WorkbenchUserId], clientIp: Option[InetAddress])
 
 final case class ResourceChange(parent: Option[FullyQualifiedResourceId])
 
@@ -40,7 +39,6 @@ final case class AccessChangeEvent(eventType: AccessChangeEventType,
 object SamAuditModelJsonSupport {
   import DefaultJsonProtocol._
   import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
-  import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
   import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 
   implicit object InetAddressFormat extends RootJsonFormat[InetAddress] {
@@ -52,7 +50,7 @@ object SamAuditModelJsonSupport {
     }
   }
 
-  implicit val AuditInfoFormat = jsonFormat3(AuditInfo)
+  implicit val AuditInfoFormat = jsonFormat2(AuditInfo)
 
   implicit val ResourceChangeFormat = jsonFormat1(ResourceChange)
   implicit val ResourceEventTypeFormat = new RootJsonFormat[ResourceEventType] {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -66,7 +66,7 @@ trait AccessPolicyDAO {
 
   def listFlattenedPolicyMembers(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[SamUser]]
 
-  def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean, samRequestContext: SamRequestContext): IO[Unit]
+  def setPolicyIsPublic(policyId: FullyQualifiedPolicyId, isPublic: Boolean, samRequestContext: SamRequestContext): IO[Boolean]
 
   def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -74,10 +74,10 @@ class GoogleExtensions(
 
   override val emailDomain = googleServicesConfig.appsDomain
   private[google] val allUsersGroupEmail = WorkbenchEmail(
-    s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}GROUP_${allUsersGroupName.value}@$emailDomain")
+    s"${googleServicesConfig.resourceNamePrefix.getOrElse("")}GROUP_${CloudExtensions.allUsersGroupName.value}@$emailDomain")
 
   override def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext)(implicit executionContext: ExecutionContext): Future[WorkbenchGroup] = {
-    val allUsersGroup = BasicWorkbenchGroup(allUsersGroupName, Set.empty, allUsersGroupEmail)
+    val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, allUsersGroupEmail)
     for {
       createdGroup <- directoryDAO.createGroup(allUsersGroup, samRequestContext = samRequestContext).unsafeToFuture() recover {
         case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) => allUsersGroup
@@ -101,7 +101,7 @@ class GoogleExtensions(
 
 
   def onBoot(samApplication: SamApplication)(implicit system: ActorSystem): IO[Unit] = {
-    val samRequestContext = SamRequestContext(None) // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods
+    val samRequestContext = SamRequestContext() // `SamRequestContext()` is used so that we don't trace 1-off boot/init methods
     val extensionResourceType =
       resourceTypes.getOrElse(CloudExtensions.resourceTypeName, throw new Exception(s"${CloudExtensions.resourceTypeName} resource type not found"))
     val googleSubjectId = GoogleSubjectId(googleServicesConfig.serviceAccountClientId)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitor.scala
@@ -192,7 +192,7 @@ class GoogleGroupSyncMonitorActor(
 
   private def parseMessage(message: PubSubMessage): WorkbenchGroupIdentity =
     (Try {
-      import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport.PolicyIdentityFormat
+      import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport.FullyQualifiedPolicyIdFormat
       message.contents.parseJson.convertTo[FullyQualifiedPolicyId]
     } recover {
       case _: DeserializationException =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.FutureSupport
 
@@ -42,7 +43,7 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
   extends LazyLogging with FutureSupport {
 
   def init(): IO[Set[ResourceTypeName]] =
-    accessPolicyDAO.upsertResourceTypes(resourceTypes.values.toSet, SamRequestContext(None))
+    accessPolicyDAO.upsertResourceTypes(resourceTypes.values.toSet, SamRequestContext())
 
   def synchronizeGroupMembers(groupId: WorkbenchGroupIdentity, visitedGroups: Set[WorkbenchGroupIdentity] = Set.empty[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): Future[Map[WorkbenchEmail, Seq[SyncReportItem]]] = {
     def toSyncReportItem(operation: String, email: String, result: Try[Unit]) =
@@ -68,7 +69,7 @@ class GoogleGroupSynchronizer(directoryDAO: DirectoryDAO,
               .map(_.map { loadedPolicy =>
                 if (loadedPolicy.public) {
                   // include all users group when synchronizing a public policy
-                  AccessPolicy.members.modify(_ + googleExtensions.allUsersGroupName)(loadedPolicy)
+                  AccessPolicy.members.modify(_ + CloudExtensions.allUsersGroupName)(loadedPolicy)
                 } else {
                   loadedPolicy
                 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -56,7 +56,7 @@ object SamJsonSupport {
 
   implicit val UserResourcesResponseFormat = jsonFormat6(UserResourcesResponse.apply)
 
-  implicit val PolicyIdentityFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
+  implicit val FullyQualifiedPolicyIdFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
 
   implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -20,11 +20,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object CloudExtensions {
   val resourceTypeName = ResourceTypeName("cloud-extension")
+  val allUsersGroupName = WorkbenchGroupName("All_Users")
 }
 
 trait CloudExtensions {
-  val allUsersGroupName = WorkbenchGroupName("All_Users")
-
   // this is temporary until we get the admin group rolled into a sam group
   def isWorkbenchAdmin(memberEmail: WorkbenchEmail): Future[Boolean]
 
@@ -96,7 +95,7 @@ trait NoExtensions extends CloudExtensions {
   override val emailDomain = "example.com"
 
   override def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext)(implicit executionContext: ExecutionContext): Future[WorkbenchGroup] = {
-    val allUsersGroup = BasicWorkbenchGroup(allUsersGroupName, Set.empty, WorkbenchEmail(s"GROUP_${allUsersGroupName.value}@$emailDomain"))
+    val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"GROUP_${CloudExtensions.allUsersGroupName.value}@$emailDomain"))
     for {
       createdGroup <- directoryDAO.createGroup(allUsersGroup, samRequestContext = samRequestContext).unsafeToFuture() recover {
         case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) => allUsersGroup

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PermissionsByUsers.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PermissionsByUsers.scala
@@ -1,0 +1,83 @@
+package org.broadinstitute.dsde.workbench.sam.service
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchSubject
+import org.broadinstitute.dsde.workbench.sam.audit.AccessChange
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, ResourceAction, ResourceRoleName, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.util.groupByFirstInPair
+
+/**
+  * Utility class for comparing collections of policies for use in audit logs
+  * @param policies
+  */
+private[service] class PermissionsByUsers(policies: Iterable[AccessPolicy]) {
+  private val memberRoles: Set[(WorkbenchSubject, ResourceRoleName)] = flattenMemberRoles(policies)
+  private val memberActions: Set[(WorkbenchSubject, ResourceAction)] = flattenMemberActions(policies)
+  private val memberDescendantRoles: Set[(WorkbenchSubject, (ResourceTypeName, ResourceRoleName))] = flattenMemberDependantRoles(policies)
+  private val memberDescendantActions: Set[(WorkbenchSubject, (ResourceTypeName, ResourceAction))] = flattenMemberDependantActions(policies)
+
+  /**
+    * Returns the set of access changes if all the permissions in `other` are removed from `this`.
+    */
+  def removeAll(other: PermissionsByUsers): Set[AccessChange] = {
+    val memberRolesDiff = groupByFirstInPair(this.memberRoles removedAll other.memberRoles)
+    val memberActionsDiff = groupByFirstInPair(this.memberActions removedAll other.memberActions)
+    val memberDescendantRolesDiff = groupByFirstInPair(this.memberDescendantRoles removedAll other.memberDescendantRoles)
+    val memberDescendantActionsDiff = groupByFirstInPair(this.memberDescendantActions removedAll other.memberDescendantActions)
+    compileDiff(memberRolesDiff, memberActionsDiff, memberDescendantRolesDiff, memberDescendantActionsDiff)
+  }
+
+  private def compileDiff(
+      memberRolesDiff: Map[WorkbenchSubject, Iterable[ResourceRoleName]],
+      memberActionsDiff: Map[WorkbenchSubject, Iterable[ResourceAction]],
+      memberDescendantRolesDiff: Map[WorkbenchSubject, Iterable[(ResourceTypeName, ResourceRoleName)]],
+      memberDescendantActionsDiff: Map[WorkbenchSubject, Iterable[(ResourceTypeName, ResourceAction)]]) = {
+    for {
+      member <- memberRolesDiff.keySet ++ memberActionsDiff.keySet ++ memberDescendantRolesDiff.keySet ++ memberDescendantActionsDiff.keySet
+    } yield {
+      AccessChange(
+        member,
+        memberRolesDiff.get(member),
+        memberActionsDiff.get(member),
+        memberDescendantRolesDiff.get(member).map(groupByFirstInPair),
+        memberDescendantActionsDiff.get(member).map(groupByFirstInPair)
+      )
+    }
+  }
+
+  private def flattenMemberRoles(policies: Iterable[AccessPolicy]): Set[(WorkbenchSubject, ResourceRoleName)] =
+    (for {
+      policy <- policies
+      member <- policy.members ++ maybeAllUsers(policy.public)
+      role <- policy.roles
+    } yield (member, role)).toSet
+
+  private def flattenMemberActions(policies: Iterable[AccessPolicy]): Set[(WorkbenchSubject, ResourceAction)] =
+    (for {
+      policy <- policies
+      member <- policy.members ++ maybeAllUsers(policy.public)
+      action <- policy.actions
+    } yield (member, action)).toSet
+
+  private def flattenMemberDependantRoles(policies: Iterable[AccessPolicy]): Set[(WorkbenchSubject, (ResourceTypeName, ResourceRoleName))] =
+    (for {
+      policy <- policies
+      member <- policy.members ++ maybeAllUsers(policy.public)
+      descendantPermission <- policy.descendantPermissions
+      role <- descendantPermission.roles
+    } yield (member, (descendantPermission.resourceType, role))).toSet
+
+  private def flattenMemberDependantActions(policies: Iterable[AccessPolicy]): Set[(WorkbenchSubject, (ResourceTypeName, ResourceAction))] =
+    (for {
+      policy <- policies
+      member <- policy.members ++ maybeAllUsers(policy.public)
+      descendantPermission <- policy.descendantPermissions
+      action <- descendantPermission.actions
+    } yield (member, (descendantPermission.resourceType, action))).toSet
+
+  private def maybeAllUsers(public: Boolean) =
+    if (public) {
+      LazyList(CloudExtensions.allUsersGroupName)
+    } else {
+      LazyList.empty
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -31,7 +31,7 @@ class PolicyEvaluatorService(
           Set(SamResourceActions.setPublicPolicy(ManagedGroupService.adminNotifierPolicyName)),
           Set.empty,
           true
-        ), SamRequestContext(None)) // `SamRequestContext(None)` is used so that we don't trace 1-off boot/init methods
+        ), SamRequestContext()) // `SamRequestContext()` is used so that we don't trace 1-off boot/init methods
       .void
       .recoverWith {
         case duplicateException: WorkbenchExceptionWithErrorReport if duplicateException.errorReport.statusCode.contains(StatusCodes.Conflict) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -8,7 +8,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChangeEvent, AuditLogger, ResourceChange, ResourceCreated, ResourceDeleted, ResourceEvent, ResourceUpdated}
+import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChangeEvent, AccessRemoved, AuditLogger, ResourceChange, ResourceCreated, ResourceDeleted, ResourceEvent, ResourceUpdated}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -638,11 +638,11 @@ class ResourceService(
     accessPolicyDAO.listResourceChildren(resourceId, samRequestContext)
   }
 
-  private def createAccessChangeEvents(resource: FullyQualifiedResourceId, beforePolicies: Iterable[AccessPolicy], afterPolicies: Iterable[AccessPolicy]): Iterable[AccessChangeEvent] = {
+  private[service] def createAccessChangeEvents(resource: FullyQualifiedResourceId, beforePolicies: Iterable[AccessPolicy], afterPolicies: Iterable[AccessPolicy]): Iterable[AccessChangeEvent] = {
     val before = new PermissionsByUsers(beforePolicies)
     val after = new PermissionsByUsers(afterPolicies)
 
-    val removeEvent = AccessChangeEvent(AccessAdded, resource, before.removeAll(after))
+    val removeEvent = AccessChangeEvent(AccessRemoved, resource, before.removeAll(after))
     val addEvent = AccessChangeEvent(AccessAdded, resource, after.removeAll(before))
 
     // only include event in results if there are changes

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -9,7 +9,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChangeEvent, AccessRemoved, AuditLogger, ParentRemoved, ParentUpdated, ResourceChange, ResourceCreated, ResourceDeleted, ResourceEvent}
+import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChangeEvent, AccessRemoved, AuditLogger, ResourceParentRemoved, ResourceParentUpdated, ResourceChange, ResourceCreated, ResourceDeleted, ResourceEvent}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -605,7 +605,7 @@ class ResourceService(
             _ <- accessPolicyDAO.setResourceParent(childResource, parentResource, samRequestContext)
             _ <- AuditLogger.logAuditEventIO(
               samRequestContext,
-              ResourceEvent(ParentUpdated, childResource, Option(ResourceChange(parentResource))))
+              ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
           } yield ()
         case LoadResourceAuthDomainResult.Constrained(_) => IO.raiseError(
           new WorkbenchExceptionWithErrorReport(
@@ -629,7 +629,7 @@ class ResourceService(
           _ <- accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
           _ <- AuditLogger.logAuditEventIO(
             samRequestContext,
-            ResourceEvent(ParentRemoved, resourceId, Option(ResourceChange(oldParent))))
+            ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
         } yield ()
       }
     } yield maybeOldParent.isDefined

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -116,7 +116,8 @@ class ResourceService(
           _ <- AuditLogger.logAuditEventIO(
             samRequestContext,
             ResourceEvent(ResourceCreated,
-              FullyQualifiedResourceId(resourceType.name, resourceId)))
+              FullyQualifiedResourceId(resourceType.name, resourceId),
+              parentOpt.map(ResourceChange)))
 
           changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId),
             LazyList.empty, persisted.accessPolicies)
@@ -508,9 +509,9 @@ class ResourceService(
     } yield policyChanged
   }
 
-  private def onPolicyUpdateIfChanged(policyIdentity: FullyQualifiedPolicyId, orginalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext)(policyChanged: Boolean) = {
+  private def onPolicyUpdateIfChanged(policyIdentity: FullyQualifiedPolicyId, originalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext)(policyChanged: Boolean) = {
     val maybeFireNotification = if (policyChanged) {
-      onPolicyUpdate(policyIdentity, orginalPolicies, samRequestContext)
+      onPolicyUpdate(policyIdentity, originalPolicies, samRequestContext)
     } else {
       IO.unit
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
@@ -43,7 +43,7 @@ class StatusService(
     if (ldapRegistrationDAO.getConnectionType() != ConnectionType.LDAP) {
       HealthMonitor.failedStatus("Connection of RegistrationDAO is not to OpenDJ")
     } else {
-      if (ldapRegistrationDAO.checkStatus(SamRequestContext(None)))
+      if (ldapRegistrationDAO.checkStatus(SamRequestContext()))
         HealthMonitor.OkStatus
       else
         HealthMonitor.failedStatus(s"LDAP database connection invalid or timed out checking")
@@ -55,7 +55,7 @@ class StatusService(
     if (directoryDAO.getConnectionType() != ConnectionType.Postgres) {
       HealthMonitor.failedStatus("Connection of RegistrationDAO is not to Postgres")
     } else {
-      if (directoryDAO.checkStatus(SamRequestContext(None)))
+      if (directoryDAO.checkStatus(SamRequestContext()))
         HealthMonitor.OkStatus
       else
         HealthMonitor.failedStatus("Postgres database connection invalid or timed out checking")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/OpenCensusIOUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/OpenCensusIOUtils.scala
@@ -33,7 +33,7 @@ object OpenCensusIOUtils {
   private def traceIOSpan[T](name: String, spanIO: IO[Span], samRequestContext: SamRequestContext, failureStatus: Throwable => Status) (f: SamRequestContext => IO[T]): IO[T] = {
     for {
       span <- spanIO
-      result <- f(samRequestContext.copy(parentSpan = Option(span))).attempt
+      result <- f(samRequestContext.copy(parentSpan = Option(span), None)).attempt
       _ <- IO(endSpan(span, Status.OK))
     } yield result.toTry.get
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/SamRequestContext.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/SamRequestContext.scala
@@ -1,6 +1,11 @@
 package org.broadinstitute.dsde.workbench.sam.util
 
 import io.opencensus.trace.Span
+import org.broadinstitute.dsde.workbench.sam.audit.AuditInfo
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
+
+import java.net.InetAddress
+import java.time.Instant
 
 /**
   * Contains any additional data for the request.
@@ -13,4 +18,8 @@ import io.opencensus.trace.Span
   *                   parent span.
   *
  */
-case class SamRequestContext (parentSpan: Option[Span])
+case class SamRequestContext(parentSpan: Option[Span] = None,
+                             clientIp: Option[InetAddress] = None,
+                             samUser: Option[SamUser] = None) {
+  def createAuditInfo: AuditInfo = AuditInfo(samUser.map(_.id), Instant.now(), clientIp)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/SamRequestContext.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/SamRequestContext.scala
@@ -5,7 +5,6 @@ import org.broadinstitute.dsde.workbench.sam.audit.AuditInfo
 import org.broadinstitute.dsde.workbench.sam.model.SamUser
 
 import java.net.InetAddress
-import java.time.Instant
 
 /**
   * Contains any additional data for the request.
@@ -21,5 +20,5 @@ import java.time.Instant
 case class SamRequestContext(parentSpan: Option[Span] = None,
                              clientIp: Option[InetAddress] = None,
                              samUser: Option[SamUser] = None) {
-  def createAuditInfo: AuditInfo = AuditInfo(samUser.map(_.id), Instant.now(), clientIp)
+  def createAuditInfo: AuditInfo = AuditInfo(samUser.map(_.id), clientIp)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/package.scala
@@ -1,0 +1,14 @@
+package org.broadinstitute.dsde.workbench.sam
+
+package object util {
+  /**
+    * Takes a list of pairs and returns a map grouped by the first element with values of lists of the second
+    * @param list pairs to group by first element
+    * @tparam X type of first element in pair
+    * @tparam Y type of second element in pair
+    * @return map grouped by first element
+    */
+  def groupByFirstInPair[X, Y](list: Iterable[(X, Y)]): Map[X, Iterable[Y]] = {
+    list.groupBy(_._1).map { case (key, pairs) => key -> pairs.map(_._2) }
+  }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -67,6 +67,14 @@
         <appender-ref ref="Sentry" />
     </logger>
 
+    <!-- auditing in tests makes a ton of logs, set level to info to see them -->
+    <logger name="org.broadinstitute.dsde.workbench.sam.audit.AuditLogger$" level="off" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
     <root level="warn">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -109,6 +109,14 @@ object Generator {
     email <- genNonPetEmail
     roles <- Gen.listOf(genRoleName).map(_.toSet)
     actions <- Gen.listOf(genResourceAction).map(_.toSet)
+  } yield AccessPolicy(id, members, email, roles, actions, Set.empty, public = false)
+
+  val genPolicyWithDescendantPermissions: Gen[AccessPolicy] = for{
+    id <- genPolicyIdentity
+    members <- Gen.listOf(genWorkbenchSubject).map(_.toSet)
+    email <- genNonPetEmail
+    roles <- Gen.listOf(genRoleName).map(_.toSet)
+    actions <- Gen.listOf(genResourceAction).map(_.toSet)
     descendantPermissions <- Gen.listOf(genAccessPolicyDescendantPermissions).map(_.toSet)
   } yield AccessPolicy(id, members, email, roles, actions, descendantPermissions, public = false)
 

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -97,13 +97,20 @@ object Generator {
     policyName <- genAccessPolicyName
   } yield FullyQualifiedPolicyId(r, policyName)
 
+  val genAccessPolicyDescendantPermissions: Gen[AccessPolicyDescendantPermissions] = for {
+    resourceType <- genResourceTypeName
+    roles <- Gen.listOf(genRoleName).map(_.toSet)
+    actions <- Gen.listOf(genResourceAction).map(_.toSet)
+  } yield AccessPolicyDescendantPermissions(resourceType, actions, roles)
+
   val genPolicy: Gen[AccessPolicy] = for{
     id <- genPolicyIdentity
     members <- Gen.listOf(genWorkbenchSubject).map(_.toSet)
     email <- genNonPetEmail
     roles <- Gen.listOf(genRoleName).map(_.toSet)
     actions <- Gen.listOf(genResourceAction).map(_.toSet)
-  } yield AccessPolicy(id, members, email, roles, actions, Set.empty, public = false)
+    descendantPermissions <- Gen.listOf(genAccessPolicyDescendantPermissions).map(_.toSet)
+  } yield AccessPolicy(id, members, email, roles, actions, descendantPermissions, public = false)
 
   implicit val arbNonPetEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genNonPetEmail)
   implicit val arbOAuth2BearerToken: Arbitrary[OAuth2BearerToken] = Arbitrary(genOAuth2BearerToken)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -54,7 +54,7 @@ trait TestSupport{
   implicit val futureTimeout = Timeout(Span(10, Seconds))
   implicit val eqWorkbenchException: Eq[WorkbenchException] = (x: WorkbenchException, y: WorkbenchException) => x.getMessage == y.getMessage
 
-  val samRequestContext = SamRequestContext(None)
+  val samRequestContext = SamRequestContext()
 
   def dummyResourceType(name: ResourceTypeName) = ResourceType(name, Set.empty, Set(ResourceRole(ResourceRoleName("owner"), Set.empty)), ResourceRoleName("owner"))
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.yaml.snakeyaml.Yaml
 
-import scala.jdk.CollectionConverters._
+  import scala.jdk.CollectionConverters._
 
 /**
   * These tests verify that the apis published in swagger/api-docs.yaml call the correct SamUserDirectives.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -169,7 +169,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
         val newPolicy = policy.copy(public = isPublic)
         IO {
           policies.put(resourceAndPolicyName, newPolicy) match {
-            case Some(AccessPolicy(_, _, _, _, _, _, public)) if public != isPublic => true
+            case Some(AccessPolicy(_, _, _, _, _, _, public)) => public != isPublic
             case _ => false
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -740,7 +740,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         // create a user and a group containing that single user
         val allUserGroups = for (i <- 1 to userCount) yield {
-          val user = dao.createUser(Generator.genWorkbenchUserGoogle.sample.get.copy(id = WorkbenchUserId(s"user$i")), samRequestContext).unsafeRunSync()
+          val user = dao.createUser(Generator.genWorkbenchUserGoogle.sample.get.copy(id = WorkbenchUserId(s"user$i"), email = WorkbenchEmail(s"user$i@email"), googleSubjectId = None), samRequestContext).unsafeRunSync()
           val group = BasicWorkbenchGroup(WorkbenchGroupName(s"usergroup$i"), Set(user.id), WorkbenchEmail(s"usergroup$i"))
           dao.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -110,13 +110,13 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
         case p: AccessPolicy =>
           when(mockAccessPolicyDAO.loadPolicy(p.id, samRequestContext)).thenReturn(IO.pure(Option(testPolicy)))
       }
-      when(mockDirectoryDAO.loadGroup(ge.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(BasicWorkbenchGroup(ge.allUsersGroupName, Set.empty, ge.allUsersGroupEmail))))
+      when(mockDirectoryDAO.loadGroup(CloudExtensions.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, ge.allUsersGroupEmail))))
       when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.unit)
       when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.pure(Some((new GregorianCalendar(2017, 11, 22).getTime()))))
 
       val subGroups = Seq(inSamSubGroup, inGoogleSubGroup, inBothSubGroup)
       subGroups.foreach { g => when(mockDirectoryDAO.loadSubjectEmail(g.id, samRequestContext)).thenReturn(IO.pure(Option(g.email))) }
-      when(mockDirectoryDAO.loadSubjectEmail(ge.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(ge.allUsersGroupEmail)))
+      when(mockDirectoryDAO.loadSubjectEmail(CloudExtensions.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(ge.allUsersGroupEmail)))
 
       val added = Seq(inSamSubGroup.email, WorkbenchEmail(inSamUserProxyEmail)) ++ (target match {
         case _: BasicWorkbenchGroup => Seq.empty
@@ -578,7 +578,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
     val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
-    val allUsersGroup = BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
+    val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
     val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
       override def matches(group: BasicWorkbenchGroup): Boolean = group.id == allUsersGroup.id
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -55,7 +55,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
       assert(mockGooglePubSubDAO.subscriptionsByName.contains(subscriptionName))
     }
 
-    import SamJsonSupport.PolicyIdentityFormat
+    import SamJsonSupport.FullyQualifiedPolicyIdFormat
     import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchGroupNameFormat
     mockGooglePubSubDAO.publishMessages(topicName, Seq(groupToSyncId.toJson.compactPrint, policyToSyncId.toJson.compactPrint))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -14,7 +14,7 @@ import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam
 import org.broadinstitute.dsde.workbench.sam.Generator._
-import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChange, AccessChangeEvent, AccessChangeEventType, AccessRemoved, AuditEventType, AuditLogger, ParentRemoved, ParentUpdated, ResourceCreated, ResourceDeleted}
+import org.broadinstitute.dsde.workbench.sam.audit.{AccessAdded, AccessChange, AccessChangeEvent, AccessChangeEventType, AccessRemoved, AuditEventType, AuditLogger, ResourceParentRemoved, ResourceParentUpdated, ResourceCreated, ResourceDeleted}
 import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.resourceTypeReader
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
@@ -1675,7 +1675,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     policyDAO.createResource(parent, samRequestContext).unsafeRunSync()
     policyDAO.createResource(resource, samRequestContext).unsafeRunSync()
 
-    runAuditLogTest(service.setResourceParent(resource.fullyQualifiedId, parent.fullyQualifiedId, samRequestContext), List(ParentUpdated), tryTwice = false)
+    runAuditLogTest(service.setResourceParent(resource.fullyQualifiedId, parent.fullyQualifiedId, samRequestContext), List(ResourceParentUpdated), tryTwice = false)
   }
 
   it should "be called on deleteResourceParent" in {
@@ -1685,7 +1685,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     policyDAO.createResource(parent, samRequestContext).unsafeRunSync()
     policyDAO.createResource(resource, samRequestContext).unsafeRunSync()
 
-    runAuditLogTest(service.deleteResourceParent(resource.fullyQualifiedId, samRequestContext), List(ParentRemoved))
+    runAuditLogTest(service.deleteResourceParent(resource.fullyQualifiedId, samRequestContext), List(ResourceParentRemoved))
   }
 
   it should "be called on removeSubjectFromPolicy" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1436,7 +1436,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result shouldBe empty
   }
 
-  it should "not show not changes for the same beforePolicies and afterPolicies" in forAll(genPolicy) { testPolicy =>
+  it should "not show not changes for the same beforePolicies and afterPolicies" in forAll(genPolicyWithDescendantPermissions) { testPolicy =>
     val resource = genResource.sample.get
     val beforePolicies = List(testPolicy)
     val afterPolicies = beforePolicies
@@ -1444,7 +1444,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result shouldBe empty
   }
 
-  it should "show changes for empty beforePolicies" in forAll(genPolicy) { testPolicy =>
+  it should "show changes for empty beforePolicies" in forAll(genPolicyWithDescendantPermissions) { testPolicy =>
     val beforePolicies = List.empty
     val afterPolicies = List(testPolicy)
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1463,7 +1463,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedChangeEvents
   }
 
-  it should "show changes for empty afterPolicies" in forAll(genPolicy) { testPolicy =>
+  it should "show changes for empty afterPolicies" in forAll(genPolicyWithDescendantPermissions) { testPolicy =>
     val beforePolicies = List(testPolicy)
     val afterPolicies = List.empty
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1482,7 +1482,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedChangeEvents
   }
 
-  it should "show changes for member addition to a policy" in forAll(genPolicy, genWorkbenchSubject) { (testPolicy, testSubject) =>
+  it should "show changes for member addition to a policy" in forAll(genPolicyWithDescendantPermissions, genWorkbenchSubject) { (testPolicy, testSubject) =>
     val beforePolicies = List(testPolicy)
     val afterPolicies = List(AccessPolicy.members.modify(_ + testSubject)(testPolicy))
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1490,7 +1490,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedChangeEvents
   }
 
-  it should "show changes for member removal from a policy" in forAll(genPolicy, genWorkbenchSubject) { (testPolicy, testSubject) =>
+  it should "show changes for member removal from a policy" in forAll(genPolicyWithDescendantPermissions, genWorkbenchSubject) { (testPolicy, testSubject) =>
     val beforePolicies = List(AccessPolicy.members.modify(_ + testSubject)(testPolicy))
     val afterPolicies = List(testPolicy)
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1498,7 +1498,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedChangeEvents
   }
 
-  it should "not show changes for redundant permission addition for member" in forAll(genPolicy, genWorkbenchSubject) { (testPolicy, testSubject) =>
+  it should "not show changes for redundant permission addition for member" in forAll(genPolicyWithDescendantPermissions, genWorkbenchSubject) { (testPolicy, testSubject) =>
     val addTestSubject = AccessPolicy.members.modify(_ + testSubject)
     val beforePolicies = List(addTestSubject(testPolicy), testPolicy)
     val afterPolicies = List(addTestSubject(testPolicy), addTestSubject(testPolicy))
@@ -1506,7 +1506,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result shouldBe empty
   }
 
-  it should "not show changes for redundant permission removal for member" in forAll(genPolicy, genWorkbenchSubject) { (testPolicy, testSubject) =>
+  it should "not show changes for redundant permission removal for member" in forAll(genPolicyWithDescendantPermissions, genWorkbenchSubject) { (testPolicy, testSubject) =>
     val addTestSubject = AccessPolicy.members.modify(_ + testSubject)
     val beforePolicies = List(addTestSubject(testPolicy), addTestSubject(testPolicy))
     val afterPolicies = List(addTestSubject(testPolicy), testPolicy)
@@ -1514,7 +1514,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result shouldBe empty
   }
 
-  it should "show changes for permission removal from a policy " in forAll(genPolicy, genResourceTypeName) { (testPolicy, descendantType) =>
+  it should "show changes for permission removal from a policy " in forAll(genPolicyWithDescendantPermissions, genResourceTypeName) { (testPolicy, descendantType) =>
     val testRole = ResourceRoleName("testRole")
     val testAction = ResourceAction("testAction")
     val testDRole = ResourceRoleName("testDRole")
@@ -1544,7 +1544,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     }
   }
 
-  it should "show changes for permission addition to a policy " in forAll(genPolicy, genResourceTypeName) { (testPolicy, descendantType) =>
+  it should "show changes for permission addition to a policy " in forAll(genPolicyWithDescendantPermissions, genResourceTypeName) { (testPolicy, descendantType) =>
     val testRole = ResourceRoleName("testRole")
     val testAction = ResourceAction("testAction")
     val testDRole = ResourceRoleName("testDRole")
@@ -1574,7 +1574,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     }
   }
 
-  it should "detect additions and removals at the same time" in forAll(genPolicy, genWorkbenchSubject, genWorkbenchSubject) { (testPolicy, testSubject1, testSubject2) =>
+  it should "detect additions and removals at the same time" in forAll(genPolicyWithDescendantPermissions, genWorkbenchSubject, genWorkbenchSubject) { (testPolicy, testSubject1, testSubject2) =>
     val beforePolicies = List(AccessPolicy.members.modify(_ + testSubject1)(testPolicy))
     val afterPolicies = List(AccessPolicy.members.modify(_ + testSubject2)(testPolicy))
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1583,7 +1583,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedAddEvents ++ expectedRemoveEvents
   }
 
-  it should "show changes for switch to public policy " in forAll(genPolicy) { testPolicy =>
+  it should "show changes for switch to public policy " in forAll(genPolicyWithDescendantPermissions) { testPolicy =>
     val beforePolicies = List(testPolicy)
     val afterPolicies = List(AccessPolicy.public.set(true)(testPolicy))
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)
@@ -1591,7 +1591,7 @@ class ResourceServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures wi
     result should contain theSameElementsAs expectedChangeEvents
   }
 
-  it should "show changes for switch to private policy " in forAll(genPolicy) { testPolicy =>
+  it should "show changes for switch to private policy " in forAll(genPolicyWithDescendantPermissions) { testPolicy =>
     val beforePolicies = List(AccessPolicy.public.set(true)(testPolicy))
     val afterPolicies = List(testPolicy)
     val result = service.createAccessChangeEvents(testPolicy.id.resource, beforePolicies, afterPolicies)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/StatusServiceSpec.scala
@@ -51,7 +51,7 @@ class StatusServiceSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll
     val directoryDAO = new MockDirectoryDAO {
       override def checkStatus(samRequestContext: SamRequestContext): Boolean = response
     }
-    directoryDAO.createGroup(BasicWorkbenchGroup(NoExtensions.allUsersGroupName, Set.empty, allUsersEmail), samRequestContext = samRequestContext).unsafeRunSync()
+    directoryDAO.createGroup(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, allUsersEmail), samRequestContext = samRequestContext).unsafeRunSync()
     directoryDAO
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -62,7 +62,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     clearDatabase()
 
     googleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
-    when(googleExtensions.allUsersGroupName).thenReturn(NoExtensions.allUsersGroupName)
     when(googleExtensions.getOrCreateAllUsersGroup(any[DirectoryDAO], any[SamRequestContext])(any[ExecutionContext])).thenReturn(NoExtensions.getOrCreateAllUsersGroup(dirDAO, samRequestContext))
     when(googleExtensions.onUserCreate(any[SamUser], any[SamRequestContext])).thenReturn(Future.successful(()))
     when(googleExtensions.onUserDelete(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(Future.successful(()))
@@ -96,8 +95,8 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     registrationDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(azureB2CId = None)) // ldap does not know about azure or enabled
     dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
     registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-    dirDAO.loadGroup(service.cloudExtensions.allUsersGroupName, samRequestContext).unsafeRunSync() shouldBe
-      Some(BasicWorkbenchGroup(service.cloudExtensions.allUsersGroupName, Set(defaultUser.id), service.cloudExtensions.getOrCreateAllUsersGroup(dirDAO, samRequestContext).futureValue.email))
+    dirDAO.loadGroup(CloudExtensions.allUsersGroupName, samRequestContext).unsafeRunSync() shouldBe
+      Some(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(defaultUser.id), service.cloudExtensions.getOrCreateAllUsersGroup(dirDAO, samRequestContext).futureValue.email))
   }
 
   it should "reject blocked domain" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/PPWM-13
from the doc linked in the ticket:
This section goes beyond admin apis and addresses audit logging in sam as a whole. Sam should have a new audit logging capability that emits messages for every access control change. Messages should contain who made the change, timestamp, client IP, and details about the change. Changes to capture are:

- Resource events:
  - Resource created (include parent if there is one)
  - Resource updated (new parent or removal of parent)
  - Resource deletion
- Access change events:
  - Access added - when a subjects or permissions are added to a policy (including policy creation)  log the net change - what subjects have gained which permissions (roles, actions, descendant roles and actions)
  - Access removed - when a subjects or permissions are removed from a policy (including policy deletion) log the net change - what subjects have lost which permissions (roles, actions, descendant roles and actions)
 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
