### PR TITLE
[TOAZ-146] Use separate B2C policy for sensitive scopes 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val workbenchGoogleV = "0.21-8ce5b9b"
   val workbenchGoogle2V = "0.24-447afa5"
   val workbenchNotificationsV = "0.3-d74ff96"
-  val workbenchOauth2V = "0.2-1962b9a"
+  val workbenchOauth2V = "0.2-35b51165-SNAP"
   val monocleVersion = "2.0.5"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val workbenchGoogleV = "0.21-8ce5b9b"
   val workbenchGoogle2V = "0.24-447afa5"
   val workbenchNotificationsV = "0.3-d74ff96"
-  val workbenchOauth2V = "0.2-51eb1287-SNAP"
+  val workbenchOauth2V = "0.2-20f9225"
   val monocleVersion = "2.0.5"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val workbenchGoogleV = "0.21-8ce5b9b"
   val workbenchGoogle2V = "0.24-447afa5"
   val workbenchNotificationsV = "0.3-d74ff96"
-  val workbenchOauth2V = "0.2-35b51165-SNAP"
+  val workbenchOauth2V = "0.2-51eb1287-SNAP"
   val monocleVersion = "2.0.5"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-146

Bumps wb-libs dependency for https://github.com/broadinstitute/workbench-libs/pull/1006. This supports using the new per-env B2C policies which support dynamic GCP scopes.

Manually tested oauth functionality on a fiab.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
