### PR TITLE
[WOR-541] Pull in fix for Azure SDK NoClassDefFoundError

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val workbenchNotificationsV = "0.3-d74ff96"
   val workbenchOauth2V = "0.2-20f9225"
   val monocleVersion = "2.0.5"
-  val crlVersion = "1.2.0-SNAPSHOT"
+  val crlVersion = "1.2.3-SNAPSHOT"
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")


### PR DESCRIPTION
We are getting `NoClassDefFoundError`s during exception handling scenarios when talking to azure as we setup pet managed identities. I've tested this against Sam on a BEE; prior to pulling in the fix the `NoClassDefFoundError` was being thrown when calling the pet managed identity endpoint. After pulling in the new CRL, the error is no longer thrown and a sane error is returned to the API caller. 

This PR pulls in an updated CRL lib that in turn pulls in a fixed Azure sdk which should fix this issue (https://github.com/DataBiosphere/terra-cloud-resource-lib/pull/145)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
