### PR TITLE
[WOR-526] Allow multiple Azure marketplace plans

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -112,7 +112,7 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
       planId <- IO.fromOption(planIdOpt)(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: could not retrieve plan for managed app"))
       )
-      _ <- IO.raiseUnless(planId == crlService.getManagedAppPlanId)(
+      _ <- IO.raiseUnless(crlService.getManagedAppPlanIds.contains(planId))(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: wrong managed app plan"))
       )
     } yield ()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
@@ -29,7 +29,7 @@ class CrlService(config: AzureServicesConfig) {
     IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
   }
 
-  def getManagedAppPlanId: String = config.managedAppPlanId
+  def getManagedAppPlanIds: Seq[String] = config.managedAppPlanIds
 
   private def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
     val credential = new ClientSecretCredentialBuilder()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -168,7 +168,7 @@ object AppConfig {
       config.getString("managedAppClientId"),
       config.getString("managedAppClientSecret"),
       config.getString("managedAppTenantId"),
-      config.getString("managedAppPlanId")
+      config.as[Seq[String]]("managedAppPlanIds")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -1,3 +1,3 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-case class AzureServicesConfig(managedAppClientId: String, managedAppClientSecret: String, managedAppTenantId: String, managedAppPlanId: String) {}
+case class AzureServicesConfig(managedAppClientId: String, managedAppClientSecret: String, managedAppTenantId: String, managedAppPlanIds: Seq[String]) {}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -70,8 +70,8 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 403 if user has access to the billing profile but the MRG could not be validated" in {
     // Change the managed app plan
     val mockCrlService = MockCrlService()
-    when(mockCrlService.getManagedAppPlanId)
-      .thenReturn("some-other-plan")
+    when(mockCrlService.getManagedAppPlanIds)
+      .thenReturn(Seq("some-other-plan", "yet-another-plan"))
     val samRoutes = genSamRoutes(crlService = Some(mockCrlService))
 
     // User has no access

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
@@ -32,8 +32,8 @@ object MockCrlService extends MockitoSugar {
     when(mockCrlService.buildMsiManager(any[TenantId], any[SubscriptionId]))
       .thenReturn(IO.pure(mockMsi))
 
-    when(mockCrlService.getManagedAppPlanId)
-      .thenReturn(mockPlanName)
+    when(mockCrlService.getManagedAppPlanIds)
+      .thenReturn(Seq(mockPlanName))
 
     mockCrlService
   }


### PR DESCRIPTION
Sam expects a single value for Azure marketplace plans. In dev we have two available plans, and may have even more in the future. This change converts the config value to an Seq and checks for membership there rather than a bare string comparison. 

Since this is changing the type in the config, I've broken this into a 3 stage process:

Plan
- [Merge this forwards compatible FC develop config change PR](https://github.com/broadinstitute/firecloud-develop/pull/3106)
- Merge this PR
- Merge https://github.com/broadinstitute/firecloud-develop/pull/3105 which removes the old field.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
