### PR TITLE
[TOAZ-177] Add route to administratively get a pet MI for a given user

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -798,6 +798,9 @@ resourceTypes = {
       get_pet_private_key = {
         description = ""
       }
+      get_pet_managed_identity = {
+        description = ""
+      }
       alter_policies = {
         description = ""
       }
@@ -812,6 +815,9 @@ resourceTypes = {
       }
       google = {
         roleActions = ["get_pet_private_key"]
+      }
+      azure = {
+        roleActions = ["get_pet_managed_identity"]
       }
     }
     reuseIds = false

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1187,7 +1187,8 @@ paths:
     post:
       tags:
         - Azure
-      summary: administratively gets or creates a pet managed identity for the specified user
+      summary: gets or creates a pet managed identity for the specified user, get_pet_managed_identity
+        action on cloud-extension/azure required
       operationId: getPetManagedIdentityForUser
       parameters:
         - name: userEmail
@@ -1221,9 +1222,10 @@ paths:
           content: { }
         403:
           description: Caller does not have permission to create a pet managed identity in the given managed resource group
+            or caller does not have get_pet_managed_identity permission on cloud-extension/azure
           content: { }
         404:
-          description: Managed resource group does not exist
+          description: User or managed resource group does not exist
           content: { }
         500:
           description: Internal Server Error

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1146,8 +1146,56 @@ paths:
     post:
       tags:
         - Azure
-      summary: gets or creates a pet managed identity for the specified user
+      summary: gets or creates a pet managed identity for the calling user
       operationId: getPetManagedIdentity
