### PR TITLE
ID-155 remove usage of opendj isEnabled

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
@@ -99,15 +99,7 @@ class LdapRegistrationDAO(
   }
 
   override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
-    for {
-      entry <- executeLdap(IO(ldapConnectionPool.getEntry(directoryConfig.enabledUsersGroupDn, Attr.member)), "isEnabled", samRequestContext)
-    } yield {
-      val result = for {
-        e <- Option(entry)
-        members <- Option(e.getAttributeValues(Attr.member))
-      } yield members.contains(subjectDn(subject))
-      result.getOrElse(false)
-    }
+    IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"LdapRegistrationDAO is deprecated")))
 
   override def createEnabledUsersGroup(samRequestContext: SamRequestContext): IO[Unit] = {
     val objectClassAttr = new Attribute("objectclass", Seq("top", "groupofnames").asJava)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAO.scala
@@ -98,6 +98,7 @@ class LdapRegistrationDAO(
     }
   }
 
+  @deprecated
   override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
     IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"LdapRegistrationDAO is deprecated")))
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -134,7 +134,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
             allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext)
             allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id, samRequestContext).unsafeToFuture() recover { case _: NameNotFoundException => false }
             tosAcceptedStatus <- tosService.getTosStatus(user.id, samRequestContext).unsafeToFuture()
-            ldapStatus <- registrationDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
+            ldapStatus = directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture() // calling postgres instead of opendj here as a temporary measure as we work toward eliminating opendj
             adminEnabled <- directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
           } yield {
             val enabledMap = Map("ldap" -> ldapStatus, "allUsersGroup" -> allUsersStatus, "google" -> googleStatus)
@@ -172,7 +172,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
     directoryDAO.loadUser(userId, samRequestContext).unsafeToFuture().flatMap {
       case Some(user) => {
         // pulled out of for comprehension to allow concurrent execution
-        val ldapStatus = registrationDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
+        val ldapStatus = directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture() // calling postgres instead of opendj here as a temporary measure as we work toward eliminating opendj
         val tosAcceptedStatus = tosService.getTosStatus(user.id, samRequestContext).unsafeToFuture()
         val adminEnabledStatus = directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
         val allUsersStatus = cloudExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext).flatMap { allUsersGroup =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -134,7 +134,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
             allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext)
             allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id, samRequestContext).unsafeToFuture() recover { case _: NameNotFoundException => false }
             tosAcceptedStatus <- tosService.getTosStatus(user.id, samRequestContext).unsafeToFuture()
-            ldapStatus = directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture() // calling postgres instead of opendj here as a temporary measure as we work toward eliminating opendj
+            ldapStatus <- directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture() // calling postgres instead of opendj here as a temporary measure as we work toward eliminating opendj
             adminEnabled <- directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
           } yield {
             val enabledMap = Map("ldap" -> ldapStatus, "allUsersGroup" -> allUsersStatus, "google" -> googleStatus)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LdapRegistrationDAOSpec.scala
@@ -114,19 +114,12 @@ class LdapRegistrationDAOSpec extends AnyFlatSpec with Matchers with TestSupport
 
     dao.enableIdentity(user.id, samRequestContext).unsafeRunSync()
 
-    assertResult(true) {
-      dao.isEnabled(user.id, samRequestContext).unsafeRunSync()
-    }
-
     dao.deleteUser(user.id, samRequestContext).unsafeRunSync()
 
     assertResult(None) {
       dao.loadUser(user.id, samRequestContext).unsafeRunSync()
     }
 
-    assertResult(false) {
-      dao.isEnabled(user.id, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "throw an exception when trying to overwrite an existing googleSubjectId" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -94,7 +94,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
     dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(enabled = true))
     registrationDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(azureB2CId = None)) // ldap does not know about azure or enabled
     dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
     dirDAO.loadGroup(CloudExtensions.allUsersGroupName, samRequestContext).unsafeRunSync() shouldBe
       Some(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(defaultUser.id), service.cloudExtensions.getOrCreateAllUsersGroup(dirDAO, samRequestContext).futureValue.email))
   }
@@ -163,7 +162,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
 
     // it should be enabled
     dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
 
     // disable the user
     val response = service.disableUser(defaultUser.id, samRequestContext).futureValue
@@ -171,7 +169,6 @@ class UserServiceSpec extends AnyFlatSpec with Matchers with TestSupport with Mo
 
     // check ldap
     dirDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe false
-    registrationDAO.isEnabled(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe false
   }
 
   it should "delete a user" in {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-155

some APIs on dev are failing because opendj responses are bigger than 20MB. It seems as though the registered users list is large enough to cause this issue right now. 

According to the Doge, opendj is not needed for checking if a user is enabled. This is a step towards progress in removing opendj and is also a fix for dev. 

Alternatives considered were optimizing the opendj call so we don't get the entire list every time. Another would be to increase the max message size limit. Both are not ideal as we are planning to get rid of opendj anyway.
Context: https://broadinstitute.slack.com/archives/C01NLH6SHJN/p1658171355005759?thread_ts=1658146736.680259&cid=C01NLH6SHJN

I think we can probably remove the implementation of registrationDAO's isEnabled, but can leave that in if folks feel it's useful to keep.

Ticket: <Link to Jira ticket> TODO - create one
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
