### PR TITLE
ID-70 Make Sam check for all users group existance before inserting

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -82,7 +82,7 @@ class GoogleExtensions(
       existingGroup <- directoryDAO.loadGroup(allUsersGroupStub.id, samRequestContext = samRequestContext).unsafeToFuture()
       allUsersGroup <- existingGroup match {
         case None => directoryDAO.createGroup(allUsersGroupStub, samRequestContext = samRequestContext).unsafeToFuture()
-        case Some(group) => Future(group)
+        case Some(group) => Future.successful(group)
       }
       existingGoogleGroup <- googleDirectoryDAO.getGoogleGroup(allUsersGroup.email)
       _ <- existingGoogleGroup match {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -579,10 +579,14 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
-    val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
-      override def matches(group: BasicWorkbenchGroup): Boolean = group.id == allUsersGroup.id
+//    val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
+//      override def matches(group: BasicWorkbenchGroup): Boolean = group.id == allUsersGroup.id
+//    }
+    val allUsersGroupNameMatcher = new ArgumentMatcher[WorkbenchGroupName] {
+      override def matches(name: WorkbenchGroupName): Boolean = name == allUsersGroup.id
     }
-    when(mockDirectoryDAO.createGroup(argThat(allUsersGroupMatcher), any[Option[String]], any[SamRequestContext])).thenReturn(IO.pure(allUsersGroup))
+//    when(mockDirectoryDAO.createGroup(argThat(allUsersGroupMatcher), any[Option[String]], any[SamRequestContext])).thenReturn(IO.pure(allUsersGroup))
+    when(mockDirectoryDAO.loadGroup(argThat(allUsersGroupNameMatcher), any[SamRequestContext])).thenReturn(IO.pure(Some(allUsersGroup)))
 
     when(mockGoogleDirectoryDAO.getGoogleGroup(any[WorkbenchEmail])).thenReturn(Future.successful(None))
     when(mockGoogleDirectoryDAO.createGroup(any[String], any[WorkbenchEmail], any[Option[Groups]])).thenReturn(Future.successful(()))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -579,13 +579,9 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val googleExtensions = new GoogleExtensions(TestSupport.fakeDistributedLock, mockDirectoryDAO, mock[RegistrationDAO](RETURNS_SMART_NULLS), null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes)
 
     val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
-//    val allUsersGroupMatcher = new ArgumentMatcher[BasicWorkbenchGroup] {
-//      override def matches(group: BasicWorkbenchGroup): Boolean = group.id == allUsersGroup.id
-//    }
     val allUsersGroupNameMatcher = new ArgumentMatcher[WorkbenchGroupName] {
       override def matches(name: WorkbenchGroupName): Boolean = name == allUsersGroup.id
     }
-//    when(mockDirectoryDAO.createGroup(argThat(allUsersGroupMatcher), any[Option[String]], any[SamRequestContext])).thenReturn(IO.pure(allUsersGroup))
     when(mockDirectoryDAO.loadGroup(argThat(allUsersGroupNameMatcher), any[SamRequestContext])).thenReturn(IO.pure(Some(allUsersGroup)))
 
     when(mockGoogleDirectoryDAO.getGoogleGroup(any[WorkbenchEmail])).thenReturn(Future.successful(None))


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-70
Sam sees a ton of the following errors in its logs:
```
SQL execution failed (Reason: ERROR: duplicate key value violates unique constraint "sam_group_name_key"
  Detail: Key (name)=(All_Users) already exists.):

   insert into SAM_GROUP (name, email, updated_date, synchronized_date) values (All_Users, GROUP_All_Users@firecloud.org, 2022-05-17T16:37:39.549503Z, null)
```

This is happening every time the “All Users Group” is being added to, because when Sam gets the all users group, it tries to create it each time, and if the create fails because the group already exists (which it always does), then the SQL error is logged and Sam continues knowing that the group exists. 

This is silly. It pollutes the log with red-herring error messages, and handling exceptions as successful is a pretty big code smell.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
