### PR TITLE
ID-158 Make Sam return NOT_FOUND if user not authorized to modify group

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -116,7 +116,8 @@ trait ManagedGroupRoutes extends SamUserDirectives with SecurityDirectives with 
       samRequestContext: SamRequestContext): Route =
     requireAction(managedGroup, SamResourceActions.sharePolicy(accessPolicyName), samUser.id, samRequestContext) {
       withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
-        complete(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext).map(_ => StatusCodes.NoContent))
+        complete(managedGroupService.addSubjectToPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext)
+          .map(if (_) StatusCodes.NoContent else StatusCodes.NotFound))
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -503,6 +503,9 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   it should "respond with a 404 when the user does not have access to modify the group" in {
     val samRoutes = TestSamRoutes(resourceTypes)
     withUserNotInGroup(samRoutes){ nonMemberRoutes =>
+      Put(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
       Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> nonMemberRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -500,6 +500,15 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     }
   }
 
+  it should "respond with a 404 when the user does not have access to modify the group" in {
+    val samRoutes = TestSamRoutes(resourceTypes)
+    withUserNotInGroup(samRoutes){ nonMemberRoutes =>
+      Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> nonMemberRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+      }
+    }
+  }
+
   // TODO:  I think this should just work and give back a 204
   // TODO: well i changed something and now it returns a 204 so maybe this TODO above is complete? Must investigate...
   it should "respond with 404 when the email address was already not present in the group and policy" in {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-158

Sam should not squash unauthorized group modification into a `NO_CONTENT` response. This gives users and downstream tools the wrong idea of what's going on. We should instead return a `NOT_FOUND` response.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
