### PR TITLE
[AJ-455] New APIs to add/delete members to policy by resourceId + policyGroupName

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1598,7 +1598,7 @@ paths:
     put:
       tags:
         - Resources
-      summary: Add a user to a policy by policy email
+      summary: Add a user to a policy by user email
       operationId: addUserToPolicyV2
       parameters:
         - name: resourceTypeName
@@ -1699,8 +1699,8 @@ paths:
     put:
       tags:
         - Resources
-      summary: Add a user to a policy by role on another resource
-      operationId: addUserToPolicyByRoleV2
+      summary: Add a member policy to a parent policy
+      operationId: addMemberPolicyV2
       parameters:
         - name: resourceTypeName
           in: path
@@ -1742,9 +1742,6 @@ paths:
         204:
           description: Successfully added a user to the policy
           content: { }
-        400:
-          description: email is not found
-          content: { }
         403:
           description: You do not have permission to alter this policy
           content: { }
@@ -1761,8 +1758,8 @@ paths:
     delete:
       tags:
         - Resources
-      summary: Remove a user from a policy by role on another resource
-      operationId: removeUserFromPolicyByRoleV2
+      summary: Remove a member policy from a parent policy
+      operationId: removeMemberPolicyV2
       parameters:
         - name: resourceTypeName
           in: path
@@ -1803,9 +1800,6 @@ paths:
       responses:
         204:
           description: Successfully removed a user from the policy
-          content: { }
-        400:
-          description: email is not found
           content: { }
         403:
           description: You do not have permission to alter this policy

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1598,7 +1598,7 @@ paths:
     put:
       tags:
         - Resources
-      summary: Add a user to a policy
+      summary: Add a user to a policy by policy email
       operationId: addUserToPolicyV2
       parameters:
         - name: resourceTypeName
@@ -1672,6 +1672,131 @@ paths:
         - name: email
           in: path
           description: Email of user to be removed
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Successfully removed a user from the policy
+          content: { }
+        400:
+          description: email is not found
+          content: { }
+        403:
+          description: You do not have permission to alter this policy
+          content: { }
+        404:
+          description: Resource type does not exist, you are not a member of any policy
+            on the resource, or user was not found
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/resources/v2/{resourceTypeName}/{resourceId}/policies/{policyName}/memberPolicies/{memberResourceTypeName}/{memberResourceId}/{memberPolicyName}:
+    put:
+      tags:
+        - Resources
+      summary: Add a user to a policy by role on another resource
+      operationId: addUserToPolicyByRoleV2
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+        - name: policyName
+          in: path
+          description: Name of the policy
+          required: true
+          schema:
+            type: string
+        - name: memberResourceTypeName
+          in: path
+          description: Type of resource for the member policy
+          required: true
+          schema:
+            type: string
+        - name: memberResourceId
+          in: path
+          description: Resource id for the member policy
+          required: true
+          schema:
+            type: string
+        - name: memberPolicyName
+          in: path
+          description: Member policy name
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Successfully added a user to the policy
+          content: { }
+        400:
+          description: email is not found
+          content: { }
+        403:
+          description: You do not have permission to alter this policy
+          content: { }
+        404:
+          description: Resource type does not exist, you are not a member of any policy
+            on the resource, or user was not found
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    delete:
+      tags:
+        - Resources
+      summary: Remove a user from a policy by role on another resource
+      operationId: removeUserFromPolicyByRoleV2
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+        - name: policyName
+          in: path
+          description: Name of the policy
+          required: true
+          schema:
+            type: string
+        - name: memberResourceTypeName
+          in: path
+          description: Type of resource for the member policy
+          required: true
+          schema:
+            type: string
+        - name: memberResourceId
+          in: path
+          description: Resource id for the member policy
+          required: true
+          schema:
+            type: string
+        - name: memberPolicyName
+          in: path
+          description: Member policy name
           required: true
           schema:
             type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1740,14 +1740,14 @@ paths:
             type: string
       responses:
         204:
-          description: Successfully added a user to the policy
+          description: Successfully added a member policy to the parent policy
           content: { }
         403:
           description: You do not have permission to alter this policy
           content: { }
         404:
           description: Resource type does not exist, you are not a member of any policy
-            on the resource, or user was not found
+            on the resource, or member policy was not found
           content: { }
         500:
           description: Internal Server Error
