### PR TITLE
Revert "[WOR-526] Allow multiple Azure marketplace plans"

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -112,7 +112,7 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
       planId <- IO.fromOption(planIdOpt)(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: could not retrieve plan for managed app"))
       )
-      _ <- IO.raiseUnless(crlService.getManagedAppPlanIds.contains(planId))(
+      _ <- IO.raiseUnless(planId == crlService.getManagedAppPlanId)(
         new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: wrong managed app plan"))
       )
     } yield ()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
@@ -29,7 +29,7 @@ class CrlService(config: AzureServicesConfig) {
     IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
   }
 
-  def getManagedAppPlanIds: Seq[String] = config.managedAppPlanIds
+  def getManagedAppPlanId: String = config.managedAppPlanId
 
   private def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
     val credential = new ClientSecretCredentialBuilder()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -168,7 +168,7 @@ object AppConfig {
       config.getString("managedAppClientId"),
       config.getString("managedAppClientSecret"),
       config.getString("managedAppTenantId"),
-      config.as[Seq[String]]("managedAppPlanIds")
+      config.getString("managedAppPlanId")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -1,3 +1,3 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-case class AzureServicesConfig(managedAppClientId: String, managedAppClientSecret: String, managedAppTenantId: String, managedAppPlanIds: Seq[String]) {}
+case class AzureServicesConfig(managedAppClientId: String, managedAppClientSecret: String, managedAppTenantId: String, managedAppPlanId: String) {}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -70,8 +70,8 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 403 if user has access to the billing profile but the MRG could not be validated" in {
     // Change the managed app plan
     val mockCrlService = MockCrlService()
-    when(mockCrlService.getManagedAppPlanIds)
-      .thenReturn(Seq("some-other-plan", "yet-another-plan"))
+    when(mockCrlService.getManagedAppPlanId)
+      .thenReturn("some-other-plan")
     val samRoutes = genSamRoutes(crlService = Some(mockCrlService))
 
     // User has no access

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
@@ -32,8 +32,8 @@ object MockCrlService extends MockitoSugar {
     when(mockCrlService.buildMsiManager(any[TenantId], any[SubscriptionId]))
       .thenReturn(IO.pure(mockMsi))
 
-    when(mockCrlService.getManagedAppPlanIds)
-      .thenReturn(Seq(mockPlanName))
+    when(mockCrlService.getManagedAppPlanId)
+      .thenReturn(mockPlanName)
 
     mockCrlService
   }


### PR DESCRIPTION
Sam is having issues in dev. There is some log chatter around the time Sam becomes unresponsive like this:

```
message: "An exception 'java.lang.NoClassDefFoundError: Could not initialize class com.azure.core.implementation.ReflectionUtilsApi' [enable DEBUG level for full stacktrace] was thrown by a user handler's exceptionCaught() method while handling the following exception:"
stack_trace: "java.lang.NoClassDefFoundError: Could not initialize class com.azure.core.implementation.ReflectionUtilsApi
```
It's possible a previous PR is causing this. While I investigate, I am getting this revert PR underway to avoid blocking the Sam pipeline. 

Reverts broadinstitute/sam#822