### PR TITLE
[TOAZ-126] Add Sam API for pet managed identities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ docker/stand-alone/server.crt
 docker/stand-alone/server.key
 docker/stand-alone/ca-bundle.crt
 sam-assembly-*-SNAPSHOT.jar
+src/test/resources/application.conf
+src/test/resources/azure_managed_app_client.json
 
 # Scala-IDE specific
 .scala_dependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
   val workbenchNotificationsV = "0.3-d74ff96"
   val workbenchOauth2V = "0.2-20f9225"
   val monocleVersion = "2.0.5"
+  val crlVersion = "1.2.0-rt-uami-SNAPSHOT"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
@@ -28,6 +29,9 @@ object Dependencies {
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_2.12")
   val excludeWorkbenchGoogle =  ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.12")
   val excludeSpringJcl =   ExclusionRule(organization = "org.springframework", name = "spring-jcl")
+  val excludeGoogleCloudResourceManager = ExclusionRule(organization = "com.google.apis", name = "google-api-services-cloudresourcemanager")
+  val excludeJerseyCore =       ExclusionRule(organization = "org.glassfish.jersey.core", name = "*")
+  val excludeJerseyMedia =      ExclusionRule(organization = "org.glassfish.jersey.media", name = "*")
 
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
   val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV
@@ -105,6 +109,8 @@ object Dependencies {
     opencensusLoggingExporter
   )
 
+  val cloudResourceLib: ModuleID = "bio.terra" % "terra-cloud-resource-lib" % crlVersion excludeAll(excludeGoogleCloudResourceManager, excludeJerseyCore, excludeJerseyMedia)
+
   // was included transitively before, now explicit
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.15"
 
@@ -160,6 +166,8 @@ object Dependencies {
     scalikeCore,
     scalikeCoreConfig,
     scalikeCoreTest,
-    postgres
+    postgres,
+
+    cloudResourceLib
   ) ++ openCensusDependencies
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val workbenchNotificationsV = "0.3-d74ff96"
   val workbenchOauth2V = "0.2-20f9225"
   val monocleVersion = "2.0.5"
-  val crlVersion = "1.2.0-rt-uami-SNAPSHOT"
+  val crlVersion = "1.2.0-SNAPSHOT"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -6,6 +6,7 @@ object Merging {
     case PathList("io", "sundr", _ @ _*) => MergeStrategy.first
     case PathList("google", "protobuf", _ @ _*) => MergeStrategy.first
     case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
+    case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard
     case x => oldStrategy(x)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -12,8 +12,7 @@ object Settings {
 
   lazy val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot",
-    Resolver.mavenLocal
+    "artifactory-snapshots" at artifactory + "libs-snapshot"
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -12,7 +12,8 @@ object Settings {
 
   lazy val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot"
+    "artifactory-snapshots" at artifactory + "libs-snapshot",
+    Resolver.mavenLocal
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings

--- a/render-test-config.sh
+++ b/render-test-config.sh
@@ -22,6 +22,7 @@ cat > ${AZURE_PROPERTIES_OUTPUT_FILE_PATH} <<EOF
 azureServices.managedAppClientId=${AZURE_MANAGED_APP_CLIENT_ID}
 azureServices.managedAppClientSecret=${AZURE_MANAGED_APP_CLIENT_SECRET}
 azureServices.managedAppTenantId=${AZURE_MANAGED_APP_TENANT_ID}
+azureServices.managedAppPlanId=terra-workspace-dev-plan
 EOF
 
 rm $AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH

--- a/render-test-config.sh
+++ b/render-test-config.sh
@@ -11,13 +11,17 @@ AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH="$(dirname $0)"/src/test/resources/azu
 AZURE_PROPERTIES_OUTPUT_FILE_PATH="$(dirname $0)"/src/test/resources/application.conf
 
 docker run --rm --cap-add IPC_LOCK \
-            -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            -e VAULT_TOKEN=$VAULT_TOKEN \
+            ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${VAULT_AZURE_MANAGED_APP_CLIENT_PATH} \
             | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
 
 AZURE_MANAGED_APP_CLIENT_ID=$(jq -r '."client-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_CLIENT_SECRET=$(jq -r '."client-secret"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
 AZURE_MANAGED_APP_TENANT_ID=$(jq -r '."tenant-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
+
+# Note: the managed app plan id is hardcoded for now but should be updated once the Managed App
+# definition is in Terraform. See: https://broadworkbench.atlassian.net/browse/TOAZ-28
 cat > ${AZURE_PROPERTIES_OUTPUT_FILE_PATH} <<EOF
 azureServices.managedAppClientId=${AZURE_MANAGED_APP_CLIENT_ID}
 azureServices.managedAppClientSecret=${AZURE_MANAGED_APP_CLIENT_SECRET}

--- a/render-test-config.sh
+++ b/render-test-config.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# TODO: Add Janitor secrets here
+# https://broadworkbench.atlassian.net/browse/ID-96
+# Call from GitHub actions once Janitor is integrated
+
+VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
+DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
+VAULT_AZURE_MANAGED_APP_CLIENT_PATH=secret/dsde/terra/azure/common/managed-app-publisher
+AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH="$(dirname $0)"/src/test/resources/azure_managed_app_client.json
+AZURE_PROPERTIES_OUTPUT_FILE_PATH="$(dirname $0)"/src/test/resources/application.conf
+
+docker run --rm --cap-add IPC_LOCK \
+            -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json ${VAULT_AZURE_MANAGED_APP_CLIENT_PATH} \
+            | jq -r .data > ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH}
+
+AZURE_MANAGED_APP_CLIENT_ID=$(jq -r '."client-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
+AZURE_MANAGED_APP_CLIENT_SECRET=$(jq -r '."client-secret"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
+AZURE_MANAGED_APP_TENANT_ID=$(jq -r '."tenant-id"' ${AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH})
+cat > ${AZURE_PROPERTIES_OUTPUT_FILE_PATH} <<EOF
+azureServices.managedAppClientId=${AZURE_MANAGED_APP_CLIENT_ID}
+azureServices.managedAppClientSecret=${AZURE_MANAGED_APP_CLIENT_SECRET}
+azureServices.managedAppTenantId=${AZURE_MANAGED_APP_TENANT_ID}
+EOF
+
+rm $AZURE_MANAGED_APP_CLIENT_OUTPUT_FILE_PATH

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -19,4 +19,5 @@
     <include file="changesets/20211010_azure_b2c_id.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220328_idx_serp_source_policy_id.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220511_tos_version.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220524_pet_user_assigned_managed_identity.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220524_pet_user_assigned_managed_identity.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220524_pet_user_assigned_managed_identity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="rtitle" id="pet_user_assigned_managed_identity">
+        <createTable tableName="SAM_PET_MANAGED_IDENTITY">
+            <column name="user_id" type="VARCHAR">
+                <constraints nullable="false" foreignKeyName="FK_SPMI_USER" referencedTableName="SAM_USER" referencedColumnNames="id" primaryKey="true"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR(40)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="subscription_id" type="VARCHAR(40)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="managed_resource_group_name" type="VARCHAR">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="object_id" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="display_name" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1118,10 +1118,16 @@ paths:
       responses:
         200:
           description: Successfully retrieved resource without creating it
-          content: { }
+          content:
+            application/json:
+              schema:
+                type: string
         201:
           description: Successfully created resource
-          content: { }
+          content:
+            application/json:
+              schema:
+                type: string
         400:
           description: Invalid or incomplete request body
           content: { }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -73,6 +73,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         200:
           description: status of specified user
@@ -93,6 +98,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         200:
           description: status of specified user
@@ -230,6 +240,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Successfully added a user to the policy
@@ -499,6 +514,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
       responses:
         201:
           description: Group created
@@ -551,6 +571,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Request sent
@@ -610,6 +635,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Successfully set access instructions
@@ -730,6 +760,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Email successfully added
@@ -1089,6 +1124,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         200:
           description: Successfully synchronized membership
@@ -1238,6 +1278,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Successfully created resource
@@ -2160,6 +2205,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         201:
           description: user successfully created
@@ -2911,13 +2961,16 @@ components:
       properties:
         tenantId:
           type: string
-          description: the Azure tenant id
+          description: the Azure tenant id (UUID)
+          example: 0cb7a640-45a2-4ed6-be9f-63519f86e04b
         subscriptionId:
           type: string
-          description: the Azure subscription id
+          description: the Azure subscription id (UUID)
+          example: 3efc5bdf-be0e-44e7-b1d7-c08931e3c16c
         managedResourceGroupName:
           type: string
           description: the name of the Azure managed resource group
+          example: my-managed-resource-group
       description: specifies a request for a pet managed identity
   securitySchemes:
     googleoauth:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1102,6 +1102,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/user/petManagedIdentity:
+    post:
+      tags:
+        - Azure
+      summary: gets or creates a pet managed identity for the specified user
+      operationId: getPetManagedIdentity
+      requestBody:
+        description: The details of the managed resource group in which to create the pet
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/GetOrCreatePetManagedIdentityRequest'
+        required: true
+      responses:
+        200:
+          description: Successfully retrieved resource without creating it
+          content: { }
+        201:
+          description: Successfully created resource
+          content: { }
+        400:
+          description: Invalid or incomplete request body
+          content: { }
+        403:
+          description: Caller does not have permission to create a pet managed identity in the given managed resource group
+          content: { }
+        404:
+          description: Managed resource group does not exist
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/resources/v2/{resourceTypeName}:
     get:
       tags:
@@ -2856,6 +2891,23 @@ components:
           type: boolean
           description: true if the user is in their proxy group
       description: ""
+    GetOrCreatePetManagedIdentityRequest:
+      required:
+        - tenantId
+        - subscriptionId
+        - managedResourceGroupName
+      type: object
+      properties:
+        tenantId:
+          type: string
+          description: the Azure tenant id
+        subscriptionId:
+          type: string
+          description: the Azure subscription id
+        managedResourceGroupName:
+          type: string
+          description: the name of the Azure managed resource group
+      description: specifies a request for a pet managed identity
   securitySchemes:
     googleoauth:
       type: oauth2

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1666,6 +1666,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Successfully added a user to the policy

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.google2.{GoogleFirestoreInterpreter, Go
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardSamUserDirectives}
+import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService, CrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.AdminConfig
 import org.broadinstitute.dsde.workbench.sam.config.{AppConfig, GoogleConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
@@ -336,7 +337,8 @@ object Boot extends IOApp with LazyLogging {
       new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, accessPolicyDAO, directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.emailDomain)
     val samApplication = SamApplication(userService, resourceService, statusService, tosService)
     val azureRoutes = config.azureServicesConfig.map { config =>
-      val azureService = new AzureService(config, ClientConfig.Builder.newBuilder().setClient("sam").build(), directoryDAO)
+      val crlSerivce = new CrlService(config)
+      val azureService = new AzureService(crlSerivce, directoryDAO)
       new AzureRoutes(azureService, policyEvaluatorService, resourceService)
     }
     cloudExtensionsInitializer match {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -337,8 +337,8 @@ object Boot extends IOApp with LazyLogging {
       new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, accessPolicyDAO, directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.emailDomain)
     val samApplication = SamApplication(userService, resourceService, statusService, tosService)
     val azureRoutes = config.azureServicesConfig.map { config =>
-      val crlSerivce = new CrlService(config)
-      val azureService = new AzureService(crlSerivce, directoryDAO)
+      val crlService = new CrlService(config)
+      val azureService = new AzureService(crlService, directoryDAO)
       new AzureRoutes(azureService, policyEvaluatorService, resourceService)
     }
     cloudExtensionsInitializer match {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.google2.{GoogleFirestoreInterpreter, Go
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardSamUserDirectives}
-import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService, CrlService}
+import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.AdminConfig
 import org.broadinstitute.dsde.workbench.sam.config.{AppConfig, GoogleConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
@@ -336,14 +336,12 @@ object Boot extends IOApp with LazyLogging {
     val managedGroupService =
       new ManagedGroupService(resourceService, policyEvaluatorService, resourceTypeMap, accessPolicyDAO, directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.emailDomain)
     val samApplication = SamApplication(userService, resourceService, statusService, tosService)
-    val azureRoutes = config.azureServicesConfig.map { config =>
-      val crlService = new CrlService(config)
-      val azureService = new AzureService(crlService, directoryDAO)
-      new AzureRoutes(azureService, policyEvaluatorService, resourceService)
+    val azureService = config.azureServicesConfig.map { config =>
+      new AzureService(new CrlService(config), directoryDAO)
     }
     cloudExtensionsInitializer match {
       case GoogleExtensionsInitializer(googleExt, synchronizer) =>
-        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig, oauth2Config, azureRoutes)
+        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig, oauth2Config, azureService)
         with StandardSamUserDirectives with GoogleExtensionRoutes {
           val googleExtensions = googleExt
           val cloudExtensions = googleExt
@@ -351,7 +349,7 @@ object Boot extends IOApp with LazyLogging {
         }
         AppDependencies(routes, samApplication, cloudExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
       case _ =>
-        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig, oauth2Config, azureRoutes)
+        val routes = new SamRoutes(resourceService, userService, statusService, managedGroupService, config.termsOfServiceConfig, directoryDAO, registrationDAO, policyEvaluatorService, tosService, config.liquibaseConfig, oauth2Config, azureService)
         with StandardSamUserDirectives with NoExtensionRoutes
         AppDependencies(routes, samApplication, NoExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionW
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes._
+import org.broadinstitute.dsde.workbench.sam.azure.AzureRoutes
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -37,7 +38,8 @@ abstract class SamRoutes(
     val policyEvaluatorService: PolicyEvaluatorService,
     val tosService: TosService,
     val liquibaseConfig: LiquibaseConfig,
-    val oidcConfig: OpenIDConnectConfiguration)(
+    val oidcConfig: OpenIDConnectConfiguration,
+    val azureRoutes: Option[AzureRoutes])(
     implicit val system: ActorSystem,
     val materializer: Materializer,
     val executionContext: ExecutionContext)
@@ -66,7 +68,8 @@ abstract class SamRoutes(
                 adminRoutes(samUser, samRequestContextWithUser) ~
                 extensionRoutes(samUser, samRequestContextWithUser) ~
                 groupRoutes(samUser, samRequestContextWithUser) ~
-                apiUserRoutes(samUser, samRequestContextWithUser)
+                apiUserRoutes(samUser, samRequestContextWithUser) ~
+                azureRoutes.map(_.routes(samUser, samRequestContext)).getOrElse(reject)
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionW
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes._
-import org.broadinstitute.dsde.workbench.sam.azure.AzureRoutes
+import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, RegistrationDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -39,7 +39,7 @@ abstract class SamRoutes(
     val tosService: TosService,
     val liquibaseConfig: LiquibaseConfig,
     val oidcConfig: OpenIDConnectConfiguration,
-    val azureRoutes: Option[AzureRoutes])(
+    val azureService: Option[AzureService])(
     implicit val system: ActorSystem,
     val materializer: Materializer,
     val executionContext: ExecutionContext)
@@ -50,7 +50,8 @@ abstract class SamRoutes(
     with TermsOfServiceRoutes
     with ExtensionRoutes
     with ManagedGroupRoutes
-    with AdminRoutes {
+    with AdminRoutes
+    with AzureRoutes {
 
   def route: server.Route = (logRequestResult & handleExceptions(myExceptionHandler)) {
     oidcConfig.swaggerRoutes("swagger/api-docs.yaml") ~
@@ -69,7 +70,7 @@ abstract class SamRoutes(
                 extensionRoutes(samUser, samRequestContextWithUser) ~
                 groupRoutes(samUser, samRequestContextWithUser) ~
                 apiUserRoutes(samUser, samRequestContextWithUser) ~
-                azureRoutes.map(_.routes(samUser, samRequestContext)).getOrElse(reject)
+                azureRoutes(samUser, samRequestContext)
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -75,7 +75,8 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
 
 object StandardSamUserDirectives {
   val SAdomain: Regex = "(\\S+@\\S+\\.iam\\.gserviceaccount\\.com$)".r
-  val UAMIPattern: Regex = "(^/subscriptions/\\S+/resourcegroups/\\S+/providers/Microsoft\\.ManagedIdentity/userAssignedIdentities/\\S+$)".r
+  // UAMI == "User Assigned Managed Identity" in Azure
+  val UamiPattern: Regex = "(^/subscriptions/\\S+/resourcegroups/\\S+/providers/Microsoft\\.ManagedIdentity/userAssignedIdentities/\\S+$)".r
   val accessTokenHeader = "OIDC_access_token"
   val emailHeader = "OIDC_CLAIM_email"
   val userIdHeader = "OIDC_CLAIM_user_id"
@@ -94,7 +95,7 @@ object StandardSamUserDirectives {
       case OIDCHeaders(_, Left(googleSubjectId), _, _, _) =>
         lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext)
 
-      case OIDCHeaders(_, Right(azureB2CId), _, _, Some(objectId@ManagedIdentityObjectId(UAMIPattern(_)))) =>
+      case OIDCHeaders(_, Right(azureB2CId), _, _, Some(objectId@ManagedIdentityObjectId(UamiPattern(_)))) =>
         // If it's a managed identity, treat it as its owner
         directoryDAO.getUserFromPetManagedIdentity(objectId, samRequestContext).flatMap {
           case Some(petsOwner) => IO.pure(petsOwner)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+import org.broadinstitute.dsde.workbench.model._
+import spray.json.DefaultJsonProtocol._
+
+object AzureJsonSupport {
+  implicit val tenantIdFormat = ValueObjectFormat(TenantId.apply)
+
+  implicit val subscriptionIdFormat = ValueObjectFormat(SubscriptionId.apply)
+
+  implicit val managedResourceGroupNameFormat = ValueObjectFormat(ManagedResourceGroupName.apply)
+
+  implicit val getPetManagedIdentityRequestFormat = jsonFormat3(GetOrCreatePetManagedIdentityRequest.apply)
+
+  implicit val managedIdentityObjectIdFormat = ValueObjectFormat(ManagedIdentityObjectId.apply)
+
+  implicit val managedIdentityDisplayNameFormat = ValueObjectFormat(ManagedIdentityDisplayName.apply)
+
+  implicit val petManagedIdentityIdFormat = jsonFormat4(PetManagedIdentityId.apply)
+
+  implicit val petManagedIdentityFormat = jsonFormat3(PetManagedIdentity.apply)
+}
+
+final case class TenantId(value: String) extends ValueObject
+final case class SubscriptionId(value: String) extends ValueObject
+final case class ManagedResourceGroupName(value: String) extends ValueObject
+final case class ManagedIdentityObjectId(value: String) extends ValueObject
+final case class ManagedIdentityDisplayName(value: String) extends ValueObject
+
+final case class GetOrCreatePetManagedIdentityRequest(tenantId: TenantId,
+                                                      subscriptionId: SubscriptionId,
+                                                      managedResourceGroupName: ManagedResourceGroupName)
+
+final case class PetManagedIdentityId(user: WorkbenchUserId,
+                                      tenantId: TenantId,
+                                      subscriptionId: SubscriptionId,
+                                      managedResourceGroupName: ManagedResourceGroupName)
+
+final case class PetManagedIdentity(id: PetManagedIdentityId,
+                                    objectId: ManagedIdentityObjectId,
+                                    displayName: ManagedIdentityDisplayName)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -4,40 +4,41 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directives, Route}
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.{SecurityDirectives, _}
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.JsString
 
-class AzureRoutes(azureService: AzureService,
-                  val policyEvaluatorService: PolicyEvaluatorService,
-                  val resourceService: ResourceService) extends SecurityDirectives {
+trait AzureRoutes extends SecurityDirectives {
+  val azureService: Option[AzureService]
 
-  def routes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
-    path("azure" / "v1" / "user" / "petManagedIdentity") {
-      post {
-        entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
-          requireCreatePetAction(request, samUser, samRequestContext) {
-            complete {
-              azureService.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
-                val status = if (created) StatusCodes.Created else StatusCodes.OK
-                status -> JsString(pet.objectId.value)
+  def azureRoutes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    azureService.map { service =>
+      path("azure" / "v1" / "user" / "petManagedIdentity") {
+        post {
+          entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
+            requireCreatePetAction(request, samUser, samRequestContext) {
+              complete {
+                service.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
+                  val status = if (created) StatusCodes.Created else StatusCodes.OK
+                  status -> JsString(pet.objectId.value)
+                }
               }
             }
           }
         }
       }
-    }
-
+    }.getOrElse(reject)
+  
   // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource
   // and  validates the user has 'link' permission.
   private def requireCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
-    onSuccess(azureService.getBillingProfileId(request)).flatMap {
+    onSuccess(azureService.flatTraverse(_.getBillingProfileId(request))).flatMap {
       case Some(resourceId) =>
         requireAction(FullyQualifiedResourceId(SamResourceTypes.spendProfile, resourceId), SamResourceActions.link, samUser.id, samRequestContext)
       case None =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -33,12 +33,12 @@ class AzureRoutes(azureService: AzureService,
       }
     }
 
-  // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource and
-  // validates the user has 'link' permission.
+  // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource
+  // and  validates the user has 'link' permission.
   private def requireCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
     onSuccess(azureService.getBillingProfileId(request)).flatMap {
       case Some(resourceId) =>
-        requireAction(FullyQualifiedResourceId(SamResourceTypes.spendProfile, resourceId), ResourceAction("link"), samUser.id, samRequestContext)
+        requireAction(FullyQualifiedResourceId(SamResourceTypes.spendProfile, resourceId), SamResourceActions.link, samUser.id, samRequestContext)
       case None =>
         Directives.failWith(
           new WorkbenchExceptionWithErrorReport(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import spray.json.JsString
 
 class AzureRoutes(azureService: AzureService,
                   val policyEvaluatorService: PolicyEvaluatorService,
@@ -25,7 +26,7 @@ class AzureRoutes(azureService: AzureService,
             complete {
               azureService.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
                 val status = if (created) StatusCodes.Created else StatusCodes.OK
-                status -> pet.objectId.value
+                status -> JsString(pet.objectId.value)
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -23,7 +23,10 @@ class AzureRoutes(azureService: AzureService,
         entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
           requireCreatePetAction(request, samUser, samRequestContext) {
             complete {
-              azureService.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext)
+              azureService.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
+                val status = if (created) StatusCodes.Created else StatusCodes.OK
+                status -> pet.objectId.value
+              }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive0, Directives, Route}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
+import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.sam.api.{SecurityDirectives, _}
+import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.{PolicyEvaluatorService, ResourceService}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+class AzureRoutes(azureService: AzureService,
+                  val policyEvaluatorService: PolicyEvaluatorService,
+                  val resourceService: ResourceService) extends SecurityDirectives {
+
+  def routes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
+    path("azure" / "v1" / "user" / "petManagedIdentity") {
+      post {
+        entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
+          requireCreatePetAction(request, samUser, samRequestContext) {
+            complete {
+              azureService.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext)
+            }
+          }
+        }
+      }
+    }
+
+  // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource and
+  // validates the user has 'link' permission.
+  private def requireCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
+    onSuccess(azureService.getBillingProfileId(request)).flatMap {
+      case Some(resourceId) =>
+        requireAction(FullyQualifiedResourceId(SamResourceTypes.spendProfile, resourceId), ResourceAction("link"), samUser.id, samRequestContext)
+      case None =>
+        Directives.failWith(
+          new WorkbenchExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, s"Managed resource group ${request.managedResourceGroupName.value} not found")))
+
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -6,6 +6,7 @@ import bio.terra.cloudres.azure.resourcemanager.msi.data.CreateUserAssignedManag
 import cats.effect.IO
 import com.azure.core.management.Region
 import com.azure.core.util.Context
+import com.azure.resourcemanager.resources.models.{GenericResource, ResourceGroup}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
@@ -16,8 +17,13 @@ import scala.jdk.CollectionConverters._
 
 class AzureService(crlService: CrlService,
                    directoryDAO: DirectoryDAO) {
-  // Static region in which to create all managed identities
+
+  // Static region in which to create all managed identities.
+  // Managed identities are regional resources in Azure but they can be used across
+  // regions. So it's safe to just use a static region and not make this configurable.
+  // See: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/managed-identities-faq#can-the-same-managed-identity-be-used-across-multiple-regions
   private val managedIdentityRegion = Region.US_EAST
+
   // Tag on the MRG to specify the Sam billing-profile id
   private val billingProfileTag = "terra.billingProfileId"
 
@@ -34,39 +40,47 @@ class AzureService(crlService: CrlService,
         // pet exists in Sam DB - return it
         case Some(p) => IO.pure((p, false))
         // pet does not exist in Sam DB - create it
-        case None =>
-          for {
-            _ <- validateManagedResourceGroup(request)
-            manager <- crlService.buildMsiManager(request.tenantId, request.subscriptionId)
-            petName = toManagedIdentityNameFromUser(user)
-            context = managedIdentityContext(request, petName)
-            azureUami <- IO(manager.identities().define(petName.value)
-              .withRegion(managedIdentityRegion)
-              .withExistingResourceGroup(request.managedResourceGroupName.value)
-              .withTags(managedIdentityTags(user).asJava)
-              .create(context))
-            petToCreate = PetManagedIdentity(id, ManagedIdentityObjectId(azureUami.id()), ManagedIdentityDisplayName(azureUami.name()))
-            createdPet <- directoryDAO.createPetManagedIdentity(petToCreate, samRequestContext)
-          } yield (createdPet, true)
+        case None => createUserPetManagedIdentity(id, user, request, samRequestContext)
       }
     } yield pet
   }
 
   /**
-    * Resolves a managed resource group in Azure and returns the terra.billingProfileId tag value.
-    * This is used for access control checks.
+    * Creates a pet managed identity in Azure and the Sam database.
     */
-  def getBillingProfileId(request: GetOrCreatePetManagedIdentityRequest): IO[Option[ResourceId]] = {
+  private def createUserPetManagedIdentity(id: PetManagedIdentityId,
+                                           user: SamUser,
+                                           request: GetOrCreatePetManagedIdentityRequest,
+                                           samRequestContext: SamRequestContext): IO[(PetManagedIdentity, Boolean)] = {
     for {
-      resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
-      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
-      billingProfileOpt = mrg.toOption.flatMap(_.tags().asScala.get(billingProfileTag))
-    } yield billingProfileOpt.map(ResourceId(_))
+      _ <- validateManagedResourceGroup(request)
+      manager <- crlService.buildMsiManager(request.tenantId, request.subscriptionId)
+      petName = toManagedIdentityNameFromUser(user)
+      context = managedIdentityContext(request, petName)
+      azureUami <- IO(manager.identities().define(petName.value)
+        .withRegion(managedIdentityRegion)
+        .withExistingResourceGroup(request.managedResourceGroupName.value)
+        .withTags(managedIdentityTags(user).asJava)
+        .create(context))
+      petToCreate = PetManagedIdentity(id, ManagedIdentityObjectId(azureUami.id()), ManagedIdentityDisplayName(azureUami.name()))
+      createdPet <- directoryDAO.createPetManagedIdentity(petToCreate, samRequestContext)
+    } yield (createdPet, true)
   }
 
   /**
-    * Validates a managed resource group. Algorithm:
-    * 1. Resolve the MRG as the publisher
+    * Resolves a managed resource group in Azure and returns the terra.billingProfileId tag value.
+    * This is used for access control checks during route handling.
+    */
+  def getBillingProfileId(request: GetOrCreatePetManagedIdentityRequest): IO[Option[ResourceId]] =
+    for {
+      resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
+      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
+    } yield mrg.toOption.flatMap(getBillingProfileFromTag)
+
+  /**
+    * Validates a managed resource group. This is only called at managed identity creation time.
+    * Algorithm:
+    * 1. Resolve the MRG in Azure
     * 2. Get the managed app id from the MRG
     * 3. Resolve the managed app as the publisher
     * 4. Get the managed app "plan" id
@@ -75,20 +89,13 @@ class AzureService(crlService: CrlService,
   private def validateManagedResourceGroup(request: GetOrCreatePetManagedIdentityRequest): IO[Unit] = {
     for {
       resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
-      resolvedMrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
-      managedByOpt = for {
-        mrg <- resolvedMrg.toOption
-        im <- Option(mrg.innerModel())
-        mb <- Option(im.managedBy())
-      } yield mb
+      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
+      managedByOpt = mrg.toOption.flatMap(getManagedBy)
       managedBy <- IO.fromOption(managedByOpt)(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Validation failed: could not retrieve managed app for managed resource group ${request.managedResourceGroupName.value}"))
       )
-      resolvedManagedApp <- IO(resourceManager.genericResources().getById(managedBy)).attempt
-      planIdOpt = for {
-        ma <- resolvedManagedApp.toOption
-        p <- Option(ma.plan())
-      } yield p.name()
+      managedApp <- IO(resourceManager.genericResources().getById(managedBy)).attempt
+      planIdOpt = managedApp.toOption.flatMap(getPlanId)
       planId <- IO.fromOption(planIdOpt)(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: could not retrieve plan for managed app"))
       )
@@ -97,6 +104,21 @@ class AzureService(crlService: CrlService,
       )
     } yield ()
   }
+
+  /** Null-safe get managedBy field from a ResourceGroup. */
+  private def getManagedBy(mrg: ResourceGroup): Option[String] =
+    for {
+      im <- Option(mrg.innerModel())
+      mb <- Option(im.managedBy())
+    } yield mb
+
+  /** Null-safe get planId from a resource. */
+  private def getPlanId(resource: GenericResource): Option[String] =
+    Option(resource.plan()).map(_.name())
+
+  /** Null-safe get billing profile tag from a ResourceGroup. */
+  private def getBillingProfileFromTag(mrg: ResourceGroup): Option[ResourceId] =
+    mrg.tags().asScala.get(billingProfileTag).map(ResourceId(_))
 
   private def managedIdentityTags(user: SamUser): Map[String, String] = {
     Map("samUserId" -> user.id.value, "samUserEmail" -> user.email.value)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -2,29 +2,25 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import bio.terra.cloudres.azure.resourcemanager.common.Defaults
 import bio.terra.cloudres.azure.resourcemanager.msi.data.CreateUserAssignedManagedIdentityRequestData
-import bio.terra.cloudres.common.ClientConfig
 import cats.effect.IO
-import com.azure.core.management.profile.AzureProfile
-import com.azure.core.management.{AzureEnvironment, Region}
+import com.azure.core.management.Region
 import com.azure.core.util.Context
-import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder}
-import com.azure.resourcemanager.msi.MsiManager
-import com.azure.resourcemanager.resources.ResourceManager
-import org.broadinstitute.dsde.workbench.sam.config.AzureServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import scala.jdk.CollectionConverters._
 
-class AzureService(azureServicesConfig: AzureServicesConfig,
-                   clientConfig: ClientConfig,
+class AzureService(crlService: CrlService,
                    directoryDAO: DirectoryDAO) {
   // Static region in which to create all managed identities
   private val managedIdentityRegion = Region.US_EAST
-
+  // Tag on the MRG to specify the Sam billing-profile id
   private val billingProfileTag = "terra.billingProfileId"
 
+  /**
+    * Looks up a pet managed identity from the database, or creates it if one does not exist.
+    */
   def getOrCreateUserPetManagedIdentity(user: SamUser,
                                         request: GetOrCreatePetManagedIdentityRequest,
                                         samRequestContext: SamRequestContext): IO[(PetManagedIdentity, Boolean)] = {
@@ -37,48 +33,52 @@ class AzureService(azureServicesConfig: AzureServicesConfig,
         // pet does not exist in Sam DB - create it
         case None =>
           for {
-            manager <- getMsiManager(request.tenantId, request.subscriptionId)
+            _ <- validateManagedResourceGroup(request)
+            manager <- crlService.buildMsiManager(request.tenantId, request.subscriptionId)
             petName = toManagedIdentityNameFromUser(user)
-            context = buildCrlContext(request, petName)
+            context = managedIdentityContext(request, petName)
             azureUami <- IO(manager.identities().define(petName.value)
               .withRegion(managedIdentityRegion)
               .withExistingResourceGroup(request.managedResourceGroupName.value)
-              .withTags(Map("samUserId" -> user.id.value, "samUserEmail" -> user.email.value).asJava)
+              .withTags(managedIdentityTags(user).asJava)
               .create(context))
             petToCreate = PetManagedIdentity(id, ManagedIdentityObjectId(azureUami.id()), ManagedIdentityDisplayName(azureUami.name()))
             createdPet <- directoryDAO.createPetManagedIdentity(petToCreate, samRequestContext)
-            // TODO write to LDAP
           } yield (createdPet, true)
       }
     } yield pet
   }
 
-  private[azure] def getMsiManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[MsiManager] = {
-    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
-    IO(Defaults.crlConfigure(clientConfig, MsiManager.configure()).authenticate(credential, profile))
+  /**
+    * Resolves a managed resource group in Azure and returns the terra.billingProfileId tag value.
+    * This is used for access control checks.
+    */
+  def getBillingProfileId(request: GetOrCreatePetManagedIdentityRequest): IO[Option[ResourceId]] = {
+    for {
+      resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
+      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
+      billingProfileOpt = mrg.toOption.flatMap(_.tags().asScala.get(billingProfileTag))
+    } yield billingProfileOpt.map(ResourceId(_))
   }
 
-  private[azure] def getResourceManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[ResourceManager] = {
-    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
-    IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
+  /**
+    * Resolves a managed resource group in Azure and validates it belongs to a Terra managed app.
+    */
+  private def validateManagedResourceGroup(request: GetOrCreatePetManagedIdentityRequest): IO[Unit] = {
+    for {
+      resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
+      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value))
+      // TODO this gives the name of the managed app; can we query that?
+      managedBy = mrg.innerModel().managedBy()
+      _ = println("managed by: " + managedBy)
+    } yield ()
   }
 
-  private[azure] def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
-    val credential = new ClientSecretCredentialBuilder()
-      .clientId(azureServicesConfig.managedAppClientId)
-      .clientSecret(azureServicesConfig.managedAppClientSecret)
-      .tenantId(azureServicesConfig.managedAppTenantId)
-      .build
-
-    val profile = new AzureProfile(
-      tenantId.value,
-      subscriptionId.value,
-      AzureEnvironment.AZURE)
-
-    (credential, profile)
+  private def managedIdentityTags(user: SamUser): Map[String, String] = {
+    Map("samUserId" -> user.id.value, "samUserEmail" -> user.email.value)
   }
 
-  private[azure] def buildCrlContext(request: GetOrCreatePetManagedIdentityRequest, petName: ManagedIdentityDisplayName): Context = {
+  private def managedIdentityContext(request: GetOrCreatePetManagedIdentityRequest, petName: ManagedIdentityDisplayName): Context = {
     Defaults.buildContext(
       CreateUserAssignedManagedIdentityRequestData.builder()
         .setTenantId(request.tenantId.value)
@@ -89,16 +89,7 @@ class AzureService(azureServicesConfig: AzureServicesConfig,
         .build())
   }
 
-  // Note:
-  private[azure] def getBillingProfileId(request: GetOrCreatePetManagedIdentityRequest): IO[Option[ResourceId]] = {
-    for {
-      resourceManager <- getResourceManager(request.tenantId, request.subscriptionId)
-      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
-      billingProfileOpt = mrg.toOption.flatMap(_.tags().asScala.get(billingProfileTag))
-    } yield billingProfileOpt.map(ResourceId(_))
-  }
-
-  private[azure] def toManagedIdentityNameFromUser(user: SamUser): ManagedIdentityDisplayName = {
+  private def toManagedIdentityNameFromUser(user: SamUser): ManagedIdentityDisplayName = {
     ManagedIdentityDisplayName(s"pet-${user.id.value}")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -1,0 +1,105 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults
+import bio.terra.cloudres.azure.resourcemanager.msi.data.CreateUserAssignedManagedIdentityRequestData
+import bio.terra.cloudres.common.ClientConfig
+import cats.effect.IO
+import com.azure.core.management.profile.AzureProfile
+import com.azure.core.management.{AzureEnvironment, Region}
+import com.azure.core.util.Context
+import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder}
+import com.azure.resourcemanager.msi.MsiManager
+import com.azure.resourcemanager.resources.ResourceManager
+import org.broadinstitute.dsde.workbench.sam.config.AzureServicesConfig
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import scala.jdk.CollectionConverters._
+
+class AzureService(azureServicesConfig: AzureServicesConfig,
+                   clientConfig: ClientConfig,
+                   directoryDAO: DirectoryDAO) {
+  // Static region in which to create all managed identities
+  private val managedIdentityRegion = Region.US_EAST
+
+  private val billingProfileTag = "terra.billingProfileId"
+
+  def getOrCreateUserPetManagedIdentity(user: SamUser,
+                                        request: GetOrCreatePetManagedIdentityRequest,
+                                        samRequestContext: SamRequestContext): IO[PetManagedIdentity] = {
+    val id = PetManagedIdentityId(user.id, request.tenantId, request.subscriptionId, request.managedResourceGroupName)
+    for {
+      existingPetOpt <- directoryDAO.loadPetManagedIdentity(id, samRequestContext)
+      pet <- existingPetOpt match {
+        // pet exists in Sam DB - return it
+        case Some(p) => IO.pure(p)
+        // pet does not exist in Sam DB - create it
+        case None =>
+          for {
+            manager <- getMsiManager(request.tenantId, request.subscriptionId)
+            petName = toManagedIdentityNameFromUser(user)
+            context = buildCrlContext(request, petName)
+            azureUami <- IO(manager.identities().define(petName.value)
+              .withRegion(managedIdentityRegion)
+              .withExistingResourceGroup(request.managedResourceGroupName.value)
+              .withTags(Map("samUserId" -> user.id.value, "samUserEmail" -> user.email.value).asJava)
+              .create(context))
+            petToCreate = PetManagedIdentity(id, ManagedIdentityObjectId(azureUami.id()), ManagedIdentityDisplayName(azureUami.name()))
+            createdPet <- directoryDAO.createPetManagedIdentity(petToCreate, samRequestContext)
+            // TODO write to LDAP
+          } yield createdPet
+      }
+    } yield pet
+  }
+
+  private[azure] def getMsiManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[MsiManager] = {
+    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
+    IO(Defaults.crlConfigure(clientConfig, MsiManager.configure()).authenticate(credential, profile))
+  }
+
+  private[azure] def getResourceManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[ResourceManager] = {
+    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
+    IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
+  }
+
+  private[azure] def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
+    val credential = new ClientSecretCredentialBuilder()
+      .clientId(azureServicesConfig.managedAppClientId)
+      .clientSecret(azureServicesConfig.managedAppClientSecret)
+      .tenantId(azureServicesConfig.managedAppTenantId)
+      .build
+
+    val profile = new AzureProfile(
+      tenantId.value,
+      subscriptionId.value,
+      AzureEnvironment.AZURE)
+
+    (credential, profile)
+  }
+
+  private[azure] def buildCrlContext(request: GetOrCreatePetManagedIdentityRequest, petName: ManagedIdentityDisplayName): Context = {
+    Defaults.buildContext(
+      CreateUserAssignedManagedIdentityRequestData.builder()
+        .setTenantId(request.tenantId.value)
+        .setSubscriptionId(request.subscriptionId.value)
+        .setResourceGroupName(request.managedResourceGroupName.value)
+        .setName(petName.value)
+        .setRegion(managedIdentityRegion)
+        .build())
+  }
+
+  // Note:
+  private[azure] def getBillingProfileId(request: GetOrCreatePetManagedIdentityRequest): IO[Option[ResourceId]] = {
+    for {
+      resourceManager <- getResourceManager(request.tenantId, request.subscriptionId)
+      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
+      billingProfileOpt = mrg.toOption.flatMap(_.tags().asScala.get(billingProfileTag))
+    } yield billingProfileOpt.map(ResourceId(_))
+  }
+
+  private[azure] def toManagedIdentityNameFromUser(user: SamUser): ManagedIdentityDisplayName = {
+    ManagedIdentityDisplayName(s"pet-${user.id.value}")
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import bio.terra.cloudres.azure.resourcemanager.common.Defaults
+import bio.terra.cloudres.common.ClientConfig
+import cats.effect.IO
+import com.azure.core.management.AzureEnvironment
+import com.azure.core.management.profile.AzureProfile
+import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder}
+import com.azure.resourcemanager.msi.MsiManager
+import com.azure.resourcemanager.resources.ResourceManager
+import org.broadinstitute.dsde.workbench.sam.config.AzureServicesConfig
+
+/**
+  * Service class for interacting with Terra Cloud Resource Library (CRL).
+  * See: https://github.com/DataBiosphere/terra-cloud-resource-lib
+  *
+  * Note: this class is Azure-specific for now because Sam uses workbench-libs for
+  * Google Cloud calls.
+  */
+class CrlService(config: AzureServicesConfig) {
+  // TODO: Update Sam tests to talk to Janitor service:
+  // https://broadworkbench.atlassian.net/browse/ID-96
+  val clientConfig = ClientConfig.Builder.newBuilder().setClient("sam").build()
+
+  def buildMsiManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[MsiManager] = {
+    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
+    IO(Defaults.crlConfigure(clientConfig, MsiManager.configure()).authenticate(credential, profile))
+  }
+
+  def buildResourceManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[ResourceManager] = {
+    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
+    IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
+  }
+
+  private def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
+    val credential = new ClientSecretCredentialBuilder()
+      .clientId(config.managedAppClientId)
+      .clientSecret(config.managedAppClientSecret)
+      .tenantId(config.managedAppTenantId)
+      .build
+
+    val profile = new AzureProfile(
+      tenantId.value,
+      subscriptionId.value,
+      AzureEnvironment.AZURE)
+
+    (credential, profile)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
@@ -32,6 +32,8 @@ class CrlService(config: AzureServicesConfig) {
     IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
   }
 
+  def getManagedAppPlanId: String = config.managedAppPlanId
+
   private def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
     val credential = new ClientSecretCredentialBuilder()
       .clientId(config.managedAppClientId)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
-import cats.syntax.all._
 import com.google.api.client.json.gson.GsonFactory
 import com.typesafe.config._
 import net.ceedubs.ficus.Ficus._
@@ -162,11 +161,13 @@ object AppConfig {
     )
   }
 
-  implicit val azureServicesConfigReader: ValueReader[Option[AzureServicesConfig]] = ValueReader.relative { config =>
-    (config.getAs[String]("managedAppClientId"),
-      config.getAs[String]("managedAppClientSecret"),
-      config.getAs[String]("managedAppTenantId")
-      ).mapN(AzureServicesConfig.apply)
+  implicit val azureServicesConfigReader: ValueReader[AzureServicesConfig] = ValueReader.relative { config =>
+    AzureServicesConfig(
+      config.getString("managedAppClientId"),
+      config.getString("managedAppClientSecret"),
+      config.getString("managedAppTenantId"),
+      config.getString("managedAppPlanId")
+    )
   }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
+import cats.syntax.all._
 import com.google.api.client.json.gson.GsonFactory
 import com.typesafe.config._
 import net.ceedubs.ficus.Ficus._
@@ -28,7 +29,8 @@ final case class AppConfig(
                             blockedEmailDomains: Seq[String],
                             termsOfServiceConfig: TermsOfServiceConfig,
                             oidcConfig: OidcConfig,
-                            adminConfig: AdminConfig
+                            adminConfig: AdminConfig,
+                            azureServicesConfig: Option[AzureServicesConfig]
                           )
 
 object AppConfig {
@@ -160,6 +162,14 @@ object AppConfig {
     )
   }
 
+  implicit val azureServicesConfigReader: ValueReader[Option[AzureServicesConfig]] = ValueReader.relative { config =>
+    (config.getAs[String]("managedAppClientId"),
+      config.getAs[String]("managedAppClientSecret"),
+      config.getAs[String]("managedAppTenantId")
+      ).mapN(AzureServicesConfig.apply)
+  }
+
+
   def readConfig(config: Config): AppConfig = {
     val googleConfigOption = for {
       googleServices <- config.getAs[GoogleServicesConfig]("googleServices")
@@ -181,7 +191,8 @@ object AppConfig {
       blockedEmailDomains = config.as[Option[Seq[String]]]("blockedEmailDomains").getOrElse(Seq.empty),
       termsOfServiceConfig = config.as[TermsOfServiceConfig]("termsOfService"),
       oidcConfig = config.as[OidcConfig]("oidc"),
-      adminConfig = config.as[AdminConfig]("admin")
+      adminConfig = config.as[AdminConfig]("admin"),
+      azureServicesConfig = config.getAs[AzureServicesConfig]("azureServices")
     )
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.config
 
 case class AzureServicesConfig(managedAppClientId: String,
                                managedAppClientSecret: String,
-                               managedAppTenantId: String) {
+                               managedAppTenantId: String,
+                               managedAppPlanId: String) {
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -1,0 +1,7 @@
+package org.broadinstitute.dsde.workbench.sam.config
+
+case class AzureServicesConfig(managedAppClientId: String,
+                               managedAppClientSecret: String,
+                               managedAppTenantId: String) {
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.dsde.workbench.sam.dataAccess
 
-import java.util.Date
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUser}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import java.util.Date
 
 /**
   * Created by dvoet on 5/26/17.
@@ -64,4 +66,8 @@ trait DirectoryDAO extends RegistrationDAO {
 
   def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
   def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean]
+
+  def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
+  def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]
+  def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.workbench.sam.db
 
 import java.sql.ResultSet
-
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.model.{GoogleSubjectId, WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityDisplayName, ManagedIdentityObjectId, ManagedResourceGroupName, SubscriptionId, TenantId}
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import scalikejdbc.TypeBinder
@@ -136,5 +136,30 @@ object SamTypeBinders {
     def apply(rs: ResultSet, index: Int): GroupMembershipPath = {
       GroupMembershipPath(rs.getArray(index).getArray.asInstanceOf[Array[java.lang.Long]].map(_.longValue()).toList.map(GroupPK))
     }
+  }
+
+  implicit val tenantIdTypeBinder: TypeBinder[TenantId] = new TypeBinder[TenantId] {
+    def apply(rs: ResultSet, label: String): TenantId = TenantId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): TenantId = TenantId(rs.getString(index))
+  }
+
+  implicit val subscriptionIdTypeBinder: TypeBinder[SubscriptionId] = new TypeBinder[SubscriptionId] {
+    def apply(rs: ResultSet, label: String): SubscriptionId = SubscriptionId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): SubscriptionId = SubscriptionId(rs.getString(index))
+  }
+
+  implicit val managedResourceGroupNameTypeBinder: TypeBinder[ManagedResourceGroupName] = new TypeBinder[ManagedResourceGroupName] {
+    def apply(rs: ResultSet, label: String): ManagedResourceGroupName = ManagedResourceGroupName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ManagedResourceGroupName = ManagedResourceGroupName(rs.getString(index))
+  }
+
+  implicit val managedIdentityObjectIdTypeBinder: TypeBinder[ManagedIdentityObjectId] = new TypeBinder[ManagedIdentityObjectId] {
+    def apply(rs: ResultSet, label: String): ManagedIdentityObjectId = ManagedIdentityObjectId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ManagedIdentityObjectId = ManagedIdentityObjectId(rs.getString(index))
+  }
+
+  implicit val managedIdentityDisplayNameTypeBinder: TypeBinder[ManagedIdentityDisplayName] = new TypeBinder[ManagedIdentityDisplayName] {
+    def apply(rs: ResultSet, label: String): ManagedIdentityDisplayName = ManagedIdentityDisplayName(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): ManagedIdentityDisplayName = ManagedIdentityDisplayName(rs.getString(index))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetManagedIdentityTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetManagedIdentityTable.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import org.broadinstitute.dsde.workbench.sam.azure._
+import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
+import scalikejdbc._
+
+final case class PetManagedIdentityRecord(userId: WorkbenchUserId,
+                                          tenantId: TenantId,
+                                          subscriptionId: SubscriptionId,
+                                          managedResourceGroupName: ManagedResourceGroupName,
+                                          objectId: ManagedIdentityObjectId,
+                                          displayName: ManagedIdentityDisplayName)
+
+object PetManagedIdentityTable extends SQLSyntaxSupportWithDefaultSamDB[PetManagedIdentityRecord] {
+  override def tableName: String = "SAM_PET_MANAGED_IDENTITY"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[PetManagedIdentityRecord])(rs: WrappedResultSet): PetManagedIdentityRecord = PetManagedIdentityRecord(
+    rs.get(e.userId),
+    rs.get(e.tenantId),
+    rs.get(e.subscriptionId),
+    rs.get(e.managedResourceGroupName),
+    rs.get(e.objectId),
+    rs.get(e.displayName)
+  )
+
+  def apply(p: SyntaxProvider[PetManagedIdentityRecord])(rs: WrappedResultSet): PetManagedIdentityRecord = apply(p.resultName)(rs)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -109,6 +109,7 @@ object SamResourceTypes {
   val resourceTypeAdminName = ResourceTypeName("resource_type_admin")
   val workspaceName = ResourceTypeName("workspace")
   val googleProjectName = ResourceTypeName("google-project")
+  val spendProfile = ResourceTypeName("spend-profile")
 }
 
 @Lenses final case class UserStatusDetails(userSubjectId: WorkbenchUserId, userEmail: WorkbenchEmail) //for backwards compatibility to old API

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -97,6 +97,7 @@ object SamResourceActions {
   val adminReadPolicies = ResourceAction("admin_read_policies")
   val adminAddMember = ResourceAction("admin_add_member")
   val adminRemoveMember = ResourceAction("admin_remove_member")
+  val link = ResourceAction("link")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -70,6 +70,12 @@ googleServices {
   }
 }
 
+azureServices {
+  managedAppClientId = ${?MANAGED_APP_CLIENT_ID}
+  managedAppClientSecret = ${?MANAGED_APP_CLIENT_SECRET}
+  managedAppTenantId = ${?MANAGED_APP_TENANT_ID}
+}
+
 schemaLock {
   lockSchemaOnBoot = true
   recheckTimeInterval = 5
@@ -115,6 +121,12 @@ testStuff = {
       }
       reuseIds = false
     }
+  }
+  # Test MRG in which to create managed identities
+  azure {
+    tenantId = "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
+    subscriptionId = "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"
+    managedResourceGroupName = "mrg-terra-integration-test-20211118"
   }
 }
 

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -70,12 +70,6 @@ googleServices {
   }
 }
 
-azureServices {
-  managedAppClientId = ${?MANAGED_APP_CLIENT_ID}
-  managedAppClientSecret = ${?MANAGED_APP_CLIENT_SECRET}
-  managedAppTenantId = ${?MANAGED_APP_TENANT_ID}
-}
-
 schemaLock {
   lockSchemaOnBoot = true
   recheckTimeInterval = 5

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -8,7 +8,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{googleServicesConfig, samRequestContext}
-import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService, CrlService, MockCrlService}
+import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.{adminAddMember, adminReadPolicies, adminRemoveMember}
@@ -23,15 +23,15 @@ import scala.concurrent.ExecutionContext
 /**
   * Created by dvoet on 7/14/17.
   */
-class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureRoutes: Option[AzureRoutes] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, azureRoutes) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureService: Option[AzureService] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, azureService) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
   def mockRegistrationDao: RegistrationDAO = registrationDAO
 }
 
-class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureRoutes: Option[AzureRoutes] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, None) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO, registrationDAO: RegistrationDAO, val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureService: Option[AzureService] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, registrationDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, azureService) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
   def mockRegistrationDao: RegistrationDAO = registrationDAO
@@ -122,7 +122,6 @@ object TestSamRoutes {
 
     val mockStatusService = new StatusService(directoryDAO, registrationDAO, cloudXtns, dbRef)
     val azureService = new AzureService(crlService.getOrElse(MockCrlService()), directoryDAO)
-    val azureRoutes = new AzureRoutes(azureService, policyEvaluatorService, mockResourceService)
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, user, directoryDAO, registrationDAO, tosService = mockTosService, cloudExtensions = cloudXtns, azureRoutes = Some(azureRoutes))
+    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, user, directoryDAO, registrationDAO, tosService = mockTosService, cloudExtensions = cloudXtns, azureService = Some(azureService))
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -2,16 +2,22 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.testkit.TestDuration
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes
+import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
+import scala.concurrent.duration._
+
+class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
+  implicit val timeout = RouteTestTimeout(15.seconds.dilated)
   private val spendProfileResourceType = configResourceTypes.getOrElse(SamResourceTypes.spendProfile,
     throw new RuntimeException("Failed to load spend-profile resource type from reference.conf"))
 
@@ -40,6 +46,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 404 if the MRG does not exist" in {
     val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
 
+    // Non-existent MRG
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("non-existent-mrg"))
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
@@ -50,11 +57,30 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 404 if the MRG exists but the user does not have access to the billing profile" in {
     val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
 
-    // Create a pet managed identity, should return 201 created
+    // User has no access
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "return 403 if user has access to the billing profile but the MRG could not be validated" in {
+    // Change the managed app plan
+    val mockCrlService = MockCrlService()
+    when(mockCrlService.getManagedAppPlanId)
+      .thenReturn("some-other-plan")
+    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType), crlService = Some(mockCrlService))
+
+    // Create mock spend-profile resource
+    Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Forbidden
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -2,33 +2,59 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.testkit.TestDuration
-import org.broadinstitute.dsde.workbench.model.ErrorReport
-import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.sam.TestSupport
-import org.broadinstitute.dsde.workbench.sam.TestSupport.azureServicesConfig
+import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.duration._
-
 class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
+  private val spendProfileResourceType = configResourceTypes.getOrElse(SamResourceTypes.spendProfile,
+    throw new RuntimeException("Failed to load spend-profile resource type from reference.conf"))
 
-  implicit val timeout = RouteTestTimeout(15.seconds.dilated)
+  "POST /api/azure/v1/user/petManagedIdentity" should "successfully create a pet managed identity" in {
+    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
 
-  "POST /api/azure/v1/user/petManagedIdentity" should "be handled" in {
-    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
+    // Create mock spend-profile resource
+    Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
 
-    val samRoutes = TestSamRoutes(Map.empty)
-    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("some-mrg"))
+    // Create a pet managed identity, should return 201 created
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+    }
 
+    // Create again, should return 200
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+    }
+  }
+
+  it should "return 404 if the MRG does not exist" in {
+    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
+
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("non-existent-mrg"))
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NotFound
-      responseAs[ErrorReport].message shouldEqual "Managed resource group some-mrg not found"
+    }
+  }
+
+  it should "return 404 if the MRG exists but the user does not have access to the billing profile" in {
+    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
+
+    // Create a pet managed identity, should return 201 created
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.NotFound
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -1,0 +1,35 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.testkit.TestDuration
+import org.broadinstitute.dsde.workbench.model.ErrorReport
+import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.TestSupport.azureServicesConfig
+import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
+import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
+
+  implicit val timeout = RouteTestTimeout(15.seconds.dilated)
+
+  "POST /api/azure/v1/user/petManagedIdentity" should "be handled" in {
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
+
+    val samRoutes = TestSamRoutes(Map.empty)
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("some-mrg"))
+
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.NotFound
+      responseAs[ErrorReport].message shouldEqual "Managed resource group some-mrg not found"
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.azure
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestDuration
 import org.broadinstitute.dsde.workbench.sam.TestSupport
@@ -34,12 +34,14 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.Created
+      contentType shouldEqual ContentTypes.`application/json`
     }
 
     // Create again, should return 200
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.OK
+      contentType shouldEqual ContentTypes.`application/json`
     }
   }
 
@@ -51,6 +53,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentTypes.`application/json`
     }
   }
 
@@ -62,6 +65,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentTypes.`application/json`
     }
   }
 
@@ -81,6 +85,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.Forbidden
+      contentType shouldEqual ContentTypes.`application/json`
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -89,7 +89,6 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     msiManager.identities().deleteById(azureRes.id())
   }
 
-  // TODO fails, need to add tag on mrg-terra-integration-test-20211118
   it should "get the billing profile id from the managed resource group" taggedAs ConnectedTest in {
     val azureServicesConfig = appConfig.azureServicesConfig
 
@@ -112,6 +111,6 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     // should return a billing profile id
     res shouldBe defined
-    res.get shouldBe ResourceId("demo-spend-profile")
+    res.get shouldBe ResourceId("wm-default-spend-profile-id")
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -50,7 +50,8 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     // create pet for user
     val request = GetOrCreatePetManagedIdentityRequest(tenantId, subscriptionId, managedResourceGroupName)
-    val res = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    val (res, created) = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    created shouldBe true
     res.id shouldBe petManagedIdentityId
     res.displayName shouldBe ManagedIdentityDisplayName(s"pet-${defaultUser.id.value}")
 
@@ -66,7 +67,8 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     azureRes.name() shouldBe res.displayName.value
 
     // call getOrCreate again
-    val res2 = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    val (res2, created2) = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    created2 shouldBe false
     res2 shouldBe res
 
     // pet should still exist in postgres and azure

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -1,0 +1,107 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
+import org.broadinstitute.dsde.workbench.sam.TestSupport._
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockRegistrationDAO, PostgresDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, UserStatus, UserStatusDetails}
+import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
+  implicit val ec = scala.concurrent.ExecutionContext.global
+  implicit val ioRuntime = cats.effect.unsafe.IORuntime.global
+
+  "AzureService" should "create a pet managed identity" in {
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
+
+    // create dependencies
+    val directoryDAO = new PostgresDirectoryDAO(dbRef, dbRef)
+    val registrationDAO = new MockRegistrationDAO
+    val tosService = new TosService(directoryDAO, registrationDAO, googleServicesConfig.appsDomain, tosConfig)
+    val userService = new UserService(directoryDAO, NoExtensions, registrationDAO, Seq.empty, tosService)
+    val azureTestConfig = config.getConfig("testStuff.azure")
+    val azureService = new AzureService(azureServicesConfig.get, clientConfig, directoryDAO)
+
+    // create user
+    val defaultUser = genWorkbenchUserAzure.sample.get
+    val userStatus = IO.fromFuture(IO(userService.createUser(defaultUser, samRequestContext))).unsafeRunSync()
+    userStatus shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+
+    // user should exist in postgres
+    directoryDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(enabled = true))
+
+    // pet managed identity should not exist in postgres
+    val tenantId = TenantId(azureTestConfig.getString("tenantId"))
+    val subscriptionId = SubscriptionId(azureTestConfig.getString("subscriptionId"))
+    val managedResourceGroupName = ManagedResourceGroupName(azureTestConfig.getString("managedResourceGroupName"))
+    val petManagedIdentityId = PetManagedIdentityId(defaultUser.id, tenantId, subscriptionId, managedResourceGroupName)
+    directoryDAO.loadPetManagedIdentity(petManagedIdentityId, samRequestContext).unsafeRunSync() shouldBe None
+
+    // managed identity should not exist in Azure
+    val msiManager = azureService.getMsiManager(tenantId, subscriptionId).unsafeRunSync()
+    msiManager.identities().listByResourceGroup(managedResourceGroupName.value).asScala.toList.exists { i =>
+      i.name() === s"pet-${defaultUser.id.value}"
+    } shouldBe false
+
+    // create pet for user
+    val request = GetOrCreatePetManagedIdentityRequest(tenantId, subscriptionId, managedResourceGroupName)
+    val res = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    res.id shouldBe petManagedIdentityId
+    res.displayName shouldBe ManagedIdentityDisplayName(s"pet-${defaultUser.id.value}")
+
+    // pet managed identity should now exist in postgres
+    directoryDAO.loadPetManagedIdentity(petManagedIdentityId, samRequestContext).unsafeRunSync() shouldBe Some(res)
+
+    // managed identity should now exist in azure
+    val azureRes = msiManager.identities().getById(res.objectId.value)
+    azureRes should not be null
+    azureRes.tenantId() shouldBe tenantId.value
+    azureRes.resourceGroupName() shouldBe managedResourceGroupName.value
+    azureRes.id() shouldBe res.objectId.value
+    azureRes.name() shouldBe res.displayName.value
+
+    // call getOrCreate again
+    val res2 = azureService.getOrCreateUserPetManagedIdentity(defaultUser, request, samRequestContext).unsafeRunSync()
+    res2 shouldBe res
+
+    // pet should still exist in postgres and azure
+    directoryDAO.loadPetManagedIdentity(petManagedIdentityId, samRequestContext).unsafeRunSync() shouldBe Some(res2)
+    val azureRes2 = msiManager.identities().getById(res.objectId.value)
+    azureRes2 should not be null
+    azureRes2.tenantId() shouldBe tenantId.value
+    azureRes2.resourceGroupName() shouldBe managedResourceGroupName.value
+    azureRes2.id() shouldBe res2.objectId.value
+    azureRes2.name() shouldBe res2.displayName.value
+
+    // delete managed identity from Azure
+    // this is a best effort -- it will be deleted anyway by Janitor
+    msiManager.identities().deleteById(azureRes.id())
+  }
+
+  it should "get the billing profile id from the managed resource group" in {
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
+
+    // create dependencies
+    val directoryDAO = new PostgresDirectoryDAO(dbRef, dbRef)
+    val azureTestConfig = config.getConfig("testStuff.azure")
+    val azureService = new AzureService(azureServicesConfig.get, clientConfig, directoryDAO)
+
+    // build request
+    val tenantId = TenantId(azureTestConfig.getString("tenantId"))
+    val subscriptionId = SubscriptionId(azureTestConfig.getString("subscriptionId"))
+    val managedResourceGroupName = ManagedResourceGroupName(azureTestConfig.getString("managedResourceGroupName"))
+    val request = GetOrCreatePetManagedIdentityRequest(tenantId, subscriptionId, managedResourceGroupName)
+
+    // call getBillingProfileId
+    val res = azureService.getBillingProfileId(request).unsafeRunSync()
+
+    // should return a billing profile id
+    res shouldBe defined
+    res.get shouldBe ResourceId("demo-spend-profile")
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
@@ -1,0 +1,92 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import cats.effect.IO
+import com.azure.core.management.Region
+import com.azure.core.util.Context
+import com.azure.resourcemanager.msi.MsiManager
+import com.azure.resourcemanager.msi.models.{Identities, Identity}
+import com.azure.resourcemanager.msi.models.Identity.DefinitionStages
+import com.azure.resourcemanager.resources.ResourceManager
+import com.azure.resourcemanager.resources.fluent.models.ResourceGroupInner
+import com.azure.resourcemanager.resources.models.{ResourceGroup, ResourceGroups}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, SamResourceTypes}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.jdk.CollectionConverters._
+
+object MockCrlService extends MockitoSugar {
+  val mockMrgName = ManagedResourceGroupName("test-mrg")
+  val mockSamSpendProfileResource = FullyQualifiedResourceId(SamResourceTypes.spendProfile, ResourceId("test-spend-profile"))
+
+  def apply() = {
+    val mockCrlService = mock[CrlService]
+    val mockRm = mockResourceManager
+    when(mockCrlService.buildResourceManager(any[TenantId], any[SubscriptionId]))
+      .thenReturn(IO.pure(mockRm))
+
+    val mockMsi = mockMsiManager
+    when(mockCrlService.buildMsiManager(any[TenantId], any[SubscriptionId]))
+      .thenReturn(IO.pure(mockMsi))
+
+    mockCrlService
+  }
+
+  private def mockResourceManager: ResourceManager = {
+    val mockResourceGroupInner = mock[ResourceGroupInner]
+    when(mockResourceGroupInner.managedBy())
+      .thenReturn("terra")
+
+    val mockResourceGroup = mock[ResourceGroup]
+    when(mockResourceGroup.tags())
+      .thenReturn(Map("terra.billingProfileId" -> mockSamSpendProfileResource.resourceId.value).asJava)
+    when(mockResourceGroup.innerModel())
+      .thenReturn(mockResourceGroupInner)
+
+    val mockResourceGroups = mock[ResourceGroups]
+    when(mockResourceGroups.getByName(anyString))
+      .thenThrow(new RuntimeException("resource group not found"))
+    when(mockResourceGroups.getByName(ArgumentMatchers.eq(mockMrgName.value)))
+      .thenReturn(mockResourceGroup)
+
+    val mockResourceManager = mock[ResourceManager]
+    when(mockResourceManager.resourceGroups())
+      .thenReturn(mockResourceGroups)
+
+    mockResourceManager
+  }
+
+  private def mockMsiManager: MsiManager = {
+    val mockIdentity = mock[Identity]
+    when(mockIdentity.name())
+      .thenReturn("mock-uami")
+    when(mockIdentity.id())
+      .thenReturn("tenant/sub/mrg/uami")
+
+    val createIdentityStage3 = mock[DefinitionStages.WithCreate]
+    when(createIdentityStage3.create(any[Context]))
+      .thenReturn(mockIdentity)
+    when(createIdentityStage3.withTags(any[java.util.Map[String, String]]))
+      .thenReturn(createIdentityStage3)
+
+    val createIdentityStage2 = mock[DefinitionStages.WithGroup]
+    when(createIdentityStage2.withExistingResourceGroup(anyString))
+      .thenReturn(createIdentityStage3)
+
+    val createIdentityStage1 = mock[DefinitionStages.Blank]
+    when(createIdentityStage1.withRegion(any[Region]()))
+      .thenReturn(createIdentityStage2)
+
+    val mockIdentities = mock[Identities]
+    when(mockIdentities.define(anyString))
+      .thenReturn(createIdentityStage1)
+
+    val mockMsiManager = mock[MsiManager]
+    when(mockMsiManager.identities())
+      .thenReturn(mockIdentities)
+
+    mockMsiManager
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -31,6 +31,8 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   private val groupAccessInstructions: mutable.Map[WorkbenchGroupName, String] = new TrieMap()
 
+  private val petManagedIdentitiesByUser: mutable.Map[PetManagedIdentityId, PetManagedIdentity] = new TrieMap()
+
   override def getConnectionType(): ConnectionType = ConnectionType.Postgres
 
   override def createGroup(group: BasicWorkbenchGroup, accessInstruction: Option[String] = None, samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup] =
@@ -329,11 +331,16 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     }
   }
 
-  override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] =
+  override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] = {
+    if (petManagedIdentitiesByUser.keySet.contains(petManagedIdentity.id)) {
+      IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"pet managed identity ${petManagedIdentity.id} already exists")))
+    }
+    petManagedIdentitiesByUser += petManagedIdentity.id -> petManagedIdentity
     IO.pure(petManagedIdentity)
+  }
 
   override def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]] =
-    IO.pure(None)
+    IO.pure(petManagedIdentitiesByUser.get(petManagedIdentityId))
 
   override def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(None)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.ConnectionType.ConnectionType
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, SamUser}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -327,4 +328,13 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
         }
     }
   }
+
+  override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] =
+    IO.pure(petManagedIdentity)
+
+  override def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]] =
+    IO.pure(None)
+
+  override def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    IO.pure(None)
 }


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/TOAZ-126

Design doc: https://docs.google.com/document/d/1cyrRTibpvMbu0DtAjDsXeQp6-U2RftO66hHNb3nw_h4/edit#heading=h.focnnsveczp4

Demo recording: https://drive.google.com/file/d/1HiiAxQDVteaznwlRQLuFrXfm9PkSJDyU/view?usp=drive_web

Friends with: https://github.com/broadinstitute/firecloud-develop/pull/2991 (but the PRs are independent)

Overview: 
* Adds `AzureRoutes` and `AzureService` classes to Sam
   * Contains single `POST /api/azure/v1/user/petManagedIdentity` API which gets or creates a pet-UAMI
* Adds CRL dependency to Sam
* Adds `SAM_PET_MANAGED_IDENTITY` SQL table and associated queries
* Updates `StandardUserInfoDirectives` to handle requests from pet UAMIs and switch back to the owning user
* Add unit + connected tests for the above

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
