### PR TITLE
[DR-2677] Add new datarepo action for exporting snapshots

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1140,7 +1140,7 @@ resourceTypes = {
         description = "Can update a datasnapshot's passport identifier (e.g. consent code)"
       }
       export_snapshot = {
-        description = "Export snapshot"
+        description = "Export-by-copy of a snapshot to a Terra workspace"
       }
     }
     ownerRoleName = "steward"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1140,7 +1140,7 @@ resourceTypes = {
         description = "Can update a datasnapshot's passport identifier (e.g. consent code)"
       }
       export_snapshot = {
-        description = "Export-by-copy of a snapshot to a Terra workspace"
+        description = "Export snapshot to a Terra workspace"
       }
     }
     ownerRoleName = "steward"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1139,11 +1139,14 @@ resourceTypes = {
       update_passport_identifier = {
         description = "Can update a datasnapshot's passport identifier (e.g. consent code)"
       }
+      export_snapshot = {
+        description = "Export snapshot"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot"]
       }
       custodian = {
         roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2677

Since only Data Repo snapshot stewards can grant read access to other users, only they should be able to export the snapshot to Terra. The snapshot custodian role is deprecated (there is a ticket to clean this up), so it is not modified here.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
