### PR TITLE
[DR-2603] New dataset, datasnapshot SAM Action: update_passport_identifier

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1053,11 +1053,14 @@ resourceTypes = {
       "alter_policies" = {
         description = "Can alter policies"
       }
+      update_passport_identifier = {
+        description = "Can update a dataset's passport identifier (e.g. PHS ID)"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier"]
       }
       custodian = {
         roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
@@ -1115,11 +1118,14 @@ resourceTypes = {
       set_public = {
         description = "set policies to public"
       }
+      update_passport_identifier = {
+        description = "Can update a datasnapshot's passport identifier (e.g. consent code)"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier"]
       }
       custodian = {
         roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2603
<Put notes here to help reviewer understand this PR>

We are adding `PATCH` endpoints to TDR to support modifying select fields in datasets and snapshots.  When modifying RAS passport identifiers (dataset PHS ID, snapshot consent code), the caller may modify how the underlying data is shared.  As such, this is a power that we wish to grant explicitly.

More detailed discussion in PR review: https://github.com/DataBiosphere/jade-data-repo/pull/1284#discussion_r877381725

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
