### PR TITLE
ID-97 Remove JSON service account configs

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -141,7 +141,7 @@ object Boot extends IOApp with LazyLogging {
           extraGoogleClientId = appConfig.oidcConfig.legacyGoogleClientId.map(ClientId),
           extraAuthParams = Some("prompt=login"))
       )
-    } yield createAppDepenciesWithSamRoutes(appConfig, cloudExtensionsInitializer, foregroundAccessPolicyDAO, foregroundDirectoryDAO, registrationDAO, oauth2Config)
+    } yield createAppDependenciesWithSamRoutes(appConfig, cloudExtensionsInitializer, foregroundAccessPolicyDAO, foregroundDirectoryDAO, registrationDAO, oauth2Config)
 
   private def cloudExtensionsInitializerResource(
       appConfig: AppConfig,
@@ -303,7 +303,6 @@ object Boot extends IOApp with LazyLogging {
                                  (implicit actorSystem: ActorSystem): NonEmptyList[HttpGoogleDirectoryDAO] = {
     val serviceAccountJsons = config.googleServicesConfig.adminSdkServiceAccountPaths.map(
       _.map(path => Files.readAllLines(Paths.get(path)).asScala.mkString))
-      .orElse(config.googleServicesConfig.adminSdkServiceAccounts.map(_.map(_.json)))
 
     val googleCredentials = serviceAccountJsons match {
       case None =>
@@ -320,7 +319,7 @@ object Boot extends IOApp with LazyLogging {
       new HttpGoogleDirectoryDAO(config.googleServicesConfig.appName, credentials, workspaceMetricBaseName))
   }
 
-  private[sam] def createAppDepenciesWithSamRoutes(
+  private[sam] def createAppDependenciesWithSamRoutes(
       config: AppConfig,
       cloudExtensionsInitializer: CloudExtensionsInitializer,
       accessPolicyDAO: AccessPolicyDAO,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import cats.data.NonEmptyList
-import com.typesafe.config.ConfigRenderOptions
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 import org.broadinstitute.dsde.workbench.google.{KeyId, KeyRingId, Location}
@@ -31,7 +30,6 @@ final case class GoogleServicesConfig(
     notificationTopic: String,
     googleKeyCacheConfig: GoogleKeyCacheConfig,
     resourceNamePrefix: Option[String],
-    adminSdkServiceAccounts: Option[NonEmptyList[ServiceAccountConfig]],
     adminSdkServiceAccountPaths: Option[NonEmptyList[String]],
     googleKms: GoogleKmsConfig,
     terraGoogleOrgNumber: String
@@ -67,10 +65,6 @@ object GoogleServicesConfig {
     )
   }
 
-  implicit val serviceAccountConfigReader: ValueReader[ServiceAccountConfig] = ValueReader.relative { config =>
-    ServiceAccountConfig(config.root().render(ConfigRenderOptions.concise))
-  }
-
   implicit val googleServicesConfigReader: ValueReader[GoogleServicesConfig] = ValueReader.relative { config =>
     val jsonCredentials = ServiceAccountCredentialJson(
       FirestoreServiceAccountJsonPath(config.getString("pathToFirestoreCredentialJson")),
@@ -94,7 +88,6 @@ object GoogleServicesConfig {
       config.getString("notifications.topicName"),
       config.as[GoogleKeyCacheConfig]("googleKeyCache"),
       config.as[Option[String]]("resourceNamePrefix"),
-      config.as[Option[NonEmptyList[ServiceAccountConfig]]]("adminSdkServiceAccounts"),
       config.as[Option[NonEmptyList[String]]]("adminSdkServiceAccountPaths"),
       config.as[GoogleKmsConfig]("kms"),
       config.getString("terraGoogleOrgNumber")
@@ -102,7 +95,6 @@ object GoogleServicesConfig {
   }
 }
 
-final case class ServiceAccountConfig(json: String) extends AnyVal
 final case class FirestoreServiceAccountJsonPath(asString: String) extends AnyVal
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal
 final case class ServiceAccountCredentialJson(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-97

This removes the `adminSdkServiceAccounts` configuration variable, now that Sam reads the service accounts from local paths instead of JSON embedded in its application configuration.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
