### PR TITLE
[PF-1681] Add workspace discover action and discoverer policy

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -64,11 +64,18 @@ resourceTypes = {
       "share_policy::reader" = {
         description = "change the membership of the reader policy for this workspace"
       }
+      "share_policy::discoverer" = {
+        description = "change the membership of the discoverer policy for this workspace"
+      }
       "share_policy::can-compute" = {
         description = "change the membership of the can-compute policy for this workspace"
       }
       "read_policy::owner" = {
         description = "view the details of the owner policy for this workspace"
+      }
+      "discover" = {
+        description = "perform discoverer action on the workspace. This lets you see a subset of workspace compared to 'read'"
+        authDomainConstrainable = true
       }
       "read" = {
         description = "perform reader actions on the workspace"
@@ -139,7 +146,7 @@ resourceTypes = {
         roleActions = []
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "own", "write", "read", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status"]
         # Workspace Manager also maintains a mapping of workspace roles to controlled resource roles. If you change this mapping, check that service's mapping as well.
         descendantRoles = {
           google-project = ["owner"]
@@ -155,7 +162,7 @@ resourceTypes = {
         }
       }
       writer = {
-        roleActions = ["read_policy::owner", "write", "read", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain", "view_migration_status"]
+        roleActions = ["read_policy::owner", "write", "read", "discover", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "add_child", "remove_child", "read_auth_domain", "view_migration_status"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
@@ -163,12 +170,15 @@ resourceTypes = {
         }
       }
       reader = {
-        roleActions = ["read_policy::owner", "read", "read_auth_domain", "view_migration_status"]
+        roleActions = ["read_policy::owner", "read", "discover", "read_auth_domain", "view_migration_status"]
         descendantRoles = {
           controlled-user-shared-workspace-resource = ["reader"]
           controlled-application-shared-workspace-resource = ["reader"]
           google-project = ["pet-creator"]
         }
+      }
+      discoverer = {
+        roleActions = ["discover"]
       }
       share-reader = {
         roleActions = ["share_policy::reader", "read_policies"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/PF-1681

For TVC, we are building a rudimentary data catalog, to allow researchers to add Data collections to their workspace (PF-1390). Data collections are stored as workspaces. We're adding workspace discover action and discoverer policy, so researchers can view Data collections in the data catalog, that they don't yet have read access to. Discover gives you read access to a subset of the workspace.

@ddietterich let me know if anyone from Broad should review.

I tagged @gpolumbo-broad. Greg, hoping you can either take a look or delegate. I'd like to have a Sam-insider double check our work!

---

**PR checklist**

- [✔️] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [✔️] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
![image](https://user-images.githubusercontent.com/10929390/182233700-df2f2c2c-c0f7-4ad1-9a64-ea7821ab4e6f.png)