+      requestBody:
+        description: The details of the managed resource group in which to create the pet
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/GetOrCreatePetManagedIdentityRequest'
+        required: true
+      responses:
+        200:
+          description: Successfully retrieved resource without creating it
+          content:
+            application/json:
+              schema:
+                type: string
+        201:
+          description: Successfully created resource
+          content:
+            application/json:
+              schema:
+                type: string
+        400:
+          description: Invalid or incomplete request body
+          content: { }
+        403:
+          description: Caller does not have permission to create a pet managed identity in the given managed resource group
+          content: { }
+        404:
+          description: Managed resource group does not exist
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/petManagedIdentity/{userEmail}:
+    post:
+      tags:
+        - Azure
+      summary: administratively gets or creates a pet managed identity for the specified user
+      operationId: getPetManagedIdentityForUser
+      parameters:
+        - name: userEmail
+          in: path
+          description: User's email address
+          required: true
+          schema:
+            type: string
       requestBody:
         description: The details of the managed resource group in which to create the pet
         content:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.model.{ResourceAction, ResourceId}
 import spray.json.DefaultJsonProtocol._
 
 object AzureJsonSupport {
@@ -40,3 +41,8 @@ final case class PetManagedIdentityId(user: WorkbenchUserId,
 final case class PetManagedIdentity(id: PetManagedIdentityId,
                                     objectId: ManagedIdentityObjectId,
                                     displayName: ManagedIdentityDisplayName)
+
+object AzureExtensions {
+  val resourceId = ResourceId("azure")
+  val getPetManagedIdentityAction = ResourceAction("get_pet_managed_identity")
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.azure
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{Directive0, Directives, Route}
+import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.{SecurityDirectives, _}
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.JsString
 
@@ -23,7 +24,7 @@ trait AzureRoutes extends SecurityDirectives {
         path("user" / "petManagedIdentity") {
           post {
             entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
-              requireCreatePetAction(request, samUser, samRequestContext) {
+              requireUserCreatePetAction(request, samUser, samRequestContext) {
                 complete {
                   service.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
                     val status = if (created) StatusCodes.Created else StatusCodes.OK
@@ -36,12 +37,17 @@ trait AzureRoutes extends SecurityDirectives {
         } ~
           path("petManagedIdentity" / Segment) { userEmail =>
             post {
-              entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
-                // TODO: there are no permission checks
-                complete {
-                  service.getOrCreateUserPetManagedIdentityByEmail(WorkbenchEmail(userEmail), request, samRequestContext).map { case (pet, created) =>
-                    val status = if (created) StatusCodes.Created else StatusCodes.OK
-                    status -> JsString(pet.objectId.value)
+              requireCloudExtensionCreatePetAction(samUser, samRequestContext) {
+                loadSamUser(WorkbenchEmail(userEmail), samRequestContext) { targetSamUser =>
+                  entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
+                    requireUserCreatePetAction(request, targetSamUser, samRequestContext) {
+                      complete {
+                        service.getOrCreateUserPetManagedIdentity(targetSamUser, request, samRequestContext).map { case (pet, created) =>
+                          val status = if (created) StatusCodes.Created else StatusCodes.OK
+                          status -> JsString(pet.objectId.value)
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -50,16 +56,34 @@ trait AzureRoutes extends SecurityDirectives {
       }
     }.getOrElse(reject)
 
-  // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource
-  // and  validates the user has 'link' permission.
-  private def requireCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
+  // Validates the provided SamUser has 'link' permission on the spend-profile resource represented by the
+  // GetOrCreatePetManagedIdentityRequest
+  private def requireUserCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
     onSuccess(azureService.flatTraverse(_.getBillingProfileId(request))).flatMap {
       case Some(resourceId) =>
         requireAction(FullyQualifiedResourceId(SamResourceTypes.spendProfile, resourceId), SamResourceActions.link, samUser.id, samRequestContext)
       case None =>
-        Directives.failWith(
+        failWith(
           new WorkbenchExceptionWithErrorReport(
             ErrorReport(StatusCodes.NotFound, s"Managed resource group ${request.managedResourceGroupName.value} not found")))
 
+    }
+
+  // Validates the provided SamUser has 'getPetManagedIdentityAction' on the 'azure' cloud-extension resource.
+  private def requireCloudExtensionCreatePetAction(samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =
+    requireAction(
+      FullyQualifiedResourceId(CloudExtensions.resourceTypeName, AzureExtensions.resourceId),
+      AzureExtensions.getPetManagedIdentityAction,
+      samUser.id,
+      samRequestContext)
+
+  // Loads a SamUser from the database by email. Fails with 404 if not found.
+  private def loadSamUser(email: WorkbenchEmail, samRequestContext: SamRequestContext): Directive1[SamUser] =
+    onSuccess(azureService.flatTraverse(_.getSamUser(email, samRequestContext))).flatMap {
+      case Some(samUser) => provide(samUser)
+      case None =>
+        failWith(
+          new WorkbenchExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, s"User ${email.value} not found")))
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -19,7 +19,7 @@ trait AzureRoutes extends SecurityDirectives {
 
   def azureRoutes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
     azureService.map { service =>
-      path("azure" / "v1") {
+      pathPrefix("azure" / "v1") {
         path("user" / "petManagedIdentity") {
           post {
             entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directives, Route}
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.ImplicitConversions.ioOnSuccessMagnet
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.{SecurityDirectives, _}
@@ -19,22 +19,37 @@ trait AzureRoutes extends SecurityDirectives {
 
   def azureRoutes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
     azureService.map { service =>
-      path("azure" / "v1" / "user" / "petManagedIdentity") {
-        post {
-          entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
-            requireCreatePetAction(request, samUser, samRequestContext) {
-              complete {
-                service.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
-                  val status = if (created) StatusCodes.Created else StatusCodes.OK
-                  status -> JsString(pet.objectId.value)
+      path("azure" / "v1") {
+        path("user" / "petManagedIdentity") {
+          post {
+            entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
+              requireCreatePetAction(request, samUser, samRequestContext) {
+                complete {
+                  service.getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext).map { case (pet, created) =>
+                    val status = if (created) StatusCodes.Created else StatusCodes.OK
+                    status -> JsString(pet.objectId.value)
+                  }
                 }
               }
             }
           }
-        }
+        } ~
+          path("petManagedIdentity" / Segment) { userEmail =>
+            post {
+              entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
+                // TODO: there are no permission checks
+                complete {
+                  service.getOrCreateUserPetManagedIdentityByEmail(WorkbenchEmail(userEmail), request, samRequestContext).map { case (pet, created) =>
+                    val status = if (created) StatusCodes.Created else StatusCodes.OK
+                    status -> JsString(pet.objectId.value)
+                  }
+                }
+              }
+            }
+          }
       }
     }.getOrElse(reject)
-  
+
   // Given a GetOrCreatePetManagedIdentityRequest, looks up the billing profile resource
   // and  validates the user has 'link' permission.
   private def requireCreatePetAction(request: GetOrCreatePetManagedIdentityRequest, samUser: SamUser, samRequestContext: SamRequestContext): Directive0 =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -75,7 +75,7 @@ class AzureService(crlService: CrlService,
       subjectOpt <- directoryDAO.loadSubjectFromEmail(email, samRequestContext)
       samUserOpt <- subjectOpt match {
         case Some(userId: WorkbenchUserId) => directoryDAO.loadUser(userId, samRequestContext)
-        case _ => IO.pure(None)
+        case _ => IO.none
       }
     } yield samUserOpt
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -7,7 +7,7 @@ import cats.effect.IO
 import com.azure.core.management.Region
 import com.azure.core.util.Context
 import com.azure.resourcemanager.resources.models.{GenericResource, ResourceGroup}
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchException, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -43,6 +43,20 @@ class AzureService(crlService: CrlService,
         case None => createUserPetManagedIdentity(id, user, request, samRequestContext)
       }
     } yield pet
+  }
+
+  def getOrCreateUserPetManagedIdentityByEmail(email: WorkbenchEmail,
+                                               request: GetOrCreatePetManagedIdentityRequest,
+                                               samRequestContext: SamRequestContext): IO[(PetManagedIdentity, Boolean)] = {
+    for {
+      subjectOpt <- directoryDAO.loadSubjectFromEmail(email, samRequestContext)
+      samUserOpt <- subjectOpt match {
+        case Some(userId: WorkbenchUserId) => directoryDAO.loadUser(userId, samRequestContext)
+        case _ => IO.pure(None)
+      }
+      samUser <- IO.fromOption(samUserOpt)(new WorkbenchException(s"Unknown user: ${email.value}"))
+      res <- getOrCreateUserPetManagedIdentity(samUser, request, samRequestContext)
+    } yield res
   }
 
   /**

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -172,6 +172,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
 
   private def createSecondUser(samRoutes: TestSamRoutes, addToSpendProfile: Boolean = true): SamUser = {
     val newUser = Generator.genWorkbenchUserGoogle.sample.get
+    // wait for Future to complete by converting to IO
     IO.fromFuture(IO(samRoutes.userService.createUser(newUser, samRequestContext))).unsafeRunSync()
     if (addToSpendProfile) {
       Put(s"/api/resources/v2/${SamResourceTypes.spendProfile.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/policies/owner/memberEmails/${newUser.email.value}") ~> samRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -4,11 +4,15 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestDuration
-import org.broadinstitute.dsde.workbench.sam.TestSupport
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes
+import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicyMembership, SamResourceTypes, SamUser}
+import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,16 +22,9 @@ import scala.concurrent.duration._
 
 class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
   implicit val timeout = RouteTestTimeout(15.seconds.dilated)
-  private val spendProfileResourceType = configResourceTypes.getOrElse(SamResourceTypes.spendProfile,
-    throw new RuntimeException("Failed to load spend-profile resource type from reference.conf"))
 
   "POST /api/azure/v1/user/petManagedIdentity" should "successfully create a pet managed identity" in {
-    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
-
-    // Create mock spend-profile resource
-    Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
-    }
+    val samRoutes = genSamRoutes()
 
     // Create a pet managed identity, should return 201 created
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
@@ -46,7 +43,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "return 404 if the MRG does not exist" in {
-    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
+    val samRoutes = genSamRoutes()
 
     // Non-existent MRG
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("non-existent-mrg"))
@@ -58,7 +55,8 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   }
 
   it should "return 404 if the MRG exists but the user does not have access to the billing profile" in {
-    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType))
+    // Don't create spend-profile resource
+    val samRoutes = genSamRoutes(createSpendProfile = false)
 
     // User has no access
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
@@ -74,19 +72,113 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val mockCrlService = MockCrlService()
     when(mockCrlService.getManagedAppPlanId)
       .thenReturn("some-other-plan")
-    val samRoutes = TestSamRoutes(Map(SamResourceTypes.spendProfile -> spendProfileResourceType), crlService = Some(mockCrlService))
+    val samRoutes = genSamRoutes(crlService = Some(mockCrlService))
 
-    // Create mock spend-profile resource
-    Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
-    }
-
+    // User has no access
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.Forbidden
       contentType shouldEqual ContentTypes.`application/json`
     }
+  }
+
+  "POST /api/azure/v1/petManagedIdentity/{email}" should "successfully create a pet managed identity for a user" in {
+    val samRoutes = genSamRoutes()
+    val newUser = createSecondUser(samRoutes)
+
+    // Create a pet managed identity for the second user, should return 201 created
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+
+    // Create again, should return 200
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  it should "return 404 for a non-existent user" in {
+    val samRoutes = genSamRoutes()
+
+    // Non-existent user
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(s"/api/azure/v1/petManagedIdentity/fake@fake.com", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  it should "return 403 if the calling user does not have access to the Azure cloud-extension" in {
+    // Don't create an cloud-extensions/azure policy
+    val samRoutes = genSamRoutes(createAzurePolicy = false)
+    val newUser = createSecondUser(samRoutes)
+
+    // User has no access
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Forbidden
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  it should "return 403 if the user does not have access to the billing profile" in {
+    val samRoutes = genSamRoutes()
+    // Don't add second user to the spend-profile resource
+    val newUser = createSecondUser(samRoutes, addToSpendProfile = false)
+
+    // User has no access
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  private def genSamRoutes(createSpendProfile: Boolean = true, createAzurePolicy: Boolean = true, crlService: Option[CrlService] = None): TestSamRoutes = {
+    val resourceTypes = configResourceTypes.view.filterKeys(k => k == SamResourceTypes.spendProfile || k == CloudExtensions.resourceTypeName)
+    val samRoutes = TestSamRoutes(resourceTypes.toMap, crlService = crlService)
+
+    // Create mock spend-profile resource
+    if (createSpendProfile) {
+      Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
+    }
+
+    // Create Azure cloud-extension resource
+    Post(s"/api/resources/v2/${CloudExtensions.resourceTypeName.value}/${AzureExtensions.resourceId}") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NoContent
+    }
+
+    // Create azure policy on cloud-extension resource
+    if (createAzurePolicy) {
+      val cloudExtensionMembers = AccessPolicyMembership(Set(samRoutes.user.email), Set(AzureExtensions.getPetManagedIdentityAction), Set.empty, None)
+      Put(s"/api/resources/v2/${CloudExtensions.resourceTypeName.value}/${AzureExtensions.resourceId.value}/policies/azure", cloudExtensionMembers) ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.Created
+      }
+    }
+
+    samRoutes
+  }
+
+  private def createSecondUser(samRoutes: TestSamRoutes, addToSpendProfile: Boolean = true): SamUser = {
+    val newUser = Generator.genWorkbenchUserGoogle.sample.get
+    IO.fromFuture(IO(samRoutes.userService.createUser(newUser, samRequestContext))).unsafeRunSync()
+    if (addToSpendProfile) {
+      Put(s"/api/resources/v2/${SamResourceTypes.spendProfile.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/policies/owner/memberEmails/${newUser.email.value}") ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
+    }
+    newUser
   }
 
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-177

**Problem statement:**
In PR https://github.com/broadinstitute/sam/pull/737 we added a [Sam route](https://sam.dsde-dev.broadinstitute.org/#/Azure/getPetManagedIdentity) to get a pet managed identity for the calling user. The WSM VM creation flight calls this Sam route with the calling user's credentials. However this doesn't actually work because Leo calls WSM as its own SA, not as the end user. So we ended up generating a pet for the Leo SA instead of the end user. 😞 

**Solution:**
The solution introduced in this PR is to add a new Sam route to request a pet managed identity on behalf of a user. This allows WSM to call Sam as its own SA, and request a pet for the user assigned to the VM. The new route follows the same pattern as the Google [getUserPetServiceAccountKey](https://sam.dsde-dev.broadinstitute.org/#/Google/getUserPetServiceAccountKey) route. The azure route checks the caller against the `cloud-extension/azure` policy in Sam. This policy will need to be created in a similar way to `cloud-extension/google` (which currently contains a handful of Terra service accounts). Aside from the new permission check, the route handling is identical to the original `getPetManagedIdentity` route.

Note: an alternative approach would be for to Leo request a pet MI up front with the calling user's token; and pass the objectId down to WSM. This approach wouldn't require Sam changes; however I thought it added a bit too much complexity to have VM creation logic spread across Leo and WSM -- it's nice for all elements of VM creation to be fully localized in the WSM stairway flight.
