### PR TITLE
ID-76 Use Spring Cloud GCP Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ LOCAL_OPENDJ=true LOCAL_POSTGRES=true sh config/docker-rsync-local-sam.sh
 ```
 NOTE: OpenDJ has some heavy memory requirements.  If you see the OpenDJ container silently dying when running this command, try opening your Docker Desktop preferenes and increasing the Memory resources, 4GB seems to be sufficient, but more may be needed as well as increasing the Swap space maybe.
 
+##### Human-Readable Logging
+To make Sam output human-readable log messages instead of Stackdriver-compatible messages, 
+add `SAM_LOG_APPENDER=Console-Standard` to your environment variables.
+
 #### Verify that local Sam is running
 [Status endpoint:
 https://local.broadinstitute.org:50443/status](https://local.broadinstitute.org:50443/status)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,7 @@ object Dependencies {
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.5.2"
   val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE" excludeAll(excludeSpringJcl)
+  val janino: ModuleID =          "org.codehaus.janino"       %  "janino"          % "3.1.7" // For if-else logic in logging config
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV
@@ -117,6 +118,7 @@ object Dependencies {
     scalaLogging,
     ficus,
     stackdriverLogging,
+    janino,
 
     akkaActor,
     akkaSlf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,6 +37,7 @@ object Dependencies {
   val ravenLogback: ModuleID =   "com.getsentry.raven"        %  "raven-logback"   % "7.8.6"
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.5.2"
+  val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE"
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV
@@ -114,6 +115,7 @@ object Dependencies {
     ravenLogback,
     scalaLogging,
     ficus,
+    stackdriverLogging,
 
     akkaActor,
     akkaSlf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_2.12")
   val excludeWorkbenchGoogle =  ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.12")
+  val excludeSpringJcl =   ExclusionRule(organization = "org.springframework", name = "spring-jcl")
 
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
   val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV
@@ -37,7 +38,7 @@ object Dependencies {
   val ravenLogback: ModuleID =   "com.getsentry.raven"        %  "raven-logback"   % "7.8.6"
   val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
   val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.5.2"
-  val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE"
+  val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE" excludeAll(excludeSpringJcl)
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,11 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <if condition='!isDefined("SAM_LOG_APPENDER")'>
+        <then>
+            <variable name="SAM_LOG_APPENDER" value="Console-Stackdriver" />
+        </then>
+    </if>
+
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <level>severity</level>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <appender name="Console-Stackdriver" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="org.springframework.cloud.gcp.logging.StackdriverJsonLayout">
                 <includeTraceId>true</includeTraceId>
                 <includeSpanId>true</includeSpanId>
             </layout>
+        </encoder>
+    </appender>
+
+    <appender name="Console-Standard" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%date %-5level [%thread] %logger{36}: %message%n</Pattern>
         </encoder>
     </appender>
 
@@ -41,7 +62,7 @@
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
@@ -49,14 +70,14 @@
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="org.broadinstitute.dsde.workbench.google" level="debug" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
@@ -64,14 +85,14 @@
     <!-- publishing messages can be too verbose logging -->
     <logger name="org.broadinstitute.dsde.workbench.google.HttpGooglePubSubDAO" level="info" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
     <root level="warn">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </root>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,11 @@
 <configuration>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <level>severity</level>
-            </fieldNames>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.springframework.cloud.gcp.logging.StackdriverJsonLayout">
+                <includeTraceId>true</includeTraceId>
+                <includeSpanId>true</includeSpanId>
+            </layout>
         </encoder>
     </appender>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,10 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
+    <if condition='!isDefined("SAM_LOG_APPENDER")'>
+        <then>
+            <variable name="SAM_LOG_APPENDER" value="Console-Stackdriver" />
+        </then>
+    </if>
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <fieldNames>
                 <level>severity</level>
             </fieldNames>
+        </encoder>
+    </appender>
+
+    <appender name="Console-Stackdriver" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="org.springframework.cloud.gcp.logging.StackdriverJsonLayout">
+                <includeTraceId>true</includeTraceId>
+                <includeSpanId>true</includeSpanId>
+            </layout>
+        </encoder>
+    </appender>
+
+    <appender name="Console-Standard" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%date %-5level [%thread] %logger{36}: %message%n</Pattern>
         </encoder>
     </appender>
 
@@ -40,14 +62,14 @@
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="org.broadinstitute.dsde.workbench.sam.service.StatusService" level="warn" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
@@ -55,14 +77,14 @@
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleDirectoryDAO" level="debug" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
@@ -70,14 +92,14 @@
     <!-- auditing in tests makes a ton of logs, set level to info to see them -->
     <logger name="org.broadinstitute.dsde.workbench.sam.audit.AuditLogger$" level="off" additivity="false">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </logger>
 
     <root level="warn">
         <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="${SAM_LOG_APPENDER}"/>
         <appender-ref ref="SYSLOG"/>
         <appender-ref ref="Sentry" />
     </root>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-76

Sam’s logs leave a lot to be desired. The biggest issue is that exceptions are serialized in such a way that each line of the stacktrace is a new log message. This makes debugging difficult, as copying a stacktrace for analysis by IntelliJ because a tedious task. Upgrading the logging appender that spits out logs to Stackdriver should help!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
