### PR TITLE
change sam gha tests to run against prod additionally to dev versions

### DIFF
--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -60,7 +60,6 @@ jobs:
     strategy:
       matrix:
         terra-env: [dev, prod] # what versions of apps do we use to emulate types of environments
-        testing-env: [qa] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
     needs: [sam-build-tag-publish-job]
     permissions:
@@ -82,6 +81,10 @@ jobs:
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   sam-automation-test-job:
+    strategy:
+      matrix:
+        terra-env: [dev, prod] # what versions of apps do we use to emulate types of environments
+        testing-env: [qa] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
     needs: [create-bee-workflow]
     permissions:
@@ -99,6 +102,9 @@ jobs:
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "ENV": "${{ matrix.testing-env }}" }'
 
   destroy-bee-workflow:
+    strategy:
+      matrix:
+        terra-env: [dev, prod] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs: [sam-automation-test-job]
     if: always() # always run to confirm bee is destroyed

--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -56,7 +56,11 @@ jobs:
           echo "HASH_TAG=$HASH_TAG"
           echo ::set-output name=custom-version-json::"{\\\"sam\\\":{\\\"appVersion\\\":\\\"$HASH_TAG\\\"}}"
 
-  create-bee-workflow-prod:
+  create-bee-workflow:
+    strategy:
+      matrix:
+        terra-env: [dev, prod] # what versions of apps do we use to emulate types of environments
+        testing-env: [qa] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
     needs: [sam-build-tag-publish-job]
     permissions:
@@ -75,11 +79,11 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
-  sam-automation-test-job-prod:
+  sam-automation-test-job:
     runs-on: ubuntu-latest
-    needs: [create-bee-workflow-prod]
+    needs: [create-bee-workflow]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -92,11 +96,11 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}", "ENV": "qa" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "ENV": "${{ matrix.testing-env }}" }'
 
-  destroy-bee-workflow-prod:
+  destroy-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [sam-automation-test-job-prod]
+    needs: [sam-automation-test-job]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'
@@ -110,61 +114,4 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}" }'
-
-  # Dev Test against BEEs
-  create-bee-workflow-dev:
-    runs-on: ubuntu-latest
-    needs: [sam-build-tag-publish-job]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: Print hash tag
-        run: |
-          echo '${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}'
-
-      - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
-        with:
-          workflow: bee-create
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}", "version-template": "dev", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
-
-  sam-automation-test-job-dev:
-    runs-on: ubuntu-latest
-    needs: [create-bee-workflow-dev]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
-        with:
-          workflow: sam-tests
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}", "ENV": "qa" }'
-
-  destroy-bee-workflow-dev:
-    runs-on: ubuntu-latest
-    needs: [sam-automation-test-job-dev]
-    if: always() # always run to confirm bee is destroyed
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
-        with:
-          workflow: bee-destroy
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}" }'

--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -78,7 +78,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   sam-automation-test-job:
     strategy:
@@ -99,7 +99,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}", "ENV": "${{ matrix.testing-env }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}" }'
 
   destroy-bee-workflow:
     strategy:
@@ -120,4 +120,4 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ matrix.terra-env }}-${{ github.run_id }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}" }'

--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -75,7 +75,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   sam-automation-test-job-prod:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}", "ENV": "qa" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}", "ENV": "qa" }'
 
   destroy-bee-workflow-prod:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-prod-${{ github.run_id }}" }'
 
   # Dev Test against BEEs
   create-bee-workflow-dev:
@@ -132,7 +132,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}", "version-template": "dev", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}", "version-template": "dev", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   sam-automation-test-job-dev:
     runs-on: ubuntu-latest
@@ -149,7 +149,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}", "ENV": "qa" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}", "ENV": "qa" }'
 
   destroy-bee-workflow-dev:
     runs-on: ubuntu-latest
@@ -167,4 +167,4 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-dev-${{ github.run_id }}" }'

--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "HASH_TAG=$HASH_TAG"
           echo ::set-output name=custom-version-json::"{\\\"sam\\\":{\\\"appVersion\\\":\\\"$HASH_TAG\\\"}}"
 
-  create-bee-workflow:
+  create-bee-workflow-prod:
     runs-on: ubuntu-latest
     needs: [sam-build-tag-publish-job]
     permissions:
@@ -75,11 +75,11 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
-  sam-automation-test-job:
+  sam-automation-test-job-prod:
     runs-on: ubuntu-latest
-    needs: [create-bee-workflow]
+    needs: [create-bee-workflow-prod]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -92,11 +92,11 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-${{ github.run_id }}", "ENV": "qa" }'
+          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}", "ENV": "qa" }'
 
-  destroy-bee-workflow:
+  destroy-bee-workflow-prod:
     runs-on: ubuntu-latest
-    needs: [sam-automation-test-job]
+    needs: [sam-automation-test-job-prod]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'
@@ -110,4 +110,61 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-${{ github.run_id }}" }'
+          inputs: '{ "bee-name": "${{ github.workflow }}-prod-${{ github.run_id }}" }'
+
+  # Dev Test against BEEs
+  create-bee-workflow-dev:
+    runs-on: ubuntu-latest
+    needs: [sam-build-tag-publish-job]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Print hash tag
+        run: |
+          echo '${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}'
+
+      - name: dispatch to terra-github-workflows
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: bee-create
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}", "version-template": "dev", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+
+  sam-automation-test-job-dev:
+    runs-on: ubuntu-latest
+    needs: [create-bee-workflow-dev]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: sam-tests
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}", "ENV": "qa" }'
+
+  destroy-bee-workflow-dev:
+    runs-on: ubuntu-latest
+    needs: [sam-automation-test-job-dev]
+    if: always() # always run to confirm bee is destroyed
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: bee-destroy
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.workflow }}-dev-${{ github.run_id }}" }'

--- a/.github/workflows/sam-automation-tests.yaml
+++ b/.github/workflows/sam-automation-tests.yaml
@@ -75,7 +75,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.workflow }}-${{ github.run_id }}", "version-template": "dev", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ github.workflow }}-${{ github.run_id }}", "version-template": "prod", "custom-version-json": "${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   sam-automation-test-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2366
<Put notes here to help reviewer understand this PR>

Currently the GHA sam tests run against the new sam code + what's in dev, in order to this be relevant for a prod release, these new sam code needs to run against what's in prod. This PR ADDs a run so now tests run against dev AND prod versions of terra (one for CD deploy to dev, one for CI deploy to prod), technically this is redundant w/ jenkins tests.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
