### PR TITLE
ID-239 Upgrade Sam Java Version to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,10 @@ jobs:
         run: |
           sh docker/run-opendj.sh start
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Git secrets setup
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 # To run, build jar using ./docker/build.sh
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note that Sam does not actually launch workflows create VMs but appears to in th
 ## Development
 ### Required Tooling:
 #### Java:
-Make sure you have Java JDK 17 installed. Instructions for our recommended package can be found [here](https://adoptopenjdk.net/)
+Make sure you have Java JDK 17 installed. Instructions for our recommended package can be found [here](https://adoptium.net/)
 #### Scala:
 Mac:
 ```$xslt

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Note that Sam does not actually launch workflows create VMs but appears to in th
 ## Development
 ### Required Tooling:
 #### Java:
-Make sure you have Java JDK 11 installed. Instructions for our recommended package can be found [here](https://adoptopenjdk.net/)
+Make sure you have Java JDK 17 installed. Instructions for our recommended package can be found [here](https://adoptopenjdk.net/)
 #### Scala:
 Mac:
 ```$xslt

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8
+FROM broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7
+FROM hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -14,7 +14,7 @@ object Settings {
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
-    javacOptions ++= Seq("--release", "11")
+    javacOptions ++= Seq("--release", "17")
   )
 
   val commonCompilerSettings = Seq(

--- a/codegen_java/project/Version.scala
+++ b/codegen_java/project/Version.scala
@@ -6,8 +6,8 @@ object Version {
     def getLastCommitFromGit = { s"""git rev-parse --short HEAD""" !! }
 
     // either specify git hash as an env var or derive it
-    // if building from the broadinstitute/scala-baseimage docker image use env var
-    // (scala-baseimage doesn't have git in it)
+    // if building from the hseeberger/scala-sbt docker image use env var
+    // (scala-sbt doesn't have git in it)
     val lastCommit = sys.env.getOrElse("GIT_HASH", getLastCommitFromGit ).trim()
     val version = baseVersion + "-" + lastCommit
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -124,13 +124,12 @@ function docker_cmd()
         echo GIT_SHA=$GIT_SHA > env.properties
         HASH_TAG=${GIT_SHA:0:12}
 
-        targetPlatform="--platform=linux/amd64"
         echo "building ${DOCKERHUB_REGISTRY}:${HASH_TAG}..."
-        docker build -t "${DOCKERHUB_REGISTRY}:${HASH_TAG}" ${targetPlatform} --pull .
+        docker build -t "${DOCKERHUB_REGISTRY}:${HASH_TAG}" --pull .
 
         echo "building ${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}..."
         cd automation
-        docker build -f Dockerfile-tests -t "${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}" ${targetPlatform} --pull .
+        docker build -f Dockerfile-tests -t "${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}" --pull .
 
         cd ..
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -101,10 +101,10 @@ function make_jar()
 
     # make jar.  cache sbt dependencies.
     set +e # Turn off error detection so that opendj has a chance to get stopped before exiting
-    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/init_schema.sh /working
+    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7 /working/docker/init_schema.sh /working
     docker restart $OPENDJ
     sleep 40
-    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working
+    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7 /working/docker/install.sh /working
     EXIT_CODE=$?
     set -e # Turn error detection back on for the rest of the script
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -101,10 +101,10 @@ function make_jar()
 
     # make jar.  cache sbt dependencies.
     set +e # Turn off error detection so that opendj has a chance to get stopped before exiting
-    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7 /working/docker/init_schema.sh /working
+    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/init_schema.sh /working
     docker restart $OPENDJ
     sleep 40
-    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage:jdk11-2.13.5-1.4.7 /working/docker/install.sh /working
+    docker run --rm --link postgres:postgres --link $OPENDJ:opendj -e DIRECTORY_URL=$DIRECTORY_URL -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e DIRECTORY_PASSWORD=$DIRECTORY_PASSWORD -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working
     EXIT_CODE=$?
     set -e # Turn error detection back on for the rest of the script
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HELP_TEXT="$(cat <<EOF
+HELP_TEXT=$(cat <<EOF
  Build jar and docker images.
    jar: build jar
    -d | --docker : (default: no action) provide either "build" or "push" to
@@ -15,7 +15,7 @@ HELP_TEXT="$(cat <<EOF
      ./docker/build.sh jar -d push -g "my-gcr-registry" -k "path-to-my-keyfile"
 \t
 EOF
-)"
+)
 
 # Enable strict evaluation semantics
 set -e
@@ -124,16 +124,17 @@ function docker_cmd()
         echo GIT_SHA=$GIT_SHA > env.properties
         HASH_TAG=${GIT_SHA:0:12}
 
+        targetPlatform="--platform=linux/amd64"
         echo "building ${DOCKERHUB_REGISTRY}:${HASH_TAG}..."
-        docker build -t $DOCKERHUB_REGISTRY:${HASH_TAG} --pull .
+        docker build -t "${DOCKERHUB_REGISTRY}:${HASH_TAG}" ${targetPlatform} --pull .
 
         echo "building ${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}..."
         cd automation
-        docker build -f Dockerfile-tests -t $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG} --pull .
+        docker build -f Dockerfile-tests -t "${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}" ${targetPlatform} --pull .
 
         cd ..
 
-        if [ $DOCKER_CMD="push" ]; then
+        if [ $DOCKER_CMD = "push" ]; then
             echo "pushing ${DOCKERHUB_REGISTRY}:${HASH_TAG}..."
             docker push $DOCKERHUB_REGISTRY:${HASH_TAG}
             docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $DOCKERHUB_REGISTRY:${DOCKERTAG_SAFE_NAME}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.2.9"
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.9.2"
-  val scalaTestV    = "3.2.3"
+  val scalaTestV    = "3.2.12"
   val scalaCheckV    = "1.14.3"
   val scalikejdbcVersion    = "3.4.2"
   val postgresDriverVersion = "42.3.4"
@@ -64,8 +64,8 @@ object Dependencies {
   val monocleMacro: ModuleID = "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion
 
   val scalaTest: ModuleID =       "org.scalatest" %% "scalatest"    % scalaTestV % "test"
-  val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestV}.0" % Test
-  val scalaTestMockito = "org.scalatestplus" %% "mockito-3-4" % s"${scalaTestV}.0" % Test
+  val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestV}.0-RC2" % Test
+  val scalaTestMockito = "org.scalatestplus" %% "mockito-4-5" % s"${scalaTestV}.0" % Test
 
   val unboundid: ModuleID = "com.unboundid" % "unboundid-ldapsdk" % "4.0.14"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -18,7 +18,7 @@ object Settings {
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   lazy val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
-    javacOptions ++= Seq("--release", "11"),
+    javacOptions ++= Seq("--release", "17"),
     scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
     scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
   )

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -9,8 +9,8 @@ object Version {
     def getLastModelCommitFromGit = { s"""git rev-parse --short HEAD""".!! }
 
     // either specify git model hash as an env var or derive it
-    // if building from the broadinstitute/scala-baseimage docker image use env var
-    // (scala-baseimage doesn't have git in it)
+    // if building from the hseeberger/scala-sbt docker image use env var
+    // (scala-sbt doesn't have git in it)
     val lastModelCommit = sys.env.getOrElse("GIT_MODEL_HASH", getLastModelCommitFromGit ).trim()
     val version = baseModelVersion + "-" + lastModelCommit
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-239
Upgrading Sam to Java 17 is something we should do anyways, but it also has the side-effect of using a docker image with an arm64 build, so Sam can run on M1 laptops! We still need to get rid of OpenDJ to actually boot Sam, but this would need to happen anyways for the sbt file-change watching!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
