### PR TITLE
ID-240 Revert error, fix handled in Firecloud Orch

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -131,7 +131,7 @@ trait ManagedGroupRoutes extends SamUserDirectives with SecurityDirectives with 
         complete(
           managedGroupService
             .addSubjectToPolicy(managedGroup.resourceId, accessPolicyName, subject, samRequestContext)
-            .map(if (_) StatusCodes.NoContent else StatusCodes.NotFound)
+            .map(_ => StatusCodes.NoContent)
         )
       }
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-240
A misunderstanding of where failures were being marked as success caused us to introduce a bug, making things that should not be failures be marked as such. Orch actually had a bug where it was transforming any response from Sam into a success, but Sam was doing the right thing all along.

Leaving the test as proof.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