@@ -1799,14 +1799,14 @@ paths:
             type: string
       responses:
         204:
-          description: Successfully removed a user from the policy
+          description: Successfully removed a member policy from the parent policy
           content: { }
         403:
           description: You do not have permission to alter this policy
           content: { }
         404:
           description: Resource type does not exist, you are not a member of any policy
-            on the resource, or user was not found
+            on the resource, or member policy was not found
           content: { }
         500:
           description: Internal Server Error

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -204,10 +204,12 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                     path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
                       val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
                         ResourceId(memberResourceId))
-                      val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                      pathEndOrSingleSlash {
-                        putUserInPolicy(policyId, subject, samRequestContext) ~
-                        deleteUserFromPolicy(policyId, subject, samRequestContext)
+                      val policySubject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
+                      withPolicy(policySubject, samRequestContext) { memberPolicy =>
+                        pathEndOrSingleSlash {
+                          putUserInPolicy(policyId, memberPolicy.id, samRequestContext) ~
+                          deleteUserFromPolicy(policyId, memberPolicy.id, samRequestContext)
+                        }
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -199,6 +199,23 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                     }
                   }
                 } ~
+                pathPrefix("memberPolicies") {
+                  requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
+                    pathPrefix(Segment) { memberResourceType =>
+                      pathPrefix(Segment) { memberResourceId =>
+                        val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
+                          ResourceId(memberResourceId))
+                        pathPrefix(Segment) { memberPolicyName =>
+                          val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
+                          pathEndOrSingleSlash {
+                            putUserInPolicy(policyId, subject, samRequestContext) ~
+                            deleteUserFromPolicy(policyId, subject, samRequestContext)
+                          }
+                        }
+                      }
+                    }
+                  }
+                } ~
                 pathPrefix("public") {
                   pathEndOrSingleSlash {
                     getPublicFlag(policyId, samUser, samRequestContext) ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -205,7 +205,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                       val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
                         ResourceId(memberResourceId))
                       val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                      requireOneOfAction(memberResource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(subject.accessPolicyName)), samUser.id, samRequestContext) {
+                      requireOneOfAction(memberResource, Set(ResourceAction("read")), samUser.id, samRequestContext) {
                         pathEndOrSingleSlash {
                           putUserInPolicy(policyId, subject, samRequestContext) ~
                           deleteUserFromPolicy(policyId, subject, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -205,11 +205,9 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                       val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
                         ResourceId(memberResourceId))
                       val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                      requireOneOfAction(memberResource, Set(ResourceAction("read")), samUser.id, samRequestContext) {
-                        pathEndOrSingleSlash {
-                          putUserInPolicy(policyId, subject, samRequestContext) ~
-                          deleteUserFromPolicy(policyId, subject, samRequestContext)
-                        }
+                      pathEndOrSingleSlash {
+                        putUserInPolicy(policyId, subject, samRequestContext) ~
+                        deleteUserFromPolicy(policyId, subject, samRequestContext)
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -201,19 +201,13 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                 } ~
                 pathPrefix("memberPolicies") {
                   requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
-                    pathPrefix(Segment) { memberResourceType =>
-                      pathPrefix(Segment) { memberResourceId =>
-                        val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
-                          ResourceId(memberResourceId))
-                        pathPrefix(Segment) { memberPolicyName =>
-                          val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                          pathEndOrSingleSlash {
-                            putUserInPolicy(policyId, subject, samRequestContext) ~
-                            deleteUserFromPolicy(policyId, subject, samRequestContext)
-                          }
-                        }
-                      }
-                    }
+                  path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
+                    val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
+                      ResourceId(memberResourceId))
+                    val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
+                    putUserInPolicy(policyId, subject, samRequestContext) ~
+                      deleteUserFromPolicy(policyId, subject, samRequestContext)
+                  }
                   }
                 } ~
                 pathPrefix("public") {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -201,13 +201,17 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                 } ~
                 pathPrefix("memberPolicies") {
                   requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
-                  path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
-                    val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
-                      ResourceId(memberResourceId))
-                    val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                    putUserInPolicy(policyId, subject, samRequestContext) ~
-                      deleteUserFromPolicy(policyId, subject, samRequestContext)
-                  }
+                    path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
+                      val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType),
+                        ResourceId(memberResourceId))
+                      val subject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
+                      requireOneOfAction(memberResource, Set(SamResourceActions.readPolicies, SamResourceActions.readPolicy(subject.accessPolicyName)), samUser.id, samRequestContext) {
+                        pathEndOrSingleSlash {
+                          putUserInPolicy(policyId, subject, samRequestContext) ~
+                          deleteUserFromPolicy(policyId, subject, samRequestContext)
+                        }
+                      }
+                    }
                   }
                 } ~
                 pathPrefix("public") {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamModelDirectives.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes.resourceTypeAdminName
-import org.broadinstitute.dsde.workbench.sam.model.{ResourceType, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, FullyQualifiedPolicyId, ResourceType, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.service.{ResourceService, UserService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -23,6 +23,12 @@ trait SamModelDirectives {
     onSuccess(userService.getSubjectFromEmail(email, samRequestContext)).map {
       case Some(subject) => subject
       case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"${email} not found"))
+    }
+
+  def withPolicy(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): Directive1[AccessPolicy] =
+    onSuccess(resourceService.loadPolicy(policyId, samRequestContext)).map {
+      case Some(policy) => policy
+      case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"policy $policyId not found"))
     }
 
   def withOptionalEntity[T](unmarshaller: FromRequestUnmarshaller[T]): Directive1[Option[T]] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -563,6 +563,9 @@ class ResourceService(
       }
     }
 
