### PR TITLE
ID-87 Add temporary endpoint to repair broken invited users

### DIFF
--- a/docker/sql_validate.sh
+++ b/docker/sql_validate.sh
@@ -3,7 +3,7 @@
 SERVICE=$1
 
 # validate mysql
-echo "sleeping for 5 seconds during postgres boot..."
-sleep 5
+echo "sleeping for 10 seconds during postgres boot..."
+sleep 10
 export PGPASSWORD=${SERVICE}-test
 psql --username ${SERVICE}-test --no-password --host=postgres --port=5432 -d testdb -c "SELECT VERSION();SELECT NOW()"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -85,6 +85,17 @@ trait AdminRoutes
                   }
                 }
               } ~
+              // This will get removed once ID-87 is resolved
+              pathPrefix("repairAllUsersGroup") {
+                pathEndOrSingleSlash {
+                  put {
+                    complete {
+                      userService
+                        .addToAllUsersGroup(WorkbenchUserId(userId), samRequestContext).map(_ => OK)
+                    }
+                  }
+                }
+              } ~
               pathPrefix("petServiceAccount") {
                 path(Segment) { project =>
                   delete {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-87
Adding an endpoint to repair users affected by the https://broadworkbench.atlassian.net/browse/PROD-677 issue. Invited users were created, but never added to the All Users group because of an error occurring before that step. This new, temporary endpoint will allow us to repair the affected users. Once all users have been fixed, this endpoint should be removed. To repair a user, send a `PUT` request to `/api/admin/v1/user/{user_id}/repairAllUsersGroup`. An `OK` response means the operation was successful. 

I've tested this code locally, and made sure that hitting the endpoint does the right thing. I'm not writing a test, since setting up a bugged-out user and writing a test to remediate it is far too much effort for a temporary endpoint.

Also including a tiny fix for running Sam locally by bumping up the wait time for the docker script to wait for postgres to become live.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
