### PR TITLE
[ID-257] update api description for listResourcesAndPoliciesV2 skip-tests

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1237,7 +1237,7 @@ paths:
     get:
       tags:
         - Resources
-      summary: List resources with their roles and action for this resource type accessible to the caller
+      summary: List resources (of a resource type) with the caller's roles and policy actions (but not role actions) for each resource.
       operationId: listResourcesAndPoliciesV2
       parameters:
         - name: resourceTypeName

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1237,7 +1237,7 @@ paths:
     get:
       tags:
         - Resources
-      summary: List resources (of a resource type) with the caller's roles and actions for each resource. Note: currently this will only show the actions granted directly on the policy and not the default actions on the role.
+      summary: List resources (of a resource type) with the caller's roles and actions for each resource. Note that currently this will only show the actions granted directly on the policy and not the default actions on the role.
       operationId: listResourcesAndPoliciesV2
       parameters:
         - name: resourceTypeName

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1237,7 +1237,7 @@ paths:
     get:
       tags:
         - Resources
-      summary: List resources (of a resource type) with the caller's roles and actions granted directly on the policy but not the default actions on the role for each resource.
+      summary: List resources (of a resource type) with the caller's roles and actions (but currently it will only show the actions granted directly on the policy and not the default actions on the role) for each resource.
       operationId: listResourcesAndPoliciesV2
       parameters:
         - name: resourceTypeName

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1237,7 +1237,7 @@ paths:
     get:
       tags:
         - Resources
-      summary: List resources (of a resource type) with the caller's roles and actions (but currently it will only show the actions granted directly on the policy and not the default actions on the role) for each resource.
+      summary: List resources (of a resource type) with the caller's roles and actions for each resource. Note: currently this will only show the actions granted directly on the policy and not the default actions on the role.
       operationId: listResourcesAndPoliciesV2
       parameters:
         - name: resourceTypeName

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1237,7 +1237,7 @@ paths:
     get:
       tags:
         - Resources
-      summary: List resources (of a resource type) with the caller's roles and policy actions (but not role actions) for each resource.
+      summary: List resources (of a resource type) with the caller's roles and actions granted directly on the policy but not the default actions on the role for each resource.
       operationId: listResourcesAndPoliciesV2
       parameters:
         - name: resourceTypeName


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-257
<Put notes here to help reviewer understand this PR>

Problem:
The listResourcesAndPoliciesV2 API returns an empty list of actions for each resource. Turns out this is because we don't include role actions, only policy actions which are generally unused.

Solution:
Short term fix (this PR): update the API description to align with the current behavior.
Long-term fix (which is not this PR) would be to add role actions to this API: https://broadworkbench.atlassian.net/browse/ID-264


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
