### PR TITLE
ID-91 Read service accounts from file instead of inlined json

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -33,11 +33,13 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.io.File
 import java.net.URI
+import java.nio.file.{Files, Paths}
 import javax.net.SocketFactory
 import javax.net.ssl.SSLContext
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 object Boot extends IOApp with LazyLogging {
@@ -231,7 +233,7 @@ object Boot extends IOApp with LazyLogging {
             new File(config.googleServicesConfig.pemFile),
             Option(config.googleServicesConfig.subEmail)
           ))
-      case Some(accounts) => accounts.map(account => Json(account.json, Option(config.googleServicesConfig.subEmail)))
+      case Some(accounts) => accounts.map(account => Json(Files.readAllLines(Paths.get(account)).asScala.mkString, Option(config.googleServicesConfig.subEmail)))
     }).map { credentials =>
       new HttpGoogleDirectoryDAO(config.googleServicesConfig.appName, credentials, workspaceMetricBaseName)
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
+import com.typesafe.config.ConfigRenderOptions
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 import org.broadinstitute.dsde.workbench.google.{KeyId, KeyRingId, Location}
@@ -30,7 +31,8 @@ final case class GoogleServicesConfig(
     notificationTopic: String,
     googleKeyCacheConfig: GoogleKeyCacheConfig,
     resourceNamePrefix: Option[String],
-    adminSdkServiceAccounts: Option[NonEmptyList[String]],
+    adminSdkServiceAccounts: Option[NonEmptyList[ServiceAccountConfig]],
+    adminSdkServiceAccountPaths: Option[NonEmptyList[String]],
     googleKms: GoogleKmsConfig,
     terraGoogleOrgNumber: String
 )
@@ -65,6 +67,10 @@ object GoogleServicesConfig {
     )
   }
 
+  implicit val serviceAccountConfigReader: ValueReader[ServiceAccountConfig] = ValueReader.relative { config =>
+    ServiceAccountConfig(config.root().render(ConfigRenderOptions.concise))
+  }
+
   implicit val googleServicesConfigReader: ValueReader[GoogleServicesConfig] = ValueReader.relative { config =>
     val jsonCredentials = ServiceAccountCredentialJson(
       FirestoreServiceAccountJsonPath(config.getString("pathToFirestoreCredentialJson")),
@@ -88,13 +94,15 @@ object GoogleServicesConfig {
       config.getString("notifications.topicName"),
       config.as[GoogleKeyCacheConfig]("googleKeyCache"),
       config.as[Option[String]]("resourceNamePrefix"),
-      config.as[Option[NonEmptyList[String]]]("adminSdkServiceAccounts"),
+      config.as[Option[NonEmptyList[ServiceAccountConfig]]]("adminSdkServiceAccounts"),
+      config.as[Option[NonEmptyList[String]]]("adminSdkServiceAccountPaths"),
       config.as[GoogleKmsConfig]("kms"),
       config.getString("terraGoogleOrgNumber")
     )
   }
 }
 
+final case class ServiceAccountConfig(json: String) extends AnyVal
 final case class FirestoreServiceAccountJsonPath(asString: String) extends AnyVal
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal
 final case class ServiceAccountCredentialJson(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -102,6 +102,7 @@ object GoogleServicesConfig {
   }
 }
 
+//TODO: Once ID-91 is merged and deployed, we cann remove ServiceAccountConfig and the adminServiceAccounts variable
 final case class ServiceAccountConfig(json: String) extends AnyVal
 final case class FirestoreServiceAccountJsonPath(asString: String) extends AnyVal
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
-import com.typesafe.config.ConfigRenderOptions
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 import org.broadinstitute.dsde.workbench.google.{KeyId, KeyRingId, Location}
@@ -31,7 +30,7 @@ final case class GoogleServicesConfig(
     notificationTopic: String,
     googleKeyCacheConfig: GoogleKeyCacheConfig,
     resourceNamePrefix: Option[String],
-    adminSdkServiceAccounts: Option[NonEmptyList[ServiceAccountConfig]],
+    adminSdkServiceAccounts: Option[NonEmptyList[String]],
     googleKms: GoogleKmsConfig,
     terraGoogleOrgNumber: String
 )
@@ -66,10 +65,6 @@ object GoogleServicesConfig {
     )
   }
 
-  implicit val serviceAccountConfigReader: ValueReader[ServiceAccountConfig] = ValueReader.relative { config =>
-    ServiceAccountConfig(config.root().render(ConfigRenderOptions.concise))
-  }
-
   implicit val googleServicesConfigReader: ValueReader[GoogleServicesConfig] = ValueReader.relative { config =>
     val jsonCredentials = ServiceAccountCredentialJson(
       FirestoreServiceAccountJsonPath(config.getString("pathToFirestoreCredentialJson")),
@@ -93,14 +88,13 @@ object GoogleServicesConfig {
       config.getString("notifications.topicName"),
       config.as[GoogleKeyCacheConfig]("googleKeyCache"),
       config.as[Option[String]]("resourceNamePrefix"),
-      config.as[Option[NonEmptyList[ServiceAccountConfig]]]("adminSdkServiceAccounts"),
+      config.as[Option[NonEmptyList[String]]]("adminSdkServiceAccounts"),
       config.as[GoogleKmsConfig]("kms"),
       config.getString("terraGoogleOrgNumber")
     )
   }
 }
 
-final case class ServiceAccountConfig(json: String) extends AnyVal
 final case class FirestoreServiceAccountJsonPath(asString: String) extends AnyVal
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal
 final case class ServiceAccountCredentialJson(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -102,7 +102,6 @@ object GoogleServicesConfig {
   }
 }
 
-//TODO: Once ID-91 is merged and deployed, we cann remove ServiceAccountConfig and the adminServiceAccounts variable
 final case class ServiceAccountConfig(json: String) extends AnyVal
 final case class FirestoreServiceAccountJsonPath(asString: String) extends AnyVal
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-91
This changes comes from a request from DevOps to make Sam read admin service accounts from file instead of from JSON embedded in the `sam.conf` file. This is a sibling PR of https://github.com/broadinstitute/firecloud-develop/pull/2982.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