+  def loadPolicy(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicy]] =
+    accessPolicyDAO.loadPolicy(policyId, samRequestContext)
+
   def loadResourcePolicy(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] =
     accessPolicyDAO.loadPolicyMembership(policyIdentity, samRequestContext)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -616,7 +616,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, ResourceAction("read")))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -632,7 +632,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("read"), SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -643,8 +643,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
-  it should "403 adding without read_policies permission" in {
-    // differs from happy case in that owner role does not have read_policies
+  it should "403 adding without read permission" in {
+    // differs from happy case in that owner role does not have read
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
@@ -685,7 +685,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, ResourceAction("read")))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -707,7 +707,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("read"), SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -726,12 +726,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
-  it should "403 removing without read_policies permission" in {
-    // differs from happy case in that owner role does not have read_policies on the memberPolicy
+  it should "403 removing without read permission" in {
+    // differs from happy case in that owner role does not have read on the memberPolicy
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -622,6 +622,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
+
+    val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
+    val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
+    runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
+
     Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -674,6 +679,10 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
+
+    val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
+    val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
+    runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
 
     val parentPolicyId = FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")),
       AccessPolicyName(resourceType.ownerRoleName.value))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -629,7 +629,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   it should "403 adding without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
@@ -641,7 +645,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   it should "404 adding without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -680,7 +688,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   it should "403 removing without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
@@ -700,7 +712,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   it should "404 removing without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -616,7 +616,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, ResourceAction("read")))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -632,23 +632,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("read"), SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
-      ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
-
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  it should "403 adding without read permission" in {
-    // differs from happy case in that owner role does not have read
-    val resourceType = ResourceType(
-      ResourceTypeName("rt"),
-      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -685,7 +669,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, ResourceAction("read")))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
@@ -707,31 +691,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("read"), SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
-      ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
-
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")),
-        AccessPolicyName(resourceType.ownerRoleName.value)),
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")),
-        AccessPolicyName("reader")),
-      samRequestContext
-    ))
-
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Forbidden
-    }
-  }
-
-  it should "403 removing without read permission" in {
-    // differs from happy case in that owner role does not have read on the memberPolicy
-    val resourceType = ResourceType(
-      ResourceTypeName("rt"),
-      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
       ResourceRoleName("owner"))
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-455
In order to add users by policy group, we currently need the policy email. However, requesting policy information is sensitive. These APIs allows a caller to give/revoke permission to policy groups by name (reader, writer, owner, etc), instead of by policyEmail.

Changes:
- 2 new APIs for adding and deleting users by policy group name under `/api/resources/v2/{resourceTypeName}/{resourceId}/policies/{policyName}/memberPolicies/{memberResourceTypeName}/{memberResourceId}/{memberPolicyName}`
- Update to override API to add users from both the "memberEmail" and "memberPolicy" section of the override payload (previously the memberPolicy section was ignored)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
