### PR TITLE
ID-279: Scalafmt fix (actually this time)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           git secrets --scan-history
 
       - name: Run Scalafmt Check
-        id: Scalafmt Check
+        id: scalafmtCheck
         run: sbt scalafmtCheckAll scalafmtSbtCheck
 
       - name: Run unit tests and generate coverage report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
           ./minnie-kenny.sh --force
           git secrets --scan-history
 
+      - name: Run Scalafmt Check
+        id: Scalafmt Check
+        run: sbt scalafmtCheckAll scalafmtSbtCheck
+
       - name: Run unit tests and generate coverage report
         id: coverageReport
         run: sbt coverage "testOnly --" coverageReport

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,15 +5,15 @@ object Dependencies {
   val akkaHttpV = "10.2.9"
   val jacksonV = "2.9.5"
   val scalaLoggingV = "3.9.2"
-  val scalaTestV    = "3.2.12"
-  val scalaCheckV    = "1.14.3"
-  val scalikejdbcVersion    = "3.4.2"
+  val scalaTestV = "3.2.12"
+  val scalaCheckV = "1.14.3"
+  val scalikejdbcVersion = "3.4.2"
   val postgresDriverVersion = "42.3.4"
   val http4sVersion = "0.21.13"
 
-  val workbenchUtilV   = "0.6-74c9fc2"
-  val workbenchUtil2V   = "0.2-447afa5"
-  val workbenchModelV  = "0.15-f9f0d4c"
+  val workbenchUtilV = "0.6-74c9fc2"
+  val workbenchUtil2V = "0.2-447afa5"
+  val workbenchModelV = "0.15-f9f0d4c"
   val workbenchGoogleV = "0.21-8ce5b9b"
   val workbenchGoogle2V = "0.24-447afa5"
   val workbenchNotificationsV = "0.3-d74ff96"
@@ -21,84 +21,91 @@ object Dependencies {
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.3-SNAPSHOT"
 
-  val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
-  val excludeAkkaProtobufV3 =   ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
-  val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
-  val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
-  val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
+  val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
+  val excludeAkkaProtobufV3 = ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
+  val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
+  val excludeWorkbenchUtil = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
+  val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_2.12")
-  val excludeWorkbenchGoogle =  ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.12")
-  val excludeSpringJcl =   ExclusionRule(organization = "org.springframework", name = "spring-jcl")
+  val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.12")
+  val excludeSpringJcl = ExclusionRule(organization = "org.springframework", name = "spring-jcl")
   val excludeGoogleCloudResourceManager = ExclusionRule(organization = "com.google.apis", name = "google-api-services-cloudresourcemanager")
-  val excludeJerseyCore =       ExclusionRule(organization = "org.glassfish.jersey.core", name = "*")
-  val excludeJerseyMedia =      ExclusionRule(organization = "org.glassfish.jersey.media", name = "*")
+  val excludeJerseyCore = ExclusionRule(organization = "org.glassfish.jersey.core", name = "*")
+  val excludeJerseyMedia = ExclusionRule(organization = "org.glassfish.jersey.media", name = "*")
 
   val jacksonAnnotations: ModuleID = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV
-  val jacksonDatabind: ModuleID =    "com.fasterxml.jackson.core" % "jackson-databind"    % jacksonV
-  val jacksonCore: ModuleID =        "com.fasterxml.jackson.core" % "jackson-core"        % jacksonV
+  val jacksonDatabind: ModuleID = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonV
+  val jacksonCore: ModuleID = "com.fasterxml.jackson.core" % "jackson-core" % jacksonV
 
-  val logstashLogback: ModuleID = "net.logstash.logback"      % "logstash-logback-encoder" % "6.6"
-  val logbackClassic: ModuleID = "ch.qos.logback"             %  "logback-classic" % "1.2.11"
-  val ravenLogback: ModuleID =   "com.getsentry.raven"        %  "raven-logback"   % "7.8.6"
-  val scalaLogging: ModuleID =   "com.typesafe.scala-logging" %% "scala-logging"   % scalaLoggingV
-  val ficus: ModuleID =          "com.iheart"                 %% "ficus"           % "1.5.2"
-  val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE" excludeAll(excludeSpringJcl)
-  val janino: ModuleID =          "org.codehaus.janino"       %  "janino"          % "3.1.7" // For if-else logic in logging config
+  val logstashLogback: ModuleID = "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
+  val logbackClassic: ModuleID = "ch.qos.logback" % "logback-classic" % "1.2.11"
+  val ravenLogback: ModuleID = "com.getsentry.raven" % "raven-logback" % "7.8.6"
+  val scalaLogging: ModuleID = "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV
+  val ficus: ModuleID = "com.iheart" %% "ficus" % "1.5.2"
+  val stackdriverLogging: ModuleID = "org.springframework.cloud" % "spring-cloud-gcp-logging" % "1.2.8.RELEASE" excludeAll excludeSpringJcl
+  val janino: ModuleID = "org.codehaus.janino" % "janino" % "3.1.7" // For if-else logic in logging config
 
-  val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
-  val akkaSlf4j: ModuleID =         "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV
-  val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV               excludeAll(excludeAkkaProtobufV3)
-  val akkaHttp: ModuleID =          "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor)
-  val akkaHttpSprayJson: ModuleID = "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV
-  val akkaTestKit: ModuleID =       "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test"
-  val akkaHttpTestKit: ModuleID =   "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test"
-  val scalaCheck: ModuleID =        "org.scalacheck"      %%  "scalacheck"           % scalaCheckV % "test"
+  val akkaActor: ModuleID = "com.typesafe.akka" %% "akka-actor" % akkaV
+  val akkaSlf4j: ModuleID = "com.typesafe.akka" %% "akka-slf4j" % akkaV
+  val akkaStream: ModuleID = "com.typesafe.akka" %% "akka-stream" % akkaV excludeAll excludeAkkaProtobufV3
+  val akkaHttp: ModuleID = "com.typesafe.akka" %% "akka-http" % akkaHttpV excludeAll excludeAkkaActor
+  val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV
+  val akkaTestKit: ModuleID = "com.typesafe.akka" %% "akka-testkit" % akkaV % "test"
+  val akkaHttpTestKit: ModuleID = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test"
+  val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
-  val excludIoGrpc =  ExclusionRule(organization = "io.grpc", name = "grpc-core")
+  val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.1"
 
-  val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll(excludIoGrpc)
-  val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20220401-1.32.1" excludeAll(excludIoGrpc) //force this version
+  val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll excludIoGrpc
+  val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20220401-1.32.1" excludeAll excludIoGrpc // force this version
 
-  val monocle: ModuleID = "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion
-  val monocleMacro: ModuleID = "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion
+  val monocle: ModuleID = "com.github.julien-truffaut" %% "monocle-core" % monocleVersion
+  val monocleMacro: ModuleID = "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion
 
-  val scalaTest: ModuleID =       "org.scalatest" %% "scalatest"    % scalaTestV % "test"
+  val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestV % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % s"${scalaTestV}.0-RC2" % Test
   val scalaTestMockito = "org.scalatestplus" %% "mockito-4-5" % s"${scalaTestV}.0" % Test
 
   // All of workbench-libs pull in Akka; exclude it since we provide our own Akka dependency.
   // workbench-google pulls in workbench-{util, model, metrics}; exclude them so we can control the library versions individually.
-  val workbenchUtil: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-util"   % workbenchUtilV excludeAll(excludeWorkbenchModel)
-  val workbenchUtil2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-util2"   % workbenchUtil2V excludeAll(excludeWorkbenchModel)
-  val workbenchModel: ModuleID =     "org.broadinstitute.dsde.workbench" %% "workbench-model"  % workbenchModelV
-  val workbenchGoogle: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll(excludeWorkbenchModel, excludeWorkbenchUtil)
-  val workbenchOauth2: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V
-  val workbenchOauth2Tests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V % "test" classifier "tests"
+  val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % workbenchUtilV excludeAll excludeWorkbenchModel
+  val workbenchUtil2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util2" % workbenchUtil2V excludeAll excludeWorkbenchModel
+  val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
+  val workbenchGoogle: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll (excludeWorkbenchModel, excludeWorkbenchUtil)
+  val workbenchOauth2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V
+  val workbenchOauth2Tests: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V % "test" classifier "tests"
   // the name of the auto-value package changed from auto-value to auto-value-annotations so old libraries are not evicted
   // leading to merge errors during sbt assembly. At this time the old version of auto-value is pulled in through the google2
   // workbench-libs dependency so exclude auto-value from there
-  val excludGoogleAutoValue =  ExclusionRule(organization = "com.google.auto.value", name = "auto-value")
-  val workbenchGoogle2: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll(excludeWorkbenchModel, excludeWorkbenchUtil, excludGoogleAutoValue)
-  val workbenchNotifications: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll(excludeWorkbenchGoogle, excludeWorkbenchModel)
-  val workbenchGoogleTests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
-  val workbenchGoogle2Tests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.123.28" % "test" //needed for mocking google cloud storage
+  val excludGoogleAutoValue = ExclusionRule(organization = "com.google.auto.value", name = "auto-value")
+  val workbenchGoogle2: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll (excludeWorkbenchModel, excludeWorkbenchUtil, excludGoogleAutoValue)
+  val workbenchNotifications: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+  val workbenchGoogleTests: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
+  val workbenchGoogle2Tests: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.123.28" % "test" // needed for mocking google cloud storage
 
   val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.1"
 
-  val scalikeCore =       "org.scalikejdbc"                   %% "scalikejdbc"         % scalikejdbcVersion
-  val scalikeCoreConfig = "org.scalikejdbc"                   %% "scalikejdbc-config"  % scalikejdbcVersion
-  val scalikeCoreTest =   "org.scalikejdbc"                   %% "scalikejdbc-test"    % scalikejdbcVersion   % "test"
-  val postgres = "org.postgresql"                    %  "postgresql"          % postgresDriverVersion
+  val scalikeCore = "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion
+  val scalikeCoreConfig = "org.scalikejdbc" %% "scalikejdbc-config" % scalikejdbcVersion
+  val scalikeCoreTest = "org.scalikejdbc" %% "scalikejdbc-test" % scalikejdbcVersion % "test"
+  val postgres = "org.postgresql" % "postgresql" % postgresDriverVersion
 
-  val excludeScalaCllectionCompat =  ExclusionRule(organization = "org.scala-lang.modules", name = "scala-collection-compat_2.12")
+  val excludeScalaCllectionCompat = ExclusionRule(organization = "org.scala-lang.modules", name = "scala-collection-compat_2.12")
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2" // excludeAll(excludIoGrpc, excludeCatsEffect )
-  val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" excludeAll(excludeAkkaProtobufV3, excludeAkkaStream)// excludeAll(excludIoGrpc, excludeCatsEffect)
-  val opencensusStackDriverExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.31.1" // excludeAll(excludIoGrpc, excludeCatsEffect)
-  val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging"     % "0.31.1" // excludeAll(excludIoGrpc, excludeCatsEffect)
+  val opencensusAkkaHttp: ModuleID =
+    "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2" excludeAll (excludeAkkaProtobufV3, excludeAkkaStream) // excludeAll(excludIoGrpc, excludeCatsEffect)
+  val opencensusStackDriverExporter: ModuleID =
+    "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.31.1" // excludeAll(excludIoGrpc, excludeCatsEffect)
+  val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging" % "0.31.1" // excludeAll(excludIoGrpc, excludeCatsEffect)
 
   val openCensusDependencies = Seq(
     opencensusScalaCode,
@@ -107,7 +114,8 @@ object Dependencies {
     opencensusLoggingExporter
   )
 
-  val cloudResourceLib: ModuleID = "bio.terra" % "terra-cloud-resource-lib" % crlVersion excludeAll(excludeGoogleCloudResourceManager, excludeJerseyCore, excludeJerseyMedia)
+  val cloudResourceLib: ModuleID =
+    "bio.terra" % "terra-cloud-resource-lib" % crlVersion excludeAll (excludeGoogleCloudResourceManager, excludeJerseyCore, excludeJerseyMedia)
 
   // was included transitively before, now explicit
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.15"
@@ -123,7 +131,6 @@ object Dependencies {
     ficus,
     stackdriverLogging,
     janino,
-
     akkaActor,
     akkaSlf4j,
     akkaStream,
@@ -131,18 +138,14 @@ object Dependencies {
     akkaHttpSprayJson,
     akkaTestKit,
     akkaHttpTestKit,
-
     googleOAuth2,
     googleStorage,
-
     monocle,
     monocleMacro,
-
     scalaTest,
     scalaTestScalaCheck,
     scalaCheck,
     scalaTestMockito,
-
     workbenchUtil,
     workbenchModel,
     workbenchGoogle,
@@ -153,18 +156,13 @@ object Dependencies {
     googleStorageLocal,
     workbenchOauth2,
     workbenchOauth2Tests,
-
     commonsCodec,
-
     liquibaseCore,
-
     circeYAML,
-
     scalikeCore,
     scalikeCoreConfig,
     scalikeCoreTest,
     postgres,
-
     cloudResourceLib
   ) ++ openCensusDependencies
 }

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -1,10 +1,10 @@
 import sbtassembly.{MergeStrategy, PathList}
 
 object Merging {
-  def customMergeStrategy(oldStrategy: (String) => MergeStrategy):(String => MergeStrategy) = {
+  def customMergeStrategy(oldStrategy: (String) => MergeStrategy): (String => MergeStrategy) = {
     case PathList("org", "joda", "time", "base", "BaseDateTime.class") => MergeStrategy.first
-    case PathList("io", "sundr", _ @ _*) => MergeStrategy.first
-    case PathList("google", "protobuf", _ @ _*) => MergeStrategy.first
+    case PathList("io", "sundr", _ @_*) => MergeStrategy.first
+    case PathList("google", "protobuf", _ @_*) => MergeStrategy.first
     case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
     case "module-info.class" =>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,7 @@ object Settings {
     "artifactory-snapshots" at artifactory + "libs-snapshot"
   )
 
-  //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
+  // coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   lazy val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
     javacOptions ++= Seq("--release", "17"),
@@ -51,32 +51,31 @@ object Settings {
     "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
     "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
     "-language:postfixOps",
-    "-Ymacro-annotations",
-
+    "-Ymacro-annotations"
   )
 
-  //sbt assembly settings
+  // sbt assembly settings
   lazy val commonAssemblySettings = Seq(
     assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
     test in assembly := {},
     assembly := assembly.dependsOn(Test / scalafmtCheckAll).value,
-    assembly := assembly.dependsOn(Test / scalafmtSbtCheck).value,
+    assembly := assembly.dependsOn(Test / scalafmtSbtCheck).value
   )
 
-  //common settings for all sbt subprojects
+  // common settings for all sbt subprojects
   lazy val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
-      organization  := "org.broadinstitute.dsde.workbench",
-      scalaVersion  := "2.13.5",
+      organization := "org.broadinstitute.dsde.workbench",
+      scalaVersion := "2.13.5",
       resolvers ++= commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       Compile / compile := (Compile / compile).dependsOn(Compile / scalafmtAll).value,
-      Compile / compile := (Compile / compile).dependsOn(Compile / scalafmtSbt).value,
+      Compile / compile := (Compile / compile).dependsOn(Compile / scalafmtSbt).value
     )
 
-  //the full list of settings for the root project that's ultimately the one we build into a fat JAR and run
-  //coreDefaultSettings (inside commonSettings) sets the project name, which we want to override, so ordering is important.
-  //thus commonSettings needs to be added first.
+  // the full list of settings for the root project that's ultimately the one we build into a fat JAR and run
+  // coreDefaultSettings (inside commonSettings) sets the project name, which we want to override, so ordering is important.
+  // thus commonSettings needs to be added first.
   lazy val rootSettings = commonSettings ++ List(
     name := "sam",
     libraryDependencies ++= rootDependencies

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -57,9 +57,7 @@ object Settings {
   // sbt assembly settings
   lazy val commonAssemblySettings = Seq(
     assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
-    test in assembly := {},
-    assembly := assembly.dependsOn(Test / scalafmtCheckAll).value,
-    assembly := assembly.dependsOn(Test / scalafmtSbtCheck).value
+    test in assembly := {}
   )
 
   // common settings for all sbt subprojects

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -18,7 +18,7 @@ object Testing {
     private var resultOption: Option[Int] = None
 
     /** Run using the logger, throwing an exception only on the first failure. */
-    def runOnce(log: Logger, args: Seq[String]): Unit = {
+    def runOnce(log: Logger, args: Seq[String]): Unit =
       mutex synchronized {
         if (resultOption.isEmpty) {
           log.debug(s"Running minnie-kenny.sh${args.mkString(" ", " ", "")}")
@@ -30,14 +30,12 @@ object Testing {
             sys.error("Running minnie-kenny.sh failed. Please double check for errors above.")
         }
       }
-    }
   }
 
   // Only run one minnie-kenny.sh at a time!
   private lazy val minnieKennySingleRunner = new MinnieKennySingleRunner
-  
-  val commonTestSettings: Seq[Setting[_]] = List(
 
+  val commonTestSettings: Seq[Setting[_]] = List(
     // SLF4J initializes itself upon the first logging call.  Because sbt
     // runs tests in parallel it is likely that a second thread will
     // invoke a second logging call before SLF4J has completed
@@ -64,23 +62,20 @@ object Testing {
     ),
     testOptions in Test ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
     testOptions in IntegrationTest := Seq(Tests.Filter(s => isIntegrationTest(s))),
-
     minnieKenny := {
       val log = streams.value.log
       val args = spaceDelimited("<arg>").parsed
       minnieKennySingleRunner.runOnce(log, args)
     },
-
     parallelExecution in Test := false,
-	
     (test in Test) := {
       minnieKenny.toTask("").value
-    },
+    }
   )
 
   implicit class ProjectTestSettings(val project: Project) extends AnyVal {
     def withTestSettings: Project = project
-      .configs(IntegrationTest).settings(inConfig(IntegrationTest)(Defaults.testTasks): _*)
+      .configs(IntegrationTest)
+      .settings(inConfig(IntegrationTest)(Defaults.testTasks): _*)
   }
 }
-

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -6,12 +6,12 @@ object Version {
   val baseModelVersion = "0.1"
 
   def getVersionString = {
-    def getLastModelCommitFromGit = { s"""git rev-parse --short HEAD""".!! }
+    def getLastModelCommitFromGit = s"""git rev-parse --short HEAD""".!!
 
     // either specify git model hash as an env var or derive it
     // if building from the hseeberger/scala-sbt docker image use env var
     // (scala-sbt doesn't have git in it)
-    val lastModelCommit = sys.env.getOrElse("GIT_MODEL_HASH", getLastModelCommitFromGit ).trim()
+    val lastModelCommit = sys.env.getOrElse("GIT_MODEL_HASH", getLastModelCommitFromGit).trim()
     val version = baseModelVersion + "-" + lastModelCommit
 
     // The project isSnapshot string passed in via command line settings, if desired.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -19,7 +19,7 @@ import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.service._
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamUserDirectives.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, TosServic
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.RejectionHandlers.{MethodDisabled, termsOfServiceRejectionHandler}
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.{SamUser, TermsOfServiceAcceptance}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam.api.StandardSamUserDirectives._
 import org.broadinstitute.dsde.workbench.sam.azure.ManagedIdentityObjectId
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.TosService
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -45,29 +45,21 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
     val googleSubjectId = (oidcHeaders.externalId.left.toOption ++ oidcHeaders.googleSubjectIdFromAzure).headOption
     val azureB2CId = oidcHeaders.externalId.toOption // .right is missing (compared to .left above) since Either is Right biased
 
-    SamUser(
-      genWorkbenchUserId(System.currentTimeMillis()),
-      googleSubjectId,
-      oidcHeaders.email,
-      azureB2CId,
-      false,
-      None)
+    SamUser(genWorkbenchUserId(System.currentTimeMillis()), googleSubjectId, oidcHeaders.email, azureB2CId, false, None)
   }
 
-  /**
-    * Utility function that knows how to convert all the various headers into OIDCHeaders
+  /** Utility function that knows how to convert all the various headers into OIDCHeaders
     */
-  private def requireOidcHeaders: Directive1[OIDCHeaders] = {
+  private def requireOidcHeaders: Directive1[OIDCHeaders] =
     (headerValueByName(accessTokenHeader).as(OAuth2BearerToken) &
       externalIdFromHeaders &
       headerValueByName(emailHeader).as(WorkbenchEmail) &
       optionalHeaderValueByName(googleIdFromAzureHeader).map(_.map(GoogleSubjectId)) &
       optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId))).as(OIDCHeaders)
-  }
 
   private def externalIdFromHeaders: Directive1[Either[GoogleSubjectId, AzureB2CId]] = headerValueByName(userIdHeader).map { idString =>
     Try(BigInt(idString)).fold(
-      _ => Right(AzureB2CId(idString)),    // could not parse id as a Long, treat id as b2c id which are uuids
+      _ => Right(AzureB2CId(idString)), // could not parse id as a Long, treat id as b2c id which are uuids
       _ => Left(GoogleSubjectId(idString)) // id is a number which is what google subject ids look like
     )
   }
@@ -83,7 +75,7 @@ object StandardSamUserDirectives {
   val googleIdFromAzureHeader = "OAUTH2_CLAIM_google_id"
   val managedIdentityObjectIdHeader = "OAUTH2_CLAIM_xms_mirid"
 
-  def getSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] = {
+  def getSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] =
     oidcHeaders match {
       case OIDCHeaders(_, Left(googleSubjectId), WorkbenchEmail(SAdomain(_)), _, _) =>
         // If it's a PET account, we treat it as its owner
@@ -95,7 +87,7 @@ object StandardSamUserDirectives {
       case OIDCHeaders(_, Left(googleSubjectId), _, _, _) =>
         lookUpByGoogleSubjectId(googleSubjectId, directoryDAO, samRequestContext)
 
-      case OIDCHeaders(_, Right(azureB2CId), _, _, Some(objectId@ManagedIdentityObjectId(UamiPattern(_)))) =>
+      case OIDCHeaders(_, Right(azureB2CId), _, _, Some(objectId @ ManagedIdentityObjectId(UamiPattern(_)))) =>
         // If it's a managed identity, treat it as its owner
         directoryDAO.getUserFromPetManagedIdentity(objectId, samRequestContext).flatMap {
           case Some(petsOwner) => IO.pure(petsOwner)
@@ -105,9 +97,8 @@ object StandardSamUserDirectives {
       case OIDCHeaders(_, Right(azureB2CId), _, _, _) =>
         loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, samRequestContext)
     }
-  }
 
-  def getActiveSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO,  tosService: TosService, samRequestContext: SamRequestContext): IO[SamUser] = {
+  def getActiveSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, tosService: TosService, samRequestContext: SamRequestContext): IO[SamUser] =
     for {
       user <- getSamUser(oidcHeaders, directoryDAO, samRequestContext)
     } yield {
@@ -122,9 +113,13 @@ object StandardSamUserDirectives {
 
       user
     }
-  }
 
-  private def loadUserMaybeUpdateAzureB2CId(azureB2CId: AzureB2CId, maybeGoogleSubjectId: Option[GoogleSubjectId], directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext) = {
+  private def loadUserMaybeUpdateAzureB2CId(
+      azureB2CId: AzureB2CId,
+      maybeGoogleSubjectId: Option[GoogleSubjectId],
+      directoryDAO: DirectoryDAO,
+      samRequestContext: SamRequestContext
+  ) =
     for {
       maybeUser <- directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext)
       maybeUserAgain <- (maybeUser, maybeGoogleSubjectId) match {
@@ -133,9 +128,8 @@ object StandardSamUserDirectives {
         case _ => IO.pure(maybeUser)
       }
     } yield maybeUserAgain.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Azure Id $azureB2CId not found in sam")))
-  }
 
-  private def updateUserAzureB2CId(azureB2CId: AzureB2CId, googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext) = {
+  private def updateUserAzureB2CId(azureB2CId: AzureB2CId, googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext) =
     for {
       maybeSubject <- directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
       _ <- maybeSubject match {
@@ -144,10 +138,7 @@ object StandardSamUserDirectives {
         case _ => IO.unit
       }
       maybeUser <- directoryDAO.loadUserByAzureB2CId(azureB2CId, samRequestContext)
-    } yield {
-      maybeUser
-    }
-  }
+    } yield maybeUser
 
   private def lookUpByGoogleSubjectId(googleSubjectId: GoogleSubjectId, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] =
     directoryDAO.loadUserByGoogleSubjectId(googleSubjectId, samRequestContext).flatMap { maybeUser =>
@@ -155,4 +146,10 @@ object StandardSamUserDirectives {
     }
 }
 
-final case class OIDCHeaders(token: OAuth2BearerToken, externalId: Either[GoogleSubjectId, AzureB2CId], email: WorkbenchEmail, googleSubjectIdFromAzure: Option[GoogleSubjectId], managedIdentityObjectId: Option[ManagedIdentityObjectId] = None)
+final case class OIDCHeaders(
+    token: OAuth2BearerToken,
+    externalId: Either[GoogleSubjectId, AzureB2CId],
+    email: WorkbenchEmail,
+    googleSubjectIdFromAzure: Option[GoogleSubjectId],
+    managedIdentityObjectId: Option[ManagedIdentityObjectId] = None
+)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -14,21 +14,20 @@ import org.broadinstitute.dsde.workbench.sam.model._
 
 import scala.concurrent.duration.Duration
 
-/**
-  * Created by dvoet on 7/18/17.
+/** Created by dvoet on 7/18/17.
   */
 final case class AppConfig(
-                            emailDomain: String,
-                            distributedLockConfig: DistributedLockConfig,
-                            googleConfig: Option[GoogleConfig],
-                            resourceTypes: Set[ResourceType],
-                            liquibaseConfig: LiquibaseConfig,
-                            blockedEmailDomains: Seq[String],
-                            termsOfServiceConfig: TermsOfServiceConfig,
-                            oidcConfig: OidcConfig,
-                            adminConfig: AdminConfig,
-                            azureServicesConfig: Option[AzureServicesConfig]
-                          )
+    emailDomain: String,
+    distributedLockConfig: DistributedLockConfig,
+    googleConfig: Option[GoogleConfig],
+    resourceTypes: Set[ResourceType],
+    liquibaseConfig: LiquibaseConfig,
+    blockedEmailDomains: Seq[String],
+    termsOfServiceConfig: TermsOfServiceConfig,
+    oidcConfig: OidcConfig,
+    adminConfig: AdminConfig,
+    azureServicesConfig: Option[AzureServicesConfig]
+)
 
 object AppConfig {
   implicit val oidcReader: ValueReader[OidcConfig] = ValueReader.relative { config =>
@@ -49,7 +48,9 @@ object AppConfig {
         ResourceRoleName(uqPath),
         config.as[Set[String]](s"$uqPath.roleActions").map(ResourceAction.apply),
         config.as[Option[Set[String]]](s"$uqPath.includedRoles").getOrElse(Set.empty).map(ResourceRoleName.apply),
-        config.as[Option[Map[String, Set[String]]]](s"$uqPath.descendantRoles").getOrElse(Map.empty)
+        config
+          .as[Option[Map[String, Set[String]]]](s"$uqPath.descendantRoles")
+          .getOrElse(Map.empty)
           .map { case (resourceTypeName, roleNames) =>
             (ResourceTypeName(resourceTypeName), roleNames.map(ResourceRoleName.apply))
           }
@@ -141,7 +142,6 @@ object AppConfig {
       config.as[Seq[String]]("managedAppPlanIds")
     )
   }
-
 
   def readConfig(config: Config): AppConfig = {
     val googleConfigOption = for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -21,10 +21,13 @@ import scala.util.{Failure, Try}
 import cats.effect.Temporal
 import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
 
-class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)(implicit timer: Temporal[IO]) extends DirectoryDAO with DatabaseSupport with PostgresGroupDAO {
+class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)(implicit timer: Temporal[IO])
+    extends DirectoryDAO
+    with DatabaseSupport
+    with PostgresGroupDAO {
 
-  override def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String], samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup] = {
-    serializableWriteTransaction("createGroup", samRequestContext)({ implicit session =>
+  override def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String], samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup] =
+    serializableWriteTransaction("createGroup", samRequestContext) { implicit session =>
       val groupId: GroupPK = insertGroup(group)
 
       accessInstructionsOpt.map { accessInstructions =>
@@ -34,12 +37,12 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       insertGroupMembers(groupId, group.members)
 
       group
-    })
-  }
+    }
 
   private def insertGroup(group: BasicWorkbenchGroup)(implicit session: DBSession): GroupPK = {
     val groupTableColumn = GroupTable.column
-    val insertGroupQuery = samsql"""insert into ${GroupTable.table} (${groupTableColumn.name}, ${groupTableColumn.email}, ${groupTableColumn.updatedDate}, ${groupTableColumn.synchronizedDate})
+    val insertGroupQuery =
+      samsql"""insert into ${GroupTable.table} (${groupTableColumn.name}, ${groupTableColumn.email}, ${groupTableColumn.updatedDate}, ${groupTableColumn.synchronizedDate})
            values (${group.id}, ${group.email}, ${Option(Instant.now())}, ${None})"""
 
     Try {
@@ -52,14 +55,15 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
   private def insertAccessInstructions(groupId: GroupPK, accessInstructions: String)(implicit session: DBSession): Int = {
     val accessInstructionsColumn = AccessInstructionsTable.column
-    val insertAccessInstructionsQuery = samsql"insert into ${AccessInstructionsTable.table} (${accessInstructionsColumn.groupId}, ${accessInstructionsColumn.instructions}) values (${groupId}, ${accessInstructions})"
+    val insertAccessInstructionsQuery =
+      samsql"insert into ${AccessInstructionsTable.table} (${accessInstructionsColumn.groupId}, ${accessInstructionsColumn.instructions}) values (${groupId}, ${accessInstructions})"
 
     insertAccessInstructionsQuery.update().apply()
   }
 
-  override def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]] = {
+  override def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]] =
     for {
-      results <- readOnlyTransaction("loadGroup", samRequestContext)({ implicit session =>
+      results <- readOnlyTransaction("loadGroup", samRequestContext) { implicit session =>
         val g = GroupTable.syntax("g")
         val sg = GroupTable.syntax("sg")
         val gm = GroupMemberTable.syntax("gm")
@@ -76,15 +80,19 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                   left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
                   where ${g.name} = ${groupName}"""
           .map { rs =>
-            (rs.get[WorkbenchEmail](g.resultName.email),
+            (
+              rs.get[WorkbenchEmail](g.resultName.email),
               rs.stringOpt(gm.resultName.memberUserId).map(WorkbenchUserId),
               rs.stringOpt(sg.resultName.name).map(WorkbenchGroupName),
               rs.stringOpt(p.resultName.name).map(AccessPolicyName(_)),
               rs.stringOpt(r.resultName.name).map(ResourceId(_)),
-              rs.stringOpt(rt.resultName.name).map(ResourceTypeName(_)))
-          }.list().apply()
-      })
-    } yield {
+              rs.stringOpt(rt.resultName.name).map(ResourceTypeName(_))
+            )
+          }
+          .list()
+          .apply()
+      }
+    } yield
       if (results.isEmpty) {
         None
       } else {
@@ -92,43 +100,44 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         val members: Set[WorkbenchSubject] = results.collect {
           case (_, Some(userId), None, None, None, None) => userId
           case (_, None, Some(subGroupName), None, None, None) => subGroupName
-          case (_, None, Some(_), Some(policyName), Some(resourceName), Some(resourceTypeName)) => FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceName), policyName)
+          case (_, None, Some(_), Some(policyName), Some(resourceName), Some(resourceTypeName)) =>
+            FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceTypeName, resourceName), policyName)
         }.toSet
 
         Option(BasicWorkbenchGroup(groupName, members, email))
       }
-    }
-  }
 
-  override def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
+  override def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     batchLoadGroupEmail(Set(groupName), samRequestContext).map(_.toMap.get(groupName))
-  }
 
-  override def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]] = {
+  override def batchLoadGroupEmail(
+      groupNames: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]] =
     if (groupNames.isEmpty) {
       IO.pure(LazyList.empty)
     } else {
-      readOnlyTransaction("batchLoadGroupEmail", samRequestContext)({ implicit session =>
+      readOnlyTransaction("batchLoadGroupEmail", samRequestContext) { implicit session =>
         val g = GroupTable.column
 
         samsql"select ${g.name}, ${g.email} from ${GroupTable.table} where ${g.name} in (${groupNames})"
-            .map(rs => (rs.get[WorkbenchGroupName](g.name), rs.get[WorkbenchEmail](g.email)))
-            .list().apply().to(LazyList)
-      })
+          .map(rs => (rs.get[WorkbenchGroupName](g.name), rs.get[WorkbenchEmail](g.email)))
+          .list()
+          .apply()
+          .to(LazyList)
+      }
     }
-  }
 
-  override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("deleteGroup", samRequestContext)({ implicit session =>
+  override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("deleteGroup", samRequestContext) { implicit session =>
       deleteGroup(groupName)
-    })
-  }
+    }
 
-  /**
-    * @return true if the subject was added, false if it was already there
+  /** @return
+    *   true if the subject was added, false if it was already there
     */
-  override def addGroupMember(groupId: WorkbenchGroupIdentity, addMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
-    serializableWriteTransaction("addGroupMember", samRequestContext)({ implicit session =>
+  override def addGroupMember(groupId: WorkbenchGroupIdentity, addMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
+    serializableWriteTransaction("addGroupMember", samRequestContext) { implicit session =>
       val numberAdded = insertGroupMembers(queryForGroupPKs(Set(groupId)).head, Set(addMember))
       if (numberAdded > 0) {
         updateGroupUpdatedDate(groupId)
@@ -136,14 +145,13 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       } else {
         false
       }
-    })
-  }
+    }
 
-  /**
-    * @return true if the subject was removed, false if it was already gone
+  /** @return
+    *   true if the subject was removed, false if it was already gone
     */
-  override def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
-    serializableWriteTransaction("removeGroupMember", samRequestContext)({ implicit session =>
+  override def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
+    serializableWriteTransaction("removeGroupMember", samRequestContext) { implicit session =>
       val removed = removeGroupMember(groupId, removeMember)
 
       if (removed) {
@@ -151,40 +159,41 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
 
       removed
-    })
-  }
+    }
 
-  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
-    readOnlyTransaction("isGroupMember", samRequestContext)({ implicit session =>
+  override def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
+    readOnlyTransaction("isGroupMember", samRequestContext) { implicit session =>
       isGroupMember(groupId, member)
-    })
-  }
+    }
 
-  override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("updateSynchronizedDate", samRequestContext)({ implicit session =>
+  override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("updateSynchronizedDate", samRequestContext) { implicit session =>
       val g = GroupTable.column
-      samsql"update ${GroupTable.table} set ${g.synchronizedDate} = ${Instant.now()} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})".update().apply()
-    })
-  }
+      samsql"update ${GroupTable.table} set ${g.synchronizedDate} = ${Instant.now()} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})"
+        .update()
+        .apply()
+    }
 
-  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]] = {
-    readOnlyTransaction("getSynchronizedDate", samRequestContext)({ implicit session =>
+  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]] =
+    readOnlyTransaction("getSynchronizedDate", samRequestContext) { implicit session =>
       val g = GroupTable.column
       samsql"select ${g.synchronizedDate} from ${GroupTable.table} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})"
-        .map(rs => rs.timestampOpt(g.synchronizedDate).map(_.toJavaUtilDate)).single().apply()
+        .map(rs => rs.timestampOpt(g.synchronizedDate).map(_.toJavaUtilDate))
+        .single()
+        .apply()
         .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
-    })
-  }
+    }
 
-  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
-    readOnlyTransaction("getSynchronizedEmail", samRequestContext)({ implicit session =>
+  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
+    readOnlyTransaction("getSynchronizedEmail", samRequestContext) { implicit session =>
       val g = GroupTable.column
 
       samsql"select ${g.email} from ${GroupTable.table} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})"
-        .map(rs => rs.get[Option[WorkbenchEmail]](g.email)).single().apply()
+        .map(rs => rs.get[Option[WorkbenchEmail]](g.email))
+        .single()
+        .apply()
         .getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"$groupId not found")))
-    })
-  }
+    }
 
   /*
     This query is better than it looks. The problem that this gets around is that we are given an email address,
@@ -198,8 +207,8 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     each of the four tables.
    */
 
-  override def loadSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] = {
-    readOnlyTransaction("loadSubjectFromEmail", samRequestContext)({ implicit session =>
+  override def loadSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] =
+    readOnlyTransaction("loadSubjectFromEmail", samRequestContext) { implicit session =>
       val u = UserTable.syntax
       val g = GroupTable.syntax
       val pet = PetServiceAccountTable.syntax
@@ -230,33 +239,36 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                 on ${res.resourceTypeId} = ${srt.id}
                 where ${g.email} = ${email}"""
 
-      val result = query.map(rs =>
-        SubjectConglomerate(
-          rs.stringOpt(1).map(WorkbenchUserId),
-          rs.stringOpt(2).map(WorkbenchGroupName),
-          rs.stringOpt(3).map(WorkbenchUserId),
-          rs.stringOpt(4).map(GoogleProject),
-          rs.stringOpt(5).map(name => ResourceTypeName(name)),
-          rs.stringOpt(6).map(id => ResourceId(id)),
-          rs.stringOpt(7).map(name => AccessPolicyName(name))
-        )).list().apply()
+      val result = query
+        .map(rs =>
+          SubjectConglomerate(
+            rs.stringOpt(1).map(WorkbenchUserId),
+            rs.stringOpt(2).map(WorkbenchGroupName),
+            rs.stringOpt(3).map(WorkbenchUserId),
+            rs.stringOpt(4).map(GoogleProject),
+            rs.stringOpt(5).map(name => ResourceTypeName(name)),
+            rs.stringOpt(6).map(id => ResourceId(id)),
+            rs.stringOpt(7).map(name => AccessPolicyName(name))
+          )
+        )
+        .list()
+        .apply()
 
-      //The typical cases are the first two. However, if the subject being loaded is a policy, it will return
-      //two rows- one for the underlying group, and one for the policy itself. An alternative is to resolve this
-      //within the query itself.
+      // The typical cases are the first two. However, if the subject being loaded is a policy, it will return
+      // two rows- one for the underlying group, and one for the policy itself. An alternative is to resolve this
+      // within the query itself.
       result.map(unmarshalSubjectConglomerate) match {
         case List() => None
         case List(subject) => Some(subject)
         case List(_: WorkbenchGroupName, policySubject: FullyQualifiedPolicyId) => Some(policySubject)
-        case List(policySubject: FullyQualifiedPolicyId, _: WorkbenchGroupName) => Some(policySubject) //order in unions isn't guaranteed so support both cases
+        case List(policySubject: FullyQualifiedPolicyId, _: WorkbenchGroupName) => Some(policySubject) // order in unions isn't guaranteed so support both cases
         case _ => throw new WorkbenchException(s"Database error: email $email refers to too many subjects.")
 
       }
-    })
-  }
+    }
 
-  def loadPolicyEmail(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
-    readOnlyTransaction("loadPolicyEmail", samRequestContext)({ implicit session =>
+  def loadPolicyEmail(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
+    readOnlyTransaction("loadPolicyEmail", samRequestContext) { implicit session =>
       val g = GroupTable.syntax
       val pol = PolicyTable.syntax
       val srt = ResourceTypeTable.syntax
@@ -276,29 +288,29 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                       ${pol.name} = ${policyId.accessPolicyName}"""
 
       query.map(rs => rs.get[WorkbenchEmail](g.resultName.email)).single().apply()
-    })
-  }
+    }
 
-  override def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
+  override def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     subject match {
       case subject: WorkbenchGroupName => loadGroupEmail(subject, samRequestContext)
-      case subject: PetServiceAccountId => for {
-        petSA <- loadPetServiceAccount(subject, samRequestContext)
-      } yield petSA.map(_.serviceAccount.email)
-      case subject: WorkbenchUserId => for {
-        user <- loadUser(subject, samRequestContext)
-      } yield user.map(_.email)
+      case subject: PetServiceAccountId =>
+        for {
+          petSA <- loadPetServiceAccount(subject, samRequestContext)
+        } yield petSA.map(_.serviceAccount.email)
+      case subject: WorkbenchUserId =>
+        for {
+          user <- loadUser(subject, samRequestContext)
+        } yield user.map(_.email)
       case subject: FullyQualifiedPolicyId => loadPolicyEmail(subject, samRequestContext)
       case _ => throw new WorkbenchException(s"unexpected subject [$subject]")
     }
-  }
 
-  override def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] = {
-    readOnlyTransaction("loadSubjectFromGoogleSubjectId", samRequestContext)({ implicit session =>
+  override def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] =
+    readOnlyTransaction("loadSubjectFromGoogleSubjectId", samRequestContext) { implicit session =>
       val u = UserTable.syntax
       val pet = PetServiceAccountTable.syntax
 
-      //Only pets and users can have googleSubjectIds so we won't bother checking for the other types of WorkbenchSubjects
+      // Only pets and users can have googleSubjectIds so we won't bother checking for the other types of WorkbenchSubjects
       val query = samsql"""
               select ${u.id}, ${None}, ${None} from ${UserTable as u}
                 where ${u.googleSubjectId} = ${googleSubjectId}
@@ -306,26 +318,30 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
               select ${None}, ${pet.userId}, ${pet.project} from ${PetServiceAccountTable as pet}
                 where ${pet.googleSubjectId} = ${googleSubjectId}"""
 
-      val result = query.map(rs =>
-        SubjectConglomerate(
-          rs.stringOpt(1).map(WorkbenchUserId),
-          None,
-          rs.stringOpt(2).map(WorkbenchUserId),
-          rs.stringOpt(3).map(GoogleProject),
-          None,
-          None,
-          None)
-      ).single().apply()
+      val result = query
+        .map(rs =>
+          SubjectConglomerate(
+            rs.stringOpt(1).map(WorkbenchUserId),
+            None,
+            rs.stringOpt(2).map(WorkbenchUserId),
+            rs.stringOpt(3).map(GoogleProject),
+            None,
+            None,
+            None
+          )
+        )
+        .single()
+        .apply()
 
       result.map(unmarshalSubjectConglomerate)
-    })
-  }
+    }
 
-  override def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] = {
-    serializableWriteTransaction("createUser", samRequestContext)({ implicit session =>
+  override def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] =
+    serializableWriteTransaction("createUser", samRequestContext) { implicit session =>
       val userColumn = UserTable.column
 
-      val insertUserQuery = samsql"insert into ${UserTable.table} (${userColumn.id}, ${userColumn.email}, ${userColumn.googleSubjectId}, ${userColumn.enabled}, ${userColumn.azureB2cId}, ${userColumn.acceptedTosVersion}) values (${user.id}, ${user.email}, ${user.googleSubjectId}, ${user.enabled}, ${user.azureB2CId}, ${user.acceptedTosVersion})"
+      val insertUserQuery =
+        samsql"insert into ${UserTable.table} (${userColumn.id}, ${userColumn.email}, ${userColumn.googleSubjectId}, ${userColumn.enabled}, ${userColumn.azureB2cId}, ${userColumn.acceptedTosVersion}) values (${user.id}, ${user.email}, ${user.googleSubjectId}, ${user.enabled}, ${user.azureB2CId}, ${user.acceptedTosVersion})"
 
       Try {
         insertUserQuery.update().apply()
@@ -334,89 +350,105 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
           Failure(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"identity with id ${user.id} already exists")))
       }.get
       user
-    })
-  }
+    }
 
-  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
-    readOnlyTransaction("loadUser", samRequestContext)({ implicit session =>
+  override def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    readOnlyTransaction("loadUser", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
 
       val loadUserQuery = samsql"select ${userTable.resultAll} from ${UserTable as userTable} where ${userTable.id} = ${userId}"
-      loadUserQuery.map(UserTable(userTable))
-        .single().apply().map(UserTable.unmarshalUserRecord)
-    })
-  }
+      loadUserQuery
+        .map(UserTable(userTable))
+        .single()
+        .apply()
+        .map(UserTable.unmarshalUserRecord)
+    }
 
-  override def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
-    readOnlyTransaction("loadUserByGoogleSubjectId", samRequestContext)({ implicit session =>
+  override def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    readOnlyTransaction("loadUserByGoogleSubjectId", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
 
       val loadUserQuery = samsql"select ${userTable.resultAll} from ${UserTable as userTable} where ${userTable.googleSubjectId} = ${userId}"
-      loadUserQuery.map(UserTable(userTable))
-        .single().apply().map(UserTable.unmarshalUserRecord)
-    })
-  }
+      loadUserQuery
+        .map(UserTable(userTable))
+        .single()
+        .apply()
+        .map(UserTable.unmarshalUserRecord)
+    }
 
-  override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
-    readOnlyTransaction("loadUserByAzureB2CId", samRequestContext)({ implicit session =>
+  override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    readOnlyTransaction("loadUserByAzureB2CId", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
 
       val loadUserQuery = samsql"select ${userTable.resultAll} from ${UserTable as userTable} where ${userTable.azureB2cId} = ${userId}"
-      loadUserQuery.map(UserTable(userTable))
-        .single().apply().map(UserTable.unmarshalUserRecord)
-    })
-  }
+      loadUserQuery
+        .map(UserTable(userTable))
+        .single()
+        .apply()
+        .map(UserTable.unmarshalUserRecord)
+    }
 
-  override def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("setUserAzureB2CId", samRequestContext)({ implicit session =>
+  override def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("setUserAzureB2CId", samRequestContext) { implicit session =>
       val u = UserTable.column
-      val results = samsql"update ${UserTable.table} set ${u.azureB2cId} = $b2cId where ${u.id} = $userId and (${u.azureB2cId} is null or ${u.azureB2cId} = $b2cId)".update().apply()
+      val results =
+        samsql"update ${UserTable.table} set ${u.azureB2cId} = $b2cId where ${u.id} = $userId and (${u.azureB2cId} is null or ${u.azureB2cId} = $b2cId)"
+          .update()
+          .apply()
 
       if (results != 1) {
-        throw new WorkbenchException(s"Cannot update azureB2cId for user ${userId} because user does not exist or the azureB2cId has already been set for this user")
+        throw new WorkbenchException(
+          s"Cannot update azureB2cId for user ${userId} because user does not exist or the azureB2cId has already been set for this user"
+        )
       } else {
         ()
       }
-    })
-  }
+    }
 
-  override def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("deleteUser", samRequestContext)({ implicit session =>
+  override def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("deleteUser", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
       samsql"delete from ${UserTable.table} where ${userTable.id} = ${userId}".update().apply()
-    })
-  }
+    }
 
-  override def listUsersGroups(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] = {
+  override def listUsersGroups(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] =
     listMemberOfGroups(userId, samRequestContext)
-  }
 
   /** Extracts a WorkbenchGroupIdentity from a SQL query
     *
-    * @param rs of form (groupName, Option[policyName], Option[resourceName], Option[resourceTypeName]
-    * @param g SQLSyntaxProvider for GroupTable
-    * @param p SQLSyntaxProvider for PolicyTable
-    * @param r SQLSyntaxProvider for ResourceTable
-    * @param rt SQLSyntaxProvider for ResourceTypeTable
-    * @return Either a WorkbenchGroupName or a FullyQualifiedPolicyId if policy information is available
+    * @param rs
+    *   of form (groupName, Option[policyName], Option[resourceName], Option[resourceTypeName]
+    * @param g
+    *   SQLSyntaxProvider for GroupTable
+    * @param p
+    *   SQLSyntaxProvider for PolicyTable
+    * @param r
+    *   SQLSyntaxProvider for ResourceTable
+    * @param rt
+    *   SQLSyntaxProvider for ResourceTypeTable
+    * @return
+    *   Either a WorkbenchGroupName or a FullyQualifiedPolicyId if policy information is available
     */
-  private def resultSetToGroupIdentity(rs: WrappedResultSet,
-                                       g: QuerySQLSyntaxProvider[SQLSyntaxSupport[GroupRecord], GroupRecord],
-                                       p: QuerySQLSyntaxProvider[SQLSyntaxSupport[PolicyRecord], PolicyRecord],
-                                       r: QuerySQLSyntaxProvider[SQLSyntaxSupport[ResourceRecord], ResourceRecord],
-                                       rt: QuerySQLSyntaxProvider[SQLSyntaxSupport[ResourceTypeRecord], ResourceTypeRecord]): WorkbenchGroupIdentity = {
+  private def resultSetToGroupIdentity(
+      rs: WrappedResultSet,
+      g: QuerySQLSyntaxProvider[SQLSyntaxSupport[GroupRecord], GroupRecord],
+      p: QuerySQLSyntaxProvider[SQLSyntaxSupport[PolicyRecord], PolicyRecord],
+      r: QuerySQLSyntaxProvider[SQLSyntaxSupport[ResourceRecord], ResourceRecord],
+      rt: QuerySQLSyntaxProvider[SQLSyntaxSupport[ResourceTypeRecord], ResourceTypeRecord]
+  ): WorkbenchGroupIdentity =
     (rs.stringOpt(p.resultName.name), rs.stringOpt(r.resultName.name), rs.stringOpt(rt.resultName.name)) match {
       case (Some(policyName), Some(resourceId), Some(resourceTypeName)) =>
         FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName(resourceTypeName), ResourceId(resourceId)), AccessPolicyName(policyName))
       case (None, None, None) =>
         rs.get[WorkbenchGroupName](g.resultName.name)
       case (policyOpt, resourceOpt, resourceTypeOpt) =>
-        throw new WorkbenchException(s"Inconsistent result. Expected either nothing or names for the policy, resource, and resource type, but instead got (policy = ${policyOpt}, resource = ${resourceOpt}, resourceType = ${resourceTypeOpt})")
+        throw new WorkbenchException(
+          s"Inconsistent result. Expected either nothing or names for the policy, resource, and resource type, but instead got (policy = ${policyOpt}, resource = ${resourceOpt}, resourceType = ${resourceTypeOpt})"
+        )
     }
-  }
 
-  override def listUserDirectMemberships(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchGroupIdentity]] = {
-    readOnlyTransaction("listUserDirectMemberships", samRequestContext)({ implicit session =>
+  override def listUserDirectMemberships(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchGroupIdentity]] =
+    readOnlyTransaction("listUserDirectMemberships", samRequestContext) { implicit session =>
       val gm = GroupMemberTable.syntax("gm")
       val g = GroupTable.syntax("g")
       val p = PolicyTable.syntax("p")
@@ -430,42 +462,39 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
               left join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
               left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
               where ${gm.memberUserId} = ${userId}"""
-        .map(resultSetToGroupIdentity(_, g, p, r, rt)).list().apply().to(LazyList)
-    })
-  }
+        .map(resultSetToGroupIdentity(_, g, p, r, rt))
+        .list()
+        .apply()
+        .to(LazyList)
+    }
 
-  /**
-    * This query attempts to list the User records that are members of ALL the groups given in the groupIds parameter.
+  /** This query attempts to list the User records that are members of ALL the groups given in the groupIds parameter.
     *
-    * The overall approach is to take each group and flatten its membership to determine the full set of all the users
-    * that are a member of that group, its children, its children's children, etc. Once we have the flattened group
-    * membership for each group, we do a big join statement to select only those users that showed up in the flattened
-    * list for each group.
+    * The overall approach is to take each group and flatten its membership to determine the full set of all the users that are a member of that group, its
+    * children, its children's children, etc. Once we have the flattened group membership for each group, we do a big join statement to select only those users
+    * that showed up in the flattened list for each group.
     *
-    * The crux of this implementation is the use of PostgreSQL's `WITH` statement, https://www.postgresql.org/docs/9.6/queries-with.html
-    * These statements allow us to create Common Table Expressions (CTE), which are basically temporary tables that
-    * exist only for the duration of the query.  You can create multiple CTEs using a single `WITH` by comma separating
-    * each `SELECT` that creates each individual CTE.  In this implementation, we use `WITH RECURSIVE` to create N CTEs
-    * where N is the cardinality of the groupIds parameter.  Each of these CTEs is the flattened group membership for
-    * one of the WorkbenchGroupIdentities.
+    * The crux of this implementation is the use of PostgreSQL's `WITH` statement, https://www.postgresql.org/docs/9.6/queries-with.html These statements allow
+    * us to create Common Table Expressions (CTE), which are basically temporary tables that exist only for the duration of the query. You can create multiple
+    * CTEs using a single `WITH` by comma separating each `SELECT` that creates each individual CTE. In this implementation, we use `WITH RECURSIVE` to create N
+    * CTEs where N is the cardinality of the groupIds parameter. Each of these CTEs is the flattened group membership for one of the WorkbenchGroupIdentities.
     *
-    * The final part of the query intersects all the tables defined in the CTE to give us the final result of only
-    * those memberUserIds that showed up as an entry in every CTE.
+    * The final part of the query intersects all the tables defined in the CTE to give us the final result of only those memberUserIds that showed up as an
+    * entry in every CTE.
     * @param groupIds
-    * @return Set of WorkbenchUserIds that are members of each group specified by groupIds
+    * @return
+    *   Set of WorkbenchUserIds that are members of each group specified by groupIds
     */
-  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]] = {
-    readOnlyTransaction("listIntersectionGroupUsers", samRequestContext)({ implicit session =>
+  override def listIntersectionGroupUsers(groupIds: Set[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]] =
+    readOnlyTransaction("listIntersectionGroupUsers", samRequestContext) { implicit session =>
       val f = GroupMemberFlatTable.syntax("f")
       val groupMemberQueries = groupIds.map { groupId =>
         samsqls"select ${f.result.memberUserId} from ${GroupMemberFlatTable as f} where ${f.memberUserId} is not null and ${f.groupId} = (${workbenchGroupIdentityToGroupPK(groupId)})"
       }
       samsql"""${groupMemberQueries.reduce((left, right) => samsqls"$left intersect $right")}""".map(rs => WorkbenchUserId(rs.string(1))).list().apply().toSet
-    })
-  }
+    }
 
-
-  private def listMemberOfGroups(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]]  = {
+  private def listMemberOfGroups(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] = {
     val f = GroupMemberFlatTable.syntax("f")
     val g = GroupTable.syntax("g")
     val p = PolicyTable.syntax("p")
@@ -476,7 +505,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       case _ => throw new WorkbenchException(s"Unexpected WorkbenchSubject. Expected WorkbenchUserId or WorkbenchGroupIdentity but got ${subject}")
     }
 
-    readOnlyTransaction("listMemberOfGroups", samRequestContext)({ implicit session =>
+    readOnlyTransaction("listMemberOfGroups", samRequestContext) { implicit session =>
       val r = ResourceTable.syntax("r")
       val rt = ResourceTypeTable.syntax("rt")
 
@@ -490,18 +519,17 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
             ${where}"""
 
       listGroupsQuery.map(resultSetToGroupIdentity(_, g, p, r, rt)).list().apply().toSet
-    })
+    }
   }
 
-  override def listAncestorGroups(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] = {
+  override def listAncestorGroups(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] =
     listMemberOfGroups(groupId, samRequestContext)
-  }
 
   override def listFlattenedGroupMembers(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]] = {
     val f = GroupMemberFlatTable.syntax("f")
     val g = GroupTable.syntax("g")
 
-    readOnlyTransaction("listFlattenedGroupMembers", samRequestContext)({ implicit session =>
+    readOnlyTransaction("listFlattenedGroupMembers", samRequestContext) { implicit session =>
       val query = samsql"""select distinct ${f.result.memberUserId}
         from ${GroupMemberFlatTable as f}
         join ${GroupTable as g} on ${g.id} = ${f.groupId}
@@ -509,52 +537,48 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         and ${f.memberUserId} is not null"""
 
       query.map(_.get[WorkbenchUserId](f.resultName.memberUserId)).list().apply().toSet
-    })
-  }
-
-  override def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] = {
-    subject match {
-      case userId: WorkbenchUserId =>
-        serializableWriteTransaction("enableIdentity", samRequestContext)({ implicit session =>
-        val u = UserTable.column
-        samsql"update ${UserTable.table} set ${u.enabled} = true where ${u.id} = ${userId}".update().apply()
-      })
-      case _ => IO.unit // other types of WorkbenchSubjects cannot be enabled
     }
   }
 
-  override def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("disableIdentity", samRequestContext)({ implicit session =>
+  override def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] =
+    subject match {
+      case userId: WorkbenchUserId =>
+        serializableWriteTransaction("enableIdentity", samRequestContext) { implicit session =>
+          val u = UserTable.column
+          samsql"update ${UserTable.table} set ${u.enabled} = true where ${u.id} = ${userId}".update().apply()
+        }
+      case _ => IO.unit // other types of WorkbenchSubjects cannot be enabled
+    }
+
+  override def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("disableIdentity", samRequestContext) { implicit session =>
       subject match {
         case userId: WorkbenchUserId =>
           val u = UserTable.column
           samsql"update ${UserTable.table} set ${u.enabled} = false where ${u.id} = ${userId}".update().apply()
         case _ => // other types of WorkbenchSubjects cannot be disabled
       }
-    })
-  }
+    }
 
-  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] = {
-    serializableWriteTransaction("acceptTermsOfService", samRequestContext)({ implicit session =>
+  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
+    serializableWriteTransaction("acceptTermsOfService", samRequestContext) { implicit session =>
       val u = UserTable.column
       samsql"""update ${UserTable.table} set ${u.acceptedTosVersion} = ${tosVersion}
               where ${u.id} = ${userId}
               and (${u.acceptedTosVersion} is null
                 or ${u.acceptedTosVersion} != ${tosVersion})""".update().apply() > 0
-    })
-  }
+    }
 
-  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] = {
-    serializableWriteTransaction("rejectTermsOfService", samRequestContext)({ implicit session =>
+  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
+    serializableWriteTransaction("rejectTermsOfService", samRequestContext) { implicit session =>
       val u = UserTable.column
       samsql"""update ${UserTable.table} set ${u.acceptedTosVersion} = null
               where ${u.id} = ${userId}
               and ${u.acceptedTosVersion} is not null""".update().apply() > 0
-    })
-  }
+    }
 
-  override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
-    readOnlyTransaction("isEnabled", samRequestContext)({ implicit session =>
+  override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
+    readOnlyTransaction("isEnabled", samRequestContext) { implicit session =>
       val userIdOpt = subject match {
         case user: WorkbenchUserId => Option(user)
         case PetServiceAccountId(user, _) => Option(user)
@@ -563,15 +587,18 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val u = UserTable.column
 
-      userIdOpt.flatMap { userId =>
-        samsql"select ${u.enabled} from ${UserTable.table} where ${u.id} = ${userId}"
-          .map(rs => rs.boolean(u.enabled)).single().apply()
-      }.getOrElse(false)
-    })
-  }
+      userIdOpt
+        .flatMap { userId =>
+          samsql"select ${u.enabled} from ${UserTable.table} where ${u.id} = ${userId}"
+            .map(rs => rs.boolean(u.enabled))
+            .single()
+            .apply()
+        }
+        .getOrElse(false)
+    }
 
-  override def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
-    readOnlyTransaction("getUserFromPetServiceAccount", samRequestContext)({ implicit session =>
+  override def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    readOnlyTransaction("getUserFromPetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax
       val userTable = UserTable.syntax
 
@@ -582,22 +609,21 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val userRecordOpt: Option[UserRecord] = loadUserQuery.map(UserTable(userTable)).single().apply()
       userRecordOpt.map(UserTable.unmarshalUserRecord)
-    })
-  }
+    }
 
-  override def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
-    serializableWriteTransaction("createPetServiceAccount", samRequestContext)({ implicit session =>
+  override def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] =
+    serializableWriteTransaction("createPetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountColumn = PetServiceAccountTable.column
 
       samsql"""insert into ${PetServiceAccountTable.table} (${petServiceAccountColumn.userId}, ${petServiceAccountColumn.project}, ${petServiceAccountColumn.googleSubjectId}, ${petServiceAccountColumn.email}, ${petServiceAccountColumn.displayName})
            values (${petServiceAccount.id.userId}, ${petServiceAccount.id.project}, ${petServiceAccount.serviceAccount.subjectId}, ${petServiceAccount.serviceAccount.email}, ${petServiceAccount.serviceAccount.displayName})"""
-        .update().apply()
+        .update()
+        .apply()
       petServiceAccount
-    })
-  }
+    }
 
-  override def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Option[PetServiceAccount]] = {
-    readOnlyTransaction("loadPetServiceAccount", samRequestContext)({ implicit session =>
+  override def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Option[PetServiceAccount]] =
+    readOnlyTransaction("loadPetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax
 
       val loadPetQuery = samsql"""select ${petServiceAccountTable.resultAll}
@@ -606,21 +632,20 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val petRecordOpt = loadPetQuery.map(PetServiceAccountTable(petServiceAccountTable)).single().apply()
       petRecordOpt.map(unmarshalPetServiceAccountRecord)
-    })
-  }
+    }
 
-  override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("deletePetServiceAccount", samRequestContext)({ implicit session =>
+  override def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("deletePetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax
-      val deletePetQuery = samsql"delete from ${PetServiceAccountTable.table} where ${petServiceAccountTable.userId} = ${petServiceAccountId.userId} and ${petServiceAccountTable.project} = ${petServiceAccountId.project}"
+      val deletePetQuery =
+        samsql"delete from ${PetServiceAccountTable.table} where ${petServiceAccountTable.userId} = ${petServiceAccountId.userId} and ${petServiceAccountTable.project} = ${petServiceAccountId.project}"
       if (deletePetQuery.update().apply() != 1) {
         throw new WorkbenchException(s"${petServiceAccountId} cannot be deleted because it already does not exist")
       }
-    })
-  }
+    }
 
-  override def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] = {
-    readOnlyTransaction("getAllPetServiceAccountsForUser", samRequestContext)({ implicit session =>
+  override def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] =
+    readOnlyTransaction("getAllPetServiceAccountsForUser", samRequestContext) { implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax
 
       val loadPetsQuery = samsql"""select ${petServiceAccountTable.resultAll}
@@ -628,11 +653,10 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val petRecords = loadPetsQuery.map(PetServiceAccountTable(petServiceAccountTable)).list().apply()
       petRecords.map(unmarshalPetServiceAccountRecord)
-    })
-  }
+    }
 
-  override def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
-    serializableWriteTransaction("updatePetServiceAccount", samRequestContext)({ implicit session =>
+  override def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] =
+    serializableWriteTransaction("updatePetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountColumn = PetServiceAccountTable.column
       val updatePetQuery = samsql"""update ${PetServiceAccountTable.table} set
         ${petServiceAccountColumn.googleSubjectId} = ${petServiceAccount.serviceAccount.subjectId},
@@ -645,34 +669,36 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
 
       petServiceAccount
-    })
-  }
+    }
 
-  private def unmarshalPetServiceAccountRecord(petRecord: PetServiceAccountRecord): PetServiceAccount = {
-    PetServiceAccount(PetServiceAccountId(petRecord.userId, petRecord.project), ServiceAccount(petRecord.googleSubjectId, petRecord.email, petRecord.displayName))
-  }
+  private def unmarshalPetServiceAccountRecord(petRecord: PetServiceAccountRecord): PetServiceAccount =
+    PetServiceAccount(
+      PetServiceAccountId(petRecord.userId, petRecord.project),
+      ServiceAccount(petRecord.googleSubjectId, petRecord.email, petRecord.displayName)
+    )
 
   case class SubjectConglomerate(
-                                  userId: Option[WorkbenchUserId],
-                                  groupName: Option[WorkbenchGroupName],
-                                  petUserId: Option[WorkbenchUserId],
-                                  petProject: Option[GoogleProject],
-                                  policyResourceType: Option[ResourceTypeName],
-                                  policyResourceId: Option[ResourceId],
-                                  policyName: Option[AccessPolicyName])
+      userId: Option[WorkbenchUserId],
+      groupName: Option[WorkbenchGroupName],
+      petUserId: Option[WorkbenchUserId],
+      petProject: Option[GoogleProject],
+      policyResourceType: Option[ResourceTypeName],
+      policyResourceId: Option[ResourceId],
+      policyName: Option[AccessPolicyName]
+  )
 
-  private def unmarshalSubjectConglomerate(subjectConglomerate: SubjectConglomerate): WorkbenchSubject = {
+  private def unmarshalSubjectConglomerate(subjectConglomerate: SubjectConglomerate): WorkbenchSubject =
     subjectConglomerate match {
       case SubjectConglomerate(Some(userId), None, None, None, None, None, None) => userId
       case SubjectConglomerate(None, Some(groupName), None, None, None, None, None) => groupName
       case SubjectConglomerate(None, None, Some(petUserId), Some(petProject), None, None, None) => PetServiceAccountId(petUserId, petProject)
-      case SubjectConglomerate(None, None, None, None, Some(policyResourceType), Some(policyResourceId), Some(policyName)) => FullyQualifiedPolicyId(FullyQualifiedResourceId(policyResourceType, policyResourceId), policyName)
+      case SubjectConglomerate(None, None, None, None, Some(policyResourceType), Some(policyResourceId), Some(policyName)) =>
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(policyResourceType, policyResourceId), policyName)
       case _ => throw new WorkbenchException("Not found")
     }
-  }
 
-  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]] = {
-    readOnlyTransaction("getManagedGroupAccessInstructions", samRequestContext)({ implicit session =>
+  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]] =
+    readOnlyTransaction("getManagedGroupAccessInstructions", samRequestContext) { implicit session =>
       val groupTable = GroupTable.syntax
       val accessInstructionsTable = AccessInstructionsTable.syntax
 
@@ -693,11 +719,10 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
           // the group exists but the access instructions will be null in the query result if there are no instructions
           Option(accessInstructionsRecord.instructions)
       }
-    })
-  }
+    }
 
-  override def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("setManagedGroupAccessInstructions", samRequestContext)({ implicit session =>
+  override def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("setManagedGroupAccessInstructions", samRequestContext) { implicit session =>
       val groupPKQuery = workbenchGroupIdentityToGroupPK(groupName)
       val accessInstructionsColumn = AccessInstructionsTable.column
 
@@ -709,41 +734,40 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                             where ${AccessInstructionsTable.syntax.groupId} = (${groupPKQuery})"""
 
       upsertAccessInstructionsQuery.update().apply()
-    })
-  }
+    }
 
-  override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] = {
-    serializableWriteTransaction("setGoogleSubjectId", samRequestContext)({ implicit session =>
+  override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("setGoogleSubjectId", samRequestContext) { implicit session =>
       val u = UserTable.column
       val updateGoogleSubjectIdQuery =
         samsql"""update ${UserTable.table} set ${u.googleSubjectId} = ${googleSubjectId}
                 where ${u.id} = ${userId} and ${u.googleSubjectId} is null"""
 
       if (updateGoogleSubjectIdQuery.update().apply() != 1) {
-        throw new WorkbenchException(s"Cannot update googleSubjectId for user ${userId} because user does not exist or the googleSubjectId has already been set for this user")
+        throw new WorkbenchException(
+          s"Cannot update googleSubjectId for user ${userId} because user does not exist or the googleSubjectId has already been set for this user"
+        )
       }
-    })
-  }
+    }
 
-  override def checkStatus(samRequestContext: SamRequestContext): Boolean = {
+  override def checkStatus(samRequestContext: SamRequestContext): Boolean =
     writeDbRef.inLocalTransaction { session =>
       session.connection.isValid((2 seconds).toSeconds.intValue())
     }
-  }
 
-  override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] = {
-    serializableWriteTransaction("createPetManagedIdentity", samRequestContext)({ implicit session =>
+  override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] =
+    serializableWriteTransaction("createPetManagedIdentity", samRequestContext) { implicit session =>
       val petManagedIdentityColumn = PetManagedIdentityTable.column
 
       samsql"""insert into ${PetManagedIdentityTable.table} (${petManagedIdentityColumn.userId}, ${petManagedIdentityColumn.tenantId}, ${petManagedIdentityColumn.subscriptionId}, ${petManagedIdentityColumn.managedResourceGroupName}, ${petManagedIdentityColumn.objectId}, ${petManagedIdentityColumn.displayName})
            values (${petManagedIdentity.id.user}, ${petManagedIdentity.id.tenantId}, ${petManagedIdentity.id.subscriptionId}, ${petManagedIdentity.id.managedResourceGroupName}, ${petManagedIdentity.objectId}, ${petManagedIdentity.displayName})"""
-        .update().apply()
+        .update()
+        .apply()
       petManagedIdentity
-    })
-  }
+    }
 
-  override def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]] = {
-    readOnlyTransaction("loadPetManagedIdentity", samRequestContext)({ implicit session =>
+  override def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]] =
+    readOnlyTransaction("loadPetManagedIdentity", samRequestContext) { implicit session =>
       val petManagedIdentityTable = PetManagedIdentityTable.syntax
 
       val loadPetQuery = samsql"""select ${petManagedIdentityTable.resultAll}
@@ -752,15 +776,17 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val petRecordOpt = loadPetQuery.map(PetManagedIdentityTable(petManagedIdentityTable)).single().apply()
       petRecordOpt.map(unmarshalPetManagedIdentityRecord)
-    })
-  }
+    }
 
-  private def unmarshalPetManagedIdentityRecord(petRecord: PetManagedIdentityRecord): PetManagedIdentity = {
-    PetManagedIdentity(PetManagedIdentityId(petRecord.userId, petRecord.tenantId, petRecord.subscriptionId, petRecord.managedResourceGroupName), petRecord.objectId, petRecord.displayName)
-  }
+  private def unmarshalPetManagedIdentityRecord(petRecord: PetManagedIdentityRecord): PetManagedIdentity =
+    PetManagedIdentity(
+      PetManagedIdentityId(petRecord.userId, petRecord.tenantId, petRecord.subscriptionId, petRecord.managedResourceGroupName),
+      petRecord.objectId,
+      petRecord.displayName
+    )
 
-  override def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
-    readOnlyTransaction("getUserFromPetManagedIdentity", samRequestContext)({ implicit session =>
+  override def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    readOnlyTransaction("getUserFromPetManagedIdentity", samRequestContext) { implicit session =>
       val petManagedIdentityTable = PetManagedIdentityTable.syntax
       val userTable = UserTable.syntax
 
@@ -771,6 +797,5 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val userRecordOpt: Option[UserRecord] = loadUserQuery.map(UserTable(userTable)).single().apply()
       userRecordOpt.map(UserTable.unmarshalUserRecord)
-    })
-  }
+    }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -293,12 +293,12 @@ class GoogleExtensions(
       _ <- withProxyEmail(user.id) { proxyEmail =>
         googleDirectoryDAO.addMemberToGroup(proxyEmail, WorkbenchEmail(user.email.value))
       }
-      _ <- forAllPets(user.id, samRequestContext) { (petServiceAccount: PetServiceAccount) => enablePetServiceAccount(petServiceAccount, samRequestContext) }
+      _ <- forAllPets(user.id, samRequestContext)((petServiceAccount: PetServiceAccount) => enablePetServiceAccount(petServiceAccount, samRequestContext))
     } yield ()
 
   override def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] =
     for {
-      _ <- forAllPets(user.id, samRequestContext) { (petServiceAccount: PetServiceAccount) => disablePetServiceAccount(petServiceAccount, samRequestContext) }
+      _ <- forAllPets(user.id, samRequestContext)((petServiceAccount: PetServiceAccount) => disablePetServiceAccount(petServiceAccount, samRequestContext))
       _ <- withProxyEmail(user.id) { proxyEmail =>
         googleDirectoryDAO.removeMemberFromGroup(proxyEmail, WorkbenchEmail(user.email.value))
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -19,8 +19,7 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * Created by mbemis on 5/22/17.
+/** Created by mbemis on 5/22/17.
   */
 class ResourceService(
     private val resourceTypes: Map[ResourceTypeName, ResourceType],
@@ -29,16 +28,18 @@ class ResourceService(
     private val directoryDAO: DirectoryDAO,
     private val cloudExtensions: CloudExtensions,
     val emailDomain: String,
-    private val allowedAdminEmailDomains: Set[String])(implicit val executionContext: ExecutionContext)
+    private val allowedAdminEmailDomains: Set[String]
+)(implicit val executionContext: ExecutionContext)
     extends LazyLogging {
 
   private[service] case class ValidatableAccessPolicy(
-                                              policyName: AccessPolicyName,
-                                              emailsToSubjects: Map[WorkbenchEmail, Option[WorkbenchSubject]],
-                                              roles: Set[ResourceRoleName],
-                                              actions: Set[ResourceAction],
-                                              descendantPermissions: Set[AccessPolicyDescendantPermissions],
-                                              memberPolicies: Option[Set[PolicyIdentifiers]]=Option.empty)
+      policyName: AccessPolicyName,
+      emailsToSubjects: Map[WorkbenchEmail, Option[WorkbenchSubject]],
+      roles: Set[ResourceRoleName],
+      actions: Set[ResourceAction],
+      descendantPermissions: Set[AccessPolicyDescendantPermissions],
+      memberPolicies: Option[Set[PolicyIdentifiers]] = Option.empty
+  )
 
   def getResourceTypes(): IO[Map[ResourceTypeName, ResourceType]] =
     IO.pure(resourceTypes)
@@ -46,12 +47,13 @@ class ResourceService(
   def getResourceType(name: ResourceTypeName): IO[Option[ResourceType]] =
     IO.pure(resourceTypes.get(name))
 
-  /**
-    * Creates each resource type in the database and creates a resource for each with the resource type SamResourceTypes.resourceTypeAdmin.
+  /** Creates each resource type in the database and creates a resource for each with the resource type SamResourceTypes.resourceTypeAdmin.
     *
     * This will fail if SamResourceTypes.resourceTypeAdmin does not exist in resourceTypes
     */
-  def initResourceTypes(samRequestContext: SamRequestContext = SamRequestContext()): IO[Iterable[ResourceType]] = // `SamRequestContext()` is used so that we don't trace 1-off boot/init methods
+  def initResourceTypes(
+      samRequestContext: SamRequestContext = SamRequestContext()
+  ): IO[Iterable[ResourceType]] = // `SamRequestContext()` is used so that we don't trace 1-off boot/init methods
     resourceTypes.get(SamResourceTypes.resourceTypeAdminName) match {
       case None =>
         IO.raiseError(new WorkbenchException(s"Could not initialize resource types because ${SamResourceTypes.resourceTypeAdminName.value} does not exist."))
@@ -66,7 +68,8 @@ class ResourceService(
               Map.empty,
               Set(resourceTypeAdmin.ownerRoleName),
               Set.empty,
-              Set.empty)
+              Set.empty
+            )
             // note that this skips all validations and just creates a resource with owner policies with no members
             // it will require someone with direct database access to bootstrap
             persistResource(resourceTypeAdmin, ResourceId(rtName.value), Set(policy), Set.empty, None, samRequestContext).recover {
@@ -81,9 +84,8 @@ class ResourceService(
   def createResourceType(resourceType: ResourceType, samRequestContext: SamRequestContext): IO[ResourceType] =
     accessPolicyDAO.createResourceType(resourceType, samRequestContext)
 
-  /**
-    * Create a resource with default policies. The default policies contain 1 policy with the same name as the
-    * owner role for the resourceType, has the owner role, membership contains only samUser
+  /** Create a resource with default policies. The default policies contain 1 policy with the same name as the owner role for the resourceType, has the owner
+    * role, membership contains only samUser
     *
     * @param resourceType
     * @param resourceId
@@ -95,62 +97,77 @@ class ResourceService(
       .find(_.roleName == resourceType.ownerRoleName)
       .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
     val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None))
+      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None)
+    )
     createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
   }
 
-  /**
-    * Validates the resource first and if any validations fail, an exception is thrown with an error report that
-    * describes what failed.  If validations pass, then the Resource should be persisted.
+  /** Validates the resource first and if any validations fail, an exception is thrown with an error report that describes what failed. If validations pass,
+    * then the Resource should be persisted.
     *
     * @param resourceType
     * @param resourceId
     * @param policiesMap
     * @param userId
-    * @return Future[Resource]
+    * @return
+    *   Future[Resource]
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, policiesMap: Map[AccessPolicyName, AccessPolicyMembership], authDomain: Set[WorkbenchGroupName], parentOpt: Option[FullyQualifiedResourceId], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Resource] = {
+  def createResource(
+      resourceType: ResourceType,
+      resourceId: ResourceId,
+      policiesMap: Map[AccessPolicyName, AccessPolicyMembership],
+      authDomain: Set[WorkbenchGroupName],
+      parentOpt: Option[FullyQualifiedResourceId],
+      userId: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Resource] = {
     logger.info(s"Creating new `${resourceType.name}` with resourceId: `${resourceId}`")
     makeValidatablePolicies(policiesMap, samRequestContext).flatMap { policies =>
       validateCreateResource(resourceType, resourceId, policies, authDomain, userId, parentOpt, samRequestContext).flatMap {
-        case Seq() => for {
-          persisted <- persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)
+        case Seq() =>
+          for {
+            persisted <- persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)
 
-          _ <- AuditLogger.logAuditEventIO(
-            samRequestContext,
-            ResourceEvent(ResourceCreated,
-              FullyQualifiedResourceId(resourceType.name, resourceId),
-              parentOpt.map(ResourceChange)))
+            _ <- AuditLogger.logAuditEventIO(
+              samRequestContext,
+              ResourceEvent(ResourceCreated, FullyQualifiedResourceId(resourceType.name, resourceId), parentOpt.map(ResourceChange))
+            )
 
-          changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId),
-            LazyList.empty, persisted.accessPolicies)
+            changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId), LazyList.empty, persisted.accessPolicies)
 
-          _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq:_*)
-        } yield persisted
+            _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq: _*)
+          } yield persisted
         case errorReports: Seq[ErrorReport] =>
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports))
       }
     }
   }
 
-  /**
-    * This method only persists the resource and then overwrites/creates the policies for that resource.
-    * Be very careful if calling this method directly because it will not validate the resource or its policies.
-    * If you want to create a Resource, use createResource() which will also perform critical validations
+  /** This method only persists the resource and then overwrites/creates the policies for that resource. Be very careful if calling this method directly because
+    * it will not validate the resource or its policies. If you want to create a Resource, use createResource() which will also perform critical validations
     *
     * @param resourceType
     * @param resourceId
     * @param policies
     * @param authDomain
-    * @return Future[Resource]
+    * @return
+    *   Future[Resource]
     */
-  private def persistResource(resourceType: ResourceType, resourceId: ResourceId, policies: Set[ValidatableAccessPolicy], authDomain: Set[WorkbenchGroupName], parentOpt: Option[FullyQualifiedResourceId], samRequestContext: SamRequestContext) = {
+  private def persistResource(
+      resourceType: ResourceType,
+      resourceId: ResourceId,
+      policies: Set[ValidatableAccessPolicy],
+      authDomain: Set[WorkbenchGroupName],
+      parentOpt: Option[FullyQualifiedResourceId],
+      samRequestContext: SamRequestContext
+  ) = {
     val accessPolicies = policies.map(constructAccessPolicy(resourceType, resourceId, _, public = false)) // can't set public at create time
     accessPolicyDAO.createResource(Resource(resourceType.name, resourceId, authDomain, accessPolicies = accessPolicies, parent = parentOpt), samRequestContext)
   }
 
-  private def constructAccessPolicy(resourceType: ResourceType, resourceId: ResourceId, validatableAccessPolicy: ValidatableAccessPolicy, public: Boolean) = {
-    AccessPolicy(FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), validatableAccessPolicy.policyName),
+  private def constructAccessPolicy(resourceType: ResourceType, resourceId: ResourceId, validatableAccessPolicy: ValidatableAccessPolicy, public: Boolean) =
+    AccessPolicy(
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), validatableAccessPolicy.policyName),
       validatableAccessPolicy.emailsToSubjects.values.flatten.toSet,
       generateGroupEmail(),
       validatableAccessPolicy.roles,
@@ -158,9 +175,16 @@ class ResourceService(
       validatableAccessPolicy.descendantPermissions,
       public
     )
-  }
 
-  private def validateCreateResource(resourceType: ResourceType, resourceId: ResourceId, policies: Set[ValidatableAccessPolicy], authDomain: Set[WorkbenchGroupName], userId: WorkbenchUserId, parentOpt: Option[FullyQualifiedResourceId], samRequestContext: SamRequestContext): IO[Seq[ErrorReport]] =
+  private def validateCreateResource(
+      resourceType: ResourceType,
+      resourceId: ResourceId,
+      policies: Set[ValidatableAccessPolicy],
+      authDomain: Set[WorkbenchGroupName],
+      userId: WorkbenchUserId,
+      parentOpt: Option[FullyQualifiedResourceId],
+      samRequestContext: SamRequestContext
+  ): IO[Seq[ErrorReport]] =
     for {
       resourceIdErrors <- IO.pure(validateUrlSafe(resourceId.value))
       ownerPolicyErrors <- IO.pure(validateOwnerPolicyExists(resourceType, policies, parentOpt))
@@ -170,15 +194,22 @@ class ResourceService(
 
   private val validUrlSafePattern = "[-a-zA-Z0-9._~%]+".r
 
-  private def validateUrlSafe(input: String): Option[ErrorReport] = {
+  private def validateUrlSafe(input: String): Option[ErrorReport] =
     if (!validUrlSafePattern.pattern.matcher(input).matches) {
-      Option(ErrorReport(s"Invalid input: $input. Valid characters are alphanumeric characters, periods, tildes, percents, underscores, and dashes. Try url encoding."))
+      Option(
+        ErrorReport(
+          s"Invalid input: $input. Valid characters are alphanumeric characters, periods, tildes, percents, underscores, and dashes. Try url encoding."
+        )
+      )
     } else {
       None
     }
-  }
 
-  private def validateOwnerPolicyExists(resourceType: ResourceType, policies: Set[ValidatableAccessPolicy], parentOpt: Option[FullyQualifiedResourceId]): Option[ErrorReport] =
+  private def validateOwnerPolicyExists(
+      resourceType: ResourceType,
+      policies: Set[ValidatableAccessPolicy],
+      parentOpt: Option[FullyQualifiedResourceId]
+  ): Option[ErrorReport] =
     parentOpt match {
       case None =>
         // make sure there is an owner policy if there is no parent
@@ -193,7 +224,12 @@ class ResourceService(
       case Some(_) => None // if a parent exists, the parent's owners are effectively owners of this resource
     }
 
-  private def validateAuthDomain(resourceType: ResourceType, authDomain: Set[WorkbenchGroupName], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[ErrorReport]] =
+  private def validateAuthDomain(
+      resourceType: ResourceType,
+      authDomain: Set[WorkbenchGroupName],
+      userId: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ErrorReport]] =
     validateAuthDomainPermissions(authDomain, userId, samRequestContext).map { permissionsErrors =>
       val constrainableErrors = validateAuthDomainConstraints(resourceType, authDomain).toSeq
       val errors = constrainableErrors ++ permissionsErrors.flatten
@@ -202,7 +238,11 @@ class ResourceService(
       } else None
     }
 
-  private def validateAuthDomainPermissions(authDomain: Set[WorkbenchGroupName], userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[List[Option[ErrorReport]]] =
+  private def validateAuthDomainPermissions(
+      authDomain: Set[WorkbenchGroupName],
+      userId: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[List[Option[ErrorReport]]] =
     authDomain.toList.traverse { groupName =>
       val resource = FullyQualifiedResourceId(ManagedGroupService.managedGroupTypeName, ResourceId(groupName.value))
       policyEvaluatorService.hasPermission(resource, ManagedGroupService.useAction, userId, samRequestContext).map {
@@ -217,17 +257,37 @@ class ResourceService(
     } else None
 
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupName]] =
-    accessPolicyDAO.loadResourceAuthDomain(resource, samRequestContext).flatMap(result => result match {
-      case LoadResourceAuthDomainResult.Constrained(authDomain) => IO.pure(authDomain.toList.toSet)
-      case LoadResourceAuthDomainResult.NotConstrained => IO.pure(Set.empty)
-      case LoadResourceAuthDomainResult.ResourceNotFound => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Resource ${resource} not found")))
-    })
+    accessPolicyDAO
+      .loadResourceAuthDomain(resource, samRequestContext)
+      .flatMap(result =>
+        result match {
+          case LoadResourceAuthDomainResult.Constrained(authDomain) => IO.pure(authDomain.toList.toSet)
+          case LoadResourceAuthDomainResult.NotConstrained => IO.pure(Set.empty)
+          case LoadResourceAuthDomainResult.ResourceNotFound =>
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Resource ${resource} not found")))
+        }
+      )
 
   @VisibleForTesting
-  def createPolicy(policyIdentity: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], roles: Set[ResourceRoleName], actions: Set[ResourceAction], descendantPermissions: Set[AccessPolicyDescendantPermissions], samRequestContext: SamRequestContext): IO[AccessPolicy] =
+  def createPolicy(
+      policyIdentity: FullyQualifiedPolicyId,
+      members: Set[WorkbenchSubject],
+      roles: Set[ResourceRoleName],
+      actions: Set[ResourceAction],
+      descendantPermissions: Set[AccessPolicyDescendantPermissions],
+      samRequestContext: SamRequestContext
+  ): IO[AccessPolicy] =
     createPolicy(policyIdentity, members, generateGroupEmail(), roles, actions, descendantPermissions, samRequestContext)
 
-  private def createPolicy(policyIdentity: FullyQualifiedPolicyId, members: Set[WorkbenchSubject], email: WorkbenchEmail, roles: Set[ResourceRoleName], actions: Set[ResourceAction], descendantPermissions: Set[AccessPolicyDescendantPermissions], samRequestContext: SamRequestContext): IO[AccessPolicy] =
+  private def createPolicy(
+      policyIdentity: FullyQualifiedPolicyId,
+      members: Set[WorkbenchSubject],
+      email: WorkbenchEmail,
+      roles: Set[ResourceRoleName],
+      actions: Set[ResourceAction],
+      descendantPermissions: Set[AccessPolicyDescendantPermissions],
+      samRequestContext: SamRequestContext
+  ): IO[AccessPolicy] =
     accessPolicyDAO.createPolicy(AccessPolicy(policyIdentity, members, email, roles, actions, descendantPermissions, public = false), samRequestContext)
 
   // IF Resource ID reuse is allowed (as defined by the Resource Type), then we can delete the resource
@@ -246,38 +306,36 @@ class ResourceService(
       _ <- accessPolicyDAO.deleteAllResourcePolicies(resource, samRequestContext).unsafeToFuture()
       _ <- maybeDeleteResource(resource, samRequestContext).unsafeToFuture()
 
-      _ <- AuditLogger.logAuditEventIO(
-        samRequestContext,
-        ResourceEvent(ResourceDeleted, resource)).unsafeToFuture()
+      _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceDeleted, resource)).unsafeToFuture()
     } yield ()
 
   /** Check if a resource has any children. If so, then throw a 400. */
-  def checkNoChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = {
+  def checkNoChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
     listResourceChildren(resource, samRequestContext) map { list =>
-      if (list.nonEmpty) throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again."))
+      if (list.nonEmpty)
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again.")
+        )
     }
-  }
 
   // TODO: CA-993 Once we can check if a policy applies to any children, we need to update this to throw if we try
   // to delete any policies that apply to children
   @throws(classOf[WorkbenchExceptionWithErrorReport])
-  def deletePolicy(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Unit] = {
+  def deletePolicy(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       policyEmailOpt <- directoryDAO.loadSubjectEmail(policyId, samRequestContext)
       policyEmail = policyEmailOpt.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found")))
       _ <- IO.fromFuture(IO(cloudExtensions.onGroupDelete(policyEmail)))
       _ <- accessPolicyDAO.deletePolicy(policyId, samRequestContext)
     } yield ()
-  }
 
-  def cloudDeletePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[LazyList[AccessPolicy]] = {
+  def cloudDeletePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[LazyList[AccessPolicy]] =
     for {
       policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource, samRequestContext).unsafeToFuture()
       _ <- Future.traverse(policiesToDelete) { policy =>
         cloudExtensions.onGroupDelete(policy.email)
       }
     } yield policiesToDelete
-  }
 
   private def maybeDeleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
     resourceTypes.get(resource.resourceTypeName) match {
@@ -293,8 +351,7 @@ class ResourceService(
   def listUserResourceRoles(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
     accessPolicyDAO.listUserResourceRoles(resource, samUser.id, samRequestContext).unsafeToFuture()
 
-  /**
-    * Overwrites an existing policy (keyed by resourceType/resourceId/policyName), saves a new one if it doesn't exist yet
+  /** Overwrites an existing policy (keyed by resourceType/resourceId/policyName), saves a new one if it doesn't exist yet
     * @param resourceType
     * @param policyName
     * @param resource
@@ -302,7 +359,13 @@ class ResourceService(
     * @return
     */
   @throws(classOf[WorkbenchExceptionWithErrorReport])
-  def overwritePolicy(resourceType: ResourceType, policyName: AccessPolicyName, resource: FullyQualifiedResourceId, policyMembership: AccessPolicyMembership, samRequestContext: SamRequestContext): IO[AccessPolicy] = {
+  def overwritePolicy(
+      resourceType: ResourceType,
+      policyName: AccessPolicyName,
+      resource: FullyQualifiedResourceId,
+      policyMembership: AccessPolicyMembership,
+      samRequestContext: SamRequestContext
+  ): IO[AccessPolicy] =
     for {
       policy <- makeCreatablePolicy(policyName, policyMembership, samRequestContext)
       _ <- validatePolicy(resourceType, policy).map {
@@ -311,33 +374,38 @@ class ResourceService(
         case None =>
       }
       overwrittenPolicy <- createOrUpdatePolicy(FullyQualifiedPolicyId(resource, policyName), policy, samRequestContext)
-    } yield {
-      overwrittenPolicy
-    }
-  }
+    } yield overwrittenPolicy
 
-  /**
-    * Overwrites an existing admin policy, saves a new one if it doesn't exist yet.  */
-  def overwriteAdminPolicy(resourceType: ResourceType, policyName: AccessPolicyName, resource: FullyQualifiedResourceId, policyMembership: AccessPolicyMembership, samRequestContext: SamRequestContext): IO[AccessPolicy] =
+  /** Overwrites an existing admin policy, saves a new one if it doesn't exist yet.
+    */
+  def overwriteAdminPolicy(
+      resourceType: ResourceType,
+      policyName: AccessPolicyName,
+      resource: FullyQualifiedResourceId,
+      policyMembership: AccessPolicyMembership,
+      samRequestContext: SamRequestContext
+  ): IO[AccessPolicy] =
     failUnlessAllAdminEmailDomainsAllowed(policyMembership) *>
       overwritePolicy(resourceType, policyName, resource, policyMembership, samRequestContext)
-
 
   def failUnlessAllAdminEmailDomainsAllowed(membership: AccessPolicyMembership): IO[Unit] =
     NonEmptyList
       .fromList(membership.memberEmails.toList.filterNot { email =>
         allowedAdminEmailDomains contains email.value.split("@").last
       })
-      .traverse_(invalidEmails => IO.raiseError {
-        new WorkbenchExceptionWithErrorReport(ErrorReport(
-          StatusCodes.BadRequest,
-          s"You have specified at least one invalid admin member email",
-          invalidEmails.toList.map(email => ErrorReport(s"Invalid admin member email: $email"))
-        ))
-      })
+      .traverse_(invalidEmails =>
+        IO.raiseError {
+          new WorkbenchExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"You have specified at least one invalid admin member email",
+              invalidEmails.toList.map(email => ErrorReport(s"Invalid admin member email: $email"))
+            )
+          )
+        }
+      )
 
-  /**
-    * Overwrites an existing policy's membership (keyed by resourceType/resourceId/policyName) if it exists
+  /** Overwrites an existing policy's membership (keyed by resourceType/resourceId/policyName) if it exists
     *
     * @param policyId
     * @param membersList
@@ -352,43 +420,57 @@ class ResourceService(
           accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext).flatMap { originalPolicies =>
             originalPolicies.find(_.id == policyId) match {
               case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"policy $policyId does not exist")))
-              case Some(existingPolicy) => Applicative[IO].whenA(existingPolicy.members != newMembers) {
-                for {
-                  _ <- accessPolicyDAO.overwritePolicyMembers(policyId, newMembers, samRequestContext)
-                  _ <- onPolicyUpdate(policyId, originalPolicies, samRequestContext)
-                } yield ()
-              }
+              case Some(existingPolicy) =>
+                Applicative[IO].whenA(existingPolicy.members != newMembers) {
+                  for {
+                    _ <- accessPolicyDAO.overwritePolicyMembers(policyId, newMembers, samRequestContext)
+                    _ <- onPolicyUpdate(policyId, originalPolicies, samRequestContext)
+                  } yield ()
+                }
             }
           }
       }
     }
 
-  /**
-    * Overwrites the policy if it already exists or creates a new policy entry if it does not exist.
-    * Triggers update to Google Group upon successfully updating the policy.
-    * Note: This method DOES NOT validate the policy and should probably not be called directly unless you know the
-    * contents are valid.  To validate and save the policy, use overwritePolicy()
-    * Note: this function DOES NOT update the email or public fields of a policy
+  /** Overwrites the policy if it already exists or creates a new policy entry if it does not exist. Triggers update to Google Group upon successfully updating
+    * the policy. Note: This method DOES NOT validate the policy and should probably not be called directly unless you know the contents are valid. To validate
+    * and save the policy, use overwritePolicy() Note: this function DOES NOT update the email or public fields of a policy
     * @param policyIdentity
     * @param policy
     * @return
     */
-  private def createOrUpdatePolicy(policyIdentity: FullyQualifiedPolicyId, policy: ValidatableAccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy] = {
+  private def createOrUpdatePolicy(
+      policyIdentity: FullyQualifiedPolicyId,
+      policy: ValidatableAccessPolicy,
+      samRequestContext: SamRequestContext
+  ): IO[AccessPolicy] = {
     val workbenchSubjects = policy.emailsToSubjects.values.flatten.toSet ++
-      policy.memberPolicies.getOrElse(Set.empty).map(p =>
-        FullyQualifiedPolicyId(FullyQualifiedResourceId(p.resourceTypeName, p.resourceId), p.policyName)
-      )
+      policy.memberPolicies.getOrElse(Set.empty).map(p => FullyQualifiedPolicyId(FullyQualifiedResourceId(p.resourceTypeName, p.resourceId), p.policyName))
     accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext).flatMap { originalPolicies =>
       originalPolicies.find(_.id == policyIdentity) match {
         case None =>
           for {
-            result <- createPolicy(policyIdentity, workbenchSubjects, generateGroupEmail(), policy.roles, policy.actions, policy.descendantPermissions, samRequestContext)
+            result <- createPolicy(
+              policyIdentity,
+              workbenchSubjects,
+              generateGroupEmail(),
+              policy.roles,
+              policy.actions,
+              policy.descendantPermissions,
+              samRequestContext
+            )
             _ <- onPolicyUpdate(policyIdentity, originalPolicies, samRequestContext)
-          } yield {
-            result
-          }
+          } yield result
         case Some(existingAccessPolicy) =>
-          val newAccessPolicy = AccessPolicy(policyIdentity, workbenchSubjects, existingAccessPolicy.email, policy.roles, policy.actions, policy.descendantPermissions, existingAccessPolicy.public)
+          val newAccessPolicy = AccessPolicy(
+            policyIdentity,
+            workbenchSubjects,
+            existingAccessPolicy.email,
+            policy.roles,
+            policy.actions,
+            policy.descendantPermissions,
+            existingAccessPolicy.public
+          )
           if (newAccessPolicy == existingAccessPolicy) {
             // short cut if access policy is unchanged
             IO.pure(newAccessPolicy)
@@ -396,15 +478,16 @@ class ResourceService(
             for {
               result <- accessPolicyDAO.overwritePolicy(newAccessPolicy, samRequestContext)
               _ <- onPolicyUpdate(policyIdentity, originalPolicies, samRequestContext)
-            } yield {
-              result
-            }
+            } yield result
           }
       }
     }
   }
 
-  private def mapEmailsToSubjects(workbenchEmails: Set[WorkbenchEmail], samRequestContext: SamRequestContext): IO[Map[WorkbenchEmail, Option[WorkbenchSubject]]] = {
+  private def mapEmailsToSubjects(
+      workbenchEmails: Set[WorkbenchEmail],
+      samRequestContext: SamRequestContext
+  ): IO[Map[WorkbenchEmail, Option[WorkbenchSubject]]] = {
     val eventualSubjects = workbenchEmails.map { workbenchEmail =>
       directoryDAO.loadSubjectFromEmail(workbenchEmail, samRequestContext).map(workbenchEmail -> _)
     }
@@ -412,8 +495,13 @@ class ResourceService(
     eventualSubjects.toList.sequence.map(_.toMap)
   }
 
-  //Disallow orphaning, leaving when it's via a group, or leaving when the resource is public
-  def leaveResource(resourceType: ResourceType, resourceId: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[List[Boolean]] =
+  // Disallow orphaning, leaving when it's via a group, or leaving when the resource is public
+  def leaveResource(
+      resourceType: ResourceType,
+      resourceId: FullyQualifiedResourceId,
+      samUser: SamUser,
+      samRequestContext: SamRequestContext
+  ): IO[List[Boolean]] =
     accessPolicyDAO.listAccessPolicies(resourceId, samRequestContext) flatMap { policiesForResource =>
       val policiesForUser = policiesForResource.filter(_.members.contains(samUser.id)).toSet
       val publicPoliciesForResource = policiesForResource.filter(_.public).toSet
@@ -424,7 +512,8 @@ class ResourceService(
         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "You can only leave a resource that you have direct access to."))
 
       // 2. Make sure that the user cannot leave the resource if they only have access via a public policy
-      if ((policiesForUser -- publicPoliciesForResource).isEmpty) throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "You may not leave a public resource."))
+      if ((policiesForUser -- publicPoliciesForResource).isEmpty)
+        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "You may not leave a public resource."))
 
       // 3. Make sure that removing the user will not orphan it, i.e. there must be at least one other owner on an "owning" policy
       val ownerPolicies = policiesForUser.filter(_.roles.contains(resourceType.ownerRoleName))
@@ -441,14 +530,13 @@ class ResourceService(
       }
     }
 
-  /**
-    * Validates a policy in the context of a ResourceType.  When validating the policy, we want to collect each entity
-    * that was problematic and report that back using ErrorReports
+  /** Validates a policy in the context of a ResourceType. When validating the policy, we want to collect each entity that was problematic and report that back
+    * using ErrorReports
     * @param resourceType
     * @param policy
     * @return
     */
-  private[service] def validatePolicy(resourceType: ResourceType, policy: ValidatableAccessPolicy): IO[Option[ErrorReport]] = {
+  private[service] def validatePolicy(resourceType: ResourceType, policy: ValidatableAccessPolicy): IO[Option[ErrorReport]] =
     for {
       descendantPermissionsErrors <- validateDescendantPermissions(policy.descendantPermissions)
     } yield {
@@ -463,14 +551,13 @@ class ResourceService(
         Some(ErrorReport("You have specified an invalid policy", validationErrors.toSeq))
       } else None
     }
-  }
 
-  /**
-    * A valid email is one that matches the email address for a previously persisted WorkbenchSubject.
-    * @param emailsToSubjects Keys are the member email addresses we want to add to the policy, values are the
-    *                         corresponding result of trying to lookup the subject in the Directory using that email
-    *                         address.  If we failed to find a matching subject, then the email address is invalid
-    * @return an optional ErrorReport enumerating all invalid email addresses
+  /** A valid email is one that matches the email address for a previously persisted WorkbenchSubject.
+    * @param emailsToSubjects
+    *   Keys are the member email addresses we want to add to the policy, values are the corresponding result of trying to lookup the subject in the Directory
+    *   using that email address. If we failed to find a matching subject, then the email address is invalid
+    * @return
+    *   an optional ErrorReport enumerating all invalid email addresses
     */
   private def validateMemberEmails(emailsToSubjects: Map[WorkbenchEmail, Option[WorkbenchSubject]]): Option[ErrorReport] = {
     val invalidEmails = emailsToSubjects.collect { case (email, None) => email }
@@ -492,7 +579,8 @@ class ResourceService(
         ErrorReport(
           s"You have specified an invalid role for resource type ${resourceType.name}. Valid roles are: ${resourceType.roles.map(_.roleName).mkString(", ")}",
           roleCauses.toSeq
-        ))
+        )
+      )
     } else None
   }
 
@@ -506,7 +594,8 @@ class ResourceService(
         ErrorReport(
           s"You have specified an invalid action for resource type ${resourceType.name}. Valid actions are: ${resourceType.actionPatterns.mkString(", ")}",
           actionCauses.toSeq
-        ))
+        )
+      )
     } else None
   }
 
@@ -514,36 +603,31 @@ class ResourceService(
     val validationErrors = descendantPermissionsSet.toList.traverse { descendantPermissions =>
       for {
         maybeDescendantResourceType <- getResourceType(descendantPermissions.resourceType)
-      } yield {
-        maybeDescendantResourceType match {
-          case None => Seq(ErrorReport(s"Descendant resource type ${descendantPermissions.resourceType.value} does not exist."))
-          case Some(descendantResourceType) =>
-            validateActions(descendantResourceType, descendantPermissions.actions) ++
+      } yield maybeDescendantResourceType match {
+        case None => Seq(ErrorReport(s"Descendant resource type ${descendantPermissions.resourceType.value} does not exist."))
+        case Some(descendantResourceType) =>
+          validateActions(descendantResourceType, descendantPermissions.actions) ++
             validateRoles(descendantResourceType, descendantPermissions.roles)
-        }
       }
     }
 
     validationErrors.map(_.flatten)
   }
 
-  private def onPolicyUpdate(policyId: FullyQualifiedPolicyId, originalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext): IO[Unit] = {
+  private def onPolicyUpdate(policyId: FullyQualifiedPolicyId, originalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext): IO[Unit] =
     for {
       updatedPolicies <- accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext)
-      changeEvents = createAccessChangeEvents(policyId.resource,
-        originalPolicies,
-        updatedPolicies)
+      changeEvents = createAccessChangeEvents(policyId.resource, originalPolicies, updatedPolicies)
 
-      _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq:_*)
+      _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq: _*)
 
       _ <- IO.fromFuture(IO(cloudExtensions.onGroupUpdate(Seq(policyId), samRequestContext))).attempt.flatMap {
         case Left(regrets) => IO(logger.error(s"error calling cloudExtensions.onGroupUpdate for $policyId", regrets))
         case Right(_) => IO.unit
       }
     } yield ()
-  }
 
-  def addSubjectToPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
+  def addSubjectToPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
     subject match {
       case subject: FullyQualifiedPolicyId if policyIdentity.resource.resourceTypeName.equals(ManagedGroupService.managedGroupTypeName) =>
         // https://broadworkbench.atlassian.net/browse/CA-257
@@ -557,26 +641,28 @@ class ResourceService(
           _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
         } yield policyChanged
     }
-  }
 
-  def removeSubjectFromPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = {
+  def removeSubjectFromPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
     for {
       originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
       _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
       policyChanged <- directoryDAO.removeGroupMember(policyIdentity, subject, samRequestContext)
       _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
     } yield policyChanged
-  }
 
   def failWhenPolicyNotExists(policies: Iterable[AccessPolicy], policyId: FullyQualifiedPolicyId): IO[Unit] =
     IO.raiseUnless(policies.exists(_.id == policyId)) {
-      new WorkbenchExceptionWithErrorReport(ErrorReport(
-        StatusCodes.NotFound,
-        s"""No policy matching "${policyId.accessPolicyName}" found on resource "${policyId.resource}"."""
-      ))
+      new WorkbenchExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.NotFound,
+          s"""No policy matching "${policyId.accessPolicyName}" found on resource "${policyId.resource}"."""
+        )
+      )
     }
 
-  private def onPolicyUpdateIfChanged(policyIdentity: FullyQualifiedPolicyId, originalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext)(policyChanged: Boolean) = {
+  private def onPolicyUpdateIfChanged(policyIdentity: FullyQualifiedPolicyId, originalPolicies: Iterable[AccessPolicy], samRequestContext: SamRequestContext)(
+      policyChanged: Boolean
+  ) = {
     val maybeFireNotification = if (policyChanged) {
       onPolicyUpdate(policyIdentity, originalPolicies, samRequestContext)
     } else {
@@ -598,14 +684,30 @@ class ResourceService(
   def loadResourcePolicy(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] =
     accessPolicyDAO.loadPolicyMembership(policyIdentity, samRequestContext)
 
-  private def makeValidatablePolicies(policies: Map[AccessPolicyName, AccessPolicyMembership], samRequestContext: SamRequestContext): IO[Set[ValidatableAccessPolicy]] =
-    policies.toList.traverse {
-      case (accessPolicyName, accessPolicyMembership) => makeCreatablePolicy(accessPolicyName, accessPolicyMembership, samRequestContext)
-    }.map(_.toSet)
+  private def makeValidatablePolicies(
+      policies: Map[AccessPolicyName, AccessPolicyMembership],
+      samRequestContext: SamRequestContext
+  ): IO[Set[ValidatableAccessPolicy]] =
+    policies.toList
+      .traverse { case (accessPolicyName, accessPolicyMembership) =>
+        makeCreatablePolicy(accessPolicyName, accessPolicyMembership, samRequestContext)
+      }
+      .map(_.toSet)
 
-  private def makeCreatablePolicy(accessPolicyName: AccessPolicyName, accessPolicyMembership: AccessPolicyMembership, samRequestContext: SamRequestContext): IO[ValidatableAccessPolicy] =
+  private def makeCreatablePolicy(
+      accessPolicyName: AccessPolicyName,
+      accessPolicyMembership: AccessPolicyMembership,
+      samRequestContext: SamRequestContext
+  ): IO[ValidatableAccessPolicy] =
     mapEmailsToSubjects(accessPolicyMembership.memberEmails, samRequestContext).map { emailsToSubjects =>
-      ValidatableAccessPolicy(accessPolicyName, emailsToSubjects, accessPolicyMembership.roles, accessPolicyMembership.actions, accessPolicyMembership.getDescendantPermissions, accessPolicyMembership.memberPolicies)
+      ValidatableAccessPolicy(
+        accessPolicyName,
+        emailsToSubjects,
+        accessPolicyMembership.roles,
+        accessPolicyMembership.actions,
+        accessPolicyMembership.getDescendantPermissions,
+        accessPolicyMembership.memberPolicies
+      )
     }
 
   private def generateGroupEmail() = WorkbenchEmail(s"policy-${UUID.randomUUID}@$emailDomain")
@@ -616,29 +718,31 @@ class ResourceService(
       case Some(accessPolicy) => IO.pure(accessPolicy.public)
     }
 
-  /**
-    * Sets the public field of a policy. Raises an error if the policy has an auth domain and public == true.
-    * Triggers update to Google Group upon successfully updating the policy.
+  /** Sets the public field of a policy. Raises an error if the policy has an auth domain and public == true. Triggers update to Google Group upon successfully
+    * updating the policy.
     *
-    * @param policyId the fully qualified id of the policy
-    * @param public true to make the policy public, false to make it private
+    * @param policyId
+    *   the fully qualified id of the policy
+    * @param public
+    *   true to make the policy public, false to make it private
     * @return
     */
   def setPublic(policyId: FullyQualifiedPolicyId, public: Boolean, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       authDomain <- accessPolicyDAO.loadResourceAuthDomain(policyId.resource, samRequestContext)
       _ <- authDomain match {
-        case LoadResourceAuthDomainResult.ResourceNotFound => IO.raiseError(
-          new WorkbenchExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, s"ResourceId ${policyId.resource} not found.")))
+        case LoadResourceAuthDomainResult.ResourceNotFound =>
+          IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"ResourceId ${policyId.resource} not found.")))
         case LoadResourceAuthDomainResult.Constrained(_) =>
           // resources with auth domains logically can't have public policies but also technically allowing them poses a problem
           // because the logic for public resources is different. However, sharing with the auth domain should have the
           // exact same effect as making a policy public: anyone in the auth domain can access.
           if (public)
-          IO.raiseError(
-            new WorkbenchExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, "Cannot make auth domain protected resources public. Share directly with auth domain groups instead.")))
+            IO.raiseError(
+              new WorkbenchExceptionWithErrorReport(
+                ErrorReport(StatusCodes.BadRequest, "Cannot make auth domain protected resources public. Share directly with auth domain groups instead.")
+              )
+            )
           else IO.unit
         case LoadResourceAuthDomainResult.NotConstrained =>
           for {
@@ -654,62 +758,59 @@ class ResourceService(
       accessPolicies <- accessPolicyDAO.listAccessPolicies(resourceId, samRequestContext)
       members <- accessPolicies.toList.parTraverse(accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id, samRequestContext))
       workbenchUsers = members.flatten.toSet
-    } yield {
-      workbenchUsers.map(_.toUserIdInfo)
-    }
+    } yield workbenchUsers.map(_.toUserIdInfo)
 
   @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy
-  def getResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = {
+  def getResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] =
     accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
-  }
 
-  /** In this iteration of hierarchical resources, we do not allow child resources to be in an auth domain because it
-    * would introduce additional complications when keeping Sam policies with their Google Groups. For more details,
-    * see https://docs.google.com/document/d/10qGxsV9BeM6-N_Zk27_JIayE509B8LUQBGiGrqB0taY/edit#heading=h.dxz6xjtnz9la */
-  def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId,  samRequestContext: SamRequestContext): IO[Unit] = {
+  /** In this iteration of hierarchical resources, we do not allow child resources to be in an auth domain because it would introduce additional complications
+    * when keeping Sam policies with their Google Groups. For more details, see
+    * https://docs.google.com/document/d/10qGxsV9BeM6-N_Zk27_JIayE509B8LUQBGiGrqB0taY/edit#heading=h.dxz6xjtnz9la
+    */
+  def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       authDomain <- accessPolicyDAO.loadResourceAuthDomain(childResource, samRequestContext)
       _ <- authDomain match {
         case LoadResourceAuthDomainResult.NotConstrained =>
           for {
             _ <- accessPolicyDAO.setResourceParent(childResource, parentResource, samRequestContext)
-            _ <- AuditLogger.logAuditEventIO(
-              samRequestContext,
-              ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
+            _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
           } yield ()
-        case LoadResourceAuthDomainResult.Constrained(_) => IO.raiseError(
-          new WorkbenchExceptionWithErrorReport(
-            ErrorReport(StatusCodes.BadRequest, "Cannot set the parent for a constrained resource")
+        case LoadResourceAuthDomainResult.Constrained(_) =>
+          IO.raiseError(
+            new WorkbenchExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, "Cannot set the parent for a constrained resource")
+            )
           )
-        )
-        case LoadResourceAuthDomainResult.ResourceNotFound => IO.raiseError(
-          new WorkbenchExceptionWithErrorReport(
-            ErrorReport(StatusCodes.NotFound, "Resource not found")
+        case LoadResourceAuthDomainResult.ResourceNotFound =>
+          IO.raiseError(
+            new WorkbenchExceptionWithErrorReport(
+              ErrorReport(StatusCodes.NotFound, "Resource not found")
+            )
           )
-        )
       }
     } yield ()
-  }
 
-  def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = {
+  def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] =
     for {
       maybeOldParent <- accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
       _ <- maybeOldParent.traverse { oldParent =>
         for {
           _ <- accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
-          _ <- AuditLogger.logAuditEventIO(
-            samRequestContext,
-            ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
+          _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
         } yield ()
       }
     } yield maybeOldParent.isDefined
-  }
 
-  def listResourceChildren(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = {
+  def listResourceChildren(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] =
     accessPolicyDAO.listResourceChildren(resourceId, samRequestContext)
-  }
 
-  private[service] def createAccessChangeEvents(resource: FullyQualifiedResourceId, beforePolicies: Iterable[AccessPolicy], afterPolicies: Iterable[AccessPolicy]): Iterable[AccessChangeEvent] = {
+  private[service] def createAccessChangeEvents(
+      resource: FullyQualifiedResourceId,
+      beforePolicies: Iterable[AccessPolicy],
+      afterPolicies: Iterable[AccessPolicy]
+  ): Iterable[AccessChangeEvent] = {
     val before = new PermissionsByUsers(beforePolicies)
     val after = new PermissionsByUsers(afterPolicies)
 
@@ -722,4 +823,3 @@ class ResourceService(
     addEventSet ++ removeEventSet
   }
 }
-

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.db.DbReference
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.HealthMonitor.GetCurrentStatus
@@ -17,11 +17,12 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class StatusService(
-                     val directoryDAO: DirectoryDAO,
-                     val cloudExtensions: CloudExtensions,
-                     val dbReference: DbReference,
-                     initialDelay: FiniteDuration = Duration.Zero,
-                     pollInterval: FiniteDuration = 1 minute)(implicit system: ActorSystem, executionContext: ExecutionContext)
+    val directoryDAO: DirectoryDAO,
+    val cloudExtensions: CloudExtensions,
+    val dbReference: DbReference,
+    initialDelay: FiniteDuration = Duration.Zero,
+    pollInterval: FiniteDuration = 1 minute
+)(implicit system: ActorSystem, executionContext: ExecutionContext)
     extends LazyLogging {
   implicit val askTimeout = Timeout(5 seconds)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.errorReportSource
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.sam.config.TermsOfServiceConfig
@@ -14,8 +14,8 @@ import scala.concurrent.ExecutionContext
 import java.io.{FileNotFoundException, IOException}
 import scala.io.Source
 
-
-class TosService (val directoryDao: DirectoryDAO, val appsDomain: String, val tosConfig: TermsOfServiceConfig)(implicit val executionContext: ExecutionContext) extends LazyLogging {
+class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tosConfig: TermsOfServiceConfig)(implicit val executionContext: ExecutionContext)
+    extends LazyLogging {
   val termsOfServiceFile = "termsOfService.md"
 
   def acceptTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[Boolean]] =
@@ -28,48 +28,41 @@ class TosService (val directoryDao: DirectoryDAO, val appsDomain: String, val to
       directoryDao.rejectTermsOfService(userId, samRequestContext).map(Option(_))
     } else IO.pure(None)
 
-  /**
-    * Check if Terms of service is enabled and if the user has accepted the latest version
-    * @return IO[Some(true)] if ToS is enabled and the user has accepted
-    *         IO[Some(false)] if ToS is enabled and the user hasn't accepted
-    *         IO[None] if ToS is disabled
+  /** Check if Terms of service is enabled and if the user has accepted the latest version
+    * @return
+    *   IO[Some(true)] if ToS is enabled and the user has accepted IO[Some(false)] if ToS is enabled and the user hasn't accepted IO[None] if ToS is disabled
     */
-  def getTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[Boolean]] = {
+  def getTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[Boolean]] =
     if (tosConfig.enabled) {
       directoryDao.loadUser(userId, samRequestContext).map(_.map(_.acceptedTosVersion.contains(tosConfig.version)))
     } else IO.none
-  }
 
-  /**
-    * If grace period enabled, don't check ToS, return true
-    * If ToS disabled, return true
-    * Otherwise return true if user has accepted ToS
+  /** If grace period enabled, don't check ToS, return true If ToS disabled, return true Otherwise return true if user has accepted ToS
     */
-  def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean = {
+  def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean =
     tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version)
-  }
 
-  /**
-    * Get the terms of service text and send it to the caller
-    * @return terms of service text
+  /** Get the terms of service text and send it to the caller
+    * @return
+    *   terms of service text
     */
   def getText: String = {
-    val tosFileStream = try {
-      logger.debug("Reading terms of service")
-      Source.fromResource(termsOfServiceFile)
-    } catch {
-      case e: FileNotFoundException =>
-        logger.error("Terms Of Service file not found", e)
-        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
-      case e: IOException =>
-        logger.error("Failed to read Terms of Service fail due to IO exception", e)
-        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
-    }
+    val tosFileStream =
+      try {
+        logger.debug("Reading terms of service")
+        Source.fromResource(termsOfServiceFile)
+      } catch {
+        case e: FileNotFoundException =>
+          logger.error("Terms Of Service file not found", e)
+          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
+        case e: IOException =>
+          logger.error("Failed to read Terms of Service fail due to IO exception", e)
+          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
+      }
     logger.debug("Terms of service file found")
-    try {
+    try
       tosFileStream.mkString
-    } finally {
+    finally
       tosFileStream.close
-    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -19,12 +19,13 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.matching.Regex
 
-/**
-  * Created by dvoet on 7/14/17.
+/** Created by dvoet on 7/14/17.
   */
-class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExtensions, blockedEmailDomains: Seq[String], tosService: TosService)(implicit val executionContext: ExecutionContext) extends LazyLogging {
+class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExtensions, blockedEmailDomains: Seq[String], tosService: TosService)(implicit
+    val executionContext: ExecutionContext
+) extends LazyLogging {
 
-  def createUser(user: SamUser, samRequestContext: SamRequestContext): Future[UserStatus] = {
+  def createUser(user: SamUser, samRequestContext: SamRequestContext): Future[UserStatus] =
     for {
       _ <- UserService.validateEmailAddress(user.email, blockedEmailDomains).unsafeToFuture()
       createdUser <- registerUser(user, samRequestContext).unsafeToFuture()
@@ -33,14 +34,13 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       userStatus <- getUserStatus(createdUser.id, samRequestContext = samRequestContext)
       res <- userStatus.toRight(new WorkbenchException("getUserStatus returned None after user was created")).fold(Future.failed, Future.successful)
     } yield res
-  }
 
-  def addToAllUsersGroup(uid: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit] = {
+  def addToAllUsersGroup(uid: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit] =
     for {
+
       allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext)
       _ <- directoryDAO.addGroupMember(allUsersGroup.id, uid, samRequestContext).unsafeToFuture()
     } yield ()
-  }
 
   def inviteUser(inviteeEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[UserStatusDetails] =
     for {
@@ -53,13 +53,10 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       }
     } yield UserStatusDetails(createdUser.id, createdUser.email)
 
-  /**
-    * First lookup user by either googleSubjectId or azureB2DId, whichever is populated. If the user exists
-    * throw a conflict error. If the user does not exist look them up by email. If the user email exists
-    * then this is an invited user, update their googleSubjectId and/or azureB2CId and return the updated user record.
-    * If the email does not exist, this is a new user, create them.
-    * It is critical that this method returns the updated/created SamUser record FROM THE DATABASE and not the SamUser
-    * passed in as the first parameter.
+  /** First lookup user by either googleSubjectId or azureB2DId, whichever is populated. If the user exists throw a conflict error. If the user does not exist
+    * look them up by email. If the user email exists then this is an invited user, update their googleSubjectId and/or azureB2CId and return the updated user
+    * record. If the email does not exist, this is a new user, create them. It is critical that this method returns the updated/created SamUser record FROM THE
+    * DATABASE and not the SamUser passed in as the first parameter.
     */
   protected[service] def registerUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] =
     for {
@@ -73,14 +70,15 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           createUserInternal(user, samRequestContext)
 
         case Some(_) =>
-          //We don't support inviting a group account or pet service account
+          // We don't support inviting a group account or pet service account
           IO.raiseError[SamUser](
-            new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"$user is not a regular user. Please use a different endpoint")))
+            new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"$user is not a regular user. Please use a different endpoint"))
+          )
 
       }
     } yield updated
 
-  private def acceptInvitedUser(user: SamUser, samRequestContext: SamRequestContext, uid: WorkbenchUserId): IO[SamUser] = {
+  private def acceptInvitedUser(user: SamUser, samRequestContext: SamRequestContext, uid: WorkbenchUserId): IO[SamUser] =
     for {
       groups <- directoryDAO.listUserDirectMemberships(uid, samRequestContext)
       _ <- user.googleSubjectId.traverse { googleSubjectId =>
@@ -93,10 +91,13 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       }
       _ <- IO.fromFuture(IO(cloudExtensions.onGroupUpdate(groups, samRequestContext)))
       updatedUser <- directoryDAO.loadUser(uid, samRequestContext)
-    } yield updatedUser.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"$user could not be accepted from invite because user could not be loaded from the db")))
-  }
+    } yield updatedUser.getOrElse(
+      throw new WorkbenchExceptionWithErrorReport(
+        ErrorReport(StatusCodes.InternalServerError, s"$user could not be accepted from invite because user could not be loaded from the db")
+      )
+    )
 
-  private def validateNewWorkbenchUser(newWorkbenchUser: SamUser, samRequestContext: SamRequestContext): IO[Unit] = {
+  private def validateNewWorkbenchUser(newWorkbenchUser: SamUser, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       existingUser <- newWorkbenchUser match {
         case SamUser(_, Some(googleSubjectId), _, _, _, _) => directoryDAO.loadSubjectFromGoogleSubjectId(googleSubjectId, samRequestContext)
@@ -105,21 +106,21 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       }
 
       _ <- existingUser match {
-        case Some(_) => IO.raiseError[SamUser](new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"user ${newWorkbenchUser.email} already exists")))
+        case Some(_) =>
+          IO.raiseError[SamUser](new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"user ${newWorkbenchUser.email} already exists")))
         case None => IO.unit
       }
     } yield ()
-  }
 
-  private def createUserInternal(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] = {
+  private def createUserInternal(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser] =
     for {
       createdUser <- directoryDAO.createUser(user, samRequestContext)
       _ <- IO.fromFuture(IO(cloudExtensions.onUserCreate(createdUser, samRequestContext)))
     } yield createdUser
-  }
-  def getSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): Future[Option[WorkbenchSubject]] = directoryDAO.loadSubjectFromEmail(email, samRequestContext).unsafeToFuture()
+  def getSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): Future[Option[WorkbenchSubject]] =
+    directoryDAO.loadSubjectFromEmail(email, samRequestContext).unsafeToFuture()
 
-  def getUserStatus(userId: WorkbenchUserId, userDetailsOnly: Boolean = false, samRequestContext: SamRequestContext): Future[Option[UserStatus]] = {
+  def getUserStatus(userId: WorkbenchUserId, userDetailsOnly: Boolean = false, samRequestContext: SamRequestContext): Future[Option[UserStatus]] =
     directoryDAO.loadUser(userId, samRequestContext).unsafeToFuture().flatMap {
       case Some(user) =>
         if (userDetailsOnly)
@@ -128,7 +129,9 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           for {
             googleStatus <- cloudExtensions.getUserStatus(user)
             allUsersGroup <- cloudExtensions.getOrCreateAllUsersGroup(directoryDAO, samRequestContext)
-            allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id, samRequestContext).unsafeToFuture() recover { case _: NameNotFoundException => false }
+            allUsersStatus <- directoryDAO.isGroupMember(allUsersGroup.id, user.id, samRequestContext).unsafeToFuture() recover {
+              case _: NameNotFoundException => false
+            }
             tosAcceptedStatus <- tosService.getTosStatus(user.id, samRequestContext).unsafeToFuture()
             adminEnabled <- directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
           } yield {
@@ -146,21 +149,18 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           }
       case None => Future.successful(None)
     }
-  }
 
-  def acceptTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] = {
+  def acceptTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] =
     for {
       _ <- tosService.acceptTosStatus(userId, samRequestContext)
       status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
     } yield status
-  }
 
-  def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] = {
+  def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[UserStatus]] =
     for {
       _ <- tosService.rejectTosStatus(userId, samRequestContext)
       status <- IO.fromFuture(IO(getUserStatus(userId, false, samRequestContext)))
     } yield status
-  }
 
   def getUserStatusInfo(user: SamUser, samRequestContext: SamRequestContext): IO[UserStatusInfo] = {
     val tosStatus = tosService.isTermsOfServiceStatusAcceptable(user)
@@ -169,7 +169,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
 
   def getUserStatusDiagnostics(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Option[UserStatusDiagnostics]] =
     directoryDAO.loadUser(userId, samRequestContext).unsafeToFuture().flatMap {
-      case Some(user) => {
+      case Some(user) =>
         // pulled out of for comprehension to allow concurrent execution
         val tosAcceptedStatus = tosService.getTosStatus(user.id, samRequestContext).unsafeToFuture()
         val adminEnabledStatus = directoryDAO.isEnabled(user.id, samRequestContext).unsafeToFuture()
@@ -189,11 +189,10 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           google <- googleStatus
           adminEnabled <- adminEnabledStatus
         } yield Option(UserStatusDiagnostics(ldap, allUsers, google, tosAccepted, adminEnabled))
-      }
       case None => Future.successful(None)
     }
 
-  //TODO: return type should be refactored into ADT for easier read
+  // TODO: return type should be refactored into ADT for easier read
   def getUserIdInfoFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): Future[Either[Unit, Option[UserIdInfo]]] =
     directoryDAO.loadSubjectFromEmail(email, samRequestContext).unsafeToFuture().flatMap {
       // don't attempt to handle groups or service accounts - just users
@@ -223,18 +222,16 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       case None => Future.successful(None)
     }
 
-  private def enableUserInternal(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = {
+  private def enableUserInternal(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] =
     for {
       _ <- directoryDAO.enableIdentity(user.id, samRequestContext).unsafeToFuture()
       _ <- cloudExtensions.onUserEnable(user, samRequestContext)
     } yield ()
-  }
 
   val serviceAccountDomain = "\\S+@\\S+\\.gserviceaccount\\.com".r
 
-  private def isServiceAccount(email: String) = {
+  private def isServiceAccount(email: String) =
     serviceAccountDomain.pattern.matcher(email).matches
-  }
 
   def disableUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Option[UserStatus]] =
     directoryDAO.loadUser(userId, samRequestContext).unsafeToFuture().flatMap {
@@ -243,9 +240,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
           _ <- directoryDAO.disableIdentity(user.id, samRequestContext).unsafeToFuture()
           _ <- cloudExtensions.onUserDisable(user, samRequestContext)
           userStatus <- getUserStatus(user.id, samRequestContext = samRequestContext)
-        } yield {
-          userStatus
-        }
+        } yield userStatus
       case None => Future.successful(None)
     }
 
@@ -282,13 +277,11 @@ object UserService {
   def genWorkbenchUserId(currentMilli: Long): WorkbenchUserId =
     WorkbenchUserId(genRandom(currentMilli))
 
-  def validateEmailAddress(email: WorkbenchEmail, blockedEmailDomains: Seq[String]): IO[Unit] = {
+  def validateEmailAddress(email: WorkbenchEmail, blockedEmailDomains: Seq[String]): IO[Unit] =
     email.value match {
-      case emailString if blockedEmailDomains.exists(domain => {
-        emailString.endsWith("@" + domain) || emailString.endsWith("." + domain)
-      }) => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain not permitted [${email.value}]")))
+      case emailString if blockedEmailDomains.exists(domain => emailString.endsWith("@" + domain) || emailString.endsWith("." + domain)) =>
+        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain not permitted [${email.value}]")))
       case UserService.emailRegex() => IO.unit
       case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"invalid email address [${email.value}]")))
     }
-  }
 }

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -20,14 +20,14 @@ object Generator {
   val genAzureB2CId: Gen[AzureB2CId] = Gen.uuid.map(uuid => AzureB2CId(uuid.toString))
   val genExternalId: Gen[Either[GoogleSubjectId, AzureB2CId]] = Gen.either(genGoogleSubjectId, genAzureB2CId)
   val genServiceAccountSubjectId: Gen[ServiceAccountSubjectId] = genGoogleSubjectId.map(x => ServiceAccountSubjectId(x.value))
-  val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s"+x))
+  val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s" + x))
 
   // normally the current time in millis is used to create a WorkbenchUserId but too many users are created
   // during tests that collisions happen despite randomness built into UserService.genWorkbenchUserId
   // the main requirement is that UserService.genWorkbenchUserId is given a 13 digit Long
   val genWorkbenchUserId: Gen[WorkbenchUserId] = Gen.choose(1000000000000L, 9999999999999L).map(UserService.genWorkbenchUserId)
 
-  val genValidUserInfoHeaders: Gen[List[RawHeader]] = for{
+  val genValidUserInfoHeaders: Gen[List[RawHeader]] = for {
     email <- genNonPetEmail
     accessToken <- genOAuth2BearerToken
     externalId <- genExternalId
@@ -53,11 +53,11 @@ object Generator {
     user <- genWorkbenchUserGoogle
   } yield user.copy(email = email)
 
-  val genWorkbenchUserServiceAccount = for{
+  val genWorkbenchUserServiceAccount = for {
     email <- genServiceAccountEmail
     googleSubjectId <- genGoogleSubjectId
     userId <- genWorkbenchUserId
-  }yield SamUser(userId, Option(googleSubjectId), email, None, false, None)
+  } yield SamUser(userId, Option(googleSubjectId), email, None, false, None)
 
   val genWorkbenchUserAzure = for {
     email <- genNonPetEmail
@@ -72,41 +72,58 @@ object Generator {
     userId <- genWorkbenchUserId
   } yield SamUser(userId, Option(googleSubjectId), email, Option(azureB2CId), false, None)
 
-  val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s${x.take(50)}")) //prepending `s` just so this won't be an empty string
-  val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) //prepending `s` just so this won't be an empty string
-  val genWorkbenchSubject: Gen[WorkbenchSubject] = for{
+  val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s${x.take(50)}")) // prepending `s` just so this won't be an empty string
+  val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) // prepending `s` just so this won't be an empty string
+  val genWorkbenchSubject: Gen[WorkbenchSubject] = for {
     groupId <- genWorkbenchGroupName
     userId <- genWorkbenchUserId
     res <- Gen.oneOf[WorkbenchSubject](List(userId, groupId))
-  }yield res
+  } yield res
 
-  val genBasicWorkbenchGroup = for{
+  val genBasicWorkbenchGroup = for {
     id <- genWorkbenchGroupName
     subject <- Gen.listOf[WorkbenchSubject](genWorkbenchSubject).map(_.toSet)
     email <- genNonPetEmail
   } yield BasicWorkbenchGroup(id, subject, email)
 
-  val genResourceTypeName: Gen[ResourceTypeName] = Gen.oneOf("workspace", "managed-group", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool", "entity-collection").map(ResourceTypeName.apply)
-  val genResourceTypeNameExcludeManagedGroup: Gen[ResourceTypeName] = Gen.oneOf("workspace", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool", "entity-collection").map(ResourceTypeName.apply)
-  val genResourceId : Gen[ResourceId] = Gen.uuid.map(x => ResourceId(x.toString))
-  val genAccessPolicyName : Gen[AccessPolicyName] = Gen.oneOf("member", "admin", "admin-notifier").map(AccessPolicyName.apply) //there might be possible values
-  def genAuthDomains: Gen[Set[WorkbenchGroupName]] = Gen.listOfN[ResourceId](3, genResourceId).map(x => x.map(v => WorkbenchGroupName(v.value)).toSet) //make it a list of 3 items so that unit test won't time out
-  val genNonEmptyAuthDomains: Gen[Set[WorkbenchGroupName]] = Gen.nonEmptyListOf[ResourceId](genResourceId).map(x => x.map(v => WorkbenchGroupName(v.value)).toSet)
-  val genRoleName: Gen[ResourceRoleName] = Gen.oneOf("owner", "other").map(ResourceRoleName.apply) //there might be possible values
+  val genResourceTypeName: Gen[ResourceTypeName] = Gen
+    .oneOf(
+      "workspace",
+      "managed-group",
+      "workflow-collection",
+      "caas",
+      "billing-project",
+      "notebook-cluster",
+      "cloud-extension",
+      "dockstore-tool",
+      "entity-collection"
+    )
+    .map(ResourceTypeName.apply)
+  val genResourceTypeNameExcludeManagedGroup: Gen[ResourceTypeName] = Gen
+    .oneOf("workspace", "workflow-collection", "caas", "billing-project", "notebook-cluster", "cloud-extension", "dockstore-tool", "entity-collection")
+    .map(ResourceTypeName.apply)
+  val genResourceId: Gen[ResourceId] = Gen.uuid.map(x => ResourceId(x.toString))
+  val genAccessPolicyName: Gen[AccessPolicyName] = Gen.oneOf("member", "admin", "admin-notifier").map(AccessPolicyName.apply) // there might be possible values
+  def genAuthDomains: Gen[Set[WorkbenchGroupName]] = Gen
+    .listOfN[ResourceId](3, genResourceId)
+    .map(x => x.map(v => WorkbenchGroupName(v.value)).toSet) // make it a list of 3 items so that unit test won't time out
+  val genNonEmptyAuthDomains: Gen[Set[WorkbenchGroupName]] =
+    Gen.nonEmptyListOf[ResourceId](genResourceId).map(x => x.map(v => WorkbenchGroupName(v.value)).toSet)
+  val genRoleName: Gen[ResourceRoleName] = Gen.oneOf("owner", "other").map(ResourceRoleName.apply) // there might be possible values
   val genResourceAction: Gen[ResourceAction] = Gen.oneOf(readPolicies, alterPolicies, delete, notifyAdmins, setAccessInstructions)
 
-  val genResource: Gen[Resource] = for{
+  val genResource: Gen[Resource] = for {
     resourceType <- genResourceTypeName
     id <- genResourceId
     authDomains <- genAuthDomains
   } yield Resource(resourceType, id, authDomains)
 
-  val genResourceIdentity: Gen[FullyQualifiedResourceId] = for{
+  val genResourceIdentity: Gen[FullyQualifiedResourceId] = for {
     resourceType <- genResourceTypeName
     id <- genResourceId
   } yield model.FullyQualifiedResourceId(resourceType, id)
 
-  val genPolicyIdentity: Gen[FullyQualifiedPolicyId] = for{
+  val genPolicyIdentity: Gen[FullyQualifiedPolicyId] = for {
     r <- genResourceIdentity
     policyName <- genAccessPolicyName
   } yield FullyQualifiedPolicyId(r, policyName)
@@ -117,7 +134,7 @@ object Generator {
     actions <- Gen.listOf(genResourceAction).map(_.toSet)
   } yield AccessPolicyDescendantPermissions(resourceType, actions, roles)
 
-  val genPolicy: Gen[AccessPolicy] = for{
+  val genPolicy: Gen[AccessPolicy] = for {
     id <- genPolicyIdentity
     members <- Gen.listOf(genWorkbenchSubject).map(_.toSet)
     email <- genNonPetEmail
@@ -125,7 +142,7 @@ object Generator {
     actions <- Gen.listOf(genResourceAction).map(_.toSet)
   } yield AccessPolicy(id, members, email, roles, actions, Set.empty, public = false)
 
-  val genPolicyWithDescendantPermissions: Gen[AccessPolicy] = for{
+  val genPolicyWithDescendantPermissions: Gen[AccessPolicy] = for {
     id <- genPolicyIdentity
     members <- Gen.listOf(genWorkbenchSubject).map(_.toSet)
     email <- genNonPetEmail

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -40,11 +40,9 @@ import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Awaitable, ExecutionContext}
 
-
-/**
-  * Created by dvoet on 6/27/17.
+/** Created by dvoet on 6/27/17.
   */
-trait TestSupport{
+trait TestSupport {
   def runAndWait[T](f: Awaitable[T]): T = Await.result(f, Duration.Inf)
   def runAndWait[T](f: IO[T]): T = f.unsafeRunSync()
 
@@ -53,7 +51,8 @@ trait TestSupport{
 
   val samRequestContext = SamRequestContext()
 
-  def dummyResourceType(name: ResourceTypeName) = ResourceType(name, Set.empty, Set(ResourceRole(ResourceRoleName("owner"), Set.empty)), ResourceRoleName("owner"))
+  def dummyResourceType(name: ResourceTypeName) =
+    ResourceType(name, Set.empty, Set(ResourceRole(ResourceRoleName("owner"), Set.empty)), ResourceRoleName("owner"))
 }
 
 trait PropertyBasedTesting extends ScalaCheckPropertyChecks with Configuration with Matchers {
@@ -76,16 +75,17 @@ object TestSupport extends TestSupport {
   def genGoogleSubjectId(): Option[GoogleSubjectId] = Option(GoogleSubjectId(genRandom(System.currentTimeMillis())))
   def genAzureB2CId(): AzureB2CId = AzureB2CId(genRandom(System.currentTimeMillis()))
 
-  def genSamDependencies(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty,
-                         googIamDAO: Option[GoogleIamDAO] = None,
-                         googleServicesConfig: GoogleServicesConfig = googleServicesConfig,
-                         cloudExtensions: Option[CloudExtensions] = None,
-                         googleDirectoryDAO: Option[GoogleDirectoryDAO] = None,
-                         policyAccessDAO: Option[AccessPolicyDAO] = None,
-                         policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
-                         resourceServiceOpt: Option[ResourceService] = None,
-                         tosEnabled: Boolean = false)
-                        (implicit system: ActorSystem) = {
+  def genSamDependencies(
+      resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty,
+      googIamDAO: Option[GoogleIamDAO] = None,
+      googleServicesConfig: GoogleServicesConfig = googleServicesConfig,
+      cloudExtensions: Option[CloudExtensions] = None,
+      googleDirectoryDAO: Option[GoogleDirectoryDAO] = None,
+      policyAccessDAO: Option[AccessPolicyDAO] = None,
+      policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
+      resourceServiceOpt: Option[ResourceService] = None,
+      tosEnabled: Boolean = false
+  )(implicit system: ActorSystem) = {
     val googleDirectoryDAO = new MockGoogleDirectoryDAO()
     val directoryDAO = new MockDirectoryDAO()
     val googleIamDAO = googIamDAO.getOrElse(new MockGoogleIamDAO())
@@ -97,66 +97,107 @@ object TestSupport extends TestSupport {
     val googleStorageDAO = new MockGoogleStorageDAO()
     val googleProjectDAO = new MockGoogleProjectDAO()
     val notificationDAO = new PubSubNotificationDAO(notificationPubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(distributedLock, googleIamDAO, googleStorageDAO, FakeGoogleStorageInterpreter, googleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
-    val googleExt = cloudExtensions.getOrElse(new GoogleExtensions(
+    val cloudKeyCache = new GoogleKeyCache(
       distributedLock,
-      directoryDAO,
-      policyDAO,
-      googleDirectoryDAO,
-      notificationPubSubDAO,
-      googleGroupSyncPubSubDAO,
-      googleDisableUsersPubSubDAO,
       googleIamDAO,
       googleStorageDAO,
-      googleProjectDAO,
-      cloudKeyCache,
-      notificationDAO,
-      FakeGoogleKmsInterpreter,
+      FakeGoogleStorageInterpreter,
+      googleKeyCachePubSubDAO,
       googleServicesConfig,
-      petServiceAccountConfig,
-      resourceTypes,
-      adminConfig.superAdminsGroup
-    ))
+      petServiceAccountConfig
+    )
+    val googleExt = cloudExtensions.getOrElse(
+      new GoogleExtensions(
+        distributedLock,
+        directoryDAO,
+        policyDAO,
+        googleDirectoryDAO,
+        notificationPubSubDAO,
+        googleGroupSyncPubSubDAO,
+        googleDisableUsersPubSubDAO,
+        googleIamDAO,
+        googleStorageDAO,
+        googleProjectDAO,
+        cloudKeyCache,
+        notificationDAO,
+        FakeGoogleKmsInterpreter,
+        googleServicesConfig,
+        petServiceAccountConfig,
+        resourceTypes,
+        adminConfig.superAdminsGroup
+      )
+    )
     val policyEvaluatorService = policyEvaluatorServiceOpt.getOrElse(PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO))
-    val mockResourceService = resourceServiceOpt.getOrElse(new ResourceService(
-      resourceTypes,
-      policyEvaluatorService,
-      policyDAO,
-      directoryDAO,
-      googleExt,
-      emailDomain = "example.com",
-      adminConfig.allowedEmailDomains
-    ))
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
+    val mockResourceService = resourceServiceOpt.getOrElse(
+      new ResourceService(
+        resourceTypes,
+        policyEvaluatorService,
+        policyDAO,
+        directoryDAO,
+        googleExt,
+        emailDomain = "example.com",
+        adminConfig.allowedEmailDomains
+      )
+    )
+    val mockManagedGroupService =
+      new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, tosConfig.copy(enabled = tosEnabled))
     val azureService = new AzureService(MockCrlService(), directoryDAO)
-    SamDependencies(mockResourceService, policyEvaluatorService, tosService, new UserService(directoryDAO, googleExt, Seq.empty, tosService), new StatusService(directoryDAO, googleExt, dbRef), mockManagedGroupService, directoryDAO, policyDAO, googleExt, FakeOpenIDConnectConfiguration, azureService)
+    SamDependencies(
+      mockResourceService,
+      policyEvaluatorService,
+      tosService,
+      new UserService(directoryDAO, googleExt, Seq.empty, tosService),
+      new StatusService(directoryDAO, googleExt, dbRef),
+      mockManagedGroupService,
+      directoryDAO,
+      policyDAO,
+      googleExt,
+      FakeOpenIDConnectConfiguration,
+      azureService
+    )
   }
 
   val tosConfig = config.as[TermsOfServiceConfig]("termsOfService")
 
-  def genSamRoutes(samDependencies: SamDependencies, uInfo: SamUser)(implicit system: ActorSystem, materializer: Materializer): SamRoutes = new SamRoutes(samDependencies.resourceService, samDependencies.userService, samDependencies.statusService, samDependencies.managedGroupService, samDependencies.tosService.tosConfig, samDependencies.directoryDAO, samDependencies.policyEvaluatorService, samDependencies.tosService, LiquibaseConfig("", false), samDependencies.oauth2Config, Some(samDependencies.azureService))
-    with MockSamUserDirectives
-    with GoogleExtensionRoutes {
-      override val cloudExtensions: CloudExtensions = samDependencies.cloudExtensions
-      override val googleExtensions: GoogleExtensions = samDependencies.cloudExtensions match {
-        case extensions: GoogleExtensions => extensions
-        case _ => null
-      }
-      override val googleGroupSynchronizer: GoogleGroupSynchronizer = {
-        if(samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) {
-          new GoogleGroupSynchronizer(googleExtensions.directoryDAO, googleExtensions.accessPolicyDAO, googleExtensions.googleDirectoryDAO, googleExtensions, googleExtensions.resourceTypes)(executionContext)
-        } else null
-      }
-      val googleKeyCache = samDependencies.cloudExtensions match {
-        case extensions: GoogleExtensions => extensions.googleKeyCache
-        case _ => null
-      }
-      override val user: SamUser = uInfo
-      override val newSamUser: Option[SamUser] = Option(uInfo)
+  def genSamRoutes(samDependencies: SamDependencies, uInfo: SamUser)(implicit system: ActorSystem, materializer: Materializer): SamRoutes = new SamRoutes(
+    samDependencies.resourceService,
+    samDependencies.userService,
+    samDependencies.statusService,
+    samDependencies.managedGroupService,
+    samDependencies.tosService.tosConfig,
+    samDependencies.directoryDAO,
+    samDependencies.policyEvaluatorService,
+    samDependencies.tosService,
+    LiquibaseConfig("", false),
+    samDependencies.oauth2Config,
+    Some(samDependencies.azureService)
+  ) with MockSamUserDirectives with GoogleExtensionRoutes {
+    override val cloudExtensions: CloudExtensions = samDependencies.cloudExtensions
+    override val googleExtensions: GoogleExtensions = samDependencies.cloudExtensions match {
+      case extensions: GoogleExtensions => extensions
+      case _ => null
+    }
+    override val googleGroupSynchronizer: GoogleGroupSynchronizer =
+      if (samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) {
+        new GoogleGroupSynchronizer(
+          googleExtensions.directoryDAO,
+          googleExtensions.accessPolicyDAO,
+          googleExtensions.googleDirectoryDAO,
+          googleExtensions,
+          googleExtensions.resourceTypes
+        )(executionContext)
+      } else null
+    val googleKeyCache = samDependencies.cloudExtensions match {
+      case extensions: GoogleExtensions => extensions.googleKeyCache
+      case _ => null
+    }
+    override val user: SamUser = uInfo
+    override val newSamUser: Option[SamUser] = Option(uInfo)
   }
 
-  def genSamRoutesWithDefault(implicit system: ActorSystem, materializer: Materializer): SamRoutes = genSamRoutes(genSamDependencies(), Generator.genWorkbenchUserBoth.sample.get)
+  def genSamRoutesWithDefault(implicit system: ActorSystem, materializer: Materializer): SamRoutes =
+    genSamRoutes(genSamDependencies(), Generator.genWorkbenchUserBoth.sample.get)
 
   /*
   In unit tests there really is not a difference between read and write pools.
@@ -167,9 +208,10 @@ object TestSupport extends TestSupport {
    */
   lazy val dbRef = DbReference.init(config.as[LiquibaseConfig]("liquibase"), DatabaseNames.Read, TestSupport.blockingEc)
 
-  def truncateAll: Int = {
+  def truncateAll: Int =
     dbRef.inLocalTransaction { implicit session =>
-      val tables = List(PolicyActionTable,
+      val tables = List(
+        PolicyActionTable,
         PolicyRoleTable,
         PolicyTable,
         AuthDomainTable,
@@ -186,15 +228,31 @@ object TestSupport extends TestSupport {
         PetManagedIdentityTable,
         UserTable,
         AccessInstructionsTable,
-        GroupTable)
+        GroupTable
+      )
 
-      tables.map(table => withSQL{
-        delete.from(table)
-      }.update().apply()).sum
+      tables
+        .map(table =>
+          withSQL {
+            delete.from(table)
+          }.update().apply()
+        )
+        .sum
     }
-  }
 }
 
-final case class SamDependencies(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, tosService: TosService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, directoryDAO: MockDirectoryDAO, policyDao: AccessPolicyDAO, cloudExtensions: CloudExtensions, oauth2Config: OpenIDConnectConfiguration, azureService: AzureService)
+final case class SamDependencies(
+    resourceService: ResourceService,
+    policyEvaluatorService: PolicyEvaluatorService,
+    tosService: TosService,
+    userService: UserService,
+    statusService: StatusService,
+    managedGroupService: ManagedGroupService,
+    directoryDAO: MockDirectoryDAO,
+    policyDao: AccessPolicyDAO,
+    cloudExtensions: CloudExtensions,
+    oauth2Config: OpenIDConnectConfiguration,
+    azureService: AzureService
+)
 
 object ConnectedTest extends Tag("connected test")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
@@ -25,21 +25,14 @@ import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.Future
 
-
-class AdminResourceTypesRoutesSpec
-  extends AnyFlatSpec
-    with Matchers
-    with TestSupport
-    with ScalatestRouteTest
-    with AppendedClues
-    with MockitoSugar {
+class AdminResourceTypesRoutesSpec extends AnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
 
   implicit val errorReportSource = ErrorReportSource("sam")
 
   val firecloudAdmin = Generator.genFirecloudUser.sample.get
   val broadUser = Generator.genBroadInstituteUser.sample.get
 
-  val testUser1 =  Generator.genWorkbenchUserGoogle.sample.get
+  val testUser1 = Generator.genWorkbenchUserGoogle.sample.get
   val testUser2 = Generator.genWorkbenchUserGoogle.sample.get
 
   val defaultResourceType = ResourceType(
@@ -52,14 +45,17 @@ class AdminResourceTypesRoutesSpec
   val defaultAccessPolicyMembership = AccessPolicyMembership(Set(WorkbenchEmail("testUser@example.com")), Set.empty, Set.empty, None)
   val defaultAdminPolicyName = AccessPolicyName("admin")
   val defaultAdminResourceId = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(defaultResourceType.name.value))
-  val defaultAccessPolicyResponseEntry = AccessPolicyResponseEntry(defaultAdminPolicyName, defaultAccessPolicyMembership, WorkbenchEmail("policy_email@example.com"))
+  val defaultAccessPolicyResponseEntry =
+    AccessPolicyResponseEntry(defaultAdminPolicyName, defaultAccessPolicyMembership, WorkbenchEmail("policy_email@example.com"))
 
-  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType] = Map(
-                                defaultResourceType.name -> defaultResourceType,
-                                resourceTypeAdmin.name -> resourceTypeAdmin
-                              ),
-                              isSamSuperAdmin: Boolean,
-                              user: SamUser = firecloudAdmin): SamRoutes = {
+  private def createSamRoutes(
+      resourceTypes: Map[ResourceTypeName, ResourceType] = Map(
+        defaultResourceType.name -> defaultResourceType,
+        resourceTypeAdmin.name -> resourceTypeAdmin
+      ),
+      isSamSuperAdmin: Boolean,
+      user: SamUser = firecloudAdmin
+  ): SamRoutes = {
     val directoryDAO = new MockDirectoryDAO()
     val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val emailDomain = "example.com"
@@ -75,17 +71,29 @@ class AdminResourceTypesRoutesSpec
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
     val mockUserService = new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService)
     val mockStatusService = new StatusService(directoryDAO, cloudExtensions, TestSupport.dbRef)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, cloudExtensions, emailDomain)
+    val mockManagedGroupService =
+      new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, cloudExtensions, emailDomain)
 
     runAndWait(mockUserService.createUser(user, samRequestContext))
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, user, directoryDAO, cloudExtensions, tosService = tosService)
+    new TestSamRoutes(
+      mockResourceService,
+      policyEvaluatorService,
+      mockUserService,
+      mockStatusService,
+      mockManagedGroupService,
+      user,
+      directoryDAO,
+      cloudExtensions,
+      tosService = tosService
+    )
   }
 
   "GET /api/admin/v1/resourceTypes/{resourceType}/policies/" should "200 when successful" in {
     val samRoutes = createSamRoutes(isSamSuperAdmin = true)
 
-    when(samRoutes.resourceService.listResourcePolicies(mockitoEq(defaultAdminResourceId), any[SamRequestContext])).thenReturn(IO(LazyList(defaultAccessPolicyResponseEntry)))
+    when(samRoutes.resourceService.listResourcePolicies(mockitoEq(defaultAdminResourceId), any[SamRequestContext]))
+      .thenReturn(IO(LazyList(defaultAccessPolicyResponseEntry)))
 
     Get(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -117,10 +125,22 @@ class AdminResourceTypesRoutesSpec
   "PUT /api/admin/v1/resourceTypes/{resourceType}/policies/{policyName}" should "201 when successful" in {
     val samRoutes = createSamRoutes(isSamSuperAdmin = true)
 
-    when(samRoutes.resourceService.overwriteAdminPolicy(mockitoEq(resourceTypeAdmin), mockitoEq(defaultAdminPolicyName), mockitoEq(defaultAdminResourceId), mockitoEq(defaultAccessPolicyMembership), any[SamRequestContext])).thenReturn(IO(null))
-    when(samRoutes.resourceService.listResourcePolicies(mockitoEq(defaultAdminResourceId), any[SamRequestContext])).thenReturn(IO(LazyList(defaultAccessPolicyResponseEntry)))
+    when(
+      samRoutes.resourceService.overwriteAdminPolicy(
+        mockitoEq(resourceTypeAdmin),
+        mockitoEq(defaultAdminPolicyName),
+        mockitoEq(defaultAdminResourceId),
+        mockitoEq(defaultAccessPolicyMembership),
+        any[SamRequestContext]
+      )
+    ).thenReturn(IO(null))
+    when(samRoutes.resourceService.listResourcePolicies(mockitoEq(defaultAdminResourceId), any[SamRequestContext]))
+      .thenReturn(IO(LazyList(defaultAccessPolicyResponseEntry)))
 
-    Put(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName", defaultAccessPolicyMembership) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName",
+      defaultAccessPolicyMembership
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
 
@@ -133,39 +153,56 @@ class AdminResourceTypesRoutesSpec
   }
 
   it should "403 if user isn't a Sam super admin" in {
-    val samRoutes = TestSamRoutes(Map(defaultResourceType.name -> defaultResourceType), user = firecloudAdmin,
+    val samRoutes = TestSamRoutes(
+      Map(defaultResourceType.name -> defaultResourceType),
+      user = firecloudAdmin,
       cloudExtensions = SamSuperAdminExtensions(isSamSuperAdmin = false).some
     )
 
-    Put(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName", defaultAccessPolicyMembership) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName",
+      defaultAccessPolicyMembership
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "404 if given nonexistent resource type" in {
-    val samRoutes = TestSamRoutes(Map.empty, user = firecloudAdmin,
-      cloudExtensions = SamSuperAdminExtensions(isSamSuperAdmin = true).some
-    )
+    val samRoutes = TestSamRoutes(Map.empty, user = firecloudAdmin, cloudExtensions = SamSuperAdminExtensions(isSamSuperAdmin = true).some)
 
-    Put(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName", defaultAccessPolicyMembership) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName",
+      defaultAccessPolicyMembership
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "400 if a user's email domain is not in a pre-defined approve list" in {
-    val samRoutes = TestSamRoutes(Map(defaultResourceType.name -> defaultResourceType),
+    val samRoutes = TestSamRoutes(
+      Map(defaultResourceType.name -> defaultResourceType),
       user = firecloudAdmin,
       cloudExtensions = SamSuperAdminExtensions(isSamSuperAdmin = true).some
     )
 
     runAndWait {
       for {
-        _ <- samRoutes.resourceService.createPolicy(FullyQualifiedPolicyId(defaultAdminResourceId, defaultAdminPolicyName), Set(samRoutes.user.id), Set(ResourceRoleName("test")), Set(adminAddMember), Set(), samRequestContext)
+        _ <- samRoutes.resourceService.createPolicy(
+          FullyQualifiedPolicyId(defaultAdminResourceId, defaultAdminPolicyName),
+          Set(samRoutes.user.id),
+          Set(ResourceRoleName("test")),
+          Set(adminAddMember),
+          Set(),
+          samRequestContext
+        )
         _ <- IO.fromFuture(IO(samRoutes.userService.createUser(testUser1, samRequestContext)))
       } yield ()
     }
 
-    Put(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName", defaultAccessPolicyMembership) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName",
+      defaultAccessPolicyMembership
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
@@ -173,7 +210,8 @@ class AdminResourceTypesRoutesSpec
   "DELETE /api/admin/v1/resourceTypes/{resourceType}/policies/{policyName}" should "204 when successful" in {
     val samRoutes = createSamRoutes(isSamSuperAdmin = true)
 
-    when(samRoutes.resourceService.deletePolicy(mockitoEq(FullyQualifiedPolicyId(defaultAdminResourceId, defaultAdminPolicyName)), any[SamRequestContext])).thenReturn(IO.unit)
+    when(samRoutes.resourceService.deletePolicy(mockitoEq(FullyQualifiedPolicyId(defaultAdminResourceId, defaultAdminPolicyName)), any[SamRequestContext]))
+      .thenReturn(IO.unit)
 
     Delete(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/policies/$defaultAdminPolicyName") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, genSamRoutes, googleServicesConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.{SamUser, TermsOfServiceAcceptance, UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -67,16 +67,12 @@ class AdminUserRoutesSpec extends AdminUserRoutesSpecHelper {
 
     Put(s"/api/admin/v1/user/${user.id}/disable") ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails({
-        user.id
-      }, user.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> false, "allUsersGroup" -> true, "google" -> true))
     }
 
     Put(s"/api/admin/v1/user/${user.id}/enable") ~> adminRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails({
-        user.id
-      }, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(user.id, user.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
     }
   }
 
@@ -134,7 +130,6 @@ trait AdminUserRoutesSpecHelper extends AnyFlatSpec with Matchers with Scalatest
   val petSAUserId = petSAUser.id
   val petSAEmail = petSAUser.email
 
-
   def setupAdminsGroup(googleDirectoryDAO: MockGoogleDirectoryDAO): Future[WorkbenchEmail] = {
     val adminGroupEmail = WorkbenchEmail("fc-admins@dev.test.firecloud.org")
     for {
@@ -155,7 +150,13 @@ trait AdminUserRoutesSpecHelper extends AnyFlatSpec with Matchers with Scalatest
     (user.copy(enabled = true), routes) // userService.createUser enables the user
   }
 
-  def createTestUser(testUser: SamUser = Generator.genWorkbenchUserBoth.sample.get, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, tosEnabled: Boolean = false, tosAccepted: Boolean = false): (SamUser, SamDependencies, SamRoutes) = {
+  def createTestUser(
+      testUser: SamUser = Generator.genWorkbenchUserBoth.sample.get,
+      cloudExtensions: Option[CloudExtensions] = None,
+      googleDirectoryDAO: Option[GoogleDirectoryDAO] = None,
+      tosEnabled: Boolean = false,
+      tosAccepted: Boolean = false
+  ): (SamUser, SamDependencies, SamRoutes) = {
     val samDependencies = genSamDependencies(cloudExtensions = cloudExtensions, googleDirectoryDAO = googleDirectoryDAO, tosEnabled = tosEnabled)
     val routes = genSamRoutes(samDependencies, testUser)
 
@@ -195,8 +196,28 @@ trait AdminUserRoutesSpecHelper extends AnyFlatSpec with Matchers with Scalatest
     directoryDAO.createUser(adminUser, samRequestContext).unsafeRunSync()
 
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, defaultUser, directoryDAO, cloudExtensions, tosService = tosService)
-    val adminRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, adminUser, directoryDAO, cloudExtensions, tosService = tosService)
+    val samRoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      defaultUser,
+      directoryDAO,
+      cloudExtensions,
+      tosService = tosService
+    )
+    val adminRoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      adminUser,
+      directoryDAO,
+      cloudExtensions,
+      tosService = tosService
+    )
     testCode(samRoutes, adminRoutes)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -24,61 +24,66 @@ import spray.json.DefaultJsonProtocol._
 import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
 
-/**
-  * Created by gpolumbo on 2/26/2017.
+/** Created by gpolumbo on 2/26/2017.
   */
 class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
 
   private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
-  private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+  private val policyActions: Set[ResourceAction] =
+    accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
   private val resourceActions = Set(ResourceAction("delete"), ResourceAction("notify_admins"), ResourceAction("set_access_instructions")) union policyActions
   private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
   private val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
   private val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
   private val defaultAdminNotifierRole = ResourceRole(ManagedGroupService.adminNotifierRoleName, Set(ResourceAction("notify_admins")))
   private val defaultRoles = Set(defaultOwnerRole, defaultMemberRole, defaultAdminNotifierRole)
-  private val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+  private val managedGroupResourceType =
+    ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
   private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
   private val groupId = "foo"
   private val defaultNewUser = Generator.genWorkbenchUserGoogle.sample.get
   private def defaultGoogleSubjectId = Option(GoogleSubjectId(genRandom(System.currentTimeMillis())))
 
-  def assertGroupDoesNotExist(samRoutes: TestSamRoutes, groupId: String = groupId): Unit = {
+  def assertGroupDoesNotExist(samRoutes: TestSamRoutes, groupId: String = groupId): Unit =
     Get(s"/api/group/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
-  }
 
-  def assertCreateGroup(samRoutes: TestSamRoutes, groupId: String = groupId): Unit = {
+  def assertCreateGroup(samRoutes: TestSamRoutes, groupId: String = groupId): Unit =
     Post(s"/api/group/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
-  }
 
-  def assertGetGroup(samRoutes: TestSamRoutes, groupId: String = groupId) = {
+  def assertGetGroup(samRoutes: TestSamRoutes, groupId: String = groupId) =
     Get(s"/api/group/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
-  }
 
-  def assertDeleteGroup(samRoutes: TestSamRoutes, groupId: String = groupId) = {
+  def assertDeleteGroup(samRoutes: TestSamRoutes, groupId: String = groupId) =
     Delete(s"/api/group/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
-  }
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
   def makeOtherUser(samRoutes: TestSamRoutes, samUser: SamUser = defaultNewUser) = new {
     runAndWait(samRoutes.userService.createUser(samUser, samRequestContext))
     val email = samUser.email
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, samUser, samRoutes.mockDirectoryDao,  tosService = samRoutes.tosService)
+    val routes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      samUser,
+      samRoutes.mockDirectoryDao,
+      tosService = samRoutes.tosService
+    )
   }
 
-  def setGroupMembers(samRoutes: TestSamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {
+  def setGroupMembers(samRoutes: TestSamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit =
     Put(s"/api/group/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual expectedStatus
     }
-  }
 
   def withUserNotInGroup[T](defaultRoutes: TestSamRoutes)(body: TestSamRoutes => T): T = {
     assertCreateGroup(defaultRoutes)
@@ -86,7 +91,16 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val theDude = Generator.genWorkbenchUserGoogle.sample.get.copy(enabled = true)
     defaultRoutes.directoryDAO.createUser(theDude, samRequestContext).unsafeRunSync()
-    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.mockDirectoryDao, tosService = defaultRoutes.tosService)
+    val dudesRoutes = new TestSamRoutes(
+      defaultRoutes.resourceService,
+      defaultRoutes.policyEvaluatorService,
+      defaultRoutes.userService,
+      defaultRoutes.statusService,
+      defaultRoutes.managedGroupService,
+      theDude,
+      defaultRoutes.mockDirectoryDao,
+      tosService = defaultRoutes.tosService
+    )
 
     body(dudesRoutes)
   }
@@ -102,7 +116,16 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val samRoutes = TestSamRoutes(resourceTypes)
 
     val newGuy = Generator.genWorkbenchUserGoogle.sample.get
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao,  tosService = samRoutes.tosService)
+    val newGuyRoutes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      newGuy,
+      samRoutes.mockDirectoryDao,
+      tosService = samRoutes.tosService
+    )
 
     assertCreateGroup(samRoutes)
     assertGetGroup(samRoutes)
@@ -127,8 +150,16 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuy = Generator.genWorkbenchUserGoogle.sample.get.copy(enabled = true)
     samRoutes.directoryDAO.createUser(newGuy, samRequestContext).unsafeRunSync()
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao,  tosService = samRoutes.tosService)
-
+    val newGuyRoutes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      newGuy,
+      samRoutes.mockDirectoryDao,
+      tosService = samRoutes.tosService
+    )
 
     Get(s"/api/group/$groupId") ~> newGuyRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -187,13 +218,14 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
   it should "fail with 404 if the authenticated user is not in the owner policy for the group" in {
     val defaultRoutes = TestSamRoutes(resourceTypes)
-    withUserNotInGroup(defaultRoutes){ nonMemberRoutes =>
-    assertGetGroup(nonMemberRoutes)
-    Delete(s"/api/group/$groupId") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
+    withUserNotInGroup(defaultRoutes) { nonMemberRoutes =>
+      assertGetGroup(nonMemberRoutes)
+      Delete(s"/api/group/$groupId") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+      assertGetGroup(nonMemberRoutes)
+      assertGetGroup(defaultRoutes)
     }
-    assertGetGroup(nonMemberRoutes)
-    assertGetGroup(defaultRoutes)}
   }
 
   "GET /api/group/{groupName}/member" should "succeed with 200 when the group exists and the requesting user is in the group" in {
@@ -214,7 +246,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 
     Get(s"/api/group/$groupId/member") ~> newGuy.routes.route ~> check {
@@ -223,11 +254,10 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 
   it should "fail with 404 when the requesting user is not in the group" in {
-    withUserNotInGroup( TestSamRoutes(resourceTypes)
-    ) { nonMemberRoutes =>
-
-    Get(s"/api/group/$groupId/members") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound}
+    withUserNotInGroup(TestSamRoutes(resourceTypes)) { nonMemberRoutes =>
+      Get(s"/api/group/$groupId/members") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
     }
   }
 
@@ -246,7 +276,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Get(s"/api/group/$groupId/blah") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
-      responseAs[String] should include ("must be one of")
+      responseAs[String] should include("must be one of")
     }
   }
 
@@ -260,7 +290,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Put(s"/api/group/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -270,7 +300,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
   }
@@ -303,7 +332,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val members = Set(newGuyEmail)
     Put(s"/api/group/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -315,7 +344,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Get(s"/api/group/$groupId/admin") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[String] should include (TestSamRoutes.defaultUserInfo.email.value)
+      responseAs[String] should include(TestSamRoutes.defaultUserInfo.email.value)
     }
   }
 
@@ -326,7 +355,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 
     Get(s"/api/group/$groupId/admin") ~> newGuy.routes.route ~> check {
@@ -335,11 +363,10 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 
   it should "fail with 404 when the requesting user is not in the group" in {
-    withUserNotInGroup( TestSamRoutes(resourceTypes)
-    ) { nonMemberRoutes =>
-
-    Get(s"/api/group/$groupId/admin") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound}
+    withUserNotInGroup(TestSamRoutes(resourceTypes)) { nonMemberRoutes =>
+      Get(s"/api/group/$groupId/admin") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
     }
   }
 
@@ -361,7 +388,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Put(s"/api/group/$groupId/admin", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -371,7 +398,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     val members = Set(newGuy.email)
     Put(s"/api/group/$groupId/admin", members) ~> samRoutes.route ~> check {
@@ -413,7 +439,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     val members = Set(newGuyEmail)
     Put(s"/api/group/$groupId/admin", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -423,7 +449,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     Put(s"/api/group/$groupId/admin/${newGuy.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
@@ -470,7 +495,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     Put(s"/api/group/$groupId/xmen/${newGuy.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
@@ -482,7 +506,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     Put(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> newGuy.routes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -501,12 +524,12 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
   it should "respond with a 404 when the user does not have access to modify the group" in {
     val samRoutes = TestSamRoutes(resourceTypes)
-    withUserNotInGroup(samRoutes){ nonMemberRoutes =>
+    withUserNotInGroup(samRoutes) { nonMemberRoutes =>
       Put(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> nonMemberRoutes.route ~> check {
         status shouldEqual StatusCodes.NotFound
       }
       Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
+        status shouldEqual StatusCodes.NotFound
       }
     }
   }
@@ -547,7 +570,6 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     Delete(s"/api/group/$groupId/admin/${samRoutes.user.email}") ~> newGuy.routes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
@@ -562,15 +584,14 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     Get("/api/groups") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val res = responseAs[String]
-      groupNames.foreach(res should include (_))
-      res should include ("admin")
-      res shouldNot include ("member")
+      groupNames.foreach(res should include(_))
+      res should include("admin")
+      res shouldNot include("member")
     }
   }
 
   it should "respond with 200 and an empty list if the user is not a member of any managed groups" in {
     val samRoutes = TestSamRoutes(resourceTypes)
-
 
     Get("/api/groups") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -663,7 +684,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Get(s"/api/group/$groupId/accessInstructions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[String] shouldEqual (instructions)
+      responseAs[String] shouldEqual instructions
     }
   }
 
@@ -705,7 +726,7 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
 
     Post(s"/api/group/$groupId/requestAccess") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (instructions)
+      responseAs[String] should include(instructions)
     }
   }
 
@@ -718,8 +739,12 @@ class ManagedGroupRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
   }
 }
 
-object ManagedGroupRoutesSpec{
-  def createSamRoutesWithResource(resourceTypeMap: Map[ResourceTypeName, ResourceType], resource: Resource)(implicit system: ActorSystem, materializer: Materializer, ec: ExecutionContext): TestSamRoutes ={
+object ManagedGroupRoutesSpec {
+  def createSamRoutesWithResource(resourceTypeMap: Map[ResourceTypeName, ResourceType], resource: Resource)(implicit
+      system: ActorSystem,
+      materializer: Materializer,
+      ec: ExecutionContext
+  ): TestSamRoutes = {
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceTypeMap, directoryDAO)
     val samRoutes = TestSamRoutes(resourceTypeMap, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -19,60 +19,65 @@ import scala.language.reflectiveCalls
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/**
-  * Created by gpolumbo on 2/26/2017.
+/** Created by gpolumbo on 2/26/2017.
   */
 class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matchers with ScalatestRouteTest with TestSupport with BeforeAndAfter {
 
   private val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
-  private val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+  private val policyActions: Set[ResourceAction] =
+    accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
   private val resourceActions = Set(ResourceAction("delete"), ResourceAction("notify_admins"), ResourceAction("set_access_instructions")) union policyActions
   private val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
   private val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
   private val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
   private val defaultAdminNotifierRole = ResourceRole(ManagedGroupService.adminNotifierRoleName, Set(ResourceAction("notify_admins")))
   private val defaultRoles = Set(defaultOwnerRole, defaultMemberRole, defaultAdminNotifierRole)
-  private val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+  private val managedGroupResourceType =
+    ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
   private val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
   private val groupId = "foo"
   private val defaultNewUser = Generator.genWorkbenchUserGoogle.sample.get
 
-  def assertGroupDoesNotExist(samRoutes: SamRoutes, groupId: String = groupId): Unit = {
+  def assertGroupDoesNotExist(samRoutes: SamRoutes, groupId: String = groupId): Unit =
     Get(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
-  }
 
-  def assertCreateGroup(samRoutes: SamRoutes, groupId: String = groupId): Unit = {
+  def assertCreateGroup(samRoutes: SamRoutes, groupId: String = groupId): Unit =
     Post(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
     }
-  }
 
-  def assertGetGroup(samRoutes: SamRoutes, groupId: String = groupId) = {
+  def assertGetGroup(samRoutes: SamRoutes, groupId: String = groupId) =
     Get(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
-  }
 
-  def assertDeleteGroup(samRoutes: SamRoutes, groupId: String = groupId) = {
+  def assertDeleteGroup(samRoutes: SamRoutes, groupId: String = groupId) =
     Delete(s"/api/groups/v1/$groupId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
-  }
 
   // Makes an anonymous object for a user acting on the same data as the user specified in samRoutes
   def makeOtherUser(samRoutes: SamRoutes, samUser: SamUser = defaultNewUser) = new {
     runAndWait(samRoutes.userService.createUser(samUser, samRequestContext))
     val email = samUser.email
-    val routes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, samUser, samRoutes.directoryDAO, tosService = samRoutes.tosService)
+    val routes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      samUser,
+      samRoutes.directoryDAO,
+      tosService = samRoutes.tosService
+    )
   }
 
-  def setGroupMembers(samRoutes: SamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit = {
+  def setGroupMembers(samRoutes: SamRoutes, members: Set[WorkbenchEmail], expectedStatus: StatusCode): Unit =
     Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual expectedStatus
     }
-  }
 
   def withUserNotInGroup[T](defaultRoutes: SamRoutes)(body: TestSamRoutes => T): T = {
     assertCreateGroup(defaultRoutes)
@@ -80,7 +85,16 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val theDude = Generator.genWorkbenchUserGoogle.sample.get.copy(enabled = true)
     defaultRoutes.directoryDAO.createUser(theDude, samRequestContext).unsafeRunSync()
-    val dudesRoutes = new TestSamRoutes(defaultRoutes.resourceService, defaultRoutes.policyEvaluatorService, defaultRoutes.userService, defaultRoutes.statusService, defaultRoutes.managedGroupService, theDude, defaultRoutes.directoryDAO, tosService = defaultRoutes.tosService)
+    val dudesRoutes = new TestSamRoutes(
+      defaultRoutes.resourceService,
+      defaultRoutes.policyEvaluatorService,
+      defaultRoutes.userService,
+      defaultRoutes.statusService,
+      defaultRoutes.managedGroupService,
+      theDude,
+      defaultRoutes.directoryDAO,
+      tosService = defaultRoutes.tosService
+    )
     body(dudesRoutes)
   }
 
@@ -92,9 +106,19 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   }
 
   it should "respond with 200 if the requesting user is in the member policy for the group" in {
-    val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, Generator.genResourceId.sample.get, Set.empty))
+    val samRoutes =
+      createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, Generator.genResourceId.sample.get, Set.empty))
     val newGuy = Generator.genWorkbenchUserGoogle.sample.get
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.directoryDAO, tosService = samRoutes.tosService)
+    val newGuyRoutes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      newGuy,
+      samRoutes.directoryDAO,
+      tosService = samRoutes.tosService
+    )
 
     assertCreateGroup(samRoutes = samRoutes)
     assertGetGroup(samRoutes = samRoutes)
@@ -119,8 +143,16 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val newGuy = Generator.genWorkbenchUserGoogle.sample.get.copy(enabled = true)
     samRoutes.directoryDAO.createUser(newGuy, samRequestContext).unsafeRunSync()
-    val newGuyRoutes = new TestSamRoutes(samRoutes.resourceService, samRoutes.policyEvaluatorService, samRoutes.userService, samRoutes.statusService, samRoutes.managedGroupService, newGuy, samRoutes.mockDirectoryDao, tosService = samRoutes.tosService)
-
+    val newGuyRoutes = new TestSamRoutes(
+      samRoutes.resourceService,
+      samRoutes.policyEvaluatorService,
+      samRoutes.userService,
+      samRoutes.statusService,
+      samRoutes.managedGroupService,
+      newGuy,
+      samRoutes.mockDirectoryDao,
+      tosService = samRoutes.tosService
+    )
 
     Get(s"/api/groups/v1/$groupId") ~> newGuyRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -179,13 +211,14 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
   it should "fail with 404 if the authenticated user is not in the owner policy for the group" in {
     val defaultRoutes = TestSamRoutes(resourceTypes)
-    withUserNotInGroup(defaultRoutes){ nonMemberRoutes =>
-    assertGetGroup(nonMemberRoutes)
-    Delete(s"/api/groups/v1/$groupId") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound
+    withUserNotInGroup(defaultRoutes) { nonMemberRoutes =>
+      assertGetGroup(nonMemberRoutes)
+      Delete(s"/api/groups/v1/$groupId") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+      assertGetGroup(nonMemberRoutes)
+      assertGetGroup(defaultRoutes)
     }
-    assertGetGroup(nonMemberRoutes)
-    assertGetGroup(defaultRoutes)}
   }
 
   "GET /api/groups/v1/{groupName}/member" should "succeed with 200 when the group exists and the requesting user is in the group" in {
@@ -206,7 +239,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 
     Get(s"/api/groups/v1/$groupId/member") ~> newGuy.routes.route ~> check {
@@ -215,11 +247,10 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   }
 
   it should "fail with 404 when the requesting user is not in the group" in {
-    withUserNotInGroup( TestSamRoutes(resourceTypes)
-    ) { nonMemberRoutes =>
-
-    Get(s"/api/groups/v1/$groupId/members") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound}
+    withUserNotInGroup(TestSamRoutes(resourceTypes)) { nonMemberRoutes =>
+      Get(s"/api/groups/v1/$groupId/members") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
     }
   }
 
@@ -238,7 +269,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Get(s"/api/groups/v1/$groupId/blah") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
-      responseAs[String] should include ("must be one of")
+      responseAs[String] should include("must be one of")
     }
   }
 
@@ -252,7 +283,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -262,7 +293,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
   }
@@ -295,7 +325,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     val members = Set(newGuyEmail)
     Put(s"/api/groups/v1/$groupId/member", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -307,7 +337,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Get(s"/api/groups/v1/$groupId/admin") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[String] should include (TestSamRoutes.defaultUserInfo.email.value)
+      responseAs[String] should include(TestSamRoutes.defaultUserInfo.email.value)
     }
   }
 
@@ -318,7 +348,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 
     Get(s"/api/groups/v1/$groupId/admin") ~> newGuy.routes.route ~> check {
@@ -327,11 +356,10 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   }
 
   it should "fail with 404 when the requesting user is not in the group" in {
-    withUserNotInGroup( TestSamRoutes(resourceTypes)
-    ) { nonMemberRoutes =>
-
-    Get(s"/api/groups/v1/$groupId/admin") ~> nonMemberRoutes.route ~> check {
-      status shouldEqual StatusCodes.NotFound}
+    withUserNotInGroup(TestSamRoutes(resourceTypes)) { nonMemberRoutes =>
+      Get(s"/api/groups/v1/$groupId/admin") ~> nonMemberRoutes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
     }
   }
 
@@ -353,7 +381,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -363,7 +391,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     val members = Set(newGuy.email)
     Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
@@ -405,7 +432,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     val members = Set(newGuyEmail)
     Put(s"/api/groups/v1/$groupId/admin", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (newGuyEmail.toString())
+      responseAs[String] should include(newGuyEmail.toString())
     }
   }
 
@@ -415,7 +442,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     assertCreateGroup(samRoutes)
 
     val newGuy = makeOtherUser(samRoutes)
-
 
     Put(s"/api/groups/v1/$groupId/admin/${newGuy.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
@@ -510,7 +536,8 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
   }
 
   it should "respond with 404 when the policy is invalid" in {
-    val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, Generator.genResourceId.sample.get, Set.empty))
+    val samRoutes =
+      createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, Generator.genResourceId.sample.get, Set.empty))
 
     assertCreateGroup(samRoutes)
 
@@ -526,7 +553,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     val newGuy = makeOtherUser(samRoutes)
 
-
     Delete(s"/api/groups/v1/$groupId/admin/${samRoutes.user.email}") ~> newGuy.routes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
@@ -541,9 +567,9 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     Get("/api/groups/v1") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val res = responseAs[String]
-      groupNames.foreach(res should include (_))
-      res should include ("admin")
-      res shouldNot include ("member")
+      groupNames.foreach(res should include(_))
+      res should include("admin")
+      res shouldNot include("member")
     }
   }
 
@@ -589,7 +615,6 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
   it should "fail with 404 when the group does not exist" in {
     val samRoutes = createSamRoutesWithResource(resourceTypes, Resource(ManagedGroupService.managedGroupTypeName, ResourceId("foo"), Set.empty))
-
 
     Get(s"/api/groups/v1/$groupId/admin") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -638,7 +663,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Get(s"/api/groups/v1/$groupId/accessInstructions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[String] shouldEqual (instructions)
+      responseAs[String] shouldEqual instructions
     }
   }
 
@@ -680,7 +705,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
 
     Post(s"/api/groups/v1/$groupId/requestAccess") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
-      responseAs[String] should include (instructions)
+      responseAs[String] should include(instructions)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamUserDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamUserDirectives.scala
@@ -8,8 +8,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
-/**
-  * Created by dvoet on 6/7/17.
+/** Created by dvoet on 6/7/17.
   */
 trait MockSamUserDirectives extends SamUserDirectives {
   val user: SamUser

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -1,4 +1,4 @@
- package org.broadinstitute.dsde.workbench.sam
+package org.broadinstitute.dsde.workbench.sam
 package api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -19,8 +19,7 @@ import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
-/**
-  * Created by dvoet on 6/7/17.
+/** Created by dvoet on 6/7/17.
   */
 class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
@@ -28,7 +27,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   private val resourceTypes = TestSupport.appConfig.resourceTypes
   private val resourceTypeMap = resourceTypes.map(rt => rt.name -> rt).toMap
-  private val managedGroupResourceType = resourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+  private val managedGroupResourceType =
+    resourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
   private val defaultTestUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -52,11 +52,21 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
     val mockUserService = new UserService(directoryDAO, NoExtensions, Seq.empty, tosService)
     val mockStatusService = new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
+    val mockManagedGroupService =
+      new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
     mockUserService.createUser(defaultUserInfo, samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, samUser, directoryDAO, tosService = tosService)
+    new TestSamRoutes(
+      mockResourceService,
+      policyEvaluatorService,
+      mockUserService,
+      mockStatusService,
+      mockManagedGroupService,
+      samUser,
+      directoryDAO,
+      tosService = tosService
+    )
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {
@@ -76,7 +86,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -100,7 +111,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.testActionAccess, SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.testActionAccess(ResourceAction("can_compute")), SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -131,7 +143,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -164,7 +177,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -189,10 +203,19 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   "POST /api/resource/{resourceType}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -206,14 +229,23 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   it should "400 for resourceTypeAdmin" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)),
+      Set.empty
+    )
     Post(s"/api/resource/${SamResourceTypes.resourceTypeAdminName}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "204 when valid auth domain is provided and the resource type is constrainable" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -222,7 +254,11 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, defaultUserInfo, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -234,17 +270,32 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "400 when resource type allows auth domains and id reuse" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when no policies are provided" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map.empty, Set.empty)
@@ -254,22 +305,39 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "400 when auth domain group does not exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val authDomainId = ResourceId("myAuthDomain")
-    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType), Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty))
+    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(
+      Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType),
+      Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty)
+    )
     resourceType.isAuthDomainConstrainable shouldEqual true
 
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
     // Group is never persisted
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when auth domain group exists but requesting user is not in that group" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -280,14 +348,23 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, otherUser, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resource/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "POST /api/resource/{resourceType}/{resourceId}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -302,7 +379,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/roles" should "200 on list resource roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -316,7 +398,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "404 on list resource roles when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resource/doesntexist/foo/roles") ~> samRoutes.route ~> check {
@@ -330,7 +417,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -345,25 +433,29 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   private def responsePayloadClue(str: String): String = s" -> Here is the response payload: $str"
 
-  private def createUserResourcePolicy(members: AccessPolicyMembership, resourceType: ResourceType, samRoutes: TestSamRoutes, resourceId: ResourceId, policyName: AccessPolicyName): Unit = {
+  private def createUserResourcePolicy(
+      members: AccessPolicyMembership,
+      resourceType: ResourceType,
+      samRoutes: TestSamRoutes,
+      resourceId: ResourceId,
+      policyName: AccessPolicyName
+  ): Unit = {
     findOrCreateUser(samRoutes.user, samRoutes.userService)
 
     Post(s"/api/resource/${resourceType.name}/${resourceId.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent withClue responsePayloadClue(responseAs[String])
     }
 
-
     Put(s"/api/resource/${resourceType.name}/${resourceId.value}/policies/${policyName.value}", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created withClue responsePayloadClue(responseAs[String])
     }
   }
 
-  private def findOrCreateUser(user: SamUser, userService: UserService): UserStatus = {
+  private def findOrCreateUser(user: SamUser, userService: UserService): UserStatus =
     runAndWait(userService.getUserStatus(user.id, samRequestContext = samRequestContext)) match {
       case Some(userStatus) => userStatus
       case None => runAndWait(userService.createUser(user, samRequestContext))
     }
-  }
 
   it should "200 on existing policy of a resource with read_policy" in {
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
@@ -372,7 +464,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicy(policyName)))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -390,7 +483,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -408,7 +502,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -421,7 +516,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   "PUT /api/resource/{resourceType}/{resourceId}/policies/{policyName}" should "201 on a new policy being created for a resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -438,7 +538,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "201 on a policy being updated" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -461,7 +566,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "204 on overwriting a policy's membership" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -484,7 +594,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   }
 
   it should "400 on a policy being created with invalid actions" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -498,13 +613,18 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
     Put(s"/api/resource/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
       fakeActions foreach { action => responseAs[String] should include(action.value) }
-      responseAs[String] should include ("invalid action")
+      responseAs[String] should include("invalid action")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 on a policy being created with invalid roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -517,14 +637,19 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val members = AccessPolicyMembership(Set(defaultTestUser.email), Set(ResourceAction("can_compute")), fakeRoles)
 
     Put(s"/api/resource/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
-      fakeRoles foreach { role => responseAs[String] should include (role.value) }
-      responseAs[String] should include ("invalid role")
+      fakeRoles foreach { role => responseAs[String] should include(role.value) }
+      responseAs[String] should include("invalid role")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 on a policy being created with invalid member emails" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -537,15 +662,20 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val nonExistingMembers = AccessPolicyMembership(Set(badEmail), Set(ResourceAction("can_compute")), Set(ResourceRoleName("owner")))
 
     Put(s"/api/resource/${resourceType.name}/foo/policies/canCompute", nonExistingMembers) ~> samRoutes.route ~> check {
-      responseAs[String] shouldNot include (defaultTestUser.email.value)
-      responseAs[String] should include (badEmail.value)
-      responseAs[String] should include ("invalid member email")
+      responseAs[String] shouldNot include(defaultTestUser.email.value)
+      responseAs[String] should include(badEmail.value)
+      responseAs[String] should include("invalid member email")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 when creating a policy on a resource when the user doesn't have alter_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val members = AccessPolicyMembership(Set(WorkbenchEmail("me@me.me")), Set(ResourceAction("can_compute")), Set.empty)
 
@@ -562,58 +692,78 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     val samRoutes = TestSamRoutes(Map.empty)
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
-    //Create a resource of a type that doesn't exist
+    // Create a resource of a type that doesn't exist
     Put(s"/api/resource/fakeresourcetype/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val otherUserSamRoutes = TestSamRoutes(
+      Map(resourceType.name -> resourceType),
+      Generator.genWorkbenchUserGoogle.sample.get,
+      policyAccessDAO = Some(policyDao),
+      maybeDirectoryDAO = Some(directoryDAO)
+    )
     policyDao.createResource(Resource(ResourceTypeName("rt"), ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //As a different user who isn't on any policy, try to overwrite a policy
+    // As a different user who isn't on any policy, try to overwrite a policy
     Put(s"/api/resource/${resourceType.name}/foo/policies/canCompute", members) ~> otherUserSamRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "GET /api/resource/{resourceType}/{resourceId}/policies" should "200 when listing policies for a resource and user has read_policies permission" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
   }
 
   it should "403 when listing policies for a resource and user lacks read_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource that doesn't have the read_policies action on any roles
+    // Create a resource that doesn't have the read_policies action on any roles
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Try to read the policies
+    // Try to read the policies
     Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -622,65 +772,86 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   it should "404 when listing policies for a resource type that doesnt exist" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    //List policies for a bogus resource type
+    // List policies for a bogus resource type
     Get(s"/api/resource/fakeresourcetype/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when listing policies for a resource when user can't see the resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
-    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType), Resource(resourceType.name, ResourceId("foo"), Set.empty))
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val samRoutes =
+      ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType), Resource(resourceType.name, ResourceId("foo"), Set.empty))
+    val otherUserSamRoutes = TestSamRoutes(
+      Map(resourceType.name -> resourceType),
+      Generator.genWorkbenchUserGoogle.sample.get,
+      policyAccessDAO = Some(policyDao),
+      maybeDirectoryDAO = Some(directoryDAO)
+    )
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
-    //Create the resource
+    // Create the resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //As a different user, try to read the policies
+    // As a different user, try to read the policies
     Get(s"/api/resource/${resourceType.name}/foo/policies") ~> otherUserSamRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "DELETE /api/resource/{resourceType}/{resourceId}" should "204 when deleting a resource and the user has permission to do so" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "403 when deleting a resource and the user has permission to see the resource but not delete" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resource/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -689,14 +860,19 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
   it should "404 when deleting a resource of a type that doesn't exist" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resource/INVALID_RESOURCE_TYPE/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when deleting a resource that exists but can't be seen by the user" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = createSamRoutes(Map(resourceType.name -> resourceType))
 
     samRoutes.resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -704,27 +880,32 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     runAndWait(samRoutes.userService.createUser(user, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), user, samRequestContext))
 
-    //Verify resource exists by checking for conflict on recreate
+    // Verify resource exists by checking for conflict on recreate
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Conflict
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "GET /api/resource/{resourceType}" should "200" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resource/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resource/${resourceType.name}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
@@ -736,7 +917,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
@@ -753,7 +935,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.sharePolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
@@ -769,7 +952,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val resourceId = ResourceId("foo")
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
@@ -784,11 +968,16 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "400 adding unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
     Put(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
@@ -797,7 +986,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "403 adding without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
@@ -810,7 +1004,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "404 adding without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -825,14 +1024,24 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   "DELETE /api/resource/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 deleting a member" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
@@ -841,14 +1050,24 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "204 deleting a member with can share" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
@@ -857,13 +1076,18 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "400 deleting unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
-    //runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+    // runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
 
     Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
@@ -872,14 +1096,24 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "403 removing without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -888,7 +1122,12 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
   it should "404 removing without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -896,8 +1135,13 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        testUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resource/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -909,7 +1153,8 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val resourceId = ResourceId("foo")
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
@@ -922,4 +1167,3 @@ class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     }
   }
 }
-

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV1Spec.scala
@@ -22,17 +22,17 @@ import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-/**
-  * Created by dvoet on 6/7/17.
+/** Created by dvoet on 6/7/17.
   */
 @deprecated("this allows testing of deprecated functions, remove as part of CA-1783", "")
 class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
   val defaultUserInfo = TestSamRoutes.defaultUserInfo
 
-  private val managedGroupResourceType = configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+  private val managedGroupResourceType =
+    configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
-  private val defaultTestUser =  Generator.genWorkbenchUserGoogle.sample.get
+  private val defaultTestUser = Generator.genWorkbenchUserGoogle.sample.get
 
   "GET /api/resources/v1/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {
     val samRoutes = TestSamRoutes(Map.empty)
@@ -51,7 +51,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -75,7 +76,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.testActionAccess, SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.testActionAccess(ResourceAction("can_compute")), SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -106,7 +108,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -139,7 +142,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -164,10 +168,19 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   "POST /api/resources/v1/{resourceType}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -181,17 +194,31 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   it should "400 for resourceTypeAdmin" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)),
+      Set.empty
+    )
     Post(s"/api/resources/v1/${SamResourceTypes.resourceTypeAdminName}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "POST /api/resources/v1/{resourceType} with createResource = true" should "201 create resource with content" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty, Some(true))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(true)
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
       val r = responseAs[CreateResourceResponse]
@@ -200,7 +227,7 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       r.authDomain shouldEqual createResourceRequest.authDomain
       r.resourceTypeName shouldEqual resourceType.name
 
-      val returnedNames = r.accessPolicies.map( x => x.id.accessPolicyName )
+      val returnedNames = r.accessPolicies.map(x => x.id.accessPolicyName)
       createResourceRequest.policies.keys.foreach { k =>
         returnedNames.contains(k) shouldEqual true
       }
@@ -208,17 +235,32 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   "POST /api/resources/v1/{resourceType} with createResource = false" should "204 create resource with content" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty, Some(false))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false)
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "204 when valid auth domain is provided and the resource type is constrainable" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -227,7 +269,11 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, defaultUserInfo, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -239,17 +285,32 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "400 when resource type allows auth domains and id reuse" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when no policies are provided" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map.empty, Set.empty)
@@ -259,24 +320,41 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "400 when auth domain group does not exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
 
     val authDomainId = ResourceId("myAuthDomain")
-    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType), Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty))
+    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(
+      Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType),
+      Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty)
+    )
 
     resourceType.isAuthDomainConstrainable shouldEqual true
 
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
     // Group is never persisted
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when auth domain group exists but requesting user is not in that group" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -287,14 +365,23 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, otherUser, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v1/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "POST /api/resources/v1/{resourceType}/{resourceId}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -309,7 +396,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   "GET /api/resources/v1/{resourceType}/{resourceId}/roles" should "200 on list resource roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -323,7 +415,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "404 on list resource roles when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resources/v1/doesntexist/foo/roles") ~> samRoutes.route ~> check {
@@ -332,7 +429,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   "GET /api/resources/v1/{resourceType}/{resourceId}/actions" should "200 on list resource actions" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -346,7 +448,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "404 on list resource actions when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resources/v1/doesntexist/foo/actions") ~> samRoutes.route ~> check {
@@ -360,7 +467,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -375,25 +483,29 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
   private def responsePayloadClue(str: String): String = s" -> Here is the response payload: $str"
 
-  private def createUserResourcePolicy(members: AccessPolicyMembership, resourceType: ResourceType, samRoutes: TestSamRoutes, resourceId: ResourceId, policyName: AccessPolicyName): Unit = {
+  private def createUserResourcePolicy(
+      members: AccessPolicyMembership,
+      resourceType: ResourceType,
+      samRoutes: TestSamRoutes,
+      resourceId: ResourceId,
+      policyName: AccessPolicyName
+  ): Unit = {
     findOrCreateUser(samRoutes.user, samRoutes.userService)
 
     Post(s"/api/resources/v1/${resourceType.name}/${resourceId.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent withClue responsePayloadClue(responseAs[String])
     }
 
-
     Put(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/policies/${policyName.value}", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created withClue responsePayloadClue(responseAs[String])
     }
   }
 
-  private def findOrCreateUser(user: SamUser, userService: UserService): UserStatus = {
+  private def findOrCreateUser(user: SamUser, userService: UserService): UserStatus =
     runAndWait(userService.getUserStatus(user.id, samRequestContext = samRequestContext)) match {
       case Some(userStatus) => userStatus
       case None => runAndWait(userService.createUser(user, samRequestContext))
     }
-  }
 
   it should "200 on existing policy of a resource with read_policy" in {
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set.empty)
@@ -402,7 +514,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicy(policyName)))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -420,7 +533,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -438,7 +552,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -451,7 +566,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   "PUT /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}" should "201 on a new policy being created for a resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -468,7 +588,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "201 on a policy being updated" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -491,7 +616,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "204 on overwriting a policy's membership" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -514,7 +644,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   }
 
   it should "400 on a policy being created with invalid actions" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -528,13 +663,18 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
     Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
       fakeActions foreach { action => responseAs[String] should include(action.value) }
-      responseAs[String] should include ("invalid action")
+      responseAs[String] should include("invalid action")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 on a policy being created with invalid roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -547,14 +687,19 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     val members = AccessPolicyMembership(Set(defaultTestUser.email), Set(ResourceAction("can_compute")), fakeRoles)
 
     Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
-      fakeRoles foreach { role => responseAs[String] should include (role.value) }
-      responseAs[String] should include ("invalid role")
+      fakeRoles foreach { role => responseAs[String] should include(role.value) }
+      responseAs[String] should include("invalid role")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 on a policy being created with invalid member emails" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -567,15 +712,20 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     val nonExistingMembers = AccessPolicyMembership(Set(badEmail), Set(ResourceAction("can_compute")), Set(ResourceRoleName("owner")))
 
     Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", nonExistingMembers) ~> samRoutes.route ~> check {
-      responseAs[String] shouldNot include (defaultTestUser.email.value)
-      responseAs[String] should include (badEmail.value)
-      responseAs[String] should include ("invalid member email")
+      responseAs[String] shouldNot include(defaultTestUser.email.value)
+      responseAs[String] should include(badEmail.value)
+      responseAs[String] should include("invalid member email")
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 when creating a policy on a resource when the user doesn't have alter_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val members = AccessPolicyMembership(Set(WorkbenchEmail("me@me.me")), Set(ResourceAction("can_compute")), Set.empty)
 
@@ -592,59 +742,79 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     val samRoutes = TestSamRoutes(Map.empty)
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
-    //Create a resource of a type that doesn't exist
+    // Create a resource of a type that doesn't exist
     Put(s"/api/resources/v1/fakeresourcetype/foo/policies/canCompute", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when creating a policy on a resource that the user doesnt have permission to see" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceType, directoryDAO)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val otherUserSamRoutes = TestSamRoutes(
+      Map(resourceType.name -> resourceType),
+      Generator.genWorkbenchUserGoogle.sample.get,
+      policyAccessDAO = Some(policyDao),
+      maybeDirectoryDAO = Some(directoryDAO)
+    )
     val members = AccessPolicyMembership(Set(WorkbenchEmail("foo@bar.baz")), Set(ResourceAction("can_compute")), Set.empty)
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //As a different user who isn't on any policy, try to overwrite a policy
+    // As a different user who isn't on any policy, try to overwrite a policy
     Put(s"/api/resources/v1/${resourceType.name}/foo/policies/canCompute", members) ~> otherUserSamRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "GET /api/resources/v1/{resourceType}/{resourceId}/policies" should "200 when listing policies for a resource and user has read_policies permission" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
   }
 
   it should "403 when listing policies for a resource and user lacks read_policies permission (but can see the resource)" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource that doesn't have the read_policies action on any roles
+    // Create a resource that doesn't have the read_policies action on any roles
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Try to read the policies
+    // Try to read the policies
     Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -653,68 +823,88 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   it should "404 when listing policies for a resource type that doesnt exist" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    //List policies for a bogus resource type
+    // List policies for a bogus resource type
     Get(s"/api/resources/v1/fakeresourcetype/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when listing policies for a resource when user can't see the resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceType, directoryDAO)
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(Resource(resourceType.name, ResourceId("foo"), Set.empty), samRequestContext).unsafeRunSync()
 
-    val otherUserSamRoutes = TestSamRoutes(Map(resourceType.name -> resourceType), Generator.genWorkbenchUserGoogle.sample.get, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
+    val otherUserSamRoutes = TestSamRoutes(
+      Map(resourceType.name -> resourceType),
+      Generator.genWorkbenchUserGoogle.sample.get,
+      policyAccessDAO = Some(policyDao),
+      maybeDirectoryDAO = Some(directoryDAO)
+    )
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //As a different user, try to read the policies
+    // As a different user, try to read the policies
     Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> otherUserSamRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "DELETE /api/resources/v1/{resourceType}/{resourceId}" should "204 when deleting a resource and the user has permission to do so" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "403 when deleting a resource and the user has permission to see the resource but not delete" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resources/v1/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -723,14 +913,19 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
   it should "404 when deleting a resource of a type that doesn't exist" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v1/INVALID_RESOURCE_TYPE/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when deleting a resource that exists but can't be seen by the user" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     samRoutes.resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -738,27 +933,32 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.userService.createUser(user, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), user, samRequestContext))
 
-    //Verify resource exists by checking for conflict on recreate
+    // Verify resource exists by checking for conflict on recreate
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Conflict
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "GET /api/resources/v1/{resourceType}" should "200" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resources/v1/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resources/v1/${resourceType.name}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[List[UserPolicyResponse]].size should equal(1)
@@ -770,19 +970,31 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName("owner")), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName("owner")
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     val policyName = AccessPolicyName("bar")
     val members = AccessPolicyMembership(Set.empty, Set.empty, Set.empty)
     createUserResourcePolicy(members, resourceType, samRoutes, resourceId, policyName)
-    samRoutes.resourceService.setPublic(model.FullyQualifiedPolicyId(model.FullyQualifiedResourceId(resourceType.name, resourceId), policyName), true, samRequestContext).unsafeRunSync()
+    samRoutes.resourceService
+      .setPublic(model.FullyQualifiedPolicyId(model.FullyQualifiedResourceId(resourceType.name, resourceId), policyName), true, samRequestContext)
+      .unsafeRunSync()
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resources/v1/${resourceType.name}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[List[UserPolicyResponse]].size should equal(2) withClue responsePayloadClue(responseAs[String])
@@ -795,13 +1007,16 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -812,46 +1027,68 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.sharePolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "400 adding unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
-    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 adding without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "404 adding without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -866,70 +1103,118 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
   "DELETE /api/resources/v1/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 deleting a member" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "204 deleting a member with can share" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "400 deleting unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
-    //runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+    // runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
 
-    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 removing without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "404 removing without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -937,8 +1222,13 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        testUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resources/v1/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -950,7 +1240,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -968,7 +1259,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicy(AccessPolicyName("owner"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -986,7 +1278,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.delete),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -1003,12 +1296,21 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-        model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1023,7 +1325,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.sharePolicy, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner")), SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val resourceTypeAdmin = ResourceType(
       ResourceTypeName("resource_type_admin"),
@@ -1038,14 +1341,24 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       Set(
         ResourceRole(
           ResourceRoleName("owner"),
-          Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies, SamResourceActions.setPublicPolicy(AccessPolicyName("owner"))))),
+          Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies, SamResourceActions.setPublicPolicy(AccessPolicyName("owner")))
+        )
+      ),
       ResourceRoleName("owner")
     )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-        model.FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1060,12 +1373,21 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-        model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1080,7 +1402,8 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -1107,8 +1430,17 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -1128,7 +1460,13 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
     Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
@@ -1152,8 +1490,12 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap =
+      Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1175,8 +1517,17 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v1/fakeResourceTypeName/$resourceId/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1202,8 +1553,17 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v1/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -1219,8 +1579,14 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
 
   private def initManagedGroupResourceType(): ResourceType = {
     val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
-    val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
-    val resourceActions = Set(ResourceAction("delete"), ResourceAction("notify_admins"), ResourceAction("set_access_instructions"), ManagedGroupService.useAction) union policyActions
+    val policyActions: Set[ResourceAction] =
+      accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val resourceActions = Set(
+      ResourceAction("delete"),
+      ResourceAction("notify_admins"),
+      ResourceAction("set_access_instructions"),
+      ManagedGroupService.useAction
+    ) union policyActions
     val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
     val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
     val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
@@ -1316,4 +1682,3 @@ class ResourceRoutesV1Spec extends AnyFlatSpec with Matchers with ScalatestRoute
     }
   }
 }
-

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -41,8 +41,10 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     ResourceRoleName("owner")
   )
 
-  private def createSamRoutes(resourceTypes: Map[ResourceTypeName, ResourceType] = Map(defaultResourceType.name -> defaultResourceType),
-                              samUser: SamUser = defaultUserInfo): SamRoutes = {
+  private def createSamRoutes(
+      resourceTypes: Map[ResourceTypeName, ResourceType] = Map(defaultResourceType.name -> defaultResourceType),
+      samUser: SamUser = defaultUserInfo
+  ): SamRoutes = {
     val directoryDAO = new MockDirectoryDAO()
     val accessPolicyDAO = new MockAccessPolicyDAO(resourceTypes, directoryDAO)
     val emailDomain = "example.com"
@@ -55,16 +57,27 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
     val mockUserService = new UserService(directoryDAO, NoExtensions, Seq.empty, tosService)
     val mockStatusService = new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
+    val mockManagedGroupService =
+      new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
     mockUserService.createUser(samUser, samRequestContext)
 
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, samUser, directoryDAO, tosService = tosService)
+    new TestSamRoutes(
+      mockResourceService,
+      policyEvaluatorService,
+      mockUserService,
+      mockStatusService,
+      mockManagedGroupService,
+      samUser,
+      directoryDAO,
+      tosService = tosService
+    )
   }
 
-  private val managedGroupResourceType = configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+  private val managedGroupResourceType =
+    configResourceTypes.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
-  private val defaultTestUser =  Generator.genWorkbenchUserGoogle.sample.get
+  private val defaultTestUser = Generator.genWorkbenchUserGoogle.sample.get
 
   "GET /api/resources/v2/{resourceType}/{resourceId}/actions/{action}" should "404 for unknown resource type" in {
     val samRoutes = TestSamRoutes(Map.empty)
@@ -84,10 +97,19 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   "POST /api/resources/v2/{resourceType}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -101,17 +123,31 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   it should "400 for resourceTypeAdmin" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set.empty)),
+      Set.empty
+    )
     Post(s"/api/resources/v2/${SamResourceTypes.resourceTypeAdminName}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "POST /api/resources/v2/{resourceType} with returnResource = true" should "201 create resource with content" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty, Some(true))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(true)
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
       val r = responseAs[CreateResourceResponse]
@@ -120,7 +156,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       r.authDomain shouldEqual createResourceRequest.authDomain
       r.resourceTypeName shouldEqual resourceType.name
 
-      val returnedNames = r.accessPolicies.map( x => x.id.accessPolicyName )
+      val returnedNames = r.accessPolicies.map(x => x.id.accessPolicyName)
       createResourceRequest.policies.keys.foreach { k =>
         returnedNames.contains(k) shouldEqual true
       }
@@ -128,72 +164,146 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   "POST /api/resources/v2/{resourceType} with returnResource = false" should "204 create resource with content" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty, Some(false))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false)
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "204 create resource with content with parent" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent, SamResourceActions.addChild))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent, SamResourceActions.addChild))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createParentResourceRequest = CreateResourceRequest(ResourceId("parent"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false))
+    val createParentResourceRequest = CreateResourceRequest(
+      ResourceId("parent"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false)
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createParentResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false), Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId)))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false),
+      Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId))
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "400 with parent when parents not allowed" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.addChild))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.addChild))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createParentResourceRequest = CreateResourceRequest(ResourceId("parent"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false))
+    val createParentResourceRequest = CreateResourceRequest(
+      ResourceId("parent"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false)
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createParentResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false), Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId)))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false),
+      Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId))
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 with parent when add_child not allowed on parent" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createParentResourceRequest = CreateResourceRequest(ResourceId("parent"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false))
+    val createParentResourceRequest = CreateResourceRequest(
+      ResourceId("parent"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false)
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createParentResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false), Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId)))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false),
+      Some(FullyQualifiedResourceId(resourceType.name, createParentResourceRequest.resourceId))
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "403 with parent when parent does not exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern(SamResourceActions.setParent.value, "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.setParent))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))), Set.empty, Some(false), Some(FullyQualifiedResourceId(resourceType.name, ResourceId("parent"))))
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(resourceType.ownerRoleName))),
+      Set.empty,
+      Some(false),
+      Some(FullyQualifiedResourceId(resourceType.name, ResourceId("parent")))
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "204 when valid auth domain is provided and the resource type is constrainable" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -202,7 +312,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, defaultUserInfo, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
@@ -214,17 +328,32 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "400 when resource type allows auth domains and id reuse" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), Set.empty)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      Set.empty
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when no policies are provided" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map.empty, Set.empty)
@@ -234,24 +363,41 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "400 when auth domain group does not exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
 
     val authDomainId = ResourceId("myAuthDomain")
-    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType), Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty))
+    val samRoutes = ManagedGroupRoutesSpec.createSamRoutesWithResource(
+      Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType),
+      Resource(ManagedGroupService.managedGroupTypeName, authDomainId, Set.empty)
+    )
 
     resourceType.isAuthDomainConstrainable shouldEqual true
 
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
     // Group is never persisted
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "400 when auth domain group exists but requesting user is not in that group" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", true)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", true)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     resourceType.isAuthDomainConstrainable shouldEqual true
@@ -262,14 +408,23 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(authDomainId, otherUser, samRequestContext = samRequestContext))
     val authDomain = Set(WorkbenchGroupName(authDomainId.value))
 
-    val createResourceRequest = CreateResourceRequest(ResourceId("foo"), Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))), authDomain)
+    val createResourceRequest = CreateResourceRequest(
+      ResourceId("foo"),
+      Map(AccessPolicyName("goober") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("run")), Set(resourceType.ownerRoleName))),
+      authDomain
+    )
     Post(s"/api/resources/v2/${resourceType.name}", createResourceRequest) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "POST /api/resources/v2/{resourceType}/{resourceId}" should "204 create resource" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -284,28 +439,35 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   "DELETE /api/resources/v2/{resourceType}/{resourceId}/leave" should "204 when a user tries to leave a resource with allowLeaving enabled" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true, None)
     runAndWait(samRoutes.userService.createUser(secondUser, samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email, secondUser.email), Set.empty, Set(ResourceRoleName("owner"))))
+    val policiesMap =
+      Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email, secondUser.email), Set.empty, Set(ResourceRoleName("owner"))))
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
-    //Verify that user does actually have access to the resource that they created
+    // Verify that user does actually have access to the resource that they created
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run"))
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Verify that the user no longer has any actions on the resource
+    // Verify that the user no longer has any actions on the resource
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set.empty)
@@ -313,7 +475,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user tries to leave a resource with allowLeaving disabled" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = false)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = false
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -327,7 +495,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user tries to leave a resource with allowLeaving enabled but has indirect access" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val managedGroupResourceType = initManagedGroupResourceType()
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
@@ -347,23 +521,29 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user tries to leave a resource with allowLeaving enabled but the resource would become orphaned" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
 
-    //Create the resource with default policies
+    // Create the resource with default policies
     Post(s"/api/resources/v2/${resourceType.name}/${resourceId.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
       responseAs[ErrorReport].message should equal("You may not leave a resource if you are the only owner. Please add another owner before leaving.")
     }
 
-    //Verify that the user did not leave the resource
+    // Verify that the user did not leave the resource
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run"))
@@ -371,7 +551,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "204 when a user tries to leave a public resource with allowLeaving enabled and the user has other means of access" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false), ResourceActionPattern("view", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false), ResourceActionPattern("view", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     // create a second owner so our test user can leave the owner policy without orphaning the resource
@@ -385,20 +571,23 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     )
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.setPublic(FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), AccessPolicyName("ap-public")), true, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService
+        .setPublic(FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), AccessPolicyName("ap-public")), true, samRequestContext)
+    )
 
-    //Verify that user does actually have access to the resource that they created
+    // Verify that user does actually have access to the resource that they created
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run", "view"))
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Verify that the user now only has the public actions on the resource
+    // Verify that the user now only has the public actions on the resource
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("view"))
@@ -406,28 +595,37 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user tries to leave a public resource with allowLeaving enabled and they don't have other means of access" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
     val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set.empty, Set(ResourceRoleName("owner"))))
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.setPublic(FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), AccessPolicyName("ap")), true, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService
+        .setPublic(FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, resourceId), AccessPolicyName("ap")), true, samRequestContext)
+    )
 
-    //Verify that user does actually have access to the resource that they created
+    // Verify that user does actually have access to the resource that they created
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run"))
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
       responseAs[ErrorReport].message should equal("You may not leave a public resource.")
     }
 
-    //Verify that the user no longer has any actions on the resource
+    // Verify that the user no longer has any actions on the resource
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run"))
@@ -435,7 +633,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when leaving a resource type that has not explicitly set allowLeaving to true" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val resourceId = ResourceId("foo")
@@ -449,7 +652,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       responseAs[String] should equal(s"Leaving a resource of type ${resourceType.name.value} is not supported")
     }
 
-    //Verify that the user did not leave the resource
+    // Verify that the user did not leave the resource
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set("run"))
@@ -457,7 +660,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user attempts to leave a resource that they do not have access to" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true, None)
@@ -467,13 +676,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(secondUser.email), Set.empty, Set(ResourceRoleName("owner"))))
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
-    //Verify that user does actually have access to the resource that they created
+    // Verify that user does actually have access to the resource that they created
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set.empty)
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
       responseAs[ErrorReport].message should equal("You can only leave a resource that you have direct access to.")
@@ -481,16 +690,22 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "403 when a user attempts to leave a resource that does not exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"), allowLeaving = true)
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner"),
+      allowLeaving = true
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Verify that user does actually have access to the resource that they created
+    // Verify that user does actually have access to the resource that they created
     Get(s"/api/resources/v2/${resourceType.name}/doesnt-exist/actions") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] should equal(Set.empty)
     }
 
-    //Leave the resource
+    // Leave the resource
     Delete(s"/api/resources/v2/${resourceType.name}/doesnt-exist/leave") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
       responseAs[ErrorReport].message should equal("You can only leave a resource that you have direct access to.")
@@ -498,7 +713,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   "GET /api/resources/v2/{resourceType}/{resourceId}/roles" should "200 on list resource roles" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -512,7 +732,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "404 on list resource roles when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resources/v2/doesntexist/foo/roles") ~> samRoutes.route ~> check {
@@ -521,7 +746,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   "GET /api/resources/v2/{resourceType}/{resourceId}/actions" should "200 on list resource actions" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
@@ -535,7 +765,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   }
 
   it should "404 on list resource actions when resource type doesnt exist" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(ResourceActionPattern("run", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(ResourceActionPattern("run", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     Get(s"/api/resources/v2/doesntexist/foo/actions") ~> samRoutes.route ~> check {
@@ -546,40 +781,50 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   private def responsePayloadClue(str: String): String = s" -> Here is the response payload: $str"
 
   "DELETE /api/resources/v2/{resourceType}/{resourceId}" should "204 when deleting a resource and the user has permission to do so" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies, SamResourceActionPatterns.delete),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete, SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resources/v2/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "403 when deleting a resource and the user has permission to see the resource but not delete" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create the resource
+    // Create the resource
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies to make sure the resource exists)
+    // Read the policies to make sure the resource exists)
     Get(s"/api/resources/v2/${resourceType.name}/foo/policies") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -588,14 +833,19 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   it should "404 when deleting a resource of a type that doesn't exist" in {
     val samRoutes = TestSamRoutes(Map.empty)
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/INVALID_RESOURCE_TYPE/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "404 when deleting a resource that exists but can't be seen by the user" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("run")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     samRoutes.resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -603,12 +853,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.userService.createUser(user, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), user, samRequestContext))
 
-    //Verify resource exists by checking for conflict on recreate
+    // Verify resource exists by checking for conflict on recreate
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Conflict
     }
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
@@ -619,11 +869,14 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
 
-    setupParentRoutes(samRoutes, childResource,
+    setupParentRoutes(
+      samRoutes,
+      childResource,
       currentParentOpt = Option(currentParentResource),
-      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete))
+      actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete)
+    )
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
       withClue(responseAs[String]) {
         status shouldEqual StatusCodes.NoContent
@@ -636,31 +889,43 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val parentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
     val samRoutes = createSamRoutes(Map(defaultResourceType.name -> defaultResourceType))
 
-    setupParentRoutes(samRoutes, childResource,
+    setupParentRoutes(
+      samRoutes,
+      childResource,
       currentParentOpt = Option(parentResource),
       actionsOnChild = Set(SamResourceActions.setParent, SamResourceActions.delete),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
+      actionsOnCurrentParent = Set(SamResourceActions.removeChild)
+    )
 
-    //Throw 400 exception when delete is called
+    // Throw 400 exception when delete is called
     when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext]))
-      .thenThrow(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again.")))
+      .thenThrow(
+        new WorkbenchExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Cannot delete a resource with children. Delete the children first then try again.")
+        )
+      )
 
-    //Delete the resource
+    // Delete the resource
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${childResource.resourceId.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   "GET /api/resources/v2/{resourceType}" should "200" in {
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.readPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    //Create a resource
+    // Create a resource
     Post(s"/api/resources/v2/${resourceType.name}/foo") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
 
-    //Read the policies
+    // Read the policies
     Get(s"/api/resources/v2/${resourceType.name}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[List[UserResourcesResponse]].size should equal(1)
@@ -673,13 +938,16 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -690,46 +958,68 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.sharePolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "400 adding unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 adding without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "404 adding without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -744,70 +1034,118 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   "DELETE /api/resources/v2/{resourceType}/{resourceId}/policies/{policyName}/memberEmails/{email}" should "204 deleting a member" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "204 deleting a member with can share" in {
     // happy case
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.sharePolicy, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "400 deleting unknown subject" in {
     // differs from happy case in that we don't create user
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    //runAndWait(samRoutes.userService.createUser(testUser))
+    // runAndWait(samRoutes.userService.createUser(testUser))
 
-    //runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
+    // runAndWait(samRoutes.resourceService.addSubjectToPolicy(ResourceAndPolicyName(Resource(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id))
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
 
   it should "403 removing without permission" in {
     // differs from happy case in that owner role does not have alter_policies
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy), Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.userService.createUser(defaultTestUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), defaultTestUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        defaultTestUser.id,
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${defaultTestUser.email}"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "404 removing without any access" in {
     // differs from happy case in that testUser creates resource, not defaultUser which calls the PUT
-    val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))), ResourceRoleName("owner"))
+    val resourceType = ResourceType(
+      ResourceTypeName("rt"),
+      Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -815,8 +1153,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(resourceType.name,  ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)), testUser.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        testUser.id,
+        samRequestContext
+      )
+    )
 
     Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberEmails/${testUser.email}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -825,25 +1168,28 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   "PUT /api/resources/v2/{resourceTypeName}/{resourceId}/policies/{policyName}/memberPolicies/{memberResourceTypeName}" +
     "/{memberResourceId}/{memberPolicyName}" should "204 adding a member" in {
-    // happy path
-    val resourceType = ResourceType(
-      ResourceTypeName("rt"),
-      Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
+      // happy path
+      val resourceType = ResourceType(
+        ResourceTypeName("rt"),
+        Set(SamResourceActionPatterns.alterPolicies),
+        Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+        ResourceRoleName("owner")
+      )
+      val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+      runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
+      runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
 
-    val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
-    val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
-    runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
+      val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
+      val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
+      runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
 
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
+      Put(
+        s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+      ) ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
     }
-  }
 
   it should "403 adding without alter_policies permission" in {
     // differs from happy case in that owner role does not have alter_policies
@@ -851,12 +1197,15 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -867,7 +1216,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -876,37 +1226,41 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
 
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
-    Put(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   "DELETE /api/resources/v2/{resourceTypeName}/{resourceId}/policies/{policyName}/memberPolicies/{memberResourceTypeName}" +
     "/{memberResourceId}/{memberPolicyName}" should "204 deleting a member" in {
-    // happy path
-    val resourceType = ResourceType(
-      ResourceTypeName("rt"),
-      Set(SamResourceActionPatterns.alterPolicies),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
-      ResourceRoleName("owner"))
-    val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
+      // happy path
+      val resourceType = ResourceType(
+        ResourceTypeName("rt"),
+        Set(SamResourceActionPatterns.alterPolicies),
+        Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies))),
+        ResourceRoleName("owner")
+      )
+      val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
+      runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
+      runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
 
-    val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
-    val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
-    runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
+      val memberResource = FullyQualifiedResourceId(resourceType.name, ResourceId("bar"))
+      val memberPolicy = FullyQualifiedPolicyId(memberResource, AccessPolicyName("reader"))
+      runAndWait(samRoutes.resourceService.createPolicy(memberPolicy, Set(), Set(), Set(), Set(), samRequestContext))
 
-    val parentPolicyId = FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")),
-      AccessPolicyName(resourceType.ownerRoleName.value))
-    val childPolicyId = FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")),
-      AccessPolicyName("reader"))
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(parentPolicyId, childPolicyId, samRequestContext))
+      val parentPolicyId =
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value))
+      val childPolicyId = FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")), AccessPolicyName("reader"))
+      runAndWait(samRoutes.resourceService.addSubjectToPolicy(parentPolicyId, childPolicyId, samRequestContext))
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.NoContent
+      Delete(
+        s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+      ) ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
     }
-  }
 
   it should "403 removing without alter_policies permission" in {
     // differs from happy case in that owner role does not have alter_policies
@@ -914,20 +1268,23 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.sharePolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("splat"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), defaultUserInfo, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), defaultUserInfo, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")),
-        AccessPolicyName(resourceType.ownerRoleName.value)),
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")),
-        AccessPolicyName("reader")),
-      samRequestContext
-    ))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")), AccessPolicyName("reader")),
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -938,7 +1295,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false)),
       Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("can_compute")))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
     val testUser = Generator.genWorkbenchUserGoogle.sample.get
 
@@ -947,15 +1305,17 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("foo"), testUser, samRequestContext))
     runAndWait(samRoutes.resourceService.createResource(resourceType, ResourceId("bar"), testUser, samRequestContext))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")),
-        AccessPolicyName(resourceType.ownerRoleName.value)),
-      FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")),
-        AccessPolicyName("reader")),
-      samRequestContext
-    ))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("foo")), AccessPolicyName(resourceType.ownerRoleName.value)),
+        FullyQualifiedPolicyId(FullyQualifiedResourceId(resourceType.name, ResourceId("bar")), AccessPolicyName("reader")),
+        samRequestContext
+      )
+    )
 
-    Delete(s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader") ~> samRoutes.route ~> check {
+    Delete(
+      s"/api/resources/v2/${resourceType.name}/foo/policies/${resourceType.ownerRoleName}/memberPolicies/${resourceType.name}/bar/reader"
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -965,7 +1325,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -983,7 +1344,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicy),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicy(AccessPolicyName("owner"))))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -1001,7 +1363,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.delete),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.delete))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -1018,12 +1381,21 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-      model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1038,7 +1410,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.sharePolicy, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.sharePolicy(AccessPolicyName("owner")), SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val resourceTypeAdmin = ResourceType(
       ResourceTypeName("resource_type_admin"),
@@ -1053,14 +1426,24 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       Set(
         ResourceRole(
           ResourceRoleName("owner"),
-          Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies, SamResourceActions.setPublicPolicy(AccessPolicyName("owner"))))),
+          Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies, SamResourceActions.setPublicPolicy(AccessPolicyName("owner")))
+        )
+      ),
       ResourceRoleName("owner")
     )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-      model.FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1075,12 +1458,21 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    runAndWait(samRoutes.resourceService.addSubjectToPolicy(model.FullyQualifiedPolicyId(
-      model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)), AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)), samRoutes.user.id, samRequestContext))
+    runAndWait(
+      samRoutes.resourceService.addSubjectToPolicy(
+        model.FullyQualifiedPolicyId(
+          model.FullyQualifiedResourceId(TestSamRoutes.resourceTypeAdmin.name, ResourceId(resourceType.name.value)),
+          AccessPolicyName(TestSamRoutes.resourceTypeAdmin.ownerRoleName.value)
+        ),
+        samRoutes.user.id,
+        samRequestContext
+      )
+    )
 
     val resourceId = ResourceId("foo")
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, samRoutes.user, samRequestContext))
@@ -1095,7 +1487,8 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       ResourceTypeName("rt"),
       Set(SamResourceActionPatterns.alterPolicies, SamResourceActionPatterns.readPolicies),
       Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.alterPolicies, SamResourceActions.readPolicies))),
-      ResourceRoleName("owner"))
+      ResourceRoleName("owner")
+    )
 
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
@@ -1122,8 +1515,17 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -1143,7 +1545,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
     runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set.empty, None, defaultUserInfo.id, samRequestContext))
 
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
@@ -1167,8 +1575,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap =
+      Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1190,8 +1602,17 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v2/fakeResourceTypeName/$resourceId/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1217,8 +1638,17 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId(authDomain), defaultUserInfo, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
-    val policiesMap = Map(AccessPolicyName("ap") -> AccessPolicyMembership(Set(defaultUserInfo.email), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction), Set(ResourceRoleName("owner"))))
-    runAndWait(samRoutes.resourceService.createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext))
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembership(
+        Set(defaultUserInfo.email),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
+    )
 
     Get(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -1234,8 +1664,14 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
   private def initManagedGroupResourceType(): ResourceType = {
     val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
-    val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
-    val resourceActions = Set(ResourceAction("delete"), ResourceAction("notify_admins"), ResourceAction("set_access_instructions"), ManagedGroupService.useAction) union policyActions
+    val policyActions: Set[ResourceAction] =
+      accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val resourceActions = Set(
+      ResourceAction("delete"),
+      ResourceAction("notify_admins"),
+      ResourceAction("set_access_instructions"),
+      ManagedGroupService.useAction
+    ) union policyActions
     val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
     val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
     val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
@@ -1331,9 +1767,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     }
   }
 
-  private def mockPermissionsForResource(samRoutes: SamRoutes,
-                                         resource: FullyQualifiedResourceId,
-                                         actionsOnResource: Set[ResourceAction]): Unit = {
+  private def mockPermissionsForResource(samRoutes: SamRoutes, resource: FullyQualifiedResourceId, actionsOnResource: Set[ResourceAction]): Unit = {
 
     val actionAllowed = new ArgumentMatcher[Iterable[ResourceAction]] {
       override def matches(argument: Iterable[ResourceAction]): Boolean = actionsOnResource.intersect(argument.toSet).nonEmpty
@@ -1342,24 +1776,28 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
       override def matches(argument: Iterable[ResourceAction]): Boolean = actionsOnResource.intersect(argument.toSet).isEmpty
     }
 
-    when(samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionAllowed), mockitoEq(defaultUserInfo.id), any[SamRequestContext])).
-      thenReturn(IO.pure(true))
+    when(
+      samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionAllowed), mockitoEq(defaultUserInfo.id), any[SamRequestContext])
+    ).thenReturn(IO.pure(true))
 
-    when(samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionNotAllowed), mockitoEq(defaultUserInfo.id), any[SamRequestContext])).
-      thenReturn(IO.pure(false))
+    when(
+      samRoutes.policyEvaluatorService.hasPermissionOneOf(mockitoEq(resource), argThat(actionNotAllowed), mockitoEq(defaultUserInfo.id), any[SamRequestContext])
+    ).thenReturn(IO.pure(false))
 
-    when(samRoutes.policyEvaluatorService.listUserResourceActions(mockitoEq(resource), mockitoEq(defaultUserInfo.id), any[SamRequestContext])).
-      thenReturn(IO.pure(actionsOnResource))
+    when(samRoutes.policyEvaluatorService.listUserResourceActions(mockitoEq(resource), mockitoEq(defaultUserInfo.id), any[SamRequestContext]))
+      .thenReturn(IO.pure(actionsOnResource))
   }
 
   // mock out a bunch of calls in ResourceService and PolicyEvaluatorService to reduce bloat in /parent tests
-  private def setupParentRoutes(samRoutes: SamRoutes,
-                                childResource: FullyQualifiedResourceId,
-                                currentParentOpt: Option[FullyQualifiedResourceId] = None,
-                                newParentOpt: Option[FullyQualifiedResourceId] = None,
-                                actionsOnChild: Set[ResourceAction],
-                                actionsOnCurrentParent: Set[ResourceAction] = Set.empty,
-                                actionsOnNewParent: Set[ResourceAction] = Set.empty): Unit = {
+  private def setupParentRoutes(
+      samRoutes: SamRoutes,
+      childResource: FullyQualifiedResourceId,
+      currentParentOpt: Option[FullyQualifiedResourceId] = None,
+      newParentOpt: Option[FullyQualifiedResourceId] = None,
+      actionsOnChild: Set[ResourceAction],
+      actionsOnCurrentParent: Set[ResourceAction] = Set.empty,
+      actionsOnNewParent: Set[ResourceAction] = Set.empty
+  ): Unit = {
     // mock responses for child resource
     mockPermissionsForResource(samRoutes, childResource, actionsOnResource = actionsOnChild)
 
@@ -1370,8 +1808,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
           .thenReturn(IO(Option(currentParent)))
         when(samRoutes.resourceService.deleteResourceParent(mockitoEq(childResource), any[SamRequestContext]))
           .thenReturn(IO.pure(true))
-        mockPermissionsForResource(samRoutes, currentParent,
-          actionsOnResource = actionsOnCurrentParent)
+        mockPermissionsForResource(samRoutes, currentParent, actionsOnResource = actionsOnCurrentParent)
       case None =>
         when(samRoutes.resourceService.getResourceParent(mockitoEq(childResource), any[SamRequestContext]))
           .thenReturn(IO(None))
@@ -1396,9 +1833,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val fullyQualifiedParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(fullyQualifiedParentResource),
-      actionsOnChild = Set(SamResourceActions.getParent))
+      actionsOnChild = Set(SamResourceActions.getParent)
+    )
 
     Get(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -1411,8 +1851,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val fullyQualifiedParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource, currentParentOpt = Option(fullyQualifiedParentResource),
-      actionsOnChild = Set(SamResourceActions.readPolicies))
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
+      currentParentOpt = Option(fullyQualifiedParentResource),
+      actionsOnChild = Set(SamResourceActions.readPolicies)
+    )
 
     Get(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1446,11 +1890,18 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val fullyQualifiedParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("parent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource, newParentOpt = Option(fullyQualifiedParentResource),
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
+      newParentOpt = Option(fullyQualifiedParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", fullyQualifiedParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      fullyQualifiedParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -1461,14 +1912,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnCurrentParent = Set(SamResourceActions.removeChild),
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
@@ -1479,14 +1936,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.readPolicies),
       actionsOnCurrentParent = Set(SamResourceActions.removeChild),
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1497,14 +1960,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnCurrentParent = Set(SamResourceActions.removeChild),
-      actionsOnNewParent = Set(SamResourceActions.readPolicies))
+      actionsOnNewParent = Set(SamResourceActions.readPolicies)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1515,14 +1984,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnCurrentParent = Set(SamResourceActions.readPolicies),
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1533,14 +2008,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set.empty,
       actionsOnCurrentParent = Set(SamResourceActions.removeChild),
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
@@ -1551,14 +2032,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnCurrentParent = Set(SamResourceActions.removeChild),
-      actionsOnNewParent = Set(SamResourceActions.readPolicies))
+      actionsOnNewParent = Set(SamResourceActions.readPolicies)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1568,14 +2055,19 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val nonexistentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("nonexistentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = None,
       newParentOpt = Option(nonexistentParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnNewParent = Set(SamResourceActions.readPolicies)
     )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", nonexistentParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      nonexistentParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1586,14 +2078,20 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       newParentOpt = Option(newParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
       actionsOnCurrentParent = Set.empty,
-      actionsOnNewParent = Set(SamResourceActions.addChild))
+      actionsOnNewParent = Set(SamResourceActions.addChild)
+    )
 
-    Put(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent", newParentResource) ~> samRoutes.route ~> check {
+    Put(
+      s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent",
+      newParentResource
+    ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -1603,10 +2101,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
+      actionsOnCurrentParent = Set(SamResourceActions.removeChild)
+    )
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
@@ -1618,10 +2119,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       actionsOnChild = Set(SamResourceActions.readPolicies),
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
+      actionsOnCurrentParent = Set(SamResourceActions.removeChild)
+    )
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1633,10 +2137,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
-      actionsOnCurrentParent = Set(SamResourceActions.readPolicies))
+      actionsOnCurrentParent = Set(SamResourceActions.readPolicies)
+    )
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1647,8 +2154,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val fullyQualifiedChildResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("child"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
-      actionsOnChild = Set(SamResourceActions.setParent))
+    setupParentRoutes(samRoutes, fullyQualifiedChildResource, actionsOnChild = Set(SamResourceActions.setParent))
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1660,10 +2166,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       actionsOnChild = Set.empty,
-      actionsOnCurrentParent = Set(SamResourceActions.removeChild))
+      actionsOnCurrentParent = Set(SamResourceActions.removeChild)
+    )
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1675,10 +2184,13 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val currentParentResource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("currentParent"))
     val samRoutes = createSamRoutes()
 
-    setupParentRoutes(samRoutes, fullyQualifiedChildResource,
+    setupParentRoutes(
+      samRoutes,
+      fullyQualifiedChildResource,
       currentParentOpt = Option(currentParentResource),
       actionsOnChild = Set(SamResourceActions.setParent),
-      actionsOnCurrentParent = Set.empty)
+      actionsOnCurrentParent = Set.empty
+    )
 
     Delete(s"/api/resources/v2/${defaultResourceType.name}/${fullyQualifiedChildResource.resourceId.value}/parent") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1719,8 +2231,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, parent,
-      actionsOnResource = Set.empty)
+    mockPermissionsForResource(samRoutes, parent, actionsOnResource = Set.empty)
 
     Get(s"/api/resources/v2/${defaultResourceType.name}/${parent.resourceId.value}/children") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1733,8 +2244,11 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyToDelete.accessPolicyName)))
+    mockPermissionsForResource(
+      samRoutes,
+      resource,
+      actionsOnResource = Set(SamResourceActions.alterPolicies, SamResourceActions.deletePolicy(policyToDelete.accessPolicyName))
+    )
     when(samRoutes.resourceService.deletePolicy(mockitoEq(policyToDelete), any[SamRequestContext]))
       .thenReturn(IO.unit)
 
@@ -1746,12 +2260,12 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
   it should "403 if user is missing both alter_policies and delete_policy on the resource" in {
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("resource"))
     val policyToDelete = FullyQualifiedPolicyId(resource, AccessPolicyName("policyToDelete"))
-    val otherPolicy = AccessPolicyWithoutMembers(FullyQualifiedPolicyId(resource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false)
+    val otherPolicy =
+      AccessPolicyWithoutMembers(FullyQualifiedPolicyId(resource, AccessPolicyName("not_owner")), WorkbenchEmail(""), Set.empty, Set.empty, false)
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.readPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.readPolicies))
 
     Delete(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyToDelete.accessPolicyName}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1764,8 +2278,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set.empty)
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set.empty)
 
     Delete(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyToDelete.accessPolicyName}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1779,8 +2292,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.readPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.readPolicies))
 
     // mock response to load policy
     when(samRoutes.resourceService.loadResourcePolicy(mockitoEq(FullyQualifiedPolicyId(resource, policyName)), any[SamRequestContext]))
@@ -1799,8 +2311,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.readPolicy(policyName)))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.readPolicy(policyName)))
 
     // mock response to load policy
     when(samRoutes.resourceService.loadResourcePolicy(mockitoEq(FullyQualifiedPolicyId(resource, policyName)), any[SamRequestContext]))
@@ -1818,8 +2329,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.delete))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.delete))
 
     Get(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyName.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1832,8 +2342,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     val samRoutes = createSamRoutes()
 
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set.empty)
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set.empty)
 
     Get(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyName.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1844,11 +2353,18 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("resource"))
     val policyName = AccessPolicyName("policy")
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute")), Set.empty, None)
-    val policy = AccessPolicy(FullyQualifiedPolicyId(resource, policyName), Set(defaultUserInfo.id), WorkbenchEmail("policy@example.com"), members.roles, members.actions, members.getDescendantPermissions, false)
+    val policy = AccessPolicy(
+      FullyQualifiedPolicyId(resource, policyName),
+      Set(defaultUserInfo.id),
+      WorkbenchEmail("policy@example.com"),
+      members.roles,
+      members.actions,
+      members.getDescendantPermissions,
+      false
+    )
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.alterPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.alterPolicies))
 
     when(samRoutes.resourceService.overwritePolicy(any[ResourceType], mockitoEq(policyName), mockitoEq(resource), mockitoEq(members), any[SamRequestContext]))
       .thenReturn(IO(policy))
@@ -1862,11 +2378,18 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val resource = FullyQualifiedResourceId(defaultResourceType.name, ResourceId("resource"))
     val policyName = AccessPolicyName("policy")
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute")), Set.empty, None)
-    val policy = AccessPolicy(FullyQualifiedPolicyId(resource, policyName), Set(defaultUserInfo.id), WorkbenchEmail("policy@example.com"), members.roles, members.actions, members.getDescendantPermissions, false)
+    val policy = AccessPolicy(
+      FullyQualifiedPolicyId(resource, policyName),
+      Set(defaultUserInfo.id),
+      WorkbenchEmail("policy@example.com"),
+      members.roles,
+      members.actions,
+      members.getDescendantPermissions,
+      false
+    )
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.alterPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.alterPolicies))
 
     when(samRoutes.resourceService.overwritePolicy(any[ResourceType], mockitoEq(policyName), mockitoEq(resource), mockitoEq(members), any[SamRequestContext]))
       .thenReturn(IO(policy))
@@ -1877,7 +2400,15 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
 
     // update existing policy
     val members2 = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute"), ResourceAction("new_action")), Set.empty, None)
-    val policy2 = AccessPolicy(FullyQualifiedPolicyId(resource, policyName), Set(defaultUserInfo.id), WorkbenchEmail("policy@example.com"), members2.roles, members2.actions, members2.getDescendantPermissions, false)
+    val policy2 = AccessPolicy(
+      FullyQualifiedPolicyId(resource, policyName),
+      Set(defaultUserInfo.id),
+      WorkbenchEmail("policy@example.com"),
+      members2.roles,
+      members2.actions,
+      members2.getDescendantPermissions,
+      false
+    )
     when(samRoutes.resourceService.overwritePolicy(any[ResourceType], mockitoEq(policyName), mockitoEq(resource), mockitoEq(members2), any[SamRequestContext]))
       .thenReturn(IO(policy2))
 
@@ -1892,8 +2423,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute")), Set.empty, None)
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.alterPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.alterPolicies))
 
     when(samRoutes.resourceService.overwritePolicy(any[ResourceType], mockitoEq(policyName), mockitoEq(resource), mockitoEq(members), any[SamRequestContext]))
       .thenReturn(IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "You have specified an invalid policy"))))
@@ -1909,8 +2439,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute")), Set.empty, None)
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.readPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.readPolicies))
 
     Put(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyName}", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
@@ -1923,8 +2452,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val members = AccessPolicyMembership(Set(defaultUserInfo.email), Set(ResourceAction("can_compute")), Set.empty, None)
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set.empty)
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set.empty)
 
     Put(s"/api/resources/v2/${resource.resourceTypeName}/${resource.resourceId}/policies/${policyName}", members) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
@@ -1938,8 +2466,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val response = AccessPolicyResponseEntry(policyName, members, WorkbenchEmail("policy@example.com"))
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.readPolicies))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.readPolicies))
 
     when(samRoutes.resourceService.listResourcePolicies(mockitoEq(resource), any[SamRequestContext]))
       .thenReturn(IO(LazyList(response)))
@@ -1956,8 +2483,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val response = AccessPolicyResponseEntry(policyName, members, WorkbenchEmail("policy@example.com"))
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set(SamResourceActions.delete))
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set(SamResourceActions.delete))
 
     when(samRoutes.resourceService.listResourcePolicies(mockitoEq(resource), any[SamRequestContext]))
       .thenReturn(IO(LazyList(response)))
@@ -1974,8 +2500,7 @@ class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport wi
     val response = AccessPolicyResponseEntry(policyName, members, WorkbenchEmail("policy@example.com"))
 
     val samRoutes = createSamRoutes()
-    mockPermissionsForResource(samRoutes, resource,
-      actionsOnResource = Set.empty)
+    mockPermissionsForResource(samRoutes, resource, actionsOnResource = Set.empty)
 
     when(samRoutes.resourceService.listResourcePolicies(mockitoEq(resource), any[SamRequestContext]))
       .thenReturn(IO(LazyList(response)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
@@ -13,8 +13,7 @@ import org.yaml.snakeyaml.Yaml
 
 import scala.jdk.CollectionConverters._
 
-/**
-  * These tests verify that the apis published in swagger/api-docs.yaml call the correct SamUserDirectives.
+/** These tests verify that the apis published in swagger/api-docs.yaml call the correct SamUserDirectives.
   */
 class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
   lazy val routesFromApiYml: Iterable[PathAndMethod] = {
@@ -31,7 +30,7 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
     } yield PathAndMethod(path, method)
   }
 
-  for(PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api")) {
+  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api"))
     s"$method $path" should "call withActiveUser" in {
       val samRoutes = Mockito.spy(TestSamRoutes(Map.empty))
 
@@ -41,9 +40,8 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
         }
       }
     }
-  }
 
-  for(PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/register")) {
+  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/register"))
     s"$method $path" should "call withUserAllowInactive" in {
       val samRoutes = Mockito.spy(TestSamRoutes(Map.empty))
 
@@ -53,9 +51,8 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
         }
       }
     }
-  }
 
-  for(PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/user") || path.startsWith("/api/admin/v1/user")) {
+  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/user") || path.startsWith("/api/admin/v1/user"))
     s"$method $path" should "call withWorkbenchAdmin" in {
       val samRoutes = Mockito.spy(TestSamRoutes(Map.empty))
 
@@ -65,9 +62,8 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
         }
       }
     }
-  }
 
-  for(PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/v1/resourceTypes")) {
+  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/v1/resourceTypes"))
     s"$method $path" should "call asSamSuperAdmin" in {
       val samRoutes = Mockito.spy(TestSamRoutes(Map.empty))
 
@@ -77,16 +73,14 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
         }
       }
     }
-  }
 
-  private def createRequest(path: String, method: String) = {
+  private def createRequest(path: String, method: String) =
     method.toLowerCase match {
       case "get" => Get(path)
       case "put" => Put(path)
       case "post" => Post(path)
       case "delete" => Delete(path)
     }
-  }
 }
 
 case class PathAndMethod(path: String, method: String)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
@@ -24,24 +24,24 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.ExecutionContext
 
 class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTesting with ScalatestRouteTest with ScalaFutures with MockitoSugar with TestSupport {
-  def directives(dirDAO: DirectoryDAO = new MockDirectoryDAO(), tosConfig: TermsOfServiceConfig = TestSupport.tosConfig): StandardSamUserDirectives = new StandardSamUserDirectives {
-    override implicit val executionContext: ExecutionContext = null
-    override val directoryDAO: DirectoryDAO = dirDAO
-    override val cloudExtensions: CloudExtensions = null
-    override val termsOfServiceConfig: TermsOfServiceConfig = null
-    override val userService: UserService = null
-    override val tosService: TosService = new TosService(dirDAO, googleServicesConfig.appsDomain, tosConfig)
-  }
+  def directives(dirDAO: DirectoryDAO = new MockDirectoryDAO(), tosConfig: TermsOfServiceConfig = TestSupport.tosConfig): StandardSamUserDirectives =
+    new StandardSamUserDirectives {
+      override implicit val executionContext: ExecutionContext = null
+      override val directoryDAO: DirectoryDAO = dirDAO
+      override val cloudExtensions: CloudExtensions = null
+      override val termsOfServiceConfig: TermsOfServiceConfig = null
+      override val userService: UserService = null
+      override val tosService: TosService = new TosService(dirDAO, googleServicesConfig.appsDomain, tosConfig)
+    }
 
   "getSamUser" should "be able to get a SamUser object for regular user" in {
-    forAll(minSuccessful(20)) {
-      (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
-        val directoryDAO = new MockDirectoryDAO()
-        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(googleSubjectId = externalId.left.toOption, azureB2CId = externalId.toOption)
-        val oidcHeaders = OIDCHeaders(token, externalId, email, None)
-        directoryDAO.createUser(user, samRequestContext).unsafeRunSync()
-        val res = getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
-        res should be (user)
+    forAll(minSuccessful(20)) { (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
+      val directoryDAO = new MockDirectoryDAO()
+      val user = Generator.genWorkbenchUserGoogle.sample.get.copy(googleSubjectId = externalId.left.toOption, azureB2CId = externalId.toOption)
+      val oidcHeaders = OIDCHeaders(token, externalId, email, None)
+      directoryDAO.createUser(user, samRequestContext).unsafeRunSync()
+      val res = getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
+      res should be(user)
     }
   }
 
@@ -51,10 +51,15 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
       (serviceSubjectId: ServiceAccountSubjectId, user: SamUser, token: OAuth2BearerToken, email: WorkbenchEmail) =>
         val directoryDAO = new MockDirectoryDAO()
         directoryDAO.createUser(user, samRequestContext).unsafeRunSync()
-        directoryDAO.createPetServiceAccount(PetServiceAccount(PetServiceAccountId(user.id, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))), samRequestContext).unsafeRunSync()
+        directoryDAO
+          .createPetServiceAccount(
+            PetServiceAccount(PetServiceAccountId(user.id, GoogleProject("")), ServiceAccount(serviceSubjectId, email, ServiceAccountDisplayName(""))),
+            samRequestContext
+          )
+          .unsafeRunSync()
         val oidcHeaders = OIDCHeaders(token, Left(GoogleSubjectId(serviceSubjectId.value)), email, None)
         val res = getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
-        res should be (user)
+        res should be(user)
     }
   }
 
@@ -65,24 +70,23 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
         val oidcHeaders = OIDCHeaders(token, Left(serviceAccountUser.googleSubjectId.get), serviceAccountUser.email, None)
         directoryDAO.createUser(serviceAccountUser, samRequestContext).unsafeRunSync()
         val res = getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
-        res should be (serviceAccountUser)
+        res should be(serviceAccountUser)
     }
   }
 
   it should "fail if provided externalId doesn't exist in sam" in {
-    forAll {
-      (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
-        val directoryDAO = new MockDirectoryDAO()
-        val oidcHeaders = OIDCHeaders(token, externalId, email, None)
-        val res = intercept[WorkbenchExceptionWithErrorReport] {
-          getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
-        }
-        res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
+    forAll { (token: OAuth2BearerToken, email: WorkbenchEmail, externalId: Either[GoogleSubjectId, AzureB2CId]) =>
+      val directoryDAO = new MockDirectoryDAO()
+      val oidcHeaders = OIDCHeaders(token, externalId, email, None)
+      val res = intercept[WorkbenchExceptionWithErrorReport] {
+        getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
+      }
+      res.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
     }
   }
 
   it should "fail if PET account is not found" in {
-    forAll(genOAuth2BearerToken, genServiceAccountEmail, genGoogleSubjectId){
+    forAll(genOAuth2BearerToken, genServiceAccountEmail, genGoogleSubjectId) {
       (token: OAuth2BearerToken, email: WorkbenchEmail, googleSubjectId: GoogleSubjectId) =>
         val directoryDAO = new MockDirectoryDAO()
         val oidcHeaders = OIDCHeaders(token, Left(googleSubjectId), email, None)
@@ -114,20 +118,28 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
         directoryDAO.createUser(workbenchUser, samRequestContext).unsafeRunSync()
         val res = getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeRunSync()
         val expectedUser = workbenchUser.copy(azureB2CId = Option(azureB2CId))
-        res should be (expectedUser)
+        res should be(expectedUser)
         directoryDAO.loadUser(workbenchUser.id, samRequestContext).unsafeRunSync() shouldBe Option(expectedUser)
     }
   }
 
-  "withActiveUser" should "accept request with oidc headers" in forAll(genExternalId, genNonPetEmail, genOAuth2BearerToken, genWorkbenchUserId, minSuccessful(20)) { (externalId, email, accessToken, userId) =>
+  "withActiveUser" should "accept request with oidc headers" in forAll(
+    genExternalId,
+    genNonPetEmail,
+    genOAuth2BearerToken,
+    genWorkbenchUserId,
+    minSuccessful(20)
+  ) { (externalId, email, accessToken, userId) =>
     val services = directives()
     val headers = createRequiredHeaders(externalId, email, accessToken)
-    val user = services.directoryDAO.createUser(SamUser(userId, externalId.left.toOption, email = email, azureB2CId = externalId.toOption, true, None), samRequestContext).unsafeRunSync()
+    val user = services.directoryDAO
+      .createUser(SamUser(userId, externalId.left.toOption, email = email, azureB2CId = externalId.toOption, true, None), samRequestContext)
+      .unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(x => complete(x.toString))} ~> check {
-      status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual user.toString
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(x => complete(x.toString))) ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldEqual user.toString
+      }
   }
 
   it should "fail if user is disabled" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
@@ -135,9 +147,9 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(Right(user.azureB2CId.get), user.email, token)
     services.directoryDAO.createUser(user.copy(enabled = false), samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(_ => complete(""))} ~> check {
-      status shouldBe StatusCodes.Unauthorized
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
   }
 
   it should "fail if user has rejected terms of service" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
@@ -146,9 +158,9 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     services.directoryDAO.createUser(user.copy(enabled = true), samRequestContext).unsafeRunSync()
     services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(_ => complete(""))} ~> check {
-      status shouldBe StatusCodes.Unauthorized
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
+        status shouldBe StatusCodes.Unauthorized
+      }
   }
 
   it should "pass if user has rejected terms of service within grace period" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
@@ -157,9 +169,9 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     services.directoryDAO.createUser(user.copy(enabled = true), samRequestContext).unsafeRunSync()
     services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(_ => complete(""))} ~> check {
-      status shouldBe StatusCodes.OK
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
+        status shouldBe StatusCodes.OK
+      }
   }
 
   it should "pass if service account has rejected terms" in forAll(genWorkbenchUserServiceAccount, genOAuth2BearerToken) { (user, token) =>
@@ -168,9 +180,9 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     services.directoryDAO.createUser(user.copy(enabled = true), samRequestContext).unsafeRunSync()
     services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(_ => complete(""))} ~> check {
-      status shouldBe StatusCodes.OK
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
+        status shouldBe StatusCodes.OK
+      }
   }
 
   it should "pass if user has accepted terms of service" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
@@ -179,78 +191,88 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     services.directoryDAO.createUser(user.copy(enabled = true), samRequestContext).unsafeRunSync()
     services.tosService.acceptTosStatus(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withActiveUser(samRequestContext)(_ => complete(""))} ~> check {
-      status shouldBe StatusCodes.OK
-    }
+      handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
+        status shouldBe StatusCodes.OK
+      }
   }
 
   it should "fail if required headers are missing" in {
-    Get("/") ~> handleExceptions(myExceptionHandler){directives().withActiveUser(samRequestContext)(x => complete(x.toString))} ~> check {
+    Get("/") ~> handleExceptions(myExceptionHandler)(directives().withActiveUser(samRequestContext)(x => complete(x.toString))) ~> check {
       rejection shouldBe MissingHeaderRejection(accessTokenHeader)
     }
   }
 
-  it should "populate google id if google id from azure matches existing user" in forAll(genAzureB2CId, genWorkbenchUserGoogle, genOAuth2BearerToken) { (azureB2CId, googleUser, accessToken) =>
-    val services = directives(new MockDirectoryDAO())
-    val headers = createRequiredHeaders(Right(azureB2CId), googleUser.email, accessToken, googleUser.googleSubjectId)
-    val existingUser = services.directoryDAO.createUser(googleUser.copy(enabled = true), samRequestContext).unsafeRunSync()
-    Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler) {
-        services.withActiveUser(samRequestContext)(x => complete(x.toString))
-      } ~> check {
-      status shouldBe StatusCodes.OK
-      val exptectedUser = existingUser.copy(azureB2CId = Option(azureB2CId))
-      responseAs[String] shouldEqual exptectedUser.toString
-      services.directoryDAO.loadUser(existingUser.id, samRequestContext).unsafeRunSync() shouldEqual Some(exptectedUser)
-    }
+  it should "populate google id if google id from azure matches existing user" in forAll(genAzureB2CId, genWorkbenchUserGoogle, genOAuth2BearerToken) {
+    (azureB2CId, googleUser, accessToken) =>
+      val services = directives(new MockDirectoryDAO())
+      val headers = createRequiredHeaders(Right(azureB2CId), googleUser.email, accessToken, googleUser.googleSubjectId)
+      val existingUser = services.directoryDAO.createUser(googleUser.copy(enabled = true), samRequestContext).unsafeRunSync()
+      Get("/").withHeaders(headers) ~>
+        handleExceptions(myExceptionHandler) {
+          services.withActiveUser(samRequestContext)(x => complete(x.toString))
+        } ~> check {
+          status shouldBe StatusCodes.OK
+          val exptectedUser = existingUser.copy(azureB2CId = Option(azureB2CId))
+          responseAs[String] shouldEqual exptectedUser.toString
+          services.directoryDAO.loadUser(existingUser.id, samRequestContext).unsafeRunSync() shouldEqual Some(exptectedUser)
+        }
   }
 
-  it should "pass if google id from azure does not exist" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken, genGoogleSubjectId) { (azureUser, accessToken, googleSubjectId) =>
-    val services = directives(new MockDirectoryDAO())
-    services.directoryDAO.createUser(azureUser.copy(enabled = true), samRequestContext).unsafeRunSync()
-    val headers = createRequiredHeaders(Right(azureUser.azureB2CId.get), azureUser.email, accessToken, Option(googleSubjectId))
-    Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler) {
-        services.withActiveUser(samRequestContext)(x => complete(x.toString))
-      } ~> check {
-      status shouldBe StatusCodes.OK
-    }
+  it should "pass if google id from azure does not exist" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken, genGoogleSubjectId) {
+    (azureUser, accessToken, googleSubjectId) =>
+      val services = directives(new MockDirectoryDAO())
+      services.directoryDAO.createUser(azureUser.copy(enabled = true), samRequestContext).unsafeRunSync()
+      val headers = createRequiredHeaders(Right(azureUser.azureB2CId.get), azureUser.email, accessToken, Option(googleSubjectId))
+      Get("/").withHeaders(headers) ~>
+        handleExceptions(myExceptionHandler) {
+          services.withActiveUser(samRequestContext)(x => complete(x.toString))
+        } ~> check {
+          status shouldBe StatusCodes.OK
+        }
   }
 
-  "withNewUser" should "accept request with oidc headers" in forAll(genExternalId, genNonPetEmail, genOAuth2BearerToken, minSuccessful(20)) { (externalId, email, accessToken) =>
-    val services = directives()
-    val headers = createRequiredHeaders(externalId, email, accessToken)
-    Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler){services.withNewUser(samRequestContext)(user => complete(user.copy(id = WorkbenchUserId("")).toString))} ~> check {
-      status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption, false, None).toString
-    }
+  "withNewUser" should "accept request with oidc headers" in forAll(genExternalId, genNonPetEmail, genOAuth2BearerToken, minSuccessful(20)) {
+    (externalId, email, accessToken) =>
+      val services = directives()
+      val headers = createRequiredHeaders(externalId, email, accessToken)
+      Get("/").withHeaders(headers) ~>
+        handleExceptions(myExceptionHandler) {
+          services.withNewUser(samRequestContext)(user => complete(user.copy(id = WorkbenchUserId("")).toString))
+        } ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption, false, None).toString
+        }
   }
 
-  it should "populate google id from azure" in forAll(genAzureB2CId, genNonPetEmail, genOAuth2BearerToken, genGoogleSubjectId) { (azureB2CId, email, accessToken, googleSubjectId) =>
-    val services = directives()
-    val headers = createRequiredHeaders(Right(azureB2CId), email, accessToken, Option(googleSubjectId))
-    Get("/").withHeaders(headers) ~>
-      handleExceptions(myExceptionHandler) {
-        services.withNewUser(samRequestContext)(x => complete(x.copy(id = WorkbenchUserId("")).toString))
-      } ~> check {
-      status shouldBe StatusCodes.OK
-      responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId), false, None).toString
-    }
+  it should "populate google id from azure" in forAll(genAzureB2CId, genNonPetEmail, genOAuth2BearerToken, genGoogleSubjectId) {
+    (azureB2CId, email, accessToken, googleSubjectId) =>
+      val services = directives()
+      val headers = createRequiredHeaders(Right(azureB2CId), email, accessToken, Option(googleSubjectId))
+      Get("/").withHeaders(headers) ~>
+        handleExceptions(myExceptionHandler) {
+          services.withNewUser(samRequestContext)(x => complete(x.copy(id = WorkbenchUserId("")).toString))
+        } ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId), false, None).toString
+        }
   }
 
   it should "fail if required headers are missing" in {
-    Get("/") ~> handleExceptions(myExceptionHandler){directives().withNewUser(samRequestContext)(x => complete(x.toString))} ~> check {
+    Get("/") ~> handleExceptions(myExceptionHandler)(directives().withNewUser(samRequestContext)(x => complete(x.toString))) ~> check {
       rejection shouldBe MissingHeaderRejection(accessTokenHeader)
     }
   }
 
-  private def createRequiredHeaders(externalId: Either[GoogleSubjectId, AzureB2CId], email: WorkbenchEmail, accessToken: OAuth2BearerToken, googleIdFromAzure: Option[GoogleSubjectId] = None) = {
+  private def createRequiredHeaders(
+      externalId: Either[GoogleSubjectId, AzureB2CId],
+      email: WorkbenchEmail,
+      accessToken: OAuth2BearerToken,
+      googleIdFromAzure: Option[GoogleSubjectId] = None
+  ) =
     List(
       RawHeader(emailHeader, email.value),
       RawHeader(userIdHeader, externalId.fold(_.value, _.value)),
-      RawHeader(accessTokenHeader, accessToken.token),
+      RawHeader(accessTokenHeader, accessToken.token)
     ) ++ googleIdFromAzure.map(gid => RawHeader(googleIdFromAzureHeader, gid.value))
-  }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, Mo
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
-import org.broadinstitute.dsde.workbench.util.health.Subsystems.{Database}
+import org.broadinstitute.dsde.workbench.util.health.Subsystems.Database
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -17,7 +17,6 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
-
 
   "GET /version" should "give 200 for ok" in {
     val samRoutes = TestSamRoutes(Map.empty)
@@ -52,7 +51,16 @@ class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val mockStatusService = new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef)
     val mockManagedGroupService = new ManagedGroupService(mockResourceService, null, Map.empty, policyDAO, directoryDAO, NoExtensions, emailDomain)
     val policyEvaluatorService = PolicyEvaluatorService(emailDomain, Map.empty, policyDAO, directoryDAO)
-    val samRoutes = new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, Generator.genWorkbenchUserGoogle.sample.get, directoryDAO, tosService = tosService)
+    val samRoutes = new TestSamRoutes(
+      mockResourceService,
+      policyEvaluatorService,
+      mockUserService,
+      mockStatusService,
+      mockManagedGroupService,
+      Generator.genWorkbenchUserGoogle.sample.get,
+      directoryDAO,
+      tosService = tosService
+    )
 
     Get("/status") ~> samRoutes.route ~> check {
       responseAs[StatusCheckResponse].ok shouldEqual false

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -20,17 +20,70 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext
 
-/**
-  * Created by dvoet on 7/14/17.
+/** Created by dvoet on 7/14/17.
   */
-class TestSamRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO,  val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureService: Option[AzureService] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(false, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, azureService) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamRoutes(
+    resourceService: ResourceService,
+    policyEvaluatorService: PolicyEvaluatorService,
+    userService: UserService,
+    statusService: StatusService,
+    managedGroupService: ManagedGroupService,
+    val user: SamUser,
+    directoryDAO: DirectoryDAO,
+    val cloudExtensions: CloudExtensions = NoExtensions,
+    override val newSamUser: Option[SamUser] = None,
+    tosService: TosService,
+    override val azureService: Option[AzureService] = None
+)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+    extends SamRoutes(
+      resourceService,
+      userService,
+      statusService,
+      managedGroupService,
+      TermsOfServiceConfig(false, false, "0", "app.terra.bio/#terms-of-service"),
+      directoryDAO,
+      policyEvaluatorService,
+      tosService,
+      LiquibaseConfig("", false),
+      FakeOpenIDConnectConfiguration,
+      azureService
+    )
+    with MockSamUserDirectives
+    with ExtensionRoutes
+    with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
 }
 
-class TestSamTosEnabledRoutes(resourceService: ResourceService, policyEvaluatorService: PolicyEvaluatorService, userService: UserService, statusService: StatusService, managedGroupService: ManagedGroupService, val user: SamUser, directoryDAO: DirectoryDAO,  val cloudExtensions: CloudExtensions = NoExtensions, override val newSamUser: Option[SamUser] = None, tosService: TosService, override val azureService: Option[AzureService] = None)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
-  extends SamRoutes(resourceService, userService, statusService, managedGroupService, TermsOfServiceConfig(true, false, "0", "app.terra.bio/#terms-of-service"), directoryDAO, policyEvaluatorService, tosService, LiquibaseConfig("", false), FakeOpenIDConnectConfiguration, azureService) with MockSamUserDirectives with ExtensionRoutes with ScalaFutures {
+class TestSamTosEnabledRoutes(
+    resourceService: ResourceService,
+    policyEvaluatorService: PolicyEvaluatorService,
+    userService: UserService,
+    statusService: StatusService,
+    managedGroupService: ManagedGroupService,
+    val user: SamUser,
+    directoryDAO: DirectoryDAO,
+    val cloudExtensions: CloudExtensions = NoExtensions,
+    override val newSamUser: Option[SamUser] = None,
+    tosService: TosService,
+    override val azureService: Option[AzureService] = None
+)(implicit override val system: ActorSystem, override val materializer: Materializer, override val executionContext: ExecutionContext)
+    extends SamRoutes(
+      resourceService,
+      userService,
+      statusService,
+      managedGroupService,
+      TermsOfServiceConfig(true, false, "0", "app.terra.bio/#terms-of-service"),
+      directoryDAO,
+      policyEvaluatorService,
+      tosService,
+      LiquibaseConfig("", false),
+      FakeOpenIDConnectConfiguration,
+      azureService
+    )
+    with MockSamUserDirectives
+    with ExtensionRoutes
+    with ScalaFutures {
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def mockDirectoryDao: DirectoryDAO = directoryDAO
 }
@@ -82,14 +135,15 @@ object TestSamRoutes {
     ResourceRoleName("owner")
   )
 
-  def apply(resourceTypes: Map[ResourceTypeName, ResourceType],
-            user: SamUser = defaultUserInfo,
-            policyAccessDAO: Option[AccessPolicyDAO] = None,
-            maybeDirectoryDAO: Option[MockDirectoryDAO] = None,
-            cloudExtensions: Option[CloudExtensions] = None,
-            adminEmailDomains: Option[Set[String]] = None,
-            crlService: Option[CrlService] = None
-           )(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext) = {
+  def apply(
+      resourceTypes: Map[ResourceTypeName, ResourceType],
+      user: SamUser = defaultUserInfo,
+      policyAccessDAO: Option[AccessPolicyDAO] = None,
+      maybeDirectoryDAO: Option[MockDirectoryDAO] = None,
+      cloudExtensions: Option[CloudExtensions] = None,
+      adminEmailDomains: Option[Set[String]] = None,
+      crlService: Option[CrlService] = None
+  )(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext) = {
     val dbRef = TestSupport.dbRef
     val resourceTypesWithAdmin = resourceTypes + (resourceTypeAdmin.name -> resourceTypeAdmin)
     // need to make sure MockDirectoryDAO and MockAccessPolicyDAO share the same groups
@@ -109,9 +163,11 @@ object TestSamRoutes {
       emailDomain,
       allowedAdminEmailDomains = adminEmailDomains.getOrElse(Set.empty)
     )
-    val mockUserService = new UserService(directoryDAO, cloudXtns, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
+    val mockUserService =
+      new UserService(directoryDAO, cloudXtns, Seq.empty, new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
     val mockTosService = new TosService(directoryDAO, emailDomain, TestSupport.tosConfig)
-    val mockManagedGroupService = new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypesWithAdmin, policyDAO, directoryDAO, cloudXtns, emailDomain)
+    val mockManagedGroupService =
+      new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypesWithAdmin, policyDAO, directoryDAO, cloudXtns, emailDomain)
     TestSupport.runAndWait(mockUserService.createUser(user, samRequestContext))
     val allUsersGroup = TestSupport.runAndWait(cloudXtns.getOrCreateAllUsersGroup(directoryDAO, samRequestContext))
     TestSupport.runAndWait(googleDirectoryDAO.createGroup(allUsersGroup.id.toString, allUsersGroup.email))
@@ -119,6 +175,17 @@ object TestSamRoutes {
 
     val mockStatusService = new StatusService(directoryDAO, cloudXtns, dbRef)
     val azureService = new AzureService(crlService.getOrElse(MockCrlService()), directoryDAO)
-    new TestSamRoutes(mockResourceService, policyEvaluatorService, mockUserService, mockStatusService, mockManagedGroupService, user, directoryDAO, tosService = mockTosService, cloudExtensions = cloudXtns, azureService = Some(azureService))
+    new TestSamRoutes(
+      mockResourceService,
+      policyEvaluatorService,
+      mockUserService,
+      mockStatusService,
+      mockManagedGroupService,
+      user,
+      directoryDAO,
+      tosService = mockTosService,
+      cloudExtensions = cloudXtns,
+      azureService = Some(azureService)
+    )
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesSpec.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, genSamRoutes, googleServicesConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -14,8 +14,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-/**
-  * Created by dvoet on 6/7/17.
+/** Created by dvoet on 6/7/17.
   */
 class UserRoutesSpec extends UserRoutesSpecHelper {
   "POST /register/user" should "create user" in withDefaultRoutes { samRoutes =>
@@ -42,7 +41,7 @@ class UserRoutesSpec extends UserRoutesSpecHelper {
   }
 }
 
-trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport{
+trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
   val defaultUser = Generator.genWorkbenchUserGoogle.sample.get
   val defaultUserId = defaultUser.id
   val defaultUserEmail = defaultUser.email
@@ -53,7 +52,13 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
   val petSAUserId = petSAUser.id
   val petSAEmail = petSAUser.email
 
-  def createTestUser(testUser: SamUser = Generator.genWorkbenchUserBoth.sample.get, cloudExtensions: Option[CloudExtensions] = None, googleDirectoryDAO: Option[GoogleDirectoryDAO] = None, tosEnabled: Boolean = false, tosAccepted: Boolean = false): (SamUser, SamDependencies, SamRoutes) = {
+  def createTestUser(
+      testUser: SamUser = Generator.genWorkbenchUserBoth.sample.get,
+      cloudExtensions: Option[CloudExtensions] = None,
+      googleDirectoryDAO: Option[GoogleDirectoryDAO] = None,
+      tosEnabled: Boolean = false,
+      tosAccepted: Boolean = false
+  ): (SamUser, SamDependencies, SamRoutes) = {
     val samDependencies = genSamDependencies(cloudExtensions = cloudExtensions, googleDirectoryDAO = googleDirectoryDAO, tosEnabled = tosEnabled)
     val routes = genSamRoutes(samDependencies, testUser)
 
@@ -63,7 +68,7 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
       res.userInfo.userEmail shouldBe testUser.email
       val enabledBaseArray = Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
 
-      if (tosEnabled) res.enabled shouldBe  enabledBaseArray + ("tosAccepted" -> false) + ("adminEnabled" -> true)
+      if (tosEnabled) res.enabled shouldBe enabledBaseArray + ("tosAccepted" -> false) + ("adminEnabled" -> true)
       else res.enabled shouldBe enabledBaseArray
     }
 
@@ -84,8 +89,17 @@ trait UserRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRoute
     val directoryDAO = new MockDirectoryDAO()
 
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, defaultUser, directoryDAO,
-      newSamUser = Option(defaultUser), tosService = tosService)
+    val samRoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, NoExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      defaultUser,
+      directoryDAO,
+      newSamUser = Option(defaultUser),
+      tosService = tosService
+    )
 
     testCode(samRoutes)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1Spec.scala
@@ -7,14 +7,13 @@ import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.Generator.genNonPetEmail
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport.rootBooleanJsonFormat
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, StatusService, TosService, UserService}
 
-/**
-  * Created by dvoet on 6/7/17.
+/** Created by dvoet on 6/7/17.
   */
 class UserRoutesV1Spec extends UserRoutesSpecHelper {
 
@@ -22,8 +21,28 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper {
     val directoryDAO = new MockDirectoryDAO()
 
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, defaultUser, directoryDAO, NoExtensions, tosService = tosService)
-    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, petSAUser, directoryDAO, NoExtensions, tosService = tosService)
+    val samRoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, NoExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      defaultUser,
+      directoryDAO,
+      NoExtensions,
+      tosService = tosService
+    )
+    val SARoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, NoExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      petSAUser,
+      directoryDAO,
+      NoExtensions,
+      tosService = tosService
+    )
     testCode(samRoutes, SARoutes)
   }
 
@@ -105,8 +124,8 @@ class UserRoutesV1Spec extends UserRoutesSpecHelper {
   "POST /api/users/v1/invite/{invitee's email}" should "create user" in {
     val inviteeEmail = genNonPetEmail.sample.get
 
-    val (user, _, routes) = createTestUser() //create a valid user that can invite someone
-    Post(s"/api/users/v1/invite/${inviteeEmail}") ~> routes.route ~> check{
+    val (user, _, routes) = createTestUser() // create a valid user that can invite someone
+    Post(s"/api/users/v1/invite/${inviteeEmail}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Created
       val res = responseAs[UserStatusDetails]
       res.userEmail shouldBe inviteeEmail

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -1,26 +1,45 @@
 package org.broadinstitute.dsde.workbench.sam
 package api
 
-
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.MockDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, StatusService, TosService, UserService}
-/**
-  * Created by mtalbott on 8/8/18.
+
+/** Created by mtalbott on 8/8/18.
   */
 class UserRoutesV2Spec extends UserRoutesSpecHelper {
   def withSARoutes[T](testCode: (TestSamRoutes, TestSamRoutes) => T): T = {
     val directoryDAO = new MockDirectoryDAO()
 
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)
-    val samRoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, Seq.empty, tosService), new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef), null, defaultUser, directoryDAO, NoExtensions, tosService = tosService)
-    val SARoutes = new TestSamRoutes(null, null, new UserService(directoryDAO, NoExtensions, Seq.empty, tosService), new StatusService(directoryDAO,NoExtensions, TestSupport.dbRef), null, petSAUser, directoryDAO, NoExtensions, tosService = tosService)
+    val samRoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, NoExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      defaultUser,
+      directoryDAO,
+      NoExtensions,
+      tosService = tosService
+    )
+    val SARoutes = new TestSamRoutes(
+      null,
+      null,
+      new UserService(directoryDAO, NoExtensions, Seq.empty, tosService),
+      new StatusService(directoryDAO, NoExtensions, TestSupport.dbRef),
+      null,
+      petSAUser,
+      directoryDAO,
+      NoExtensions,
+      tosService = tosService
+    )
     testCode(samRoutes, SARoutes)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -149,7 +149,9 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
 
     // Create mock spend-profile resource
     if (createSpendProfile) {
-      Post(s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}") ~> samRoutes.route ~> check {
+      Post(
+        s"/api/resources/v2/${MockCrlService.mockSamSpendProfileResource.resourceTypeName.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}"
+      ) ~> samRoutes.route ~> check {
         status shouldEqual StatusCodes.NoContent
       }
     }
@@ -162,7 +164,10 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     // Create azure policy on cloud-extension resource
     if (createAzurePolicy) {
       val cloudExtensionMembers = AccessPolicyMembership(Set(samRoutes.user.email), Set(AzureExtensions.getPetManagedIdentityAction), Set.empty, None)
-      Put(s"/api/resources/v2/${CloudExtensions.resourceTypeName.value}/${AzureExtensions.resourceId.value}/policies/azure", cloudExtensionMembers) ~> samRoutes.route ~> check {
+      Put(
+        s"/api/resources/v2/${CloudExtensions.resourceTypeName.value}/${AzureExtensions.resourceId.value}/policies/azure",
+        cloudExtensionMembers
+      ) ~> samRoutes.route ~> check {
         status shouldEqual StatusCodes.Created
       }
     }
@@ -175,7 +180,9 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     // wait for Future to complete by converting to IO
     IO.fromFuture(IO(samRoutes.userService.createUser(newUser, samRequestContext))).unsafeRunSync()
     if (addToSpendProfile) {
-      Put(s"/api/resources/v2/${SamResourceTypes.spendProfile.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/policies/owner/memberEmails/${newUser.email.value}") ~> samRoutes.route ~> check {
+      Put(
+        s"/api/resources/v2/${SamResourceTypes.spendProfile.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/policies/owner/memberEmails/${newUser.email.value}"
+      ) ~> samRoutes.route ~> check {
         status shouldEqual StatusCodes.NoContent
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.ConnectedTest
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{PostgresDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
 import org.scalatest.concurrent.ScalaFutures

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -12,42 +12,34 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
-/**
-  * Created by dvoet on 7/17/17.
+/** Created by dvoet on 7/17/17.
   */
-class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeName, ResourceType], private val directoryDAO: MockDirectoryDAO) extends AccessPolicyDAO {
-  def this(resourceTypes: Map[ResourceTypeName, ResourceType], directoryDAO: MockDirectoryDAO) = {
+class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeName, ResourceType], private val directoryDAO: MockDirectoryDAO)
+    extends AccessPolicyDAO {
+  def this(resourceTypes: Map[ResourceTypeName, ResourceType], directoryDAO: MockDirectoryDAO) =
     this(new TrieMap[ResourceTypeName, ResourceType]() ++ resourceTypes, directoryDAO)
-  }
 
-  def this(resourceTypes: Iterable[ResourceType], directoryDAO: MockDirectoryDAO) = {
+  def this(resourceTypes: Iterable[ResourceType], directoryDAO: MockDirectoryDAO) =
     this(new TrieMap[ResourceTypeName, ResourceType] ++ resourceTypes.map(rt => rt.name -> rt).toMap, directoryDAO)
-  }
 
-  def this(resourceType: ResourceType, directoryDAO: MockDirectoryDAO) = {
+  def this(resourceType: ResourceType, directoryDAO: MockDirectoryDAO) =
     this(Map(resourceType.name -> resourceType), directoryDAO)
-  }
 
-  def this(directoryDAO: MockDirectoryDAO) = {
+  def this(directoryDAO: MockDirectoryDAO) =
     this(Map.empty[ResourceTypeName, ResourceType], directoryDAO)
-  }
 
   val resources = new TrieMap[FullyQualifiedResourceId, Resource]()
   val policies = directoryDAO.groups
 
-  override def upsertResourceTypes(resourceTypesToInit: Set[ResourceType], samRequestContext: SamRequestContext): IO[Set[ResourceTypeName]] = {
+  override def upsertResourceTypes(resourceTypesToInit: Set[ResourceType], samRequestContext: SamRequestContext): IO[Set[ResourceTypeName]] =
     for {
       existingResourceTypes <- loadResourceTypes(resourceTypesToInit.map(_.name), samRequestContext)
       newResourceTypes = resourceTypesToInit -- existingResourceTypes
       _ <- resourceTypesToInit.toList.traverse(createResourceType(_, samRequestContext))
-    } yield {
-      newResourceTypes.map(_.name)
-    }
-  }
+    } yield newResourceTypes.map(_.name)
 
-  override def loadResourceTypes(resourceTypeNames: Set[ResourceTypeName], samRequestContext: SamRequestContext): IO[Set[ResourceType]] = {
+  override def loadResourceTypes(resourceTypeNames: Set[ResourceTypeName], samRequestContext: SamRequestContext): IO[Set[ResourceType]] =
     IO.pure(resourceTypes.view.filterKeys(resourceTypeNames.contains).values.toSet)
-  }
 
   override def createResourceType(resourceType: ResourceType, samRequestContext: SamRequestContext): IO[ResourceType] = {
     resourceTypes += resourceType.name -> resourceType
@@ -56,38 +48,47 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
 
   override def createResource(resource: Resource, samRequestContext: SamRequestContext): IO[Resource] = IO {
     resources += resource.fullyQualifiedId -> resource
-    if (policies.exists {
-      case (FullyQualifiedPolicyId(FullyQualifiedResourceId(`resource`.resourceTypeName, `resource`.resourceId), _), _) =>
-        true
-      case _ => false
-    }) throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "A resource of this type and name already exists"))
+    if (
+      policies.exists {
+        case (FullyQualifiedPolicyId(FullyQualifiedResourceId(`resource`.resourceTypeName, `resource`.resourceId), _), _) =>
+          true
+        case _ => false
+      }
+    ) throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "A resource of this type and name already exists"))
     resource
   } <* resource.accessPolicies.toList.traverse(createPolicy(_, samRequestContext))
 
   override def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
-    val toRemove = policies.collect {
-      case (riapn @ FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) => riapn
-    }.toSet[WorkbenchGroupIdentity]
+    val toRemove = policies
+      .collect { case (riapn @ FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) =>
+        riapn
+      }
+      .toSet[WorkbenchGroupIdentity]
 
     resources -= resource
     policies.view.filterKeys(k => !toRemove.contains(k))
   }
 
   override def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LoadResourceAuthDomainResult] =
-    IO(resources.get(resource)).map{
-      rs =>
-        rs match {
-          case None => LoadResourceAuthDomainResult.ResourceNotFound
-          case Some(r) => NonEmptyList.fromList(r.authDomain.toList).fold[LoadResourceAuthDomainResult](LoadResourceAuthDomainResult.NotConstrained)(x => LoadResourceAuthDomainResult.Constrained(x))
-        }
+    IO(resources.get(resource)).map { rs =>
+      rs match {
+        case None => LoadResourceAuthDomainResult.ResourceNotFound
+        case Some(r) =>
+          NonEmptyList
+            .fromList(r.authDomain.toList)
+            .fold[LoadResourceAuthDomainResult](LoadResourceAuthDomainResult.NotConstrained)(x => LoadResourceAuthDomainResult.Constrained(x))
+      }
     }
 
   override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
     val resourceToRemoveOpt = resources.get(resource)
-    resourceToRemoveOpt.map( resourceToRemove => resources += resource -> resourceToRemove.copy(authDomain = Set.empty))
+    resourceToRemoveOpt.map(resourceToRemove => resources += resource -> resourceToRemove.copy(authDomain = Set.empty))
   }
 
-  override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedPolicyId]] = IO {
+  override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(
+      groupId: WorkbenchGroupIdentity,
+      samRequestContext: SamRequestContext
+  ): IO[Set[FullyQualifiedPolicyId]] = IO {
     val groupName: WorkbenchGroupName = groupId match {
       case basicGroupName: WorkbenchGroupName => basicGroupName
       // In real life, policies have a group that can be used to constrain other resources -- if we need the group name
@@ -115,18 +116,23 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
 
   override def deleteAllResourcePolicies(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
     val deletePolicies = policies.collect {
-      case (policyId@FullyQualifiedPolicyId(toDelete, _), _) if toDelete == resourceId => policyId
+      case (policyId @ FullyQualifiedPolicyId(toDelete, _), _) if toDelete == resourceId => policyId
     }
     policies.subtractAll(deletePolicies)
   }
 
-  override def listAccessPolicies(resourceTypeName: ResourceTypeName, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceIdAndPolicyName]] = IO {
+  override def listAccessPolicies(
+      resourceTypeName: ResourceTypeName,
+      user: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Set[ResourceIdAndPolicyName]] = IO {
     policies.collect {
-      case (riapn @ FullyQualifiedPolicyId(FullyQualifiedResourceId(`resourceTypeName`, _), _), accessPolicy) if accessPolicy.members.contains(user) => ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
+      case (riapn @ FullyQualifiedPolicyId(FullyQualifiedResourceId(`resourceTypeName`, _), _), accessPolicy) if accessPolicy.members.contains(user) =>
+        ResourceIdAndPolicyName(riapn.resource.resourceId, riapn.accessPolicyName)
     }.toSet
   }
 
-  override def loadPolicy(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicy]] = {
+  override def loadPolicy(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicy]] =
     listAccessPolicies(policyIdentity.resource, samRequestContext).map { policies =>
       policies.filter(_.id.accessPolicyName == policyIdentity.accessPolicyName).toSeq match {
         case Seq() => None
@@ -134,24 +140,28 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
         case _ => throw new WorkbenchException(s"More than one policy found for ${policyIdentity.accessPolicyName}")
       }
     }
-  }
 
   override def overwritePolicy(newPolicy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy] = createPolicy(newPolicy, samRequestContext)
 
-  override def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[Unit] = {
+  override def overwritePolicyMembers(id: FullyQualifiedPolicyId, memberList: Set[WorkbenchSubject], samRequestContext: SamRequestContext): IO[Unit] =
     loadPolicy(id, samRequestContext) flatMap {
       case None => throw new Exception("not found")
       case Some(policy) => overwritePolicy(policy.copy(members = memberList), samRequestContext).map(_ => ())
     }
-  }
 
   override def listAccessPolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicy]] = IO {
-    policies.collect {
-      case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) => policy
-    }.to(LazyList)
+    policies
+      .collect { case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) =>
+        policy
+      }
+      .to(LazyList)
   }
 
-  override def listAccessPoliciesForUser(resource: FullyQualifiedResourceId, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[AccessPolicyWithoutMembers]] = IO {
+  override def listAccessPoliciesForUser(
+      resource: FullyQualifiedResourceId,
+      user: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Set[AccessPolicyWithoutMembers]] = IO {
     policies.collect {
       case (FullyQualifiedPolicyId(`resource`, _), policy: AccessPolicy) if policy.members.contains(user) =>
         AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public)
@@ -177,66 +187,94 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
     }
   }
 
-  override def listPublicAccessPolicies(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[LazyList[ResourceIdAndPolicyName]] = {
+  override def listPublicAccessPolicies(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[LazyList[ResourceIdAndPolicyName]] =
     IO.pure(
-      policies.collect {
-        case (_, policy: AccessPolicy) if policy.public => ResourceIdAndPolicyName(policy.id.resource.resourceId, policy.id.accessPolicyName)
-      }.to(LazyList)
+      policies
+        .collect {
+          case (_, policy: AccessPolicy) if policy.public => ResourceIdAndPolicyName(policy.id.resource.resourceId, policy.id.accessPolicyName)
+        }
+        .to(LazyList)
     )
-  }
 
   override def listFlattenedPolicyMembers(policyIdentity: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Set[SamUser]] = IO {
-    val members = policies.collect {
-      case (`policyIdentity`, policy: AccessPolicy) => policy.members
+    val members = policies.collect { case (`policyIdentity`, policy: AccessPolicy) =>
+      policy.members
     }
-    members.flatten.collect {
-      case u: WorkbenchUserId => SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false, None)
+    members.flatten.collect { case u: WorkbenchUserId =>
+      SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false, None)
     }.toSet
   }
 
-  override def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId], samRequestContext: SamRequestContext)
-    : IO[Set[Resource]] = IO.pure(Set.empty)
+  override def listResourcesWithAuthdomains(
+      resourceTypeName: ResourceTypeName,
+      resourceId: Set[ResourceId],
+      samRequestContext: SamRequestContext
+  ): IO[Set[Resource]] = IO.pure(Set.empty)
 
   override def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[Resource]] = IO.pure(None)
 
-  override def listPublicAccessPolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithoutMembers]] = {
+  override def listPublicAccessPolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithoutMembers]] =
     IO.pure(
-      policies.collect {
-        case (_, policy: AccessPolicy) if policy.public =>
-          AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public)
-      }.to(LazyList)
+      policies
+        .collect {
+          case (_, policy: AccessPolicy) if policy.public =>
+            AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public)
+        }
+        .to(LazyList)
     )
-  }
 
   override def getResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] = IO(None)
 
-  override def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = ???
+  override def setResourceParent(
+      childResource: FullyQualifiedResourceId,
+      parentResource: FullyQualifiedResourceId,
+      samRequestContext: SamRequestContext
+  ): IO[Unit] = ???
 
   override def deleteResourceParent(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(false)
 
   override def listResourceChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] = IO(Set.empty)
 
-  override def listUserResourceActions(resourceId: FullyQualifiedResourceId, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceAction]] = IO {
-    policies.collect {
-      case (FullyQualifiedPolicyId(`resourceId`, _), policy: AccessPolicy) if policy.members.contains(user) || policy.public =>
-        val roleActions = policy.roles.flatMap {role =>
-          resourceTypes(resourceId.resourceTypeName).roles.find(_.roleName == role).map(_.actions).getOrElse(Set.empty)
-        }
+  override def listUserResourceActions(
+      resourceId: FullyQualifiedResourceId,
+      user: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Set[ResourceAction]] = IO {
+    policies
+      .collect {
+        case (FullyQualifiedPolicyId(`resourceId`, _), policy: AccessPolicy) if policy.members.contains(user) || policy.public =>
+          val roleActions = policy.roles.flatMap { role =>
+            resourceTypes(resourceId.resourceTypeName).roles.find(_.roleName == role).map(_.actions).getOrElse(Set.empty)
+          }
 
-        roleActions ++ policy.actions
-    }.flatten.toSet
+          roleActions ++ policy.actions
+      }
+      .flatten
+      .toSet
   }
 
-  override def listUserResourceRoles(resourceId: FullyQualifiedResourceId, user: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceRoleName]] = IO {
-    policies.collect {
-      case (FullyQualifiedPolicyId(`resourceId`, _), policy: AccessPolicy) if policy.members.contains(user) || policy.public =>
-        policy.roles
-    }.flatten.toSet
+  override def listUserResourceRoles(
+      resourceId: FullyQualifiedResourceId,
+      user: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Set[ResourceRoleName]] = IO {
+    policies
+      .collect {
+        case (FullyQualifiedPolicyId(`resourceId`, _), policy: AccessPolicy) if policy.members.contains(user) || policy.public =>
+          policy.roles
+      }
+      .flatten
+      .toSet
   }
 
-  override def listUserResourcesWithRolesAndActions(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Iterable[ResourceIdWithRolesAndActions]] = IO {
+  override def listUserResourcesWithRolesAndActions(
+      resourceTypeName: ResourceTypeName,
+      userId: WorkbenchUserId,
+      samRequestContext: SamRequestContext
+  ): IO[Iterable[ResourceIdWithRolesAndActions]] = IO {
     val forEachPolicy = policies.collect {
-      case (fqPolicyId @ FullyQualifiedPolicyId(FullyQualifiedResourceId(`resourceTypeName`, _), _), accessPolicy: AccessPolicy) if accessPolicy.members.contains(userId) || accessPolicy.public =>
+      case (fqPolicyId @ FullyQualifiedPolicyId(FullyQualifiedResourceId(`resourceTypeName`, _), _), accessPolicy: AccessPolicy)
+          if accessPolicy.members.contains(userId) || accessPolicy.public =>
         if (accessPolicy.public) {
           ResourceIdWithRolesAndActions(fqPolicyId.resource.resourceId, RolesAndActions.empty, RolesAndActions.empty, RolesAndActions.fromPolicy(accessPolicy))
         } else {
@@ -248,46 +286,66 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
   }
 
   private def loadDirectMemberUserEmails(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
-    val userIds = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
-      policyGroup.members.collect { case userId: WorkbenchUserId => userId }
-    }.to(LazyList)
+    val userIds = policies
+      .find(_._1 == policy)
+      .toList
+      .flatMap { case (_, policyGroup) =>
+        policyGroup.members.collect { case userId: WorkbenchUserId => userId }
+      }
+      .to(LazyList)
 
-    userIds.traverse { directoryDAO.loadUser(_, samRequestContext) }.map(_.flatMap(_.map(_.email)))
+    userIds.traverse(directoryDAO.loadUser(_, samRequestContext)).map(_.flatMap(_.map(_.email)))
   }
 
   private def loadDirectMemberGroupEmails(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchEmail]] = {
-    val groupNames = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
-      policyGroup.members.collect { case groupName: WorkbenchGroupName => groupName }
-    }.to(LazyList)
+    val groupNames = policies
+      .find(_._1 == policy)
+      .toList
+      .flatMap { case (_, policyGroup) =>
+        policyGroup.members.collect { case groupName: WorkbenchGroupName => groupName }
+      }
+      .to(LazyList)
 
-    groupNames.traverse { directoryDAO.loadGroup(_, samRequestContext) }.map(_.flatMap(_.map(_.email)))
+    groupNames.traverse(directoryDAO.loadGroup(_, samRequestContext)).map(_.flatMap(_.map(_.email)))
   }
 
   private def loadDirectMemberPolicyIdentifiers(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[LazyList[PolicyIdentifiers]] = {
-    val policyIds = policies.find(_._1 == policy).toList.flatMap { case (_, policyGroup) =>
-      policyGroup.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
-    }.to(LazyList)
+    val policyIds = policies
+      .find(_._1 == policy)
+      .toList
+      .flatMap { case (_, policyGroup) =>
+        policyGroup.members.collect { case policyId: FullyQualifiedPolicyId => policyId }
+      }
+      .to(LazyList)
 
-    policyIds.traverse { loadPolicy(_, samRequestContext) }.map(_.flatMap(_.map(p => PolicyIdentifiers(p.id.accessPolicyName, p.email, p.id.resource.resourceTypeName, p.id.resource.resourceId))))
+    policyIds
+      .traverse(loadPolicy(_, samRequestContext))
+      .map(_.flatMap(_.map(p => PolicyIdentifiers(p.id.accessPolicyName, p.email, p.id.resource.resourceTypeName, p.id.resource.resourceId))))
   }
 
-  override def loadPolicyMembership(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] = {
+  override def loadPolicyMembership(policyId: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicyMembership]] =
     listAccessPolicyMemberships(policyId.resource, samRequestContext).map { policyMemberships =>
       policyMemberships.find(_.policyName == policyId.accessPolicyName).map(_.membership)
     }
-  }
 
-  override def listAccessPolicyMemberships(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]] = {
+  override def listAccessPolicyMemberships(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithMembership]] =
     listAccessPolicies(resource, samRequestContext).flatMap { policies =>
       policies.traverse { policy =>
         for {
           users <- loadDirectMemberUserEmails(policy.id, samRequestContext)
           groups <- loadDirectMemberGroupEmails(policy.id, samRequestContext)
           subPolicies <- loadDirectMemberPolicyIdentifiers(policy.id, samRequestContext)
-        } yield {
-          AccessPolicyWithMembership(policy.id.accessPolicyName, AccessPolicyMembership(users.toSet ++ groups ++ subPolicies.map(_.policyEmail), policy.actions, policy.roles, Option(policy.descendantPermissions), Option(subPolicies.toSet)), policy.email)
-        }
+        } yield AccessPolicyWithMembership(
+          policy.id.accessPolicyName,
+          AccessPolicyMembership(
+            users.toSet ++ groups ++ subPolicies.map(_.policyEmail),
+            policy.actions,
+            policy.roles,
+            Option(policy.descendantPermissions),
+            Option(subPolicies.toSet)
+          ),
+          policy.email
+        )
       }
     }
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
@@ -13,15 +13,13 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.language.reflectiveCalls
 
-/**
-  * Created by dvoet on 6/26/17.
+/** Created by dvoet on 6/26/17.
   */
 class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfter with BeforeAndAfterAll {
   private val dummyUser = Generator.genWorkbenchUserGoogle.sample.get
 
-  override protected def beforeAll(): Unit = {
+  override protected def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   before {
     TestSupport.truncateAll
@@ -29,14 +27,16 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
 
   def sharedFixtures = new {
     val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
-    val policyActions: Set[ResourceAction] = accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val policyActions: Set[ResourceAction] =
+      accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
     val resourceActions: Set[ResourceAction] = Set(ResourceAction("delete"), SamResourceActions.notifyAdmins) union policyActions
     val resourceActionPatterns: Set[ResourceActionPattern] = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
     val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
     val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
     val defaultAdminNotifierRole = ResourceRole(ManagedGroupService.adminNotifierRoleName, Set(ResourceAction("notify_admins")))
     val defaultRoles = Set(defaultOwnerRole, defaultMemberRole, defaultAdminNotifierRole)
-    val managedGroupResourceType = ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+    val managedGroupResourceType =
+      ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
     val resourceTypes = Map(managedGroupResourceType.name -> managedGroupResourceType)
     val emailDomain = "example.com"
   }
@@ -48,10 +48,12 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(ldapDirDao, samRequestContext))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, ldapPolicyDao, ldapDirDao)
-    val resourceService = new ResourceService(shared.resourceTypes, policyEvaluatorService, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain, Set.empty)
+    val resourceService =
+      new ResourceService(shared.resourceTypes, policyEvaluatorService, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain, Set.empty)
     val userService = new UserService(ldapDirDao, NoExtensions, Seq.empty, new TosService(ldapDirDao, googleServicesConfig.appsDomain, TestSupport.tosConfig))
-    val managedGroupService = new ManagedGroupService(resourceService, policyEvaluatorService, shared.resourceTypes, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
-    shared.resourceTypes foreach {case (_, resourceType) => resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync() }
+    val managedGroupService =
+      new ManagedGroupService(resourceService, policyEvaluatorService, shared.resourceTypes, ldapPolicyDao, ldapDirDao, NoExtensions, shared.emailDomain)
+    shared.resourceTypes foreach { case (_, resourceType) => resourceService.createResourceType(resourceType, samRequestContext).unsafeRunSync() }
   }
 
   def mockServicesFixture = new {
@@ -61,9 +63,12 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
     val allUsersGroup: WorkbenchGroup = TestSupport.runAndWait(NoExtensions.getOrCreateAllUsersGroup(mockDirectoryDAO, samRequestContext))
 
     val policyEvaluatorService = PolicyEvaluatorService(shared.emailDomain, shared.resourceTypes, mockPolicyDAO, mockDirectoryDAO)
-    val resourceService = new ResourceService(shared.resourceTypes, policyEvaluatorService, mockPolicyDAO, mockDirectoryDAO, NoExtensions, shared.emailDomain, Set.empty)
-    val userService = new UserService(mockDirectoryDAO, NoExtensions,  Seq.empty, new TosService(mockDirectoryDAO,  googleServicesConfig.appsDomain, TestSupport.tosConfig))
-    val managedGroupService = new ManagedGroupService(resourceService, policyEvaluatorService, shared.resourceTypes, mockPolicyDAO, mockDirectoryDAO, NoExtensions, shared.emailDomain)
+    val resourceService =
+      new ResourceService(shared.resourceTypes, policyEvaluatorService, mockPolicyDAO, mockDirectoryDAO, NoExtensions, shared.emailDomain, Set.empty)
+    val userService =
+      new UserService(mockDirectoryDAO, NoExtensions, Seq.empty, new TosService(mockDirectoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
+    val managedGroupService =
+      new ManagedGroupService(resourceService, policyEvaluatorService, shared.resourceTypes, mockPolicyDAO, mockDirectoryDAO, NoExtensions, shared.emailDomain)
   }
 
   "RealAccessPolicyDao and MockAccessPolicyDao" should "return the same results for the same methods" in {
@@ -78,13 +83,20 @@ class MockAccessPolicyDAOSpec extends AnyFlatSpec with Matchers with TestSupport
     val intendedResource = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupName), Set.empty)
 
     // just compare top level fields because createResource returns the policies, including the default one
-    runAndWait(real.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext)).copy(accessPolicies = Set.empty) shouldEqual intendedResource
-    runAndWait(mock.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext)).copy(accessPolicies = Set.empty) shouldEqual intendedResource
-
+    runAndWait(real.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext))
+      .copy(accessPolicies = Set.empty) shouldEqual intendedResource
+    runAndWait(mock.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext))
+      .copy(accessPolicies = Set.empty) shouldEqual intendedResource
 
     val dummyEmail = WorkbenchEmail("")
     val expectedGroups = Set(ManagedGroupMembershipEntry(ResourceId(groupName), ManagedGroupService.adminRoleName, dummyEmail))
-    real.managedGroupService.listGroups(dummyUser.id, samRequestContext).unsafeRunSync().map(_.copy(groupEmail = dummyEmail)) should contain theSameElementsAs expectedGroups
-    mock.managedGroupService.listGroups(dummyUser.id, samRequestContext).unsafeRunSync().map(_.copy(groupEmail = dummyEmail)) should contain theSameElementsAs expectedGroups
+    real.managedGroupService
+      .listGroups(dummyUser.id, samRequestContext)
+      .unsafeRunSync()
+      .map(_.copy(groupEmail = dummyEmail)) should contain theSameElementsAs expectedGroups
+    mock.managedGroupService
+      .listGroups(dummyUser.id, samRequestContext)
+      .unsafeRunSync()
+      .map(_.copy(groupEmail = dummyEmail)) should contain theSameElementsAs expectedGroups
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -14,11 +14,9 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
-/**
-  * Created by mbemis on 6/23/17.
+/** Created by mbemis on 6/23/17.
   */
-class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap(),
-                       passStatusCheck: Boolean = true) extends DirectoryDAO {
+class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap(), passStatusCheck: Boolean = true) extends DirectoryDAO {
   private val groupSynchronizedDates: mutable.Map[WorkbenchGroupIdentity, Date] = new TrieMap()
   private val users: mutable.Map[WorkbenchUserId, SamUser] = new TrieMap()
   private val userAttributes: mutable.Map[WorkbenchUserId, mutable.Map[String, Any]] = new TrieMap()
@@ -33,7 +31,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   private val petManagedIdentitiesByUser: mutable.Map[PetManagedIdentityId, PetManagedIdentity] = new TrieMap()
 
-  override def createGroup(group: BasicWorkbenchGroup, accessInstruction: Option[String] = None, samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup] =
+  override def createGroup(
+      group: BasicWorkbenchGroup,
+      accessInstruction: Option[String] = None,
+      samRequestContext: SamRequestContext
+  ): IO[BasicWorkbenchGroup] =
     if (groups.keySet.contains(group.id)) {
       IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group ${group.id} already exists")))
     } else {
@@ -46,14 +48,15 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     groups.get(groupName).map(_.asInstanceOf[BasicWorkbenchGroup])
   }
 
-  override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] = {
+  override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] =
     listAncestorGroups(groupName, samRequestContext).map { ancestors =>
       if (ancestors.nonEmpty)
-        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group"))
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(StatusCodes.Conflict, s"group ${groupName.value} cannot be deleted because it is a member of at least 1 other group")
+        )
       else
         groups -= groupName
     }
-  }
 
   override def addGroupMember(groupName: WorkbenchGroupIdentity, addMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = IO {
     val group = groups(groupName)
@@ -109,7 +112,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   }
 
   private def listSubjectsGroups(subject: WorkbenchSubject, accumulatedGroups: Set[WorkbenchGroup]): Set[WorkbenchGroup] = {
-    val immediateGroups = groups.values.toSet.filter { group => group.members.contains(subject) }
+    val immediateGroups = groups.values.toSet.filter(group => group.members.contains(subject))
 
     val unvisitedGroups = immediateGroups -- accumulatedGroups
     if (unvisitedGroups.isEmpty) {
@@ -125,7 +128,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     groupIds.flatMap(groupId => listGroupUsers(groupId, Set.empty))
   }
 
-  private def listGroupUsers(groupName: WorkbenchGroupIdentity, visitedGroups: Set[WorkbenchGroupIdentity]): Set[WorkbenchUserId] = {
+  private def listGroupUsers(groupName: WorkbenchGroupIdentity, visitedGroups: Set[WorkbenchGroupIdentity]): Set[WorkbenchUserId] =
     if (!visitedGroups.contains(groupName)) {
       val members = groups.getOrElse(groupName, BasicWorkbenchGroup(null, Set.empty, WorkbenchEmail("g1@example.com"))).members
 
@@ -137,7 +140,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     } else {
       Set.empty
     }
-  }
 
   override def listAncestorGroups(groupName: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]] = IO {
     listSubjectsGroups(groupName, Set.empty).map(_.id)
@@ -149,30 +151,35 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   override def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] =
     updateUserEnabled(subject, false)
 
-  private def updateUserEnabled(subject: WorkbenchSubject, enabled: Boolean): IO[Unit] = {
+  private def updateUserEnabled(subject: WorkbenchSubject, enabled: Boolean): IO[Unit] =
     subject match {
-      case id: WorkbenchUserId => users.get(id) match {
-        case Some(user) => IO.pure(users += id -> user.copy(enabled = enabled))
-        case None => IO.unit
-      }
+      case id: WorkbenchUserId =>
+        users.get(id) match {
+          case Some(user) => IO.pure(users += id -> user.copy(enabled = enabled))
+          case None => IO.unit
+        }
       case _ => IO.unit
     }
-  }
 
   override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] = IO {
     subject match {
-      case id: WorkbenchUserId => users.get(id) match {
-        case Some(user) => user.enabled
-        case None => false
-      }
+      case id: WorkbenchUserId =>
+        users.get(id) match {
+          case Some(user) => user.enabled
+          case None => false
+        }
       case _ => false
     }
   }
 
-  override def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = loadGroup(groupName, samRequestContext).map(_.map(_.email))
+  override def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
+    loadGroup(groupName, samRequestContext).map(_.map(_.email))
 
-  override def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]] = groupNames.to(LazyList).parTraverse { name =>
-    loadGroupEmail(name, samRequestContext).map { y => (name -> y.get)}
+  override def batchLoadGroupEmail(
+      groupNames: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]] = groupNames.to(LazyList).parTraverse { name =>
+    loadGroupEmail(name, samRequestContext).map(y => name -> y.get)
   }
 
   override def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
@@ -194,8 +201,8 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   }
 
   override def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] = IO {
-    petServiceAccountsByUser.collect {
-      case (PetServiceAccountId(`userId`, _), petSA) => petSA
+    petServiceAccountsByUser.collect { case (PetServiceAccountId(`userId`, _), petSA) =>
+      petSA
     }.toSeq
   }
 
@@ -212,13 +219,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     }
   }
 
-  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]] = {
+  override def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]] =
     IO.pure(groupSynchronizedDates.get(groupId))
-  }
 
-  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = {
+  override def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     IO.pure(groups.get(WorkbenchGroupName(groupId.toString)).map(_.email))
-  }
 
   override def getUserFromPetServiceAccount(petSAId: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] = {
     val userIds = petServiceAccountsByUser.toSeq.collect {
@@ -236,12 +241,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     petServiceAccount
   }
 
-  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]] = {
+  override def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]] =
     if (groups.contains(groupName))
       IO.pure(groupAccessInstructions.get(groupName))
     else
       IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "group not found")))
-  }
 
   override def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit] = {
     groupAccessInstructions += groupName -> accessInstructions
@@ -265,35 +269,32 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   }
 
   override def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] = {
-    val res = for{
+    val res = for {
       uid <- usersWithGoogleSubjectIds.get(googleSubjectId)
     } yield uid
-   res.traverse(IO.pure)
+    res.traverse(IO.pure)
   }
 
-  override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] = {
-    users.get(userId).fold[IO[Unit]](IO.pure(new Exception(s"user $userId not found")))(
-      u => IO.pure(users.concat(List((userId, u.copy(googleSubjectId = Some(googleSubjectId))))))
-    )
-  }
+  override def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit] =
+    users
+      .get(userId)
+      .fold[IO[Unit]](IO.pure(new Exception(s"user $userId not found")))(u =>
+        IO.pure(users.concat(List((userId, u.copy(googleSubjectId = Some(googleSubjectId))))))
+      )
 
-  override def listUserDirectMemberships(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchGroupIdentity]] = {
+  override def listUserDirectMemberships(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchGroupIdentity]] =
     IO.pure(groups.filter { case (_, group) => group.members.contains(userId) }.keys.to(LazyList))
-  }
 
-  override def listFlattenedGroupMembers(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]] = {
+  override def listFlattenedGroupMembers(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]] =
     IO(listGroupUsers(groupName, Set.empty))
-  }
 
-  override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext)
-      : IO[Option[SamUser]] = IO.pure(users.values.find(_.azureB2CId.contains(userId)))
+  override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    IO.pure(users.values.find(_.azureB2CId.contains(userId)))
 
   override def setUserAzureB2CId(userId: WorkbenchUserId, b2CId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit] = IO {
     for {
       user <- users.get(userId)
-    } yield {
-      users += user.id -> user.copy(azureB2CId = Option(b2CId))
-    }
+    } yield users += user.id -> user.copy(azureB2CId = Option(b2CId))
   }
 
   override def checkStatus(samRequestContext: SamRequestContext): Boolean = passStatusCheck
@@ -301,7 +302,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   override def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(users.values.find(_.googleSubjectId.contains(userId)))
 
-  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] = {
+  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
     loadUser(userId, samRequestContext).map {
       case None => false
       case Some(user) =>
@@ -312,9 +313,8 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
           true
         }
     }
-  }
 
-  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] = {
+  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
     loadUser(userId, samRequestContext).map {
       case None => false
       case Some(user) =>
@@ -325,7 +325,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
           true
         }
     }
-  }
 
   override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] = {
     if (petManagedIdentitiesByUser.keySet.contains(petManagedIdentity.id)) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -33,8 +33,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
     val resourceTypeName = ResourceTypeName("awesomeType")
     val otherRsourceTypeName = ResourceTypeName("lessAwesomeType")
 
-    val actionPatterns = Set(ResourceActionPattern("write", "description of pattern1", false),
-                             ResourceActionPattern("read", "description of pattern2", false))
+    val actionPatterns = Set(ResourceActionPattern("write", "description of pattern1", false), ResourceActionPattern("read", "description of pattern2", false))
 
     val writeAction = ResourceAction("write")
     val readAction = ResourceAction("read")
@@ -53,15 +52,22 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
       "creates resource types in config and is idempotent" in {
         val config = ConfigFactory.load()
         val appConfig = AppConfig.readConfig(config)
-        dao.upsertResourceTypes(appConfig.resourceTypes, samRequestContext).unsafeRunSync() should contain theSameElementsAs(appConfig.resourceTypes.map(_.name))
+        dao.upsertResourceTypes(appConfig.resourceTypes, samRequestContext).unsafeRunSync() should contain theSameElementsAs (appConfig.resourceTypes.map(
+          _.name
+        ))
         dao.upsertResourceTypes(appConfig.resourceTypes, samRequestContext).unsafeRunSync() shouldBe empty
       }
 
       "only updates resource types that have changed" in {
-        dao.upsertResourceTypes(Set(resourceType, otherResourceType), samRequestContext).unsafeRunSync() should contain theSameElementsAs(Set(resourceType.name, otherResourceType.name))
+        dao.upsertResourceTypes(Set(resourceType, otherResourceType), samRequestContext).unsafeRunSync() should contain theSameElementsAs (Set(
+          resourceType.name,
+          otherResourceType.name
+        ))
         val updatedResourceType = resourceType.copy(reuseIds = !resourceType.reuseIds)
-        dao.upsertResourceTypes(Set(updatedResourceType, otherResourceType), samRequestContext).unsafeRunSync() should contain theSameElementsAs(Set(updatedResourceType.name))
-        dao.loadResourceTypes(Set(updatedResourceType.name), samRequestContext).unsafeRunSync() should contain theSameElementsAs(Set(updatedResourceType))
+        dao.upsertResourceTypes(Set(updatedResourceType, otherResourceType), samRequestContext).unsafeRunSync() should contain theSameElementsAs (Set(
+          updatedResourceType.name
+        ))
+        dao.loadResourceTypes(Set(updatedResourceType.name), samRequestContext).unsafeRunSync() should contain theSameElementsAs (Set(updatedResourceType))
       }
     }
 
@@ -198,8 +204,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             val overwriteResourceType = initialResourceType.copy(roles = newRoles)
 
             val resource = Resource(initialResourceType.name, ResourceId("resource"), Set.empty)
-            val beforeOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")), Set.empty, WorkbenchEmail("allowed@policy.com"), Set(readerRole.roleName, actionlessRole.roleName), Set.empty, Set.empty, false)
-            val afterOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")), Set.empty, WorkbenchEmail("not_allowed@policy.com"), Set(readerRole.roleName, actionlessRole.roleName), Set.empty, Set.empty, false)
+            val beforeOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("allowed@policy.com"),
+              Set(readerRole.roleName, actionlessRole.roleName),
+              Set.empty,
+              Set.empty,
+              false
+            )
+            val afterOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("not_allowed@policy.com"),
+              Set(readerRole.roleName, actionlessRole.roleName),
+              Set.empty,
+              Set.empty,
+              false
+            )
 
             dao.createResourceType(initialResourceType, samRequestContext).unsafeRunSync()
             dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -225,8 +247,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             val overwriteResourceType = initialResourceType.copy(roles = newRoles)
 
             val resource = Resource(initialResourceType.name, ResourceId("resource"), Set.empty)
-            val beforeOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")), Set.empty, WorkbenchEmail("allowed@policy.com"), Set(ownerRole.roleName, actionlessRole.roleName), Set.empty, Set.empty, false)
-            val afterOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")), Set.empty, WorkbenchEmail("not_allowed@policy.com"), Set(readingOwner.roleName, actionlessRole.roleName), Set(writeAction), Set.empty, false)
+            val beforeOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("allowed@policy.com"),
+              Set(ownerRole.roleName, actionlessRole.roleName),
+              Set.empty,
+              Set.empty,
+              false
+            )
+            val afterOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("not_allowed@policy.com"),
+              Set(readingOwner.roleName, actionlessRole.roleName),
+              Set(writeAction),
+              Set.empty,
+              false
+            )
 
             dao.createResourceType(initialResourceType, samRequestContext).unsafeRunSync()
             dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -248,8 +286,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             val overwriteResourceType = initialResourceType.copy(roles = newRoles)
 
             val resource = Resource(initialResourceType.name, ResourceId("resource"), Set.empty)
-            val beforeOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")), Set.empty, WorkbenchEmail("allowed@policy.com"), Set(readerRole.roleName, actionlessRole.roleName), Set.empty, Set.empty, false)
-            val afterOverwritePolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")), Set.empty, WorkbenchEmail("not_allowed@policy.com"), Set(readerlessReader.roleName, actionlessRole.roleName), Set.empty, Set.empty, false)
+            val beforeOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("willHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("allowed@policy.com"),
+              Set(readerRole.roleName, actionlessRole.roleName),
+              Set.empty,
+              Set.empty,
+              false
+            )
+            val afterOverwritePolicy = AccessPolicy(
+              FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("cannotHaveDeprecatedRole")),
+              Set.empty,
+              WorkbenchEmail("not_allowed@policy.com"),
+              Set(readerlessReader.roleName, actionlessRole.roleName),
+              Set.empty,
+              Set.empty,
+              false
+            )
 
             dao.createResourceType(initialResourceType, samRequestContext).unsafeRunSync()
             dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -280,7 +334,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val exception = intercept[WorkbenchExceptionWithErrorReport] {
           dao.createResource(resource, samRequestContext).unsafeRunSync()
         }
-        exception.errorReport.statusCode should equal (Some(StatusCodes.Conflict))
+        exception.errorReport.statusCode should equal(Some(StatusCodes.Conflict))
       }
 
       "raises an error when the ResourceType does not exist" in {
@@ -336,14 +390,16 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
     "loadResourceAuthDomain" - {
       "ResourceNotFound" in {
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-        dao.loadResourceAuthDomain(FullyQualifiedResourceId(resourceType.name, ResourceId("missing")), samRequestContext).unsafeRunSync() should be (ResourceNotFound)
+        dao.loadResourceAuthDomain(FullyQualifiedResourceId(resourceType.name, ResourceId("missing")), samRequestContext).unsafeRunSync() should be(
+          ResourceNotFound
+        )
       }
 
       "NotConstrained" in {
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         val resource = Resource(resourceType.name, ResourceId("verySpecialResource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
-        dao.loadResourceAuthDomain(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should be (NotConstrained)
+        dao.loadResourceAuthDomain(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should be(NotConstrained)
       }
 
       "Constrained" in {
@@ -407,7 +463,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
       }
 
       "returns None when resource isn't found" in {
-        dao.listResourceWithAuthdomains(FullyQualifiedResourceId(resourceTypeName, ResourceId("terribleResource")), samRequestContext).unsafeRunSync() shouldBe None
+        dao
+          .listResourceWithAuthdomains(FullyQualifiedResourceId(resourceTypeName, ResourceId("terribleResource")), samRequestContext)
+          .unsafeRunSync() shouldBe None
       }
     }
 
@@ -426,7 +484,10 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(resource1, samRequestContext).unsafeRunSync()
         dao.createResource(resource2, samRequestContext).unsafeRunSync()
 
-        dao.listResourcesWithAuthdomains(resourceType.name, Set(resource1.resourceId, resource2.resourceId), samRequestContext).unsafeRunSync() shouldEqual Set(resource1, resource2)
+        dao.listResourcesWithAuthdomains(resourceType.name, Set(resource1.resourceId, resource2.resourceId), samRequestContext).unsafeRunSync() shouldEqual Set(
+          resource1,
+          resource2
+        )
       }
 
       "only returns actual resources" in {
@@ -436,7 +497,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        dao.listResourcesWithAuthdomains(resourceType.name, Set(resource.resourceId, ResourceId("possiblyWorseResource")), samRequestContext).unsafeRunSync() shouldEqual Set(resource)
+        dao
+          .listResourcesWithAuthdomains(resourceType.name, Set(resource.resourceId, ResourceId("possiblyWorseResource")), samRequestContext)
+          .unsafeRunSync() shouldEqual Set(resource)
       }
     }
 
@@ -467,18 +530,47 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val resource1FullyQualifiedId = FullyQualifiedResourceId(resourceType.name, ResourceId("resource1"))
         val resource2FullyQualifiedId = FullyQualifiedResourceId(secondResourceType.name, ResourceId("resource2"))
-        val policy1 = AccessPolicy(FullyQualifiedPolicyId(resource1FullyQualifiedId, AccessPolicyName("policyName1")), Set.empty, WorkbenchEmail("policy1@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val policy2 = AccessPolicy(FullyQualifiedPolicyId(resource1FullyQualifiedId, AccessPolicyName("policyName2")), Set.empty, WorkbenchEmail("policy2@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val policy3 = AccessPolicy(FullyQualifiedPolicyId(resource2FullyQualifiedId, AccessPolicyName("policyName3")), Set.empty, WorkbenchEmail("policy3@email.com"), secondResourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val resource1 = Resource(resource1FullyQualifiedId.resourceTypeName, resource1FullyQualifiedId.resourceId, Set(sharedAuthDomain.id), Set(policy1, policy2))
-        val resource2 = Resource(resource2FullyQualifiedId.resourceTypeName, resource2FullyQualifiedId.resourceId, Set(sharedAuthDomain.id, otherGroup.id), Set(policy3))
+        val policy1 = AccessPolicy(
+          FullyQualifiedPolicyId(resource1FullyQualifiedId, AccessPolicyName("policyName1")),
+          Set.empty,
+          WorkbenchEmail("policy1@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val policy2 = AccessPolicy(
+          FullyQualifiedPolicyId(resource1FullyQualifiedId, AccessPolicyName("policyName2")),
+          Set.empty,
+          WorkbenchEmail("policy2@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val policy3 = AccessPolicy(
+          FullyQualifiedPolicyId(resource2FullyQualifiedId, AccessPolicyName("policyName3")),
+          Set.empty,
+          WorkbenchEmail("policy3@email.com"),
+          secondResourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val resource1 =
+          Resource(resource1FullyQualifiedId.resourceTypeName, resource1FullyQualifiedId.resourceId, Set(sharedAuthDomain.id), Set(policy1, policy2))
+        val resource2 =
+          Resource(resource2FullyQualifiedId.resourceTypeName, resource2FullyQualifiedId.resourceId, Set(sharedAuthDomain.id, otherGroup.id), Set(policy3))
         dao.createResource(resource1, samRequestContext).unsafeRunSync()
         dao.createResource(resource2, samRequestContext).unsafeRunSync()
 
         dirDao.updateSynchronizedDate(policy1.id, samRequestContext).unsafeRunSync()
         dirDao.updateSynchronizedDate(policy3.id, samRequestContext).unsafeRunSync()
 
-        dao.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(sharedAuthDomain.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(policy1.id, policy3.id)
+        dao.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(sharedAuthDomain.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(
+          policy1.id,
+          policy3.id
+        )
       }
 
       "returns an empty list if group is not used in an auth domain" in {
@@ -502,7 +594,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
       }
@@ -512,7 +612,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
 
         val dupException = intercept[WorkbenchExceptionWithErrorReport] {
@@ -527,7 +635,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.deletePolicy(policy.id, samRequestContext).unsafeRunSync()
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
@@ -539,7 +655,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
         val newAction = ResourceAction("new")
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction, newAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction, newAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
       }
@@ -552,7 +676,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultGroup.id, defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultGroup.id, defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
       }
@@ -563,7 +695,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val sameResourceTypeDescendant = AccessPolicyDescendantPermissions(resource.resourceTypeName, Set(writeAction), Set(ownerRoleName))
         val otherResourceTypeDescendant = AccessPolicyDescendantPermissions(otherResourceType.name, Set(readAction), Set(actionlessRole.roleName))
         val descendantPermissions = Set(sameResourceTypeDescendant, otherResourceTypeDescendant)
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), Set(readerRole.roleName), Set.empty, descendantPermissions, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          Set(readerRole.roleName),
+          Set.empty,
+          descendantPermissions,
+          false
+        )
 
         val testResult = for {
           _ <- dao.createResourceType(resourceType, samRequestContext)
@@ -571,9 +711,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           _ <- dao.createResource(resource, samRequestContext)
           _ <- dao.createPolicy(policy, samRequestContext)
           loadedPolicy <- dao.loadPolicy(policy.id, samRequestContext)
-        } yield {
-          loadedPolicy shouldEqual Option(policy)
-        }
+        } yield loadedPolicy shouldEqual Option(policy)
 
         testResult.unsafeRunSync()
       }
@@ -595,12 +733,22 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultGroup.id, defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultGroup.id, defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldBe Option(policy)
         dao.deletePolicy(policy.id, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldBe None
-        dirDao.loadGroup(WorkbenchGroupName(s"${resourceType.name}_${resource.resourceId}_${policy.id.accessPolicyName}"), samRequestContext).unsafeRunSync() shouldBe None
+        dirDao
+          .loadGroup(WorkbenchGroupName(s"${resourceType.name}_${resource.resourceId}_${policy.id.accessPolicyName}"), samRequestContext)
+          .unsafeRunSync() shouldBe None
       }
 
       "can handle deleting a policy that has already been deleted" in {
@@ -611,7 +759,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultGroup.id, defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultGroup.id, defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldBe Option(policy)
         dao.deletePolicy(policy.id, samRequestContext).unsafeRunSync()
@@ -631,16 +787,40 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val publicPolicy1Id = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("publicPolicy1Name"))
         val publicPolicy2Id = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("publicPolicy2Name"))
 
-        val privatePolicy = AccessPolicy(privatePolicyId, Set.empty, WorkbenchEmail("privatePolicy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val publicPolicy1 = AccessPolicy(publicPolicy1Id, Set.empty, WorkbenchEmail("publicPolicy1@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, true)
-        val publicPolicy2 = AccessPolicy(publicPolicy2Id, Set.empty, WorkbenchEmail("publicPolicy2@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, true)
+        val privatePolicy = AccessPolicy(
+          privatePolicyId,
+          Set.empty,
+          WorkbenchEmail("privatePolicy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val publicPolicy1 = AccessPolicy(
+          publicPolicy1Id,
+          Set.empty,
+          WorkbenchEmail("publicPolicy1@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          true
+        )
+        val publicPolicy2 = AccessPolicy(
+          publicPolicy2Id,
+          Set.empty,
+          WorkbenchEmail("publicPolicy2@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          true
+        )
 
         dao.createPolicy(privatePolicy, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicPolicy1, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicPolicy2, samRequestContext).unsafeRunSync()
 
-        val expectedResults = Set(ResourceIdAndPolicyName(resourceId, publicPolicy1.id.accessPolicyName),
-          ResourceIdAndPolicyName(resourceId, publicPolicy2.id.accessPolicyName))
+        val expectedResults =
+          Set(ResourceIdAndPolicyName(resourceId, publicPolicy1.id.accessPolicyName), ResourceIdAndPolicyName(resourceId, publicPolicy2.id.accessPolicyName))
 
         dao.listPublicAccessPolicies(resourceTypeName, samRequestContext).unsafeRunSync() should contain theSameElementsAs expectedResults
       }
@@ -661,18 +841,50 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val publicPolicy2Id = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("publicPolicy2Name"))
         val wrongPublicPolicyId = FullyQualifiedPolicyId(wrongResource.fullyQualifiedId, AccessPolicyName("wrongPolicyName"))
 
-        val privatePolicy = AccessPolicy(privatePolicyId, Set.empty, WorkbenchEmail("privatePolicy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val publicPolicy1 = AccessPolicy(publicPolicy1Id, Set.empty, WorkbenchEmail("publicPolicy1@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, true)
-        val publicPolicy2 = AccessPolicy(publicPolicy2Id, Set.empty, WorkbenchEmail("publicPolicy2@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, true)
-        val wrongPublicPolicy = AccessPolicy(wrongPublicPolicyId, Set.empty, WorkbenchEmail("wrong@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, true)
+        val privatePolicy = AccessPolicy(
+          privatePolicyId,
+          Set.empty,
+          WorkbenchEmail("privatePolicy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val publicPolicy1 = AccessPolicy(
+          publicPolicy1Id,
+          Set.empty,
+          WorkbenchEmail("publicPolicy1@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          true
+        )
+        val publicPolicy2 = AccessPolicy(
+          publicPolicy2Id,
+          Set.empty,
+          WorkbenchEmail("publicPolicy2@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          true
+        )
+        val wrongPublicPolicy = AccessPolicy(
+          wrongPublicPolicyId,
+          Set.empty,
+          WorkbenchEmail("wrong@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          true
+        )
 
         dao.createPolicy(privatePolicy, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicPolicy1, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicPolicy2, samRequestContext).unsafeRunSync()
         dao.createPolicy(wrongPublicPolicy, samRequestContext).unsafeRunSync()
 
-        val expectedResults = Set(publicPolicy1, publicPolicy2).map(policy =>
-          AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public))
+        val expectedResults =
+          Set(publicPolicy1, publicPolicy2).map(policy => AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public))
 
         dao.listPublicAccessPolicies(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should contain theSameElementsAs expectedResults
       }
@@ -687,19 +899,27 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val allMembers = Set(directMember, subGroupMember, subSubGroupMember, inTwoGroupsMember)
 
         val subSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("subSubGroup"), Set(subSubGroupMember.id), WorkbenchEmail("subSub@groups.com"))
-        val subGroup = BasicWorkbenchGroup(WorkbenchGroupName("subGroup"), Set(subSubGroup.id, subGroupMember.id, inTwoGroupsMember.id), WorkbenchEmail("sub@groups.com"))
+        val subGroup =
+          BasicWorkbenchGroup(WorkbenchGroupName("subGroup"), Set(subSubGroup.id, subGroupMember.id, inTwoGroupsMember.id), WorkbenchEmail("sub@groups.com"))
         val secondGroup = BasicWorkbenchGroup(WorkbenchGroupName("secondGroup"), Set(inTwoGroupsMember.id), WorkbenchEmail("second@groups.com"))
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policy")), Set(subGroup.id, secondGroup.id, directMember.id), WorkbenchEmail("policy@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policy")),
+          Set(subGroup.id, secondGroup.id, directMember.id),
+          WorkbenchEmail("policy@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         // control user/group to make sure fuction excludes something
         val inSomeOtherGroup = Generator.genWorkbenchUserGoogle.sample.get
         val someOtherGroup = BasicWorkbenchGroup(WorkbenchGroupName("someOtherGroup"), Set(inSomeOtherGroup.id), WorkbenchEmail("someOtherGroup@groups.com"))
 
-        (allMembers + inSomeOtherGroup).map((user) => dirDao.createUser(user, samRequestContext).unsafeRunSync())
-        Set(subSubGroup, subGroup, secondGroup, someOtherGroup).map((group) => dirDao.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync())
-
+        (allMembers + inSomeOtherGroup).map(user => dirDao.createUser(user, samRequestContext).unsafeRunSync())
+        Set(subSubGroup, subGroup, secondGroup, someOtherGroup).map(group => dirDao.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync())
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -717,11 +937,26 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val indirectPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("indirect")), Set(parentGroup.id), WorkbenchEmail("indirect@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val directPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("direct")), Set(user.id), WorkbenchEmail("direct@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val indirectPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("indirect")),
+          Set(parentGroup.id),
+          WorkbenchEmail("indirect@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val directPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("direct")),
+          Set(user.id),
+          WorkbenchEmail("direct@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         val allPolicies = Set(indirectPolicy, directPolicy)
-        val expectedResults = allPolicies.map(policy =>
-          AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public))
+        val expectedResults = allPolicies.map(policy => AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public))
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -729,7 +964,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
-        allPolicies.map((policy) => dao.createPolicy(policy, samRequestContext).unsafeRunSync())
+        allPolicies.map(policy => dao.createPolicy(policy, samRequestContext).unsafeRunSync())
 
         dao.listAccessPoliciesForUser(resource.fullyQualifiedId, user.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs expectedResults
       }
@@ -738,9 +973,25 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val user = Generator.genWorkbenchUserGoogle.sample.get
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("thisOne")), Set(user.id), WorkbenchEmail("correct@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("thisOne")),
+          Set(user.id),
+          WorkbenchEmail("correct@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         val otherResource = Resource(resourceType.name, ResourceId("notThisResource"), Set.empty)
-        val otherPolicy = AccessPolicy(FullyQualifiedPolicyId(otherResource.fullyQualifiedId, AccessPolicyName("notThisOne")), Set(user.id), WorkbenchEmail("wrong@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val otherPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(otherResource.fullyQualifiedId, AccessPolicyName("notThisOne")),
+          Set(user.id),
+          WorkbenchEmail("wrong@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         val allPolicies = Set(otherPolicy, policy)
         val expectedResults = Set(AccessPolicyWithoutMembers(policy.id, policy.email, policy.roles, policy.actions, policy.public))
 
@@ -749,7 +1000,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
         dao.createResource(otherResource, samRequestContext).unsafeRunSync()
-        allPolicies.map((policy) => dao.createPolicy(policy, samRequestContext).unsafeRunSync())
+        allPolicies.map(policy => dao.createPolicy(policy, samRequestContext).unsafeRunSync())
 
         dao.listAccessPoliciesForUser(resource.fullyQualifiedId, user.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs expectedResults
       }
@@ -764,7 +1015,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("background@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("background@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -776,22 +1035,70 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          ),
 
           // user with action
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set(readAction), Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set(readAction),
+            Set.empty,
+            false
+          ),
 
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            true
+          ),
 
-          //public with action
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set(readAction), Set.empty, true),
+          // public with action
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set(readAction),
+            Set.empty,
+            true
+          ),
 
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          ),
 
           // group with action
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set(readAction), Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set(readAction),
+            Set.empty,
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -799,10 +1106,8 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.deletePolicy(probePolicy.id, samRequestContext)
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             result <- dao.listUserResourceActions(resource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              result should contain theSameElementsAs Set(readAction)
-            }
+          } yield withClue(probePolicy) {
+            result should contain theSameElementsAs Set(readAction)
           }).unsafeRunSync()
         }
       }
@@ -816,7 +1121,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentResource = Resource(resourceType.name, ResourceId("parentResource"), Set.empty)
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("background@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("background@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -830,22 +1143,70 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            false
+          ),
 
-          //user with action
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)), false),
+          // user with action
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)),
+            false
+          ),
 
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            true
+          ),
 
-          //public with action
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)), true),
+          // public with action
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)),
+            true
+          ),
 
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            false
+          ),
 
           // group with action
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set(readAction), Set.empty)),
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -854,11 +1215,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             childResult <- dao.listUserResourceActions(resource.fullyQualifiedId, user.id, samRequestContext)
             parentResult <- dao.listUserResourceActions(parentResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              childResult should contain theSameElementsAs Set(readAction)
-              parentResult shouldBe empty
-            }
+          } yield withClue(probePolicy) {
+            childResult should contain theSameElementsAs Set(readAction)
+            parentResult shouldBe empty
           }).unsafeRunSync()
         }
       }
@@ -870,14 +1229,30 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val includesRole = ResourceRole(ResourceRoleName("includes"), Set.empty, includedRoles = Set(readerRole.roleName))
-        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set.empty, descendantRoles = Map(resourceType.name ->  Set(readerRole.roleName)))
+        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set.empty, descendantRoles = Map(resourceType.name -> Set(readerRole.roleName)))
 
         val nestedResourceType = resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole))
         val includesResource = Resource(nestedResourceType.name, ResourceId("includes"), Set.empty)
         val descendsResource = Resource(resourceType.name, ResourceId("descends"), Set.empty, parent = Option(includesResource.fullyQualifiedId))
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val includesBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("includesBackground@policy.com"), Set(includesRole.roleName), Set.empty, Set.empty, false)
-        val descendsBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("descendsBackground@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val includesBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("includesBackground@policy.com"),
+          Set(includesRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val descendsBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("descendsBackground@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -891,11 +1266,35 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          ),
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            true
+          ),
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -904,11 +1303,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             includesResult <- dao.listUserResourceActions(includesResource.fullyQualifiedId, user.id, samRequestContext)
             descendsResult <- dao.listUserResourceActions(descendsResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              includesResult should contain theSameElementsAs Set(readAction)
-              descendsResult should contain theSameElementsAs Set(readAction)
-            }
+          } yield withClue(probePolicy) {
+            includesResult should contain theSameElementsAs Set(readAction)
+            descendsResult should contain theSameElementsAs Set(readAction)
           }).unsafeRunSync()
         }
       }
@@ -920,14 +1317,30 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val includesRole = ResourceRole(ResourceRoleName("includes"), Set.empty, includedRoles = Set(readerRole.roleName))
-        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set.empty, descendantRoles = Map(resourceType.name ->  Set(readerRole.roleName)))
+        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set.empty, descendantRoles = Map(resourceType.name -> Set(readerRole.roleName)))
         val nestedResourceType = resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole))
         val parentResource = Resource(nestedResourceType.name, ResourceId("parent"), Set.empty)
         val includesResource = Resource(nestedResourceType.name, ResourceId("includes"), Set.empty, parent = Option(parentResource.fullyQualifiedId))
         val descendsResource = Resource(resourceType.name, ResourceId("descends"), Set.empty, parent = Option(includesResource.fullyQualifiedId))
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val includesBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("includesBackground@policy.com"), Set(includesRole.roleName), Set.empty, Set.empty, false)
-        val descendsBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("descendsBackground@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val includesBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("includesBackground@policy.com"),
+          Set(includesRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val descendsBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("descendsBackground@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -942,11 +1355,35 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            false
+          ),
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            true
+          ),
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -956,30 +1393,66 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             includesResult <- dao.listUserResourceActions(includesResource.fullyQualifiedId, user.id, samRequestContext)
             descendsResult <- dao.listUserResourceActions(descendsResource.fullyQualifiedId, user.id, samRequestContext)
             parentResult <- dao.listUserResourceActions(parentResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              includesResult should contain theSameElementsAs Set(readAction)
-              descendsResult should contain theSameElementsAs Set(readAction)
-              parentResult shouldBe empty
-            }
+          } yield withClue(probePolicy) {
+            includesResult should contain theSameElementsAs Set(readAction)
+            descendsResult should contain theSameElementsAs Set(readAction)
+            parentResult shouldBe empty
           }).unsafeRunSync()
         }
       }
     }
 
     "listUserResourcesWithRolesAndActions" - {
-      def createResourceHierarchy(member: Option[WorkbenchSubject], actions: Set[ResourceAction], roles: Set[ResourceRoleName], public: Boolean, resourceType: ResourceTypeName = resourceTypeName) = {
+      def createResourceHierarchy(
+          member: Option[WorkbenchSubject],
+          actions: Set[ResourceAction],
+          roles: Set[ResourceRoleName],
+          public: Boolean,
+          resourceType: ResourceTypeName = resourceTypeName
+      ) = {
         val grandParentResource = Resource(resourceType, ResourceId(uuid), Set.empty)
         // parent is of different type to ensure it is excluded in query
         val parentResource = Resource(otherResourceType.name, ResourceId(uuid), Set.empty)
         val childResource = Resource(resourceType, ResourceId(uuid), Set.empty)
 
         // background policies exist to be excluded by the db query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(childResource.fullyQualifiedId, AccessPolicyName(uuid)), Set.empty, WorkbenchEmail(s"${uuid}@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
-        val parentBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName(uuid)), Set.empty, WorkbenchEmail(s"${uuid}@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(childResource.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set.empty,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val parentBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set.empty,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
-        val probeRolesPolicy = AccessPolicy(FullyQualifiedPolicyId(grandParentResource.fullyQualifiedId, AccessPolicyName(uuid)), member.toSet, WorkbenchEmail(s"${uuid}@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType, Set.empty, roles)), public)
-        val probeActionsPolicy = AccessPolicy(FullyQualifiedPolicyId(grandParentResource.fullyQualifiedId, AccessPolicyName(uuid)), member.toSet, WorkbenchEmail(s"${uuid}@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType, actions, Set.empty)), public)
+        val probeRolesPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(grandParentResource.fullyQualifiedId, AccessPolicyName(uuid)),
+          member.toSet,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set.empty,
+          Set.empty,
+          Set(AccessPolicyDescendantPermissions(resourceType, Set.empty, roles)),
+          public
+        )
+        val probeActionsPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(grandParentResource.fullyQualifiedId, AccessPolicyName(uuid)),
+          member.toSet,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set.empty,
+          Set.empty,
+          Set(AccessPolicyDescendantPermissions(resourceType, actions, Set.empty)),
+          public
+        )
 
         (for {
           _ <- dao.createResource(grandParentResource, samRequestContext)
@@ -994,14 +1467,44 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         } yield childResource).unsafeRunSync()
       }
 
-      def createResource(member: Option[WorkbenchSubject], actions: Set[ResourceAction], roles: Set[ResourceRoleName], public: Boolean, resourceType: ResourceTypeName = resourceTypeName) = {
+      def createResource(
+          member: Option[WorkbenchSubject],
+          actions: Set[ResourceAction],
+          roles: Set[ResourceRoleName],
+          public: Boolean,
+          resourceType: ResourceTypeName = resourceTypeName
+      ) = {
         val resource = Resource(resourceType, ResourceId(uuid), Set.empty)
 
         // background policies exist to be excluded by the db query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)), Set.empty, WorkbenchEmail(s"${uuid}@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set.empty,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
-        val probeRolesPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)), member.toSet, WorkbenchEmail(s"${uuid}@policy.com"), roles, Set.empty, Set.empty, public)
-        val probeActionsPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)), member.toSet, WorkbenchEmail(s"${uuid}@policy.com"), Set.empty, actions, Set.empty, public)
+        val probeRolesPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)),
+          member.toSet,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          roles,
+          Set.empty,
+          Set.empty,
+          public
+        )
+        val probeActionsPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName(uuid)),
+          member.toSet,
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set.empty,
+          actions,
+          Set.empty,
+          public
+        )
 
         (for {
           _ <- dao.createResource(resource, samRequestContext)
@@ -1033,8 +1536,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         // kitchenSink has inherited, direct and public-direct-via-group roles
         val kitchenSink = createResourceHierarchy(Option(user.id), Set.empty, Set(readerRole.roleName), false)
-        val directProbePolicy = AccessPolicy(FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)), Set(user.id), WorkbenchEmail(s"${uuid}@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
-        val publicProbePolicy = AccessPolicy(FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)), Set(parentGroup.id), WorkbenchEmail(s"${uuid}@policy.com"), Set(actionlessRole.roleName), Set.empty, Set.empty, true)
+        val directProbePolicy = AccessPolicy(
+          FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set(user.id),
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val publicProbePolicy = AccessPolicy(
+          FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set(parentGroup.id),
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(actionlessRole.roleName),
+          Set.empty,
+          Set.empty,
+          true
+        )
         dao.createPolicy(directProbePolicy, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicProbePolicy, samRequestContext).unsafeRunSync()
 
@@ -1055,7 +1574,12 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           ResourceIdWithRolesAndActions(publicResource.resourceId, expectedRolesAndActions, RolesAndActions.empty, expectedRolesAndActions),
 
           // direct, inherited and public roles
-          ResourceIdWithRolesAndActions(kitchenSink.resourceId, RolesAndActions.fromRoles(directProbePolicy.roles ++ publicProbePolicy.roles), RolesAndActions.fromRoles(Set(readerRole.roleName)), RolesAndActions.fromPolicy(publicProbePolicy)),
+          ResourceIdWithRolesAndActions(
+            kitchenSink.resourceId,
+            RolesAndActions.fromRoles(directProbePolicy.roles ++ publicProbePolicy.roles),
+            RolesAndActions.fromRoles(Set(readerRole.roleName)),
+            RolesAndActions.fromPolicy(publicProbePolicy)
+          )
         )
 
         val actual = dao.listUserResourcesWithRolesAndActions(resourceType.name, user.id, samRequestContext).unsafeRunSync()
@@ -1069,26 +1593,49 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val includesRole = ResourceRole(ResourceRoleName("includes"), Set(writeAction), includedRoles = Set(readerRole.roleName))
-        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name ->  Set(ownerRole.roleName)))
-        val nestedResourceType = resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole, ownerRole, actionlessRole))
+        val descendsRole =
+          ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name -> Set(ownerRole.roleName)))
+        val nestedResourceType =
+          resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole, ownerRole, actionlessRole))
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
         dirDao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
         dao.upsertResourceTypes(Set(resourceType, nestedResourceType, otherResourceType), samRequestContext).unsafeRunSync()
 
-        val directAccessResource = createResource(Option(user.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
+        val directAccessResource =
+          createResource(Option(user.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
         val publicResource = createResource(None, Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), true, nestedResourceType.name)
-        val groupAccessResource = createResource(Option(parentGroup.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
+        val groupAccessResource =
+          createResource(Option(parentGroup.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
 
-        val directAccessChildResource = createResourceHierarchy(Option(user.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
-        val publicChildResource = createResourceHierarchy(None, Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), true, nestedResourceType.name)
-        val groupAccessChildResource = createResourceHierarchy(Option(parentGroup.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
+        val directAccessChildResource =
+          createResourceHierarchy(Option(user.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
+        val publicChildResource =
+          createResourceHierarchy(None, Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), true, nestedResourceType.name)
+        val groupAccessChildResource =
+          createResourceHierarchy(Option(parentGroup.id), Set(writeAction), Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
 
         // kitchenSink has inherited, direct and public-direct-via-group roles
         val kitchenSink = createResourceHierarchy(Option(user.id), Set.empty, Set(includesRole.roleName, descendsRole.roleName), false, nestedResourceType.name)
-        val directProbePolicy = AccessPolicy(FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)), Set(user.id), WorkbenchEmail(s"${uuid}@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
-        val publicProbePolicy = AccessPolicy(FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)), Set(parentGroup.id), WorkbenchEmail(s"${uuid}@policy.com"), Set(actionlessRole.roleName), Set.empty, Set.empty, true)
+        val directProbePolicy = AccessPolicy(
+          FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set(user.id),
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val publicProbePolicy = AccessPolicy(
+          FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set(parentGroup.id),
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set(actionlessRole.roleName),
+          Set.empty,
+          Set.empty,
+          true
+        )
         dao.createPolicy(directProbePolicy, samRequestContext).unsafeRunSync()
         dao.createPolicy(publicProbePolicy, samRequestContext).unsafeRunSync()
 
@@ -1110,7 +1657,12 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           ResourceIdWithRolesAndActions(publicResource.resourceId, expectedRolesAndActions, RolesAndActions.empty, expectedRolesAndActions),
 
           // direct, inherited and public roles
-          ResourceIdWithRolesAndActions(kitchenSink.resourceId, RolesAndActions.fromRoles(directProbePolicy.roles ++ publicProbePolicy.roles), RolesAndActions.fromRoles(Set(readerRole.roleName, includesRole.roleName, descendsRole.roleName)), RolesAndActions.fromPolicy(publicProbePolicy))
+          ResourceIdWithRolesAndActions(
+            kitchenSink.resourceId,
+            RolesAndActions.fromRoles(directProbePolicy.roles ++ publicProbePolicy.roles),
+            RolesAndActions.fromRoles(Set(readerRole.roleName, includesRole.roleName, descendsRole.roleName)),
+            RolesAndActions.fromPolicy(publicProbePolicy)
+          )
         )
 
         val actual = dao.listUserResourcesWithRolesAndActions(nestedResourceType.name, user.id, samRequestContext).unsafeRunSync()
@@ -1120,25 +1672,70 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val descendsDirectAccessResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(directAccessResource.fullyQualifiedId))
         val descendsPublicResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(publicResource.fullyQualifiedId))
         val descendsGroupAccessResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(groupAccessResource.fullyQualifiedId))
-        val descendsDirectAccessChildResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(directAccessChildResource.fullyQualifiedId))
+        val descendsDirectAccessChildResource =
+          Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(directAccessChildResource.fullyQualifiedId))
         val descendsPublicChildResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(publicChildResource.fullyQualifiedId))
-        val descendsGroupAccessChildResource = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(groupAccessChildResource.fullyQualifiedId))
+        val descendsGroupAccessChildResource =
+          Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(groupAccessChildResource.fullyQualifiedId))
         val descendsKitchenSink = Resource(resourceType.name, ResourceId(uuid), Set.empty, parent = Option(kitchenSink.fullyQualifiedId))
-        val allDescendantResources = Set(descendsDirectAccessResource, descendsPublicResource, descendsGroupAccessResource, descendsDirectAccessChildResource, descendsPublicChildResource, descendsGroupAccessChildResource, descendsKitchenSink)
+        val allDescendantResources = Set(
+          descendsDirectAccessResource,
+          descendsPublicResource,
+          descendsGroupAccessResource,
+          descendsDirectAccessChildResource,
+          descendsPublicChildResource,
+          descendsGroupAccessChildResource,
+          descendsKitchenSink
+        )
         allDescendantResources.map(resource => dao.createResource(resource, samRequestContext).unsafeRunSync())
 
         // all resources should have inherited owner roles only with exception of public resources which also list owner role among the public roles
         val expectedDescendantResult = Seq(
           // inherited roles/actions
-          ResourceIdWithRolesAndActions(descendsDirectAccessChildResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions.empty),
-          ResourceIdWithRolesAndActions(descendsGroupAccessChildResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions.empty),
-          ResourceIdWithRolesAndActions(descendsDirectAccessResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions.empty),
-          ResourceIdWithRolesAndActions(descendsGroupAccessResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions.empty),
-          ResourceIdWithRolesAndActions(descendsKitchenSink.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions.empty),
+          ResourceIdWithRolesAndActions(
+            descendsDirectAccessChildResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions.empty
+          ),
+          ResourceIdWithRolesAndActions(
+            descendsGroupAccessChildResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions.empty
+          ),
+          ResourceIdWithRolesAndActions(
+            descendsDirectAccessResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions.empty
+          ),
+          ResourceIdWithRolesAndActions(
+            descendsGroupAccessResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions.empty
+          ),
+          ResourceIdWithRolesAndActions(
+            descendsKitchenSink.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions.empty
+          ),
 
           // inherited and public roles/actions
-          ResourceIdWithRolesAndActions(descendsPublicChildResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions(Set(ownerRole.roleName), Set.empty)),
-          ResourceIdWithRolesAndActions(descendsPublicResource.resourceId, RolesAndActions.empty, RolesAndActions(Set(ownerRole.roleName), Set.empty), RolesAndActions(Set(ownerRole.roleName), Set.empty)),
+          ResourceIdWithRolesAndActions(
+            descendsPublicChildResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions(Set(ownerRole.roleName), Set.empty)
+          ),
+          ResourceIdWithRolesAndActions(
+            descendsPublicResource.resourceId,
+            RolesAndActions.empty,
+            RolesAndActions(Set(ownerRole.roleName), Set.empty),
+            RolesAndActions(Set(ownerRole.roleName), Set.empty)
+          )
         )
 
         val actualDescendantResult = dao.listUserResourcesWithRolesAndActions(resourceType.name, user.id, samRequestContext).unsafeRunSync()
@@ -1155,7 +1752,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("background@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("background@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -1167,13 +1772,37 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          ),
 
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            true
+          ),
 
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set(readerRole.roleName), Set.empty, Set.empty, false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(readerRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -1181,10 +1810,8 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.deletePolicy(probePolicy.id, samRequestContext)
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             result <- dao.listUserResourceRoles(resource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              result should contain theSameElementsAs Set(readerRole.roleName)
-            }
+          } yield withClue(probePolicy) {
+            result should contain theSameElementsAs Set(readerRole.roleName)
           }).unsafeRunSync()
         }
       }
@@ -1198,7 +1825,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentResource = Resource(resourceType.name, ResourceId("parentResource"), Set.empty)
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val backgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("background@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val backgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("background@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -1212,13 +1847,37 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            false
+          ),
 
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            true
+          ),
 
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))), false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(resourceType.name, Set.empty, Set(readerRole.roleName))),
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -1227,11 +1886,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             childResult <- dao.listUserResourceRoles(resource.fullyQualifiedId, user.id, samRequestContext)
             parentResult <- dao.listUserResourceRoles(parentResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              childResult should contain theSameElementsAs Set(readerRole.roleName)
-              parentResult shouldBe empty
-            }
+          } yield withClue(probePolicy) {
+            childResult should contain theSameElementsAs Set(readerRole.roleName)
+            parentResult shouldBe empty
           }).unsafeRunSync()
         }
       }
@@ -1243,14 +1900,31 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val includesRole = ResourceRole(ResourceRoleName("includes"), Set(writeAction), includedRoles = Set(readerRole.roleName))
-        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name ->  Set(ownerRole.roleName)))
+        val descendsRole =
+          ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name -> Set(ownerRole.roleName)))
 
         val nestedResourceType = resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole))
         val includesResource = Resource(nestedResourceType.name, ResourceId("includes"), Set.empty)
         val descendsResource = Resource(resourceType.name, ResourceId("descends"), Set.empty, parent = Option(includesResource.fullyQualifiedId))
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val includesBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("includesBackground@policy.com"), Set(includesRole.roleName), Set.empty, Set.empty, false)
-        val descendsBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("descendsBackground@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val includesBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("includesBackground@policy.com"),
+          Set(includesRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val descendsBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("descendsBackground@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -1264,11 +1938,35 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          ),
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            true
+          ),
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set(includesRole.roleName, descendsRole.roleName), Set.empty, Set.empty, false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set(includesRole.roleName, descendsRole.roleName),
+            Set.empty,
+            Set.empty,
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -1277,11 +1975,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             _ <- dao.createPolicy(probePolicy, samRequestContext)
             includesResult <- dao.listUserResourceRoles(includesResource.fullyQualifiedId, user.id, samRequestContext)
             descendsResult <- dao.listUserResourceRoles(descendsResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              includesResult should contain theSameElementsAs Set(includesRole.roleName, descendsRole.roleName, readerRole.roleName)
-              descendsResult should contain theSameElementsAs Set(ownerRole.roleName)
-            }
+          } yield withClue(probePolicy) {
+            includesResult should contain theSameElementsAs Set(includesRole.roleName, descendsRole.roleName, readerRole.roleName)
+            descendsResult should contain theSameElementsAs Set(ownerRole.roleName)
           }).unsafeRunSync()
         }
       }
@@ -1293,15 +1989,32 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
 
         val includesRole = ResourceRole(ResourceRoleName("includes"), Set(writeAction), includedRoles = Set(readerRole.roleName))
-        val descendsRole = ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name ->  Set(ownerRole.roleName)))
+        val descendsRole =
+          ResourceRole(ResourceRoleName("descends"), Set(readAction, writeAction), descendantRoles = Map(resourceType.name -> Set(ownerRole.roleName)))
 
         val nestedResourceType = resourceType.copy(name = ResourceTypeName("nested"), roles = Set(includesRole, descendsRole, readerRole))
         val parentResource = Resource(nestedResourceType.name, ResourceId("parent"), Set.empty)
         val includesResource = Resource(nestedResourceType.name, ResourceId("includes"), Set.empty, parent = Option(parentResource.fullyQualifiedId))
         val descendsResource = Resource(resourceType.name, ResourceId("descends"), Set.empty, parent = Option(includesResource.fullyQualifiedId))
         // backgroundPolicy makes sure there is something in the database that is excluded by the query
-        val includesBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("includesBackground@policy.com"), Set(includesRole.roleName), Set.empty, Set.empty, false)
-        val descendsBackgroundPolicy = AccessPolicy(FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")), Set.empty, WorkbenchEmail("descendsBackground@policy.com"), Set(ownerRole.roleName), Set.empty, Set.empty, false)
+        val includesBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(includesResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("includesBackground@policy.com"),
+          Set(includesRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
+        val descendsBackgroundPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(descendsResource.fullyQualifiedId, AccessPolicyName("background")),
+          Set.empty,
+          WorkbenchEmail("descendsBackground@policy.com"),
+          Set(ownerRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(user, samRequestContext).unsafeRunSync()
         dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
@@ -1316,11 +2029,35 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val probePolicies = List(
           // user with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(user.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), false),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(user.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            false
+          ),
           // public with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set.empty, WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), true),
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set.empty,
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            true
+          ),
           // group with role
-          AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")), Set(parentGroup.id), WorkbenchEmail("probe@policy.com"), Set.empty, Set.empty, Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))), false)
+          AccessPolicy(
+            FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("probe")),
+            Set(parentGroup.id),
+            WorkbenchEmail("probe@policy.com"),
+            Set.empty,
+            Set.empty,
+            Set(AccessPolicyDescendantPermissions(nestedResourceType.name, Set.empty, Set(includesRole.roleName, descendsRole.roleName))),
+            false
+          )
         )
 
         probePolicies.foreach { probePolicy =>
@@ -1330,12 +2067,10 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
             includesResult <- dao.listUserResourceRoles(includesResource.fullyQualifiedId, user.id, samRequestContext)
             descendsResult <- dao.listUserResourceRoles(descendsResource.fullyQualifiedId, user.id, samRequestContext)
             parentResult <- dao.listUserResourceRoles(parentResource.fullyQualifiedId, user.id, samRequestContext)
-          } yield {
-            withClue(probePolicy) {
-              includesResult should contain theSameElementsAs Set(includesRole.roleName, descendsRole.roleName, readerRole.roleName)
-              descendsResult should contain theSameElementsAs Set(ownerRole.roleName)
-              parentResult shouldBe empty
-            }
+          } yield withClue(probePolicy) {
+            includesResult should contain theSameElementsAs Set(includesRole.roleName, descendsRole.roleName, readerRole.roleName)
+            descendsResult should contain theSameElementsAs Set(ownerRole.roleName)
+            parentResult shouldBe empty
           }).unsafeRunSync()
         }
       }
@@ -1354,7 +2089,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(parentResource, samRequestContext).unsafeRunSync()
         dao.createResource(childResource, samRequestContext).unsafeRunSync()
 
-        val parentPolicy = AccessPolicy(FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("parent")), Set(user.id), WorkbenchEmail("parent@policy.com"), Set(descendantRole.roleName), Set.empty, Set.empty, false)
+        val parentPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(parentResource.fullyQualifiedId, AccessPolicyName("parent")),
+          Set(user.id),
+          WorkbenchEmail("parent@policy.com"),
+          Set(descendantRole.roleName),
+          Set.empty,
+          Set.empty,
+          false
+        )
         dao.createPolicy(parentPolicy, samRequestContext).unsafeRunSync()
         val parentResult = dao.listUserResourceRoles(parentResource.fullyQualifiedId, user.id, samRequestContext).unsafeRunSync()
         val childResult = dao.listUserResourceRoles(childResource.fullyQualifiedId, user.id, samRequestContext).unsafeRunSync()
@@ -1371,13 +2114,38 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val childRole = ResourceRoleName("child_role")
         val childIncludedRole = ResourceRoleName("child_included_role")
-        val childRT = ResourceType(ResourceTypeName("childRT"), Set.empty, Set(ResourceRole(childRole, Set.empty, includedRoles = Set(childIncludedRole)), ResourceRole(childIncludedRole, Set.empty)), childRole)
+        val childRT = ResourceType(
+          ResourceTypeName("childRT"),
+          Set.empty,
+          Set(ResourceRole(childRole, Set.empty, includedRoles = Set(childIncludedRole)), ResourceRole(childIncludedRole, Set.empty)),
+          childRole
+        )
 
         val parentRole = ResourceRoleName("parent_role")
-        val parentRT = ResourceType(ResourceTypeName("parentRT"), Set.empty, Set(ResourceRole(parentRole, Set.empty, descendantRoles = Map(childRT.name -> Set(childRole)))), parentRole)
+        val parentRT = ResourceType(
+          ResourceTypeName("parentRT"),
+          Set.empty,
+          Set(ResourceRole(parentRole, Set.empty, descendantRoles = Map(childRT.name -> Set(childRole)))),
+          parentRole
+        )
 
         val parentId = FullyQualifiedResourceId(parentRT.name, ResourceId("parent"))
-        val parent = Resource(parentId.resourceTypeName, parentId.resourceId, Set.empty, Set(AccessPolicy(FullyQualifiedPolicyId(parentId, AccessPolicyName("policyname")), Set(user.id), WorkbenchEmail("foo@foo.com"), Set(parentRole), Set.empty, Set.empty, false)))
+        val parent = Resource(
+          parentId.resourceTypeName,
+          parentId.resourceId,
+          Set.empty,
+          Set(
+            AccessPolicy(
+              FullyQualifiedPolicyId(parentId, AccessPolicyName("policyname")),
+              Set(user.id),
+              WorkbenchEmail("foo@foo.com"),
+              Set(parentRole),
+              Set.empty,
+              Set.empty,
+              false
+            )
+          )
+        )
 
         val childId = FullyQualifiedResourceId(childRT.name, ResourceId("child"))
         val child = Resource(childId.resourceTypeName, childId.resourceId, Set.empty, parent = Option(parent.fullyQualifiedId))
@@ -1416,13 +2184,38 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val childRT = ResourceType(ResourceTypeName("childRT"), Set.empty, Set(ResourceRole(childRole, Set.empty)), childRole)
 
         val parentRole = ResourceRoleName("parent_role")
-        val parentRT = ResourceType(ResourceTypeName("parentRT"), Set.empty, Set(ResourceRole(parentRole, Set.empty, descendantRoles = Map(childRT.name -> Set(childRole)))), parentRole)
+        val parentRT = ResourceType(
+          ResourceTypeName("parentRT"),
+          Set.empty,
+          Set(ResourceRole(parentRole, Set.empty, descendantRoles = Map(childRT.name -> Set(childRole)))),
+          parentRole
+        )
 
         val grantParentRole = ResourceRoleName("grand_parent_role")
-        val grandParentRT = ResourceType(ResourceTypeName("grandparentRT"), Set.empty, Set(ResourceRole(grantParentRole, Set.empty, descendantRoles = Map(parentRT.name -> Set(parentRole)))), grantParentRole)
+        val grandParentRT = ResourceType(
+          ResourceTypeName("grandparentRT"),
+          Set.empty,
+          Set(ResourceRole(grantParentRole, Set.empty, descendantRoles = Map(parentRT.name -> Set(parentRole)))),
+          grantParentRole
+        )
 
         val grandParentId = FullyQualifiedResourceId(grandParentRT.name, ResourceId("grandparent"))
-        val grandParent = Resource(grandParentId.resourceTypeName, grandParentId.resourceId, Set.empty, Set(AccessPolicy(FullyQualifiedPolicyId(grandParentId, AccessPolicyName("policyname")), Set(user.id), WorkbenchEmail("foo@foo.com"), Set(grantParentRole), Set.empty, Set.empty, false)))
+        val grandParent = Resource(
+          grandParentId.resourceTypeName,
+          grandParentId.resourceId,
+          Set.empty,
+          Set(
+            AccessPolicy(
+              FullyQualifiedPolicyId(grandParentId, AccessPolicyName("policyname")),
+              Set(user.id),
+              WorkbenchEmail("foo@foo.com"),
+              Set(grantParentRole),
+              Set.empty,
+              Set.empty,
+              false
+            )
+          )
+        )
 
         val parentId = FullyQualifiedResourceId(parentRT.name, ResourceId("parent"))
         val parent = Resource(parentId.resourceTypeName, parentId.resourceId, Set.empty, parent = Option(grandParent.fullyQualifiedId))
@@ -1462,7 +2255,15 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
     "setPolicyIsPublic" - {
       "can change whether a policy is public or private" in {
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("private")), Set.empty, WorkbenchEmail("private@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("private")),
+          Set.empty,
+          WorkbenchEmail("private@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -1480,9 +2281,25 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
     "listAccessPolicies" - {
       "lists all the access policy names with their resource names that a user is in for a given resource type" in {
         val resource1 = Resource(resourceType.name, ResourceId("resource1"), Set.empty)
-        val policy1 = AccessPolicy(FullyQualifiedPolicyId(resource1.fullyQualifiedId, AccessPolicyName("one")), Set(defaultUser.id), WorkbenchEmail("one@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy1 = AccessPolicy(
+          FullyQualifiedPolicyId(resource1.fullyQualifiedId, AccessPolicyName("one")),
+          Set(defaultUser.id),
+          WorkbenchEmail("one@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         val resource2 = Resource(resourceType.name, ResourceId("resource2"), Set.empty)
-        val policy2 = AccessPolicy(FullyQualifiedPolicyId(resource2.fullyQualifiedId, AccessPolicyName("two")), Set(defaultUser.id), WorkbenchEmail("two@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy2 = AccessPolicy(
+          FullyQualifiedPolicyId(resource2.fullyQualifiedId, AccessPolicyName("two")),
+          Set(defaultUser.id),
+          WorkbenchEmail("two@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -1491,7 +2308,10 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createPolicy(policy1, samRequestContext).unsafeRunSync()
         dao.createPolicy(policy2, samRequestContext).unsafeRunSync()
 
-        dao.listAccessPolicies(resourceType.name, defaultUser.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(ResourceIdAndPolicyName(resource1.resourceId, policy1.id.accessPolicyName), ResourceIdAndPolicyName(resource2.resourceId, policy2.id.accessPolicyName))
+        dao.listAccessPolicies(resourceType.name, defaultUser.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(
+          ResourceIdAndPolicyName(resource1.resourceId, policy1.id.accessPolicyName),
+          ResourceIdAndPolicyName(resource2.resourceId, policy2.id.accessPolicyName)
+        )
       }
 
       "lists the access policies for a resource" in {
@@ -1499,8 +2319,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val owner = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")), Set(defaultUser.id, defaultGroup.id), WorkbenchEmail("owner@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val reader = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")), Set(owner.id, defaultUser.id), WorkbenchEmail("reader@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val owner = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")),
+          Set(defaultUser.id, defaultGroup.id),
+          WorkbenchEmail("owner@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val reader = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")),
+          Set(owner.id, defaultUser.id),
+          WorkbenchEmail("reader@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
@@ -1517,18 +2353,57 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val owner = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")), Set(defaultUser.id, defaultGroup.id), WorkbenchEmail("owner@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val reader = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")), Set(owner.id, defaultUser.id), WorkbenchEmail("reader@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val owner = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")),
+          Set(defaultUser.id, defaultGroup.id),
+          WorkbenchEmail("owner@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val reader = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")),
+          Set(owner.id, defaultUser.id),
+          WorkbenchEmail("reader@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
         dao.createPolicy(owner, samRequestContext).unsafeRunSync()
         dao.createPolicy(reader, samRequestContext).unsafeRunSync()
 
-        val ownerPolicyWithMembership = AccessPolicyWithMembership(owner.id.accessPolicyName, AccessPolicyMembership(Set(defaultUser.email, defaultGroup.email), owner.actions, owner.roles, Option(owner.descendantPermissions), Option(Set.empty)), owner.email)
-        val readerPolicyWithMembership = AccessPolicyWithMembership(reader.id.accessPolicyName, AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId)))), reader.email)
+        val ownerPolicyWithMembership = AccessPolicyWithMembership(
+          owner.id.accessPolicyName,
+          AccessPolicyMembership(
+            Set(defaultUser.email, defaultGroup.email),
+            owner.actions,
+            owner.roles,
+            Option(owner.descendantPermissions),
+            Option(Set.empty)
+          ),
+          owner.email
+        )
+        val readerPolicyWithMembership = AccessPolicyWithMembership(
+          reader.id.accessPolicyName,
+          AccessPolicyMembership(
+            Set(owner.email, defaultUser.email),
+            reader.actions,
+            reader.roles,
+            Option(reader.descendantPermissions),
+            Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId)))
+          ),
+          reader.email
+        )
 
-        dao.listAccessPolicyMemberships(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should contain theSameElementsAs LazyList(ownerPolicyWithMembership, readerPolicyWithMembership)
+        dao.listAccessPolicyMemberships(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() should contain theSameElementsAs LazyList(
+          ownerPolicyWithMembership,
+          readerPolicyWithMembership
+        )
       }
     }
 
@@ -1538,16 +2413,39 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dirDao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
-        val owner = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")), Set(defaultUser.id, defaultGroup.id), WorkbenchEmail("owner@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
-        val reader = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")), Set(owner.id, defaultUser.id), WorkbenchEmail("reader@policy.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val owner = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner")),
+          Set(defaultUser.id, defaultGroup.id),
+          WorkbenchEmail("owner@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
+        val reader = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader")),
+          Set(owner.id, defaultUser.id),
+          WorkbenchEmail("reader@policy.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
 
         dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         dao.createResource(resource, samRequestContext).unsafeRunSync()
         dao.createPolicy(owner, samRequestContext).unsafeRunSync()
         dao.createPolicy(reader, samRequestContext).unsafeRunSync()
 
-        val ownerPolicyMembership = AccessPolicyMembership(Set(defaultUser.email, defaultGroup.email), owner.actions, owner.roles, Option(owner.descendantPermissions), Option(Set.empty))
-        val readerPolicyMembership = AccessPolicyMembership(Set(owner.email, defaultUser.email), reader.actions, reader.roles, Option(reader.descendantPermissions), Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId))))
+        val ownerPolicyMembership =
+          AccessPolicyMembership(Set(defaultUser.email, defaultGroup.email), owner.actions, owner.roles, Option(owner.descendantPermissions), Option(Set.empty))
+        val readerPolicyMembership = AccessPolicyMembership(
+          Set(owner.email, defaultUser.email),
+          reader.actions,
+          reader.roles,
+          Option(reader.descendantPermissions),
+          Option(Set(PolicyIdentifiers(owner.id.accessPolicyName, owner.email, owner.id.resource.resourceTypeName, owner.id.resource.resourceId)))
+        )
 
         dao.loadPolicyMembership(reader.id, samRequestContext).unsafeRunSync() shouldBe Option(readerPolicyMembership)
         dao.loadPolicyMembership(owner.id, samRequestContext).unsafeRunSync() shouldBe Option(ownerPolicyMembership)
@@ -1561,12 +2459,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-
-        val secondUser = defaultUser.copy(id = WorkbenchUserId("foo"), googleSubjectId = Some(GoogleSubjectId("blablabla")), email = WorkbenchEmail("bar@baz.com"), azureB2CId = Some(AzureB2CId("ooo")))
+        val secondUser = defaultUser.copy(
+          id = WorkbenchUserId("foo"),
+          googleSubjectId = Some(GoogleSubjectId("blablabla")),
+          email = WorkbenchEmail("bar@baz.com"),
+          azureB2CId = Some(AzureB2CId("ooo"))
+        )
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         dirDao.createUser(secondUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
 
@@ -1582,12 +2492,25 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val secondUser = defaultUser.copy(id = WorkbenchUserId("foo"), googleSubjectId = Some(GoogleSubjectId("blablabla")), email = WorkbenchEmail("bar@baz.com"), azureB2CId = Some(AzureB2CId("ooo")))
+        val secondUser = defaultUser.copy(
+          id = WorkbenchUserId("foo"),
+          googleSubjectId = Some(GoogleSubjectId("blablabla")),
+          email = WorkbenchEmail("bar@baz.com"),
+          azureB2CId = Some(AzureB2CId("ooo"))
+        )
 
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         dirDao.createUser(secondUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set.empty, WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set.empty,
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
 
@@ -1605,12 +2528,25 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val secondUser = defaultUser.copy(id = WorkbenchUserId("foo"), googleSubjectId = Some(GoogleSubjectId("blablabla")), email = WorkbenchEmail("bar@baz.com"), azureB2CId = Some(AzureB2CId("ooo")))
+        val secondUser = defaultUser.copy(
+          id = WorkbenchUserId("foo"),
+          googleSubjectId = Some(GoogleSubjectId("blablabla")),
+          email = WorkbenchEmail("bar@baz.com"),
+          azureB2CId = Some(AzureB2CId("ooo"))
+        )
 
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         dirDao.createUser(secondUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
 
@@ -1625,11 +2561,24 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         dao.createResource(resource, samRequestContext).unsafeRunSync()
 
-        val secondUser = defaultUser.copy(id = WorkbenchUserId("foo"), googleSubjectId = Some(GoogleSubjectId("blablabla")), email = WorkbenchEmail("bar@baz.com"), azureB2CId = Some(AzureB2CId("ooo")))
+        val secondUser = defaultUser.copy(
+          id = WorkbenchUserId("foo"),
+          googleSubjectId = Some(GoogleSubjectId("blablabla")),
+          email = WorkbenchEmail("bar@baz.com"),
+          azureB2CId = Some(AzureB2CId("ooo"))
+        )
 
         dirDao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), Set.empty, false)
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          Set.empty,
+          false
+        )
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
 
@@ -1644,14 +2593,34 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
       "overwrites descendant actions and roles" in {
         val resource = Resource(resourceType.name, ResourceId("resource"), Set.empty)
         val otherResourceType = resourceType.copy(name = ResourceTypeName("otherResourceType"))
-        val secondUser = defaultUser.copy(id = WorkbenchUserId("foo"), googleSubjectId = Some(GoogleSubjectId("blablabla")), email = WorkbenchEmail("bar@baz.com"), azureB2CId = Some(AzureB2CId("ooo")))
+        val secondUser = defaultUser.copy(
+          id = WorkbenchUserId("foo"),
+          googleSubjectId = Some(GoogleSubjectId("blablabla")),
+          email = WorkbenchEmail("bar@baz.com"),
+          azureB2CId = Some(AzureB2CId("ooo"))
+        )
 
         val sameResourceTypeDescendant = AccessPolicyDescendantPermissions(resource.resourceTypeName, Set(writeAction), Set(ownerRoleName))
         val otherResourceTypeDescendant = AccessPolicyDescendantPermissions(otherResourceType.name, Set(readAction), Set(actionlessRole.roleName))
         val initialDescendantPermissions = Set(sameResourceTypeDescendant, otherResourceTypeDescendant)
-        val updatedDescendantPermissions = Set(sameResourceTypeDescendant.copy(actions = Set(readAction)), otherResourceTypeDescendant.copy(roles = Set(readerRole.roleName)))
-        val policy = AccessPolicy(FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")), Set(defaultUser.id), WorkbenchEmail("policy@email.com"), resourceType.roles.map(_.roleName), Set(readAction, writeAction), initialDescendantPermissions, false)
-        val newPolicy = policy.copy(members = Set(defaultUser.id, secondUser.id), actions = Set(readAction), roles = Set.empty, descendantPermissions = updatedDescendantPermissions, public = true)
+        val updatedDescendantPermissions =
+          Set(sameResourceTypeDescendant.copy(actions = Set(readAction)), otherResourceTypeDescendant.copy(roles = Set(readerRole.roleName)))
+        val policy = AccessPolicy(
+          FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("policyName")),
+          Set(defaultUser.id),
+          WorkbenchEmail("policy@email.com"),
+          resourceType.roles.map(_.roleName),
+          Set(readAction, writeAction),
+          initialDescendantPermissions,
+          false
+        )
+        val newPolicy = policy.copy(
+          members = Set(defaultUser.id, secondUser.id),
+          actions = Set(readAction),
+          roles = Set.empty,
+          descendantPermissions = updatedDescendantPermissions,
+          public = true
+        )
 
         val testResult = for {
           _ <- dao.createResourceType(resourceType, samRequestContext)
@@ -1683,9 +2652,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
           _ <- dao.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext)
           resourceParentResult <- dao.getResourceParent(childResource.fullyQualifiedId, samRequestContext)
-        } yield {
-          resourceParentResult shouldBe Option(parentResource.fullyQualifiedId)
-        }
+        } yield resourceParentResult shouldBe Option(parentResource.fullyQualifiedId)
 
         testResult.unsafeRunSync()
       }
@@ -1697,9 +2664,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           _ <- dao.createResource(childResource, samRequestContext)
 
           resourceParentResult <- dao.getResourceParent(childResource.fullyQualifiedId, samRequestContext)
-        } yield {
-          resourceParentResult shouldBe None
-        }
+        } yield resourceParentResult shouldBe None
 
         testResult.unsafeRunSync()
       }
@@ -1782,9 +2747,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           _ <- dao.createResource(parentResource, samRequestContext)
           _ <- dao.setResourceParent(childResource.fullyQualifiedId, parentResource.fullyQualifiedId, samRequestContext)
           parentResourceResult <- dao.getResourceParent(childResource.fullyQualifiedId, samRequestContext)
-        } yield {
-          parentResourceResult shouldBe Option(parentResource.fullyQualifiedId)
-        }
+        } yield parentResourceResult shouldBe Option(parentResource.fullyQualifiedId)
 
         testSetup.unsafeRunSync()
 
@@ -1888,7 +2851,6 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
     }
   }
 
-  private def uuid: String = {
+  private def uuid: String =
     UUID.randomUUID().toString
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -6,7 +6,15 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
-import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityDisplayName, ManagedIdentityObjectId, ManagedResourceGroupName, PetManagedIdentity, PetManagedIdentityId, SubscriptionId, TenantId}
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  ManagedIdentityDisplayName,
+  ManagedIdentityObjectId,
+  ManagedResourceGroupName,
+  PetManagedIdentity,
+  PetManagedIdentityId,
+  SubscriptionId,
+  TenantId
+}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
@@ -22,11 +30,17 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
   val defaultGroupName = WorkbenchGroupName("group")
   val defaultGroup = BasicWorkbenchGroup(defaultGroupName, Set.empty, WorkbenchEmail("foo@bar.com"))
   val defaultUser = Generator.genWorkbenchUserBoth.sample.get
-  val defaultPetSA = PetServiceAccount(PetServiceAccountId(defaultUser.id, GoogleProject("testProject")), ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId"), WorkbenchEmail("test@pet.co"), ServiceAccountDisplayName("whoCares")))
-  val defaultPetMI = PetManagedIdentity(PetManagedIdentityId(defaultUser.id, TenantId("testTenant"), SubscriptionId("testSubscription"), ManagedResourceGroupName("testMrg")), ManagedIdentityObjectId("testObjectId"), ManagedIdentityDisplayName("Managed Identity"))
+  val defaultPetSA = PetServiceAccount(
+    PetServiceAccountId(defaultUser.id, GoogleProject("testProject")),
+    ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId"), WorkbenchEmail("test@pet.co"), ServiceAccountDisplayName("whoCares"))
+  )
+  val defaultPetMI = PetManagedIdentity(
+    PetManagedIdentityId(defaultUser.id, TenantId("testTenant"), SubscriptionId("testSubscription"), ManagedResourceGroupName("testMrg")),
+    ManagedIdentityObjectId("testObjectId"),
+    ManagedIdentityDisplayName("Managed Identity")
+  )
 
-  val actionPatterns = Set(ResourceActionPattern("write", "description of pattern1", false),
-    ResourceActionPattern("read", "description of pattern2", false))
+  val actionPatterns = Set(ResourceActionPattern("write", "description of pattern1", false), ResourceActionPattern("read", "description of pattern2", false))
   val writeAction = ResourceAction("write")
   val readAction = ResourceAction("read")
 
@@ -39,13 +53,21 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
   val resourceTypeName = ResourceTypeName("awesomeType")
   val resourceType = ResourceType(resourceTypeName, actionPatterns, roles, ownerRoleName, false)
   val defaultResource = Resource(resourceType.name, ResourceId("defaultResource"), Set.empty)
-  val defaultPolicy = AccessPolicy(FullyQualifiedPolicyId(defaultResource.fullyQualifiedId, AccessPolicyName("defaultPolicy")), Set.empty, WorkbenchEmail("default@policy.com"), roles.map(_.roleName), Set(writeAction, readAction), Set.empty, false)
+  val defaultPolicy = AccessPolicy(
+    FullyQualifiedPolicyId(defaultResource.fullyQualifiedId, AccessPolicyName("defaultPolicy")),
+    Set.empty,
+    WorkbenchEmail("default@policy.com"),
+    roles.map(_.roleName),
+    Set(writeAction, readAction),
+    Set.empty,
+    false
+  )
 
-  override protected def beforeEach(): Unit = {
+  override protected def beforeEach(): Unit =
     TestSupport.truncateAll
-  }
 
-  private def emptyWorkbenchGroup(groupName: String): BasicWorkbenchGroup = BasicWorkbenchGroup(WorkbenchGroupName(groupName), Set.empty, WorkbenchEmail(s"$groupName@test.com"))
+  private def emptyWorkbenchGroup(groupName: String): BasicWorkbenchGroup =
+    BasicWorkbenchGroup(WorkbenchGroupName(groupName), Set.empty, WorkbenchEmail(s"$groupName@test.com"))
 
   "PostgresDirectoryDAO" - {
     "createGroup" - {
@@ -125,7 +147,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
     }
 
     "loadGroup" - {
-        "load a group" in {
+      "load a group" in {
         dao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
         val loadedGroup = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"Failed to load group $defaultGroupName"))
         loadedGroup shouldEqual defaultGroup
@@ -219,7 +241,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         dao.addGroupMember(defaultPolicy.id, defaultGroup.id, samRequestContext).unsafeRunSync()
 
-        val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val loadedPolicy =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(defaultGroup.id)
       }
 
@@ -231,7 +254,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         dao.addGroupMember(defaultPolicy.id, defaultUser.id, samRequestContext).unsafeRunSync()
 
-        val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val loadedPolicy =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(defaultUser.id)
       }
 
@@ -239,12 +263,14 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
         policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
-        val memberPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
+        val memberPolicy =
+          defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
         policyDAO.createPolicy(memberPolicy, samRequestContext).unsafeRunSync()
 
         dao.addGroupMember(defaultPolicy.id, memberPolicy.id, samRequestContext).unsafeRunSync()
 
-        val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val loadedPolicy =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(memberPolicy.id)
       }
 
@@ -272,7 +298,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         }
 
         exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
-        exception.errorReport.message should include (defaultGroup.email.value)
+        exception.errorReport.message should include(defaultGroup.email.value)
       }
     }
 
@@ -284,7 +310,9 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.createGroup(group1, samRequestContext = samRequestContext).unsafeRunSync()
         dao.createGroup(group2, samRequestContext = samRequestContext).unsafeRunSync()
 
-        dao.batchLoadGroupEmail(Set(group1.id, group2.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(group1, group2).map(group => (group.id, group.email))
+        dao.batchLoadGroupEmail(Set(group1.id, group2.id), samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(group1, group2).map(group =>
+          (group.id, group.email)
+        )
       }
     }
 
@@ -344,7 +372,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.listFlattenedPolicyMembers(defaultPolicy.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(defaultUser)
         dao.removeGroupMember(defaultPolicy.id, defaultGroup.id, samRequestContext).unsafeRunSync()
 
-        val afterRemove = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val afterRemove =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         afterRemove.members shouldBe empty
         policyDAO.listFlattenedPolicyMembers(defaultPolicy.id, samRequestContext).unsafeRunSync() shouldBe empty
       }
@@ -358,7 +387,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.addGroupMember(defaultPolicy.id, defaultUser.id, samRequestContext).unsafeRunSync()
         dao.removeGroupMember(defaultPolicy.id, defaultUser.id, samRequestContext).unsafeRunSync()
 
-        val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val loadedPolicy =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members shouldBe empty
       }
 
@@ -366,13 +396,15 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
         policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
-        val memberPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
+        val memberPolicy =
+          defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
         policyDAO.createPolicy(memberPolicy, samRequestContext).unsafeRunSync()
 
         dao.addGroupMember(defaultPolicy.id, memberPolicy.id, samRequestContext).unsafeRunSync()
         dao.removeGroupMember(defaultPolicy.id, memberPolicy.id, samRequestContext).unsafeRunSync()
 
-        val loadedPolicy = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
+        val loadedPolicy =
+          policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members shouldBe empty
       }
     }
@@ -429,8 +461,16 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
 
       "list all of the policies a user is in" in {
-        val subPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")), email = WorkbenchEmail("sp@policy.com"), members = Set(defaultUser.id))
-        val parentPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")), email = WorkbenchEmail("pp@policy.com"), members = Set(subPolicy.id))
+        val subPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")),
+          email = WorkbenchEmail("sp@policy.com"),
+          members = Set(defaultUser.id)
+        )
+        val parentPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")),
+          email = WorkbenchEmail("pp@policy.com"),
+          members = Set(subPolicy.id)
+        )
 
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -485,10 +525,16 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       "get all pet service accounts for user" in {
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val petSA1 = PetServiceAccount(PetServiceAccountId(defaultUser.id, GoogleProject("testProject1")), ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId1"), WorkbenchEmail("test1@pet.co"), ServiceAccountDisplayName("whoCares")))
+        val petSA1 = PetServiceAccount(
+          PetServiceAccountId(defaultUser.id, GoogleProject("testProject1")),
+          ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId1"), WorkbenchEmail("test1@pet.co"), ServiceAccountDisplayName("whoCares"))
+        )
         dao.createPetServiceAccount(petSA1, samRequestContext).unsafeRunSync()
 
-        val petSA2 = PetServiceAccount(PetServiceAccountId(defaultUser.id, GoogleProject("testProject2")), ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId2"), WorkbenchEmail("test2@pet.co"), ServiceAccountDisplayName("whoCares")))
+        val petSA2 = PetServiceAccount(
+          PetServiceAccountId(defaultUser.id, GoogleProject("testProject2")),
+          ServiceAccount(ServiceAccountSubjectId("testGoogleSubjectId2"), WorkbenchEmail("test2@pet.co"), ServiceAccountDisplayName("whoCares"))
+        )
         dao.createPetServiceAccount(petSA2, samRequestContext).unsafeRunSync()
 
         dao.getAllPetServiceAccountsForUser(defaultUser.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Seq(petSA1, petSA2)
@@ -511,7 +557,9 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         dao.createPetServiceAccount(defaultPetSA, samRequestContext).unsafeRunSync()
 
-        val updatedPetSA = defaultPetSA.copy(serviceAccount = ServiceAccount(ServiceAccountSubjectId("updatedTestGoogleSubjectId"), WorkbenchEmail("new@pet.co"), ServiceAccountDisplayName("whoCares")))
+        val updatedPetSA = defaultPetSA.copy(serviceAccount =
+          ServiceAccount(ServiceAccountSubjectId("updatedTestGoogleSubjectId"), WorkbenchEmail("new@pet.co"), ServiceAccountDisplayName("whoCares"))
+        )
         dao.updatePetServiceAccount(updatedPetSA, samRequestContext).unsafeRunSync() shouldBe updatedPetSA
 
         dao.loadPetServiceAccount(updatedPetSA.id, samRequestContext).unsafeRunSync() shouldBe Some(updatedPetSA)
@@ -520,7 +568,9 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       "throw an exception when updating a nonexistent pet SA" in {
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
 
-        val updatedPetSA = defaultPetSA.copy(serviceAccount = ServiceAccount(ServiceAccountSubjectId("updatedTestGoogleSubjectId"), WorkbenchEmail("new@pet.co"), ServiceAccountDisplayName("whoCares")))
+        val updatedPetSA = defaultPetSA.copy(serviceAccount =
+          ServiceAccount(ServiceAccountSubjectId("updatedTestGoogleSubjectId"), WorkbenchEmail("new@pet.co"), ServiceAccountDisplayName("whoCares"))
+        )
         assertThrows[WorkbenchException] {
           dao.updatePetServiceAccount(updatedPetSA, samRequestContext).unsafeRunSync() shouldBe updatedPetSA
         }
@@ -555,7 +605,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.createGroup(subGroup2, samRequestContext = samRequestContext).unsafeRunSync()
         dao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
-        dao.isGroupMember(parentGroup.id, subGroup1.id, samRequestContext).unsafeRunSync() should be (true)
+        dao.isGroupMember(parentGroup.id, subGroup1.id, samRequestContext).unsafeRunSync() should be(true)
       }
 
       "return false when member is not in sub group" in {
@@ -567,7 +617,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.createGroup(subGroup2, samRequestContext = samRequestContext).unsafeRunSync()
         dao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
-        dao.isGroupMember(parentGroup.id, subGroup1.id, samRequestContext).unsafeRunSync() should be (false)
+        dao.isGroupMember(parentGroup.id, subGroup1.id, samRequestContext).unsafeRunSync() should be(false)
       }
 
       "return true when user is in sub group" in {
@@ -594,7 +644,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.createGroup(subGroup2, samRequestContext = samRequestContext).unsafeRunSync()
         dao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
-        dao.isGroupMember(parentGroup.id, user.id, samRequestContext).unsafeRunSync() should be (true)
+        dao.isGroupMember(parentGroup.id, user.id, samRequestContext).unsafeRunSync() should be(true)
       }
 
       "return false when user is not in sub group" in {
@@ -634,7 +684,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
 
       "return true when policy is in policy" in {
-        val memberPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
+        val memberPolicy =
+          defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
         val policy = defaultPolicy.copy(members = Set(memberPolicy.id))
 
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -646,7 +697,8 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
 
       "return false when policy is not in policy" in {
-        val memberPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
+        val memberPolicy =
+          defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("memberPolicy")), email = WorkbenchEmail("copied@policy.com"))
         val policy = defaultPolicy
 
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -742,7 +794,13 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
         // create a user and a group containing that single user
         val allUserGroups = for (i <- 1 to userCount) yield {
-          val user = dao.createUser(Generator.genWorkbenchUserGoogle.sample.get.copy(id = WorkbenchUserId(s"user$i"), email = WorkbenchEmail(s"user$i@email"), googleSubjectId = None), samRequestContext).unsafeRunSync()
+          val user = dao
+            .createUser(
+              Generator.genWorkbenchUserGoogle.sample.get
+                .copy(id = WorkbenchUserId(s"user$i"), email = WorkbenchEmail(s"user$i@email"), googleSubjectId = None),
+              samRequestContext
+            )
+            .unsafeRunSync()
           val group = BasicWorkbenchGroup(WorkbenchGroupName(s"usergroup$i"), Set(user.id), WorkbenchEmail(s"usergroup$i"))
           dao.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
         }
@@ -874,9 +932,21 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
       "lists all policies that a user is in directly" in {
         // disclaimer: not sure this ever happens in actual sam usage, but it should still work
-        val subSubPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("ssp")), email = WorkbenchEmail("ssp@policy.com"), members = Set(defaultUser.id))
-        val subPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")), email = WorkbenchEmail("sp@policy.com"), members = Set(subSubPolicy.id, defaultUser.id))
-        val parentPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")), email = WorkbenchEmail("pp@policy.com"), members = Set(subPolicy.id))
+        val subSubPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("ssp")),
+          email = WorkbenchEmail("ssp@policy.com"),
+          members = Set(defaultUser.id)
+        )
+        val subPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")),
+          email = WorkbenchEmail("sp@policy.com"),
+          members = Set(subSubPolicy.id, defaultUser.id)
+        )
+        val parentPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")),
+          email = WorkbenchEmail("pp@policy.com"),
+          members = Set(subPolicy.id)
+        )
 
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -906,8 +976,16 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
 
       "list all of the policies a group is in" in {
-        val subPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")), email = WorkbenchEmail("sp@policy.com"), members = Set(defaultGroup.id))
-        val parentPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")), email = WorkbenchEmail("pp@policy.com"), members = Set(subPolicy.id))
+        val subPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")),
+          email = WorkbenchEmail("sp@policy.com"),
+          members = Set(defaultGroup.id)
+        )
+        val parentPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")),
+          email = WorkbenchEmail("pp@policy.com"),
+          members = Set(subPolicy.id)
+        )
 
         dao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
@@ -935,10 +1013,21 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
 
       "list all of the policies a policy is in" in {
-        val subPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")), email = WorkbenchEmail("sp@policy.com"), members = Set(defaultPolicy.id))
-        val directParentPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")), email = WorkbenchEmail("pp@policy.com"), members = Set(subPolicy.id, defaultPolicy.id))
-        val indirectParentPolicy = defaultPolicy.copy(id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("ssp")), email = WorkbenchEmail("ssp@policy.com"), members = Set(subPolicy.id))
-
+        val subPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("sp")),
+          email = WorkbenchEmail("sp@policy.com"),
+          members = Set(defaultPolicy.id)
+        )
+        val directParentPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("pp")),
+          email = WorkbenchEmail("pp@policy.com"),
+          members = Set(subPolicy.id, defaultPolicy.id)
+        )
+        val indirectParentPolicy = defaultPolicy.copy(
+          id = defaultPolicy.id.copy(accessPolicyName = AccessPolicyName("ssp")),
+          email = WorkbenchEmail("ssp@policy.com"),
+          members = Set(subPolicy.id)
+        )
 
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
         policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
@@ -975,7 +1064,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.updateSynchronizedDate(defaultGroup.id, samRequestContext).unsafeRunSync()
 
         val loadedDate = dao.getSynchronizedDate(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail("failed to load date"))
-        loadedDate.getTime() should equal (new Date().getTime +- 2.seconds.toMillis)
+        loadedDate.getTime() should equal(new Date().getTime +- 2.seconds.toMillis)
       }
 
       "load the synchronized date for a policy" in {
@@ -986,7 +1075,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.updateSynchronizedDate(defaultPolicy.id, samRequestContext).unsafeRunSync()
 
         val loadedDate = dao.getSynchronizedDate(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail("failed to load date"))
-        loadedDate.getTime() should equal (new Date().getTime +- 2.seconds.toMillis)
+        loadedDate.getTime() should equal(new Date().getTime +- 2.seconds.toMillis)
       }
     }
 
@@ -1050,7 +1139,9 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
 
       "throw an exception when an email refers to more than one subject" in {
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
-        dao.createPetServiceAccount(defaultPetSA.copy(serviceAccount = defaultPetSA.serviceAccount.copy(email = defaultUser.email)), samRequestContext).unsafeRunSync()
+        dao
+          .createPetServiceAccount(defaultPetSA.copy(serviceAccount = defaultPetSA.serviceAccount.copy(email = defaultUser.email)), samRequestContext)
+          .unsafeRunSync()
 
         assertThrows[WorkbenchException] {
           dao.loadSubjectFromEmail(defaultUser.email, samRequestContext).unsafeRunSync() shouldBe Some(defaultPetSA.id)
@@ -1069,7 +1160,9 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.createUser(defaultUser, samRequestContext).unsafeRunSync()
         dao.createPetServiceAccount(defaultPetSA, samRequestContext).unsafeRunSync()
 
-        dao.loadSubjectFromGoogleSubjectId(GoogleSubjectId(defaultPetSA.serviceAccount.subjectId.value), samRequestContext).unsafeRunSync() shouldBe Some(defaultPetSA.id)
+        dao.loadSubjectFromGoogleSubjectId(GoogleSubjectId(defaultPetSA.serviceAccount.subjectId.value), samRequestContext).unsafeRunSync() shouldBe Some(
+          defaultPetSA.id
+        )
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/DisableUsersMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/DisableUsersMonitorSpec.scala
@@ -19,17 +19,24 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class DisableUsersMonitorSpec(_system: ActorSystem) extends TestKit(_system) with AnyFlatSpecLike with Matchers with PropertyBasedTesting
-  with TestSupport with MockitoSugar with BeforeAndAfter with BeforeAndAfterAll with Eventually {
+class DisableUsersMonitorSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with PropertyBasedTesting
+    with TestSupport
+    with MockitoSugar
+    with BeforeAndAfter
+    with BeforeAndAfterAll
+    with Eventually {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 100)
   def this() = this(ActorSystem("DisableUsersMonitorSpec"))
 
   val topicName = "testtopic"
   val subscriptionName = "testsub"
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -52,18 +59,22 @@ class DisableUsersMonitorSpec(_system: ActorSystem) extends TestKit(_system) wit
       assert(mockGooglePubSubDAO.subscriptionsByName.contains(subscriptionName))
     }
     when(userService.disableUser(mockitoEq(userId), any[SamRequestContext]))
-      .thenReturn(Future.successful(
-        Some(UserStatus(
-          UserStatusDetails(userId, userEmail),
-          Map(userEmail.value -> false)
-        ))
-      ))
+      .thenReturn(
+        Future.successful(
+          Some(
+            UserStatus(
+              UserStatusDetails(userId, userEmail),
+              Map(userEmail.value -> false)
+            )
+          )
+        )
+      )
 
     Await.result(mockGooglePubSubDAO.publishMessages(topicName, Seq(userId.value)), Duration.Inf)
 
     eventually {
       verify(userService, atLeastOnce).disableUser(mockitoEq(userId), any[SamRequestContext])
-      assertResult(1) { mockGooglePubSubDAO.acks.size() }
+      assertResult(1)(mockGooglePubSubDAO.acks.size())
     }
   }
 
@@ -86,7 +97,7 @@ class DisableUsersMonitorSpec(_system: ActorSystem) extends TestKit(_system) wit
     mockGooglePubSubDAO.publishMessages(topicName, Seq(userId.value))
 
     eventually {
-      assertResult(1) { mockGooglePubSubDAO.acks.size() }
+      assertResult(1)(mockGooglePubSubDAO.acks.size())
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -28,38 +28,49 @@ import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-/**
-  * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
+/** Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
-class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
-  implicit val timeout = RouteTestTimeout(5 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
+class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with ScalaFutures {
+  implicit val timeout = RouteTestTimeout(
+    5 seconds
+  ) // after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
   val workspaceResourceId = "workspace"
   val v2GoogleProjectResourceId = "v2project"
 
-  private def getPetServiceAccount(projectName: String, routes: SamRoutes) = {
+  private def getPetServiceAccount(projectName: String, routes: SamRoutes) =
     Get(s"/api/google/user/petServiceAccount/${projectName}") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@${projectName}.iam.gserviceaccount.com")
+      response.value should endWith(s"@${projectName}.iam.gserviceaccount.com")
       response.value
     }
-  }
 
-  private def getPetServiceAccountKey(projectName: String, expectedJson: String, routes: SamRoutes) = {
+  private def getPetServiceAccountKey(projectName: String, expectedJson: String, routes: SamRoutes) =
     Get(s"/api/google/user/petServiceAccount/${projectName}/key") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
-      response shouldEqual(expectedJson)
+      response shouldEqual expectedJson
     }
-  }
 
   "GET /api/google/user/petServiceAccount" should "get or create a pet service account for a user in a v2 project" in {
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
     val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
 
-    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+    when(
+      resourceService.getResourceParent(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(
+      policyEvaluatorService.hasPermissionOneOf(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        mockitoEq(Set(SamResourceActions.createPet)),
+        any[WorkbenchUserId],
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(true))
     val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
 
@@ -83,11 +94,29 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
     val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
 
-    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+    when(
+      resourceService.getResourceParent(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(
+      policyEvaluatorService.hasPermissionOneOf(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        mockitoEq(Set(SamResourceActions.createPet)),
+        any[WorkbenchUserId],
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(false))
-    when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[WorkbenchUserId], any[SamRequestContext]))
+    when(
+      policyEvaluatorService.listUserResourceActions(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        any[WorkbenchUserId],
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(Set(SamResourceActions.readPolicies)))
 
     val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
@@ -100,15 +129,32 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
 
   it should "404 when the user doesn't have any permission on the google-project resource" in {
 
-
     val policyEvaluatorService = mock[PolicyEvaluatorService](RETURNS_SMART_NULLS)
     val resourceService = mock[ResourceService](RETURNS_SMART_NULLS)
 
-    when(resourceService.getResourceParent(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[SamRequestContext]))
+    when(
+      resourceService.getResourceParent(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(Option(FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(workspaceResourceId)))))
-    when(policyEvaluatorService.hasPermissionOneOf(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), mockitoEq(Set(SamResourceActions.createPet)), any[WorkbenchUserId], any[SamRequestContext]))
+    when(
+      policyEvaluatorService.hasPermissionOneOf(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        mockitoEq(Set(SamResourceActions.createPet)),
+        any[WorkbenchUserId],
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(false))
-    when(policyEvaluatorService.listUserResourceActions(mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))), any[WorkbenchUserId], any[SamRequestContext]))
+    when(
+      policyEvaluatorService.listUserResourceActions(
+        mockitoEq(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(v2GoogleProjectResourceId))),
+        any[WorkbenchUserId],
+        any[SamRequestContext]
+      )
+    )
       .thenReturn(IO(Set.empty))
 
     val (_, _, routes) = createTestUser(policyEvaluatorServiceOpt = Option(policyEvaluatorService), resourceServiceOpt = Option(resourceService))
@@ -132,7 +178,6 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
   it should "return a user's proxy group from a pet service account" in {
     val (user, _, routes) = createTestUser()
 
-
     val petEmail = getPetServiceAccount("myproject", routes)
 
     Get(s"/api/google/user/proxyGroup/$petEmail") ~> routes.route ~> check {
@@ -151,8 +196,18 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
   }
 
-  private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
-  private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+  private val name = ResourceType(
+    ResourceTypeName("rt"),
+    Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies),
+    Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))),
+    ResourceRoleName("owner")
+  )
+  private val resourceType = ResourceType(
+    ResourceTypeName("rt"),
+    Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies),
+    Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))),
+    ResourceRoleName("owner")
+  )
 
   "POST /api/google/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
@@ -165,7 +220,9 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     import spray.json.DefaultJsonProtocol._
     val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[Seq[AccessPolicyResponseEntry]].find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
+      responseAs[Seq[AccessPolicyResponseEntry]]
+        .find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value))
+        .getOrElse(fail("created policy not returned by get request"))
     }
 
     import SamGoogleModelJsonSupport._
@@ -199,7 +256,12 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
       status shouldEqual StatusCodes.OK
     }
 
-    samDep.directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com")), samRequestContext = samRequestContext).unsafeRunSync()
+    samDep.directoryDAO
+      .createGroup(
+        BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com")),
+        samRequestContext = samRequestContext
+      )
+      .unsafeRunSync()
 
     Get(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -250,7 +312,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     Get(s"/api/google/petServiceAccount/myproject/${defaultUserInfo.email.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
-      response shouldEqual(expectedJson)
+      response shouldEqual expectedJson
     }
   }
 
@@ -278,21 +340,28 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
   }
 }
 
-trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar{
+trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
   val defaultUserId = genWorkbenchUserId.sample.get
   val defaultUserEmail = genNonPetEmail.sample.get
   val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_$defaultUserId@${googleServicesConfig.appsDomain}")
 
   val configResourceTypes = TestSupport.configResourceTypes
 
-  def createTestUser(resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty[ResourceTypeName, ResourceType],
-                     googIamDAO: Option[GoogleIamDAO] = None,
-                     googleServicesConfig: GoogleServicesConfig = TestSupport.googleServicesConfig,
-                     policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
-                     resourceServiceOpt: Option[ResourceService] = None,
-                     user: SamUser = Generator.genWorkbenchUserBoth.sample.get
-                    ): (SamUser, SamDependencies, SamRoutes) = {
-    val samDependencies = genSamDependencies(resourceTypes, googIamDAO, googleServicesConfig, policyEvaluatorServiceOpt = policyEvaluatorServiceOpt, resourceServiceOpt = resourceServiceOpt)
+  def createTestUser(
+      resourceTypes: Map[ResourceTypeName, ResourceType] = Map.empty[ResourceTypeName, ResourceType],
+      googIamDAO: Option[GoogleIamDAO] = None,
+      googleServicesConfig: GoogleServicesConfig = TestSupport.googleServicesConfig,
+      policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
+      resourceServiceOpt: Option[ResourceService] = None,
+      user: SamUser = Generator.genWorkbenchUserBoth.sample.get
+  ): (SamUser, SamDependencies, SamRoutes) = {
+    val samDependencies = genSamDependencies(
+      resourceTypes,
+      googIamDAO,
+      googleServicesConfig,
+      policyEvaluatorServiceOpt = policyEvaluatorServiceOpt,
+      resourceServiceOpt = resourceServiceOpt
+    )
     val createRoutes = genSamRoutes(samDependencies, user)
 
     // create a user
@@ -310,8 +379,16 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
     val googleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
     val expectedJson = """{"json":"yes I am"}"""
     when(googleIamDAO.findServiceAccount(any[GoogleProject], any[ServiceAccountName])).thenReturn(Future.successful(None))
-    when(googleIamDAO.createServiceAccount(any[GoogleProject], any[ServiceAccountName], any[ServiceAccountDisplayName])).thenReturn(Future.successful(ServiceAccount(ServiceAccountSubjectId("12312341234"), WorkbenchEmail("pet@myproject.iam.gserviceaccount.com"), ServiceAccountDisplayName(""))))
-    when(googleIamDAO.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(ServiceAccountKey(ServiceAccountKeyId("foo"), ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(expectedJson).encode), None, None)))
+    when(googleIamDAO.createServiceAccount(any[GoogleProject], any[ServiceAccountName], any[ServiceAccountDisplayName])).thenReturn(
+      Future.successful(
+        ServiceAccount(ServiceAccountSubjectId("12312341234"), WorkbenchEmail("pet@myproject.iam.gserviceaccount.com"), ServiceAccountDisplayName(""))
+      )
+    )
+    when(googleIamDAO.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])).thenReturn(
+      Future.successful(
+        ServiceAccountKey(ServiceAccountKeyId("foo"), ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(expectedJson).encode), None, None)
+      )
+    )
     when(googleIamDAO.removeServiceAccountKey(any[GoogleProject], any[WorkbenchEmail], any[ServiceAccountKeyId])).thenReturn(Future.successful(()))
     when(googleIamDAO.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(Seq.empty))
     when(googleIamDAO.addServiceAccountUserRoleForUser(any[GoogleProject], any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
@@ -328,8 +405,17 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
       user = samUser
     )
 
-    samDeps.cloudExtensions.asInstanceOf[GoogleExtensions].onBoot(SamApplication(samDeps.userService,
-      samDeps.resourceService, samDeps.statusService, new TosService(samDeps.directoryDAO, "example.com", TestSupport.tosConfig))).unsafeRunSync()
+    samDeps.cloudExtensions
+      .asInstanceOf[GoogleExtensions]
+      .onBoot(
+        SamApplication(
+          samDeps.userService,
+          samDeps.resourceService,
+          samDeps.statusService,
+          new TosService(samDeps.directoryDAO, "example.com", TestSupport.tosConfig)
+        )
+      )
+      .unsafeRunSync()
     (user, routes, expectedJson)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -15,11 +15,12 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 
-/**
-  * Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
+/** Unit tests of GoogleExtensionRoutes. Can use real Google services. Must mock everything else.
   */
-class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with ScalaFutures{
-  implicit val timeout = RouteTestTimeout(5 seconds) //after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
+class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with ScalaFutures {
+  implicit val timeout = RouteTestTimeout(
+    5 seconds
+  ) // after using com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper, tests seems to run a bit longer
 
   "GET /api/google/v1/user/petServiceAccount" should "get or create a pet service account for a user" in {
     val (user, _, routes) = createTestUser()
@@ -28,14 +29,14 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
     }
 
     // same result a second time
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
     }
   }
 
@@ -54,7 +55,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val petEmail = Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
       response.value
     }
 
@@ -74,8 +75,18 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val readPolicy = ResourceActionPattern("read_policy::.+", "", false)
   }
 
-  private val name = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
-  private val resourceType = ResourceType(ResourceTypeName("rt"), Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies), Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))), ResourceRoleName("owner"))
+  private val name = ResourceType(
+    ResourceTypeName("rt"),
+    Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies),
+    Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))),
+    ResourceRoleName("owner")
+  )
+  private val resourceType = ResourceType(
+    ResourceTypeName("rt"),
+    Set(SamResourceActionPatterns.alterPolicies, ResourceActionPattern("can_compute", "", false), SamResourceActionPatterns.readPolicies),
+    Set(ResourceRole(ResourceRoleName("owner"), Set(ResourceAction("alter_policies"), ResourceAction("read_policies")))),
+    ResourceRoleName("owner")
+  )
 
   "POST /api/google/v1/policy/{resourceTypeName}/{resourceId}/{accessPolicyName}/sync" should "204 Create Google group for policy" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
@@ -90,7 +101,9 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     import spray.json.DefaultJsonProtocol._
     val createdPolicy = Get(s"/api/resource/${resourceType.name}/foo/policies") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[Seq[AccessPolicyResponseEntry]].find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value)).getOrElse(fail("created policy not returned by get request"))
+      responseAs[Seq[AccessPolicyResponseEntry]]
+        .find(_.policyName == AccessPolicyName(resourceType.ownerRoleName.value))
+        .getOrElse(fail("created policy not returned by get request"))
     }
 
     import SamGoogleModelJsonSupport._
@@ -125,7 +138,12 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
       status shouldEqual StatusCodes.OK
     }
 
-    samDep.directoryDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com")), samRequestContext = samRequestContext).unsafeRunSync()
+    samDep.directoryDAO
+      .createGroup(
+        BasicWorkbenchGroup(WorkbenchGroupName(resourceType.ownerRoleName.value + ".foo." + resourceType.name), Set.empty, WorkbenchEmail("foo@bar.com")),
+        samRequestContext = samRequestContext
+      )
+      .unsafeRunSync()
 
     Get(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
@@ -143,17 +161,16 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
     Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
-      response shouldEqual(expectedJson)
+      response shouldEqual expectedJson
     }
   }
-
 
   "DELETE /api/google/v1/user/petServiceAccount/{project}/key/{keyId}" should "204 when deleting a key" in {
     val resourceTypes = Map(resourceType.name -> resourceType)
@@ -165,14 +182,14 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith (s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
     Get("/api/google/v1/user/petServiceAccount/myproject/key") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
-      response shouldEqual(expectedJson)
+      response shouldEqual expectedJson
     }
 
     // create a pet service account key
@@ -193,7 +210,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Get(s"/api/google/v1/petServiceAccount/myproject/${defaultUserInfo.email.value}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[String]
-      response shouldEqual(expectedJson)
+      response shouldEqual expectedJson
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -38,12 +38,19 @@ import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with AnyFlatSpecLike with Matchers with TestSupport with MockitoSugar with ScalaFutures with BeforeAndAfterAll with PrivateMethodTester {
+class GoogleExtensionSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with TestSupport
+    with MockitoSugar
+    with ScalaFutures
+    with BeforeAndAfterAll
+    with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -84,8 +91,14 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
     val testGroup = BasicWorkbenchGroup(groupName, Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail)
     val testPolicy = AccessPolicy(
-      model.FullyQualifiedPolicyId(
-        FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")), Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError), groupEmail, Set.empty, Set.empty, Set.empty, public = true)
+      model.FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("workspace"), ResourceId("rid")), AccessPolicyName("ap")),
+      Set(inSamSubGroup.id, inBothSubGroup.id, inSamUserId, inBothUserId, addError),
+      groupEmail,
+      Set.empty,
+      Set.empty,
+      Set.empty,
+      public = true
+    )
 
     Seq(testGroup, testPolicy).foreach { target =>
       val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
@@ -94,7 +107,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
       val mockGoogleNotificationsPubSubDAO = new MockGooglePubSubDAO
       val mockGoogleGroupSyncPubSubDAO = new MockGooglePubSubDAO
       val mockGoogleDisableUsersPubSubDAO = new MockGooglePubSubDAO
-      val ge = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGoogleNotificationsPubSubDAO, mockGoogleGroupSyncPubSubDAO, mockGoogleDisableUsersPubSubDAO, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+      val ge = new GoogleExtensions(
+        TestSupport.distributedLock,
+        mockDirectoryDAO,
+        mockAccessPolicyDAO,
+        mockGoogleDirectoryDAO,
+        mockGoogleNotificationsPubSubDAO,
+        mockGoogleGroupSyncPubSubDAO,
+        mockGoogleDisableUsersPubSubDAO,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        googleServicesConfig,
+        petServiceAccountConfig,
+        configResourceTypes,
+        superAdminsGroup
+      )
       val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, ge, configResourceTypes)
 
       target match {
@@ -103,12 +134,14 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
         case p: AccessPolicy =>
           when(mockAccessPolicyDAO.loadPolicy(p.id, samRequestContext)).thenReturn(IO.pure(Option(testPolicy)))
       }
-      when(mockDirectoryDAO.loadGroup(CloudExtensions.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, ge.allUsersGroupEmail))))
+      when(mockDirectoryDAO.loadGroup(CloudExtensions.allUsersGroupName, samRequestContext))
+        .thenReturn(IO.pure(Option(BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, ge.allUsersGroupEmail))))
       when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.unit)
-      when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.pure(Some((new GregorianCalendar(2017, 11, 22).getTime()))))
+      when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext]))
+        .thenReturn(IO.pure(Some(new GregorianCalendar(2017, 11, 22).getTime())))
 
       val subGroups = Seq(inSamSubGroup, inGoogleSubGroup, inBothSubGroup)
-      subGroups.foreach { g => when(mockDirectoryDAO.loadSubjectEmail(g.id, samRequestContext)).thenReturn(IO.pure(Option(g.email))) }
+      subGroups.foreach(g => when(mockDirectoryDAO.loadSubjectEmail(g.id, samRequestContext)).thenReturn(IO.pure(Option(g.email))))
       when(mockDirectoryDAO.loadSubjectEmail(CloudExtensions.allUsersGroupName, samRequestContext)).thenReturn(IO.pure(Option(ge.allUsersGroupEmail)))
 
       val added = Seq(inSamSubGroup.email, WorkbenchEmail(inSamUserProxyEmail)) ++ (target match {
@@ -118,7 +151,19 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
       val removed = Seq(inGoogleSubGroup.email, WorkbenchEmail(inGoogleUserProxyEmail))
 
-      when(mockGoogleDirectoryDAO.listGroupMembers(target.email)).thenReturn(Future.successful(Option(Seq(WorkbenchEmail(inGoogleUserProxyEmail).value, WorkbenchEmail(inBothUserProxyEmail).value.toLowerCase, inGoogleSubGroup.email.value, inBothSubGroup.email.value, removeError))))
+      when(mockGoogleDirectoryDAO.listGroupMembers(target.email)).thenReturn(
+        Future.successful(
+          Option(
+            Seq(
+              WorkbenchEmail(inGoogleUserProxyEmail).value,
+              WorkbenchEmail(inBothUserProxyEmail).value.toLowerCase,
+              inGoogleSubGroup.email.value,
+              inBothSubGroup.email.value,
+              removeError
+            )
+          )
+        )
+      )
       when(mockGoogleDirectoryDAO.listGroupMembers(ge.allUsersGroupEmail)).thenReturn(Future.successful(Option(Seq.empty)))
       when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
       when(mockGoogleDirectoryDAO.removeMemberFromGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
@@ -132,15 +177,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
       val results = runAndWait(synchronizer.synchronizeGroupMembers(target.id, samRequestContext = samRequestContext))
 
       results.head._1 should equal(target.email)
-      results.head._2 should contain theSameElementsAs (
-        added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
-          removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
-          Seq(
-            SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
-            SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))))
+      results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
+        removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
+        Seq(
+          SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
+          SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))
+        ))
 
-      added.foreach { email => verify(mockGoogleDirectoryDAO).addMemberToGroup(target.email, WorkbenchEmail(email.value.toLowerCase)) }
-      removed.foreach { email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(target.email, WorkbenchEmail(email.value.toLowerCase)) }
+      added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
+      removed.foreach(email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
       verify(mockDirectoryDAO).updateSynchronizedDate(target.id, samRequestContext)
     }
   }
@@ -173,9 +218,12 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val subAuthorizedGoogleGroupUserId = WorkbenchUserId("authorizedGoogleSubUser")
     val subAuthorizedGoogleGroupUserProxyEmail = s"PROXY_authorizedGoogleSubUser@${googleServicesConfig.appsDomain}"
 
-    val policyOnlySamSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inSamSubGroup"), Set(subPolicyOnlySamGroupUserId), WorkbenchEmail("inSamSubGroup@example.com"))
-    val intersectionSamSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inGoogleSubGroup"), Set(subIntersectionSamGroupUserId), WorkbenchEmail("inGoogleSubGroup@example.com"))
-    val authorizedGoogleSubGroup = BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(subAuthorizedGoogleGroupUserId), WorkbenchEmail("inBothSubGroup@example.com"))
+    val policyOnlySamSubGroup =
+      BasicWorkbenchGroup(WorkbenchGroupName("inSamSubGroup"), Set(subPolicyOnlySamGroupUserId), WorkbenchEmail("inSamSubGroup@example.com"))
+    val intersectionSamSubGroup =
+      BasicWorkbenchGroup(WorkbenchGroupName("inGoogleSubGroup"), Set(subIntersectionSamGroupUserId), WorkbenchEmail("inGoogleSubGroup@example.com"))
+    val authorizedGoogleSubGroup =
+      BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(subAuthorizedGoogleGroupUserId), WorkbenchEmail("inBothSubGroup@example.com"))
 
     // Set up constrainable resource type
     val constrainableActionPatterns = Set(ResourceActionPattern("constrainable_view", "Can be constrained by an auth domain", true))
@@ -184,10 +232,10 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val constrainableReaderRoleName = ResourceRoleName("constrainable_reader")
     val constrainableRole = ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)
     val constrainableResourceType = ResourceType(
-    ResourceTypeName(UUID.randomUUID().toString),
-    constrainableActionPatterns,
-    Set(ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)),
-    constrainableReaderRoleName
+      ResourceTypeName(UUID.randomUUID().toString),
+      constrainableActionPatterns,
+      Set(ResourceRole(constrainableReaderRoleName, constrainableResourceTypeActions)),
+      constrainableReaderRoleName
     )
     val constrainableResourceTypes = Map(constrainableResourceType.name -> constrainableResourceType)
 
@@ -195,27 +243,66 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val managedGroupId = WorkbenchGroupName("authDomainGroup")
     val resource = Resource(constrainableResourceType.name, ResourceId("rid"), Set(managedGroupId))
     val rpn = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("ap"))
-    val testPolicy = AccessPolicy(rpn, Set(policyOnlySamUserId, intersectionSamUserId, authorizedGoogleUserId, policyOnlySamSubGroup.id, intersectionSamSubGroup.id, authorizedGoogleSubGroup.id, addError), WorkbenchEmail("testPolicy@example.com"), Set(constrainableRole.roleName), constrainableRole.actions, Set.empty, public = false)
+    val testPolicy = AccessPolicy(
+      rpn,
+      Set(
+        policyOnlySamUserId,
+        intersectionSamUserId,
+        authorizedGoogleUserId,
+        policyOnlySamSubGroup.id,
+        intersectionSamSubGroup.id,
+        authorizedGoogleSubGroup.id,
+        addError
+      ),
+      WorkbenchEmail("testPolicy@example.com"),
+      Set(constrainableRole.roleName),
+      constrainableRole.actions,
+      Set.empty,
+      public = false
+    )
 
     val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
-    val ge = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, mockGoogleDirectoryDAO, null, null, null, null, null,null, null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes, superAdminsGroup)
-    val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, constrainableResourceTypes)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      constrainableResourceTypes,
+      superAdminsGroup
+    )
+    val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, ge, constrainableResourceTypes)
 
     when(mockAccessPolicyDAO.loadPolicy(testPolicy.id, samRequestContext)).thenReturn(IO.pure(Option(testPolicy)))
-    when(mockAccessPolicyDAO.loadResourceAuthDomain(resource.fullyQualifiedId, samRequestContext)).thenReturn(IO.pure(LoadResourceAuthDomainResult.Constrained(NonEmptyList.one(managedGroupId)): LoadResourceAuthDomainResult))
+    when(mockAccessPolicyDAO.loadResourceAuthDomain(resource.fullyQualifiedId, samRequestContext))
+      .thenReturn(IO.pure(LoadResourceAuthDomainResult.Constrained(NonEmptyList.one(managedGroupId)): LoadResourceAuthDomainResult))
 
-    when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id), samRequestContext)).thenReturn(IO.pure(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
+    when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id), samRequestContext))
+      .thenReturn(IO.pure(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
 
     when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.unit)
-    when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.pure(Some(new GregorianCalendar(2017, 11, 22).getTime())))
+    when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext]))
+      .thenReturn(IO.pure(Some(new GregorianCalendar(2017, 11, 22).getTime())))
 
     val added = Seq(WorkbenchEmail(intersectionSamUserProxyEmail), WorkbenchEmail(subIntersectionSamGroupUserProxyEmail))
     val removed = Seq(WorkbenchEmail(unauthorizedGoogleUserProxyEmail))
 
     // mock pre-sync google group members
-    when(mockGoogleDirectoryDAO.listGroupMembers(testPolicy.email)).thenReturn(Future.successful(Option(Seq(authorizedGoogleUserProxyEmail, unauthorizedGoogleUserProxyEmail, subAuthorizedGoogleGroupUserProxyEmail, removeError))))
+    when(mockGoogleDirectoryDAO.listGroupMembers(testPolicy.email)).thenReturn(
+      Future.successful(Option(Seq(authorizedGoogleUserProxyEmail, unauthorizedGoogleUserProxyEmail, subAuthorizedGoogleGroupUserProxyEmail, removeError)))
+    )
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
     when(mockGoogleDirectoryDAO.removeMemberFromGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
 
@@ -228,15 +315,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val results = runAndWait(synchronizer.synchronizeGroupMembers(testPolicy.id, samRequestContext = samRequestContext))
 
     results.head._1 should equal(testPolicy.email)
-    results.head._2 should contain theSameElementsAs (
-      added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
-        removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
-        Seq(
-          SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
-          SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))))
+    results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
+      removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
+      Seq(
+        SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
+        SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))
+      ))
 
-    added.foreach { email => verify(mockGoogleDirectoryDAO).addMemberToGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)) }
-    removed.foreach { email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)) }
+    added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)))
+    removed.foreach(email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)))
     verify(mockDirectoryDAO).updateSynchronizedDate(testPolicy.id, samRequestContext)
   }
 
@@ -256,17 +343,35 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleGroupSyncPubSubDAO = new MockGooglePubSubDAO
     val mockGoogleDisableUsersPubSubDAO = new MockGooglePubSubDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
-    val ge = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGoogleNotificationsPubSubDAO, mockGoogleGroupSyncPubSubDAO, mockGoogleDisableUsersPubSubDAO, mockGoogleIamDAO, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
-    val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO,ge, configResourceTypes)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      mockGoogleDirectoryDAO,
+      mockGoogleNotificationsPubSubDAO,
+      mockGoogleGroupSyncPubSubDAO,
+      mockGoogleDisableUsersPubSubDAO,
+      mockGoogleIamDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
+    val synchronizer = new GoogleGroupSynchronizer(mockDirectoryDAO, mockAccessPolicyDAO, mockGoogleDirectoryDAO, ge, configResourceTypes)
 
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
-    //create groups
+    // create groups
     mockDirectoryDAO.createGroup(topGroup, samRequestContext = samRequestContext).unsafeRunSync()
     mockDirectoryDAO.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
-    //add subGroup to topGroup
+    // add subGroup to topGroup
     runAndWait(mockGoogleDirectoryDAO.addMemberToGroup(groupEmail, subGroupEmail))
     mockDirectoryDAO.addGroupMember(topGroup.id, subGroup.id, samRequestContext).unsafeRunSync()
-    //add topGroup to subGroup - creating cycle
+    // add topGroup to subGroup - creating cycle
     runAndWait(mockGoogleDirectoryDAO.addMemberToGroup(subGroupEmail, groupEmail))
     mockDirectoryDAO.addGroupMember(subGroup.id, topGroup.id, samRequestContext).unsafeRunSync()
     when(mockGoogleDirectoryDAO.listGroupMembers(topGroup.email)).thenReturn(Future.successful(Option(Seq(subGroupEmail.value))))
@@ -276,7 +381,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   }
 
   "GoogleExtension" should "get a pet service account for a user" in {
-    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserProxyEmail: WorkbenchEmail, defaultUser: SamUser) = initPetTest
+    val (
+      dirDAO: DirectoryDAO,
+      mockGoogleIamDAO: MockGoogleIamDAO,
+      mockGoogleDirectoryDAO: MockGoogleDirectoryDAO,
+      googleExtensions: GoogleExtensions,
+      service: UserService,
+      defaultUserProxyEmail: WorkbenchEmail,
+      defaultUser: SamUser
+    ) = initPetTest
 
     // create a user
     val newUser = service.createUser(defaultUser, samRequestContext).futureValue
@@ -309,7 +422,7 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     dirDAO.loadPetServiceAccount(PetServiceAccountId(defaultUser.id, googleProject), samRequestContext).unsafeRunSync() shouldBe None
 
     // the pet should not exist in Google
-    mockGoogleIamDAO.serviceAccounts should not contain key (petServiceAccount.serviceAccount.email)
+    mockGoogleIamDAO.serviceAccounts should not contain key(petServiceAccount.serviceAccount.email)
 
   }
 
@@ -322,20 +435,46 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGoogleProjectDAO = new MockGoogleProjectDAO
 
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, dirDAO, null, mockGoogleDirectoryDAO, null, null, null, mockGoogleIamDAO, null, mockGoogleProjectDAO, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      mockGoogleIamDAO,
+      null,
+      mockGoogleProjectDAO,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val tosService = new TosService(dirDAO, "example.com", TestSupport.tosConfig)
     val service = new UserService(dirDAO, googleExtensions, Seq.empty, new TosService(dirDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
 
     val defaultUser = Generator.genWorkbenchUserGoogle.sample.get
     val defaultUserProxyEmail = WorkbenchEmail(s"PROXY_${defaultUser.id}@${googleServicesConfig.appsDomain}")
-    (dirDAO,  mockGoogleIamDAO, mockGoogleDirectoryDAO, googleExtensions, service, defaultUserProxyEmail, defaultUser)
+    (dirDAO, mockGoogleIamDAO, mockGoogleDirectoryDAO, googleExtensions, service, defaultUserProxyEmail, defaultUser)
   }
 
   protected def newDirectoryDAO(): DirectoryDAO = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.dbRef)
   protected def newAccessPolicyDAO(): AccessPolicyDAO = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.dbRef)
 
   it should "attach existing service account to pet" in {
-    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserProxyEmail: WorkbenchEmail, defaultUser: SamUser) = initPetTest
+    val (
+      dirDAO: DirectoryDAO,
+      mockGoogleIamDAO: MockGoogleIamDAO,
+      mockGoogleDirectoryDAO: MockGoogleDirectoryDAO,
+      googleExtensions: GoogleExtensions,
+      service: UserService,
+      defaultUserProxyEmail: WorkbenchEmail,
+      defaultUser: SamUser
+    ) = initPetTest
     val googleProject = GoogleProject("testproject")
 
     val (saName, saDisplayName) = googleExtensions.toPetSAFromUser(defaultUser)
@@ -352,7 +491,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   }
 
   it should "recreate service account when missing for pet" in {
-    val (dirDAO: DirectoryDAO, mockGoogleIamDAO: MockGoogleIamDAO, mockGoogleDirectoryDAO: MockGoogleDirectoryDAO, googleExtensions: GoogleExtensions, service: UserService, defaultUserProxyEmail: WorkbenchEmail, defaultUser: SamUser) = initPetTest
+    val (
+      dirDAO: DirectoryDAO,
+      mockGoogleIamDAO: MockGoogleIamDAO,
+      mockGoogleDirectoryDAO: MockGoogleDirectoryDAO,
+      googleExtensions: GoogleExtensions,
+      service: UserService,
+      defaultUserProxyEmail: WorkbenchEmail,
+      defaultUser: SamUser
+    ) = initPetTest
 
     // create a user
     val newUser = service.createUser(defaultUser, samRequestContext).futureValue
@@ -378,7 +525,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     when(mockDirectoryDAO.getSynchronizedDate(groupName, samRequestContext)).thenReturn(IO.pure(None))
     ge.getSynchronizedDate(groupName, samRequestContext).unsafeRunSync() shouldBe None
@@ -391,90 +556,214 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   it should "throw an exception with a NotFound error report when getting sync date for group that does not exist" in {
     val dirDAO = newDirectoryDAO()
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
       ge.getSynchronizedDate(groupName, samRequestContext).unsafeRunSync()
     }
     caught.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
-    caught.errorReport.message should include (groupName.toString)
+    caught.errorReport.message should include(groupName.toString)
   }
 
   it should "return None when getting sync date for a group that has not been synced" in {
     val dirDAO = newDirectoryDAO()
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO, null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val groupName = WorkbenchGroupName("group-sync")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("")), samRequestContext = samRequestContext).unsafeRunSync()
-    try {
+    try
       ge.getSynchronizedDate(groupName, samRequestContext).unsafeRunSync() shouldBe None
-    } finally {
+    finally
       dirDAO.deleteGroup(groupName, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "return sync date for a group that has been synced" in {
     val dirDAO = newDirectoryDAO()
 
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, new MockGoogleDirectoryDAO(), null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      new MockGoogleDirectoryDAO(),
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val synchronizer = new GoogleGroupSynchronizer(dirDAO, null, mockGoogleDirectoryDAO, ge, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
-    dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org")), samRequestContext = samRequestContext).unsafeRunSync()
+    dirDAO
+      .createGroup(BasicWorkbenchGroup(groupName, Set(), WorkbenchEmail("group1@test.firecloud.org")), samRequestContext = samRequestContext)
+      .unsafeRunSync()
     try {
       runAndWait(synchronizer.synchronizeGroupMembers(groupName, samRequestContext = samRequestContext))
       val syncDate = ge.getSynchronizedDate(groupName, samRequestContext).unsafeRunSync().get
-      syncDate.getTime should equal (new Date().getTime +- 1.second.toMillis)
-    } finally {
+      syncDate.getTime should equal(new Date().getTime +- 1.second.toMillis)
+    } finally
       dirDAO.deleteGroup(groupName, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "throw an exception with a NotFound error report when getting email for group that does not exist" in {
     val dirDAO = newDirectoryDAO()
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val groupName = WorkbenchGroupName("missing-group")
     val caught: WorkbenchExceptionWithErrorReport = intercept[WorkbenchExceptionWithErrorReport] {
       ge.getSynchronizedEmail(groupName, samRequestContext).unsafeRunSync()
     }
     caught.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
-    caught.errorReport.message should include (groupName.toString)
+    caught.errorReport.message should include(groupName.toString)
   }
 
   it should "return email for a group" in {
     val dirDAO = newDirectoryDAO()
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), email), samRequestContext = samRequestContext).unsafeRunSync()
-    try {
+    try
       ge.getSynchronizedEmail(groupName, samRequestContext).unsafeRunSync() shouldBe Some(email)
-    } finally {
+    finally
       dirDAO.deleteGroup(groupName, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "return None if an email is found, but the group has not been synced" in {
     val dirDAO = newDirectoryDAO()
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
     dirDAO.createGroup(BasicWorkbenchGroup(groupName, Set(), email), samRequestContext = samRequestContext).unsafeRunSync()
-    try {
+    try
       ge.getSynchronizedState(groupName, samRequestContext).unsafeRunSync() shouldBe None
-    } finally {
+    finally
       dirDAO.deleteGroup(groupName, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "return SyncState with email and last sync date if there is an email and the group has been synced" in {
     val dirDAO = newDirectoryDAO()
 
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO()
-    val ge = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
     val synchronizer = new GoogleGroupSynchronizer(dirDAO, null, mockGoogleDirectoryDAO, ge, configResourceTypes)
     val groupName = WorkbenchGroupName("group-sync")
     val email = WorkbenchEmail("foo@bar.com")
@@ -484,9 +773,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
       runAndWait(synchronizer.synchronizeGroupMembers(groupName, samRequestContext = samRequestContext))
       val maybeSyncResponse = ge.getSynchronizedState(groupName, samRequestContext).unsafeRunSync()
       maybeSyncResponse.map(_.email) should equal(Some(email))
-    } finally {
+    } finally
       dirDAO.deleteGroup(groupName, samRequestContext).unsafeRunSync()
-    }
   }
 
   it should "create google extension resource on boot" in {
@@ -501,20 +789,54 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val notificationDAO = new PubSubNotificationDAO(mockGoogleNotificationPubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(
-      TestSupport.distributedLock, mockGoogleIamDAO, mockGoogleStorageDAO, FakeGoogleStorageInterpreter, mockGoogleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
+      TestSupport.distributedLock,
+      mockGoogleIamDAO,
+      mockGoogleStorageDAO,
+      FakeGoogleStorageInterpreter,
+      mockGoogleKeyCachePubSubDAO,
+      googleServicesConfig,
+      petServiceAccountConfig
+    )
 
-    val ge = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, mockGoogleDirectoryDAO, mockGoogleNotificationPubSubDAO, mockGoogleGroupSyncPubSubDAO, mockGoogleDisableUsersPubSubDAO, mockGoogleIamDAO, mockGoogleStorageDAO, null, googleKeyCache, notificationDAO, FakeGoogleKmsInterpreter, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val ge = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      mockGoogleDirectoryDAO,
+      mockGoogleNotificationPubSubDAO,
+      mockGoogleGroupSyncPubSubDAO,
+      mockGoogleDisableUsersPubSubDAO,
+      mockGoogleIamDAO,
+      mockGoogleStorageDAO,
+      null,
+      googleKeyCache,
+      notificationDAO,
+      FakeGoogleKmsInterpreter,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
-    val app = SamApplication(new UserService(mockDirectoryDAO, ge,  Seq.empty, new TosService(mockDirectoryDAO,  googleServicesConfig.appsDomain, TestSupport.tosConfig)), new ResourceService(configResourceTypes, null, mockAccessPolicyDAO, mockDirectoryDAO, ge, "example.com", Set.empty), null,
-      new TosService(mockDirectoryDAO,  "example.com", TestSupport.tosConfig))
-    val resourceAndPolicyName = FullyQualifiedPolicyId(FullyQualifiedResourceId(CloudExtensions.resourceTypeName, GoogleExtensions.resourceId), AccessPolicyName("owner"))
+    val app = SamApplication(
+      new UserService(mockDirectoryDAO, ge, Seq.empty, new TosService(mockDirectoryDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig)),
+      new ResourceService(configResourceTypes, null, mockAccessPolicyDAO, mockDirectoryDAO, ge, "example.com", Set.empty),
+      null,
+      new TosService(mockDirectoryDAO, "example.com", TestSupport.tosConfig)
+    )
+    val resourceAndPolicyName =
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(CloudExtensions.resourceTypeName, GoogleExtensions.resourceId), AccessPolicyName("owner"))
 
     mockDirectoryDAO.loadUser(WorkbenchUserId(googleServicesConfig.serviceAccountClientId), samRequestContext).unsafeRunSync() shouldBe None
     mockAccessPolicyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).unsafeRunSync() shouldBe None
 
     ge.onBoot(app).unsafeRunSync()
 
-    val uid = mockDirectoryDAO.loadSubjectFromGoogleSubjectId(GoogleSubjectId(googleServicesConfig.serviceAccountClientId), samRequestContext).unsafeRunSync().get.asInstanceOf[WorkbenchUserId]
+    val uid = mockDirectoryDAO
+      .loadSubjectFromGoogleSubjectId(GoogleSubjectId(googleServicesConfig.serviceAccountClientId), samRequestContext)
+      .unsafeRunSync()
+      .get
+      .asInstanceOf[WorkbenchUserId]
     val owner = mockDirectoryDAO.loadUser(uid, samRequestContext).unsafeRunSync().get
     owner.googleSubjectId shouldBe Some(GoogleSubjectId(googleServicesConfig.serviceAccountClientId))
     owner.email shouldBe googleServicesConfig.serviceAccountClientEmail
@@ -531,7 +853,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val appsDomain = "test.cloudfire.org"
 
     val config = googleServicesConfig.copy(appsDomain = appsDomain)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, null,  null, null, null, null, null, null, null, null, null, null, null, config, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      config,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val userId = UserService.genWorkbenchUserId(System.currentTimeMillis())
     val proxyEmail = googleExtensions.toProxyFromUser(userId).value
@@ -540,7 +880,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
   it should "truncate username if proxy group email would otherwise be too long" in {
     val config = googleServicesConfig.copy(appsDomain = "test.cloudfire.org")
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, null, null, null, null, null, null, null, null, null, null, null, null, config, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      config,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val userId = UserService.genWorkbenchUserId(System.currentTimeMillis())
 
@@ -554,7 +912,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val allUsersGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"TEST_ALL_USERS_GROUP@test.firecloud.org"))
     val allUsersGroupNameMatcher = new ArgumentMatcher[WorkbenchGroupName] {
@@ -577,7 +953,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   it should "do Googley stuff onGroupDelete" in {
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockGoogleDirectoryDAO = mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  null, mockGoogleDirectoryDAO, null, null, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val testPolicy = BasicWorkbenchGroup(WorkbenchGroupName("blahblahblah"), Set.empty, WorkbenchEmail(s"blahblahblah@test.firecloud.org"))
 
@@ -592,23 +986,44 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
     val mockGoogleGroupSyncPubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, null, null, mockGoogleGroupSyncPubSubDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      null,
+      null,
+      mockGoogleGroupSyncPubSubDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val managedGroupId = "managedGroupId"
 
-    val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
+    val managedGroupRPN =
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
-    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGoogleGroupSyncPubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock responses for onManagedGroupUpdate
-    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext)).thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
+    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext))
+      .thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(managedGroupRPN), samRequestContext))
 
@@ -619,27 +1034,49 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
     val mockGoogleGroupSyncPubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, null, null, mockGoogleGroupSyncPubSubDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      null,
+      null,
+      mockGoogleGroupSyncPubSubDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"
-    val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
+    val managedGroupRPN =
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
 
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
-    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGoogleGroupSyncPubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish subgroup relationship to managed group
-    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId), samRequestContext)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId), samRequestContext))
+      .thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
-    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext)).thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
+    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext))
+      .thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(WorkbenchGroupName(subGroupId)), samRequestContext))
 
@@ -650,28 +1087,50 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockAccessPolicyDAO = mock[AccessPolicyDAO](RETURNS_SMART_NULLS)
     val mockGoogleGroupSyncPubSubDAO = mock[MockGooglePubSubDAO](RETURNS_SMART_NULLS)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, mockDirectoryDAO,  mockAccessPolicyDAO, null, null, mockGoogleGroupSyncPubSubDAO, null, null, null, null, null, null, null, googleServicesConfig, null, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      mockDirectoryDAO,
+      mockAccessPolicyDAO,
+      null,
+      null,
+      mockGoogleGroupSyncPubSubDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      null,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val managedGroupId = "managedGroupId"
     val subGroupId = "subGroupId"
-    val managedGroupRPN = FullyQualifiedPolicyId(
-      FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
+    val managedGroupRPN =
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("managed-group"), ResourceId(managedGroupId)), ManagedGroupService.memberPolicyName)
 
     val resource = Resource(ResourceTypeName("resource"), ResourceId("rid"), Set(WorkbenchGroupName(managedGroupId)))
     val ownerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("owner"))
     val readerRPN = FullyQualifiedPolicyId(resource.fullyQualifiedId, AccessPolicyName("reader"))
 
     // mock responses for onGroupUpdate
-    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
-    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext])).thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
+    when(mockDirectoryDAO.listAncestorGroups(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Set.empty.asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.getSynchronizedDate(any[FullyQualifiedPolicyId], any[SamRequestContext]))
+      .thenReturn(IO.pure(Some(new GregorianCalendar(2018, 8, 26).getTime())))
     when(mockGoogleGroupSyncPubSubDAO.publishMessages(any[String], any[Seq[String]])).thenReturn(Future.successful(()))
 
     // mock ancestor call to establish nested group structure for owner policy and subgroup in managed group
-    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId), samRequestContext)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
+    when(mockDirectoryDAO.listAncestorGroups(WorkbenchGroupName(subGroupId), samRequestContext))
+      .thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
     when(mockDirectoryDAO.listAncestorGroups(ownerRPN, samRequestContext)).thenReturn(IO.pure(Set(managedGroupRPN).asInstanceOf[Set[WorkbenchGroupIdentity]]))
 
     // mock responses for onManagedGroupUpdate
-    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext)).thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
+    when(mockAccessPolicyDAO.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(WorkbenchGroupName(managedGroupId), samRequestContext))
+      .thenReturn(IO.pure(Set(ownerRPN, readerRPN)))
 
     runAndWait(googleExtensions.onGroupUpdate(Seq(WorkbenchGroupName(subGroupId)), samRequestContext))
 
@@ -691,11 +1150,36 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val mockGoogleProjectDAO = new MockGoogleProjectDAO
     val notificationDAO = new PubSubNotificationDAO(mockGoogleNotificationPubSubDAO, "foo")
-    val googleKeyCache = new GoogleKeyCache(TestSupport.distributedLock, mockGoogleIamDAO, mockGoogleStorageDAO, FakeGoogleStorageInterpreter, mockGoogleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val googleKeyCache = new GoogleKeyCache(
+      TestSupport.distributedLock,
+      mockGoogleIamDAO,
+      mockGoogleStorageDAO,
+      FakeGoogleStorageInterpreter,
+      mockGoogleKeyCachePubSubDAO,
+      googleServicesConfig,
+      petServiceAccountConfig
+    )
 
-
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, mockGoogleDirectoryDAO, mockGoogleNotificationPubSubDAO, null, null, mockGoogleIamDAO, mockGoogleStorageDAO, mockGoogleProjectDAO, googleKeyCache, notificationDAO, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
-    val service = new UserService(dirDAO, googleExtensions,  Seq.empty, new TosService(dirDAO,  googleServicesConfig.appsDomain, TestSupport.tosConfig))
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      mockGoogleNotificationPubSubDAO,
+      null,
+      null,
+      mockGoogleIamDAO,
+      mockGoogleStorageDAO,
+      mockGoogleProjectDAO,
+      googleKeyCache,
+      notificationDAO,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
+    val service = new UserService(dirDAO, googleExtensions, Seq.empty, new TosService(dirDAO, googleServicesConfig.appsDomain, TestSupport.tosConfig))
 
     (googleExtensions, service)
   }
@@ -707,15 +1191,18 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
     val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(createDefaultUser.id, createDefaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    newUser shouldBe UserStatus(
+      UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
+      Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+    )
 
     // create a pet service account
     val googleProject = GoogleProject("testproject")
     val petServiceAccount = googleExtensions.createUserPetServiceAccount(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
-    //get a key, which should create a brand new one
+    // get a key, which should create a brand new one
     val firstKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
-    //get a key again, which should return the original cached key created above
+    // get a key again, which should return the original cached key created above
     val secondKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
     assert(firstKey == secondKey)
   }
@@ -727,24 +1214,29 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
     val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(createDefaultUser.id, createDefaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    newUser shouldBe UserStatus(
+      UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
+      Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+    )
 
     // create a pet service account
     val googleProject = GoogleProject("testproject")
     val petServiceAccount = googleExtensions.createUserPetServiceAccount(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
-    //get a key, which should create a brand new one
+    // get a key, which should create a brand new one
     val firstKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
-    //remove the key we just created
+    // remove the key we just created
     runAndWait(for {
       keys <- googleExtensions.googleIamDAO.listServiceAccountKeys(googleProject, petServiceAccount.serviceAccount.email)
-      _ <- keys.toList.parTraverse { key =>
-        googleExtensions.removePetServiceAccountKey(createDefaultUser.id, googleProject, key.id, samRequestContext)
-      }.unsafeToFuture()
+      _ <- keys.toList
+        .parTraverse { key =>
+          googleExtensions.removePetServiceAccountKey(createDefaultUser.id, googleProject, key.id, samRequestContext)
+        }
+        .unsafeToFuture()
     } yield ())
 
-    //get a key again, which should once again create a brand new one because we've deleted the cached one
+    // get a key again, which should once again create a brand new one because we've deleted the cached one
     val secondKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
     assert(firstKey != secondKey)
@@ -757,19 +1249,28 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
     val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
-    newUser shouldBe UserStatus(UserStatusDetails(createDefaultUser.id, createDefaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
+    newUser shouldBe UserStatus(
+      UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
+      Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
+    )
 
     // create a pet service account
     val googleProject = GoogleProject("testproject")
     val petServiceAccount = googleExtensions.createUserPetServiceAccount(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
-    //get a key, which should create a brand new one
+    // get a key, which should create a brand new one
     val firstKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
-    //remove the key we just created behind the scenes
+    // remove the key we just created behind the scenes
     val removedKeyObjects = (for {
-      keyObject <- googleExtensions.googleKeyCache.googleStorageAlg.listObjectsWithPrefix(googleExtensions.googleServicesConfig.googleKeyCacheConfig.bucketName, googleExtensions.googleKeyCache.keyNamePrefix(googleProject, petServiceAccount.serviceAccount.email))
-      _ <- googleExtensions.googleKeyCache.googleStorageAlg.removeObject(googleExtensions.googleServicesConfig.googleKeyCacheConfig.bucketName, GcsBlobName(keyObject.value))
+      keyObject <- googleExtensions.googleKeyCache.googleStorageAlg.listObjectsWithPrefix(
+        googleExtensions.googleServicesConfig.googleKeyCacheConfig.bucketName,
+        googleExtensions.googleKeyCache.keyNamePrefix(googleProject, petServiceAccount.serviceAccount.email)
+      )
+      _ <- googleExtensions.googleKeyCache.googleStorageAlg.removeObject(
+        googleExtensions.googleServicesConfig.googleKeyCacheConfig.bucketName,
+        GcsBlobName(keyObject.value)
+      )
     } yield keyObject).compile.toList.unsafeRunSync()
 
     // assert that keys still exist on service account
@@ -778,8 +1279,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
       existingKeys.exists(key => removed.value.endsWith(key.id.value))
     })
 
-    //get a key again, which should once again create a brand new one because we've deleted the cached one
-    //and all the keys removed should have been removed from google
+    // get a key again, which should once again create a brand new one because we've deleted the cached one
+    // and all the keys removed should have been removed from google
     val secondKey = googleExtensions.getPetServiceAccountKey(createDefaultUser, googleProject, samRequestContext).unsafeRunSync()
 
     // assert that keys have been removed from service account
@@ -791,16 +1292,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     assert(firstKey != secondKey)
   }
 
-  /**
-    * Function to initialize the necessary state for the tests related to private functions isConstrainable and calculateIntersectionGroup
-    * In addition to the values it returns, this function creates the 'constrainableResourceType' and the 'managedGroupResourceType' in
-    * the ResourceService and clears the database
+  /** Function to initialize the necessary state for the tests related to private functions isConstrainable and calculateIntersectionGroup In addition to the
+    * values it returns, this function creates the 'constrainableResourceType' and the 'managedGroupResourceType' in the ResourceService and clears the database
     */
   private def initPrivateTest: (DirectoryDAO, GoogleExtensions, ResourceService, ManagedGroupService, ResourceType, ResourceRole, GoogleGroupSynchronizer) = {
-    //Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.
+    // Note: we intentionally use the Managed Group resource type loaded from reference.conf for the tests here.
     val realResourceTypes = TestSupport.appConfig.resourceTypes
     val realResourceTypeMap = realResourceTypes.map(rt => rt.name -> rt).toMap
-    val managedGroupResourceType = realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
+    val managedGroupResourceType =
+      realResourceTypeMap.getOrElse(ResourceTypeName("managed-group"), throw new Error("Failed to load managed-group resource type from reference.conf"))
 
     val dirDAO = newDirectoryDAO()
     val policyDAO = newAccessPolicyDAO()
@@ -823,10 +1323,37 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
     val emailDomain = "example.com"
 
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, dirDAO, policyDAO, null, null, null, null, null, null, null, null, null, null, googleServicesConfig, petServiceAccountConfig, constrainableResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      policyDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      constrainableResourceTypes,
+      superAdminsGroup
+    )
     val constrainablePolicyEvaluatorService = PolicyEvaluatorService(emailDomain, constrainableResourceTypes, policyDAO, dirDAO)
-    val constrainableService = new ResourceService(constrainableResourceTypes, constrainablePolicyEvaluatorService, policyDAO, dirDAO, NoExtensions, emailDomain, Set.empty)
-    val managedGroupService = new ManagedGroupService(constrainableService, constrainablePolicyEvaluatorService, constrainableResourceTypes, policyDAO, dirDAO, NoExtensions, emailDomain)
+    val constrainableService =
+      new ResourceService(constrainableResourceTypes, constrainablePolicyEvaluatorService, policyDAO, dirDAO, NoExtensions, emailDomain, Set.empty)
+    val managedGroupService = new ManagedGroupService(
+      constrainableService,
+      constrainablePolicyEvaluatorService,
+      constrainableResourceTypes,
+      policyDAO,
+      dirDAO,
+      NoExtensions,
+      emailDomain
+    )
 
     constrainableService.createResourceType(constrainableResourceType, samRequestContext).unsafeRunSync()
     constrainableService.createResourceType(managedGroupResourceType, samRequestContext).unsafeRunSync()
@@ -836,7 +1363,15 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
   }
 
   "calculateIntersectionGroup" should "find the intersection of the resource auth domain and the policy" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      managedGroupService: ManagedGroupService,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val inAuthDomainUser = Generator.genWorkbenchUserBoth.sample.get
     val inPolicyUser = Generator.genWorkbenchUserBoth.sample.get
@@ -849,17 +1384,50 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), inAuthDomainUser, samRequestContext = samRequestContext))
     runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inBothUser.id, samRequestContext))
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), constrainableRole.actions, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), None, inBothUser.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(
+        Set(inPolicyUser.email, inBothUser.email),
+        constrainableRole.actions,
+        Set(constrainableRole.roleName),
+        None
+      )
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(
+        constrainableResourceType,
+        ResourceId("rid"),
+        accessPolicyMap,
+        Set(WorkbenchGroupName(managedGroupId)),
+        None,
+        inBothUser.id,
+        samRequestContext
+      )
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothUser.id)
   }
 
   it should "handle nested group structures for policies and auth domains" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      managedGroupService: ManagedGroupService,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     // User in owner policy of both auth domain and resource to be used during creation of the managed group and resource
     val superAdminOwner = Generator.genWorkbenchUserBoth.sample.get
@@ -878,45 +1446,115 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     dirDAO.createUser(inBothSubGroupUser, samRequestContext).unsafeRunSync()
 
     // Create subgroups as groups in the database
-    val inAuthDomainSubGroup = dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inAuthDomainSubGroup"), Set(inAuthDomainSubGroupUser.id), WorkbenchEmail("imAuthDomain@subGroup.com")), samRequestContext = samRequestContext).unsafeRunSync()
-    val inPolicySubGroup = dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inPolicySubGroup"), Set(inPolicySubGroupUser.id), WorkbenchEmail("inPolicy@subGroup.com")), samRequestContext = samRequestContext).unsafeRunSync()
-    val inBothSubGroup = dirDAO.createGroup(BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(inBothSubGroupUser.id), WorkbenchEmail("inBoth@subGroup.com")), samRequestContext = samRequestContext).unsafeRunSync()
+    val inAuthDomainSubGroup = dirDAO
+      .createGroup(
+        BasicWorkbenchGroup(WorkbenchGroupName("inAuthDomainSubGroup"), Set(inAuthDomainSubGroupUser.id), WorkbenchEmail("imAuthDomain@subGroup.com")),
+        samRequestContext = samRequestContext
+      )
+      .unsafeRunSync()
+    val inPolicySubGroup = dirDAO
+      .createGroup(
+        BasicWorkbenchGroup(WorkbenchGroupName("inPolicySubGroup"), Set(inPolicySubGroupUser.id), WorkbenchEmail("inPolicy@subGroup.com")),
+        samRequestContext = samRequestContext
+      )
+      .unsafeRunSync()
+    val inBothSubGroup = dirDAO
+      .createGroup(
+        BasicWorkbenchGroup(WorkbenchGroupName("inBothSubGroup"), Set(inBothSubGroupUser.id), WorkbenchEmail("inBoth@subGroup.com")),
+        samRequestContext = samRequestContext
+      )
+      .unsafeRunSync()
 
     // Create managed group to act as auth domain and add appropriate subgroups
     val managedGroupId = "fooGroup"
     runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), superAdminOwner, samRequestContext = samRequestContext))
-    runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inAuthDomainSubGroup.id, samRequestContext))
+    runAndWait(
+      managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inAuthDomainSubGroup.id, samRequestContext)
+    )
     runAndWait(managedGroupService.addSubjectToPolicy(ResourceId(managedGroupId), ManagedGroupService.memberPolicyName, inBothSubGroup.id, samRequestContext))
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(superAdminOwner.email), Set.empty, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), None, superAdminOwner.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(superAdminOwner.email), Set.empty, Set(constrainableRole.roleName), None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(
+        constrainableResourceType,
+        ResourceId("rid"),
+        accessPolicyMap,
+        Set(WorkbenchGroupName(managedGroupId)),
+        None,
+        superAdminOwner.id,
+        samRequestContext
+      )
+    )
 
     // Access policy that intersection group will be calculated for
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicySubGroup.email, inBothSubGroup.email), Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set(inPolicySubGroup.email, inBothSubGroup.email), Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothSubGroupUser.id)
   }
 
   it should "return the policy members if there is no auth domain set" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      _,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val inPolicyUser = Generator.genWorkbenchUserBoth.sample.get
     val inBothUser = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(inPolicyUser, samRequestContext).unsafeRunSync()
     dirDAO.createUser(inBothUser, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), constrainableRole.actions, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, inBothUser.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(
+        Set(inPolicyUser.email, inBothUser.email),
+        constrainableRole.actions,
+        Set(constrainableRole.roleName),
+        None
+      )
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, inBothUser.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set(inPolicyUser.email, inBothUser.email), Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
     intersectionGroup shouldEqual Set(inBothUser.id, inPolicyUser.id)
   }
 
   it should "return an empty set if none of the policy members are in the auth domain" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      managedGroupService: ManagedGroupService,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val inAuthDomainUser = Generator.genWorkbenchUserBoth.sample.get
     val inPolicyUser = Generator.genWorkbenchUserBoth.sample.get
@@ -927,95 +1565,225 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val managedGroupId = "fooGroup"
     runAndWait(managedGroupService.createManagedGroup(ResourceId(managedGroupId), inAuthDomainUser, samRequestContext = samRequestContext))
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.email), constrainableRole.actions, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set(WorkbenchGroupName(managedGroupId)), None, inAuthDomainUser.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(
+        Set(inPolicyUser.email),
+        constrainableRole.actions,
+        Set(constrainableRole.roleName),
+        None
+      )
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(
+        constrainableResourceType,
+        ResourceId("rid"),
+        accessPolicyMap,
+        Set(WorkbenchGroupName(managedGroupId)),
+        None,
+        inAuthDomainUser.id,
+        samRequestContext
+      )
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set(inPolicyUser.email), Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set(inPolicyUser.email), Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
     intersectionGroup shouldEqual Set.empty
   }
 
   it should "return an empty set if both the auth domain and the policy are empty" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, managedGroupService: ManagedGroupService, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      managedGroupService: ManagedGroupService,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val inPolicyUser = Generator.genWorkbenchUserBoth.sample.get
     val inBothUser = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(inPolicyUser, samRequestContext).unsafeRunSync()
     dirDAO.createUser(inBothUser, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(inPolicyUser.email), constrainableRole.actions, Set(constrainableRole.roleName), None),
-      AccessPolicyName("emptyPolicy") -> AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, inBothUser.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(
+        Set(inPolicyUser.email),
+        constrainableRole.actions,
+        Set(constrainableRole.roleName),
+        None
+      ),
+      AccessPolicyName("emptyPolicy") -> AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, inBothUser.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
     intersectionGroup shouldEqual Set.empty
   }
 
   "isConstrainable" should "return true when the policy has constrainable actions and roles" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      _,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val dummyUserInfo = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(dummyUserInfo, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, constrainableRole.actions, Set(constrainableRole.roleName), None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, constrainableRole.actions, Set(constrainableRole.roleName), None),
+        samRequestContext
+      )
+    )
 
     val constrained = synchronizer.isConstrainable(resource.fullyQualifiedId, accessPolicy)
     constrained shouldEqual true
   }
 
   it should "return true when the policy has a constrainable role, but no constrainable actions" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      _,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
-    val dummyUserInfo =Generator.genWorkbenchUserBoth.sample.get
+    val dummyUserInfo = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(dummyUserInfo, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, Set.empty, Set(constrainableRole.roleName), None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, Set.empty, Set(constrainableRole.roleName), None),
+        samRequestContext
+      )
+    )
 
     val constrained = synchronizer.isConstrainable(resource.fullyQualifiedId, accessPolicy)
     constrained shouldEqual true
   }
 
   it should "return true when the policy has a constrainable action, but no constrainable roles" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      _,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val dummyUserInfo = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(dummyUserInfo, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, constrainableRole.actions, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, constrainableRole.actions, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val constrained = synchronizer.isConstrainable(resource.fullyQualifiedId, accessPolicy)
     constrained shouldEqual true
   }
 
   it should "return false when the policy is not constrainable" in {
-    val (dirDAO: DirectoryDAO, ge: GoogleExtensions, constrainableService: ResourceService, _, constrainableResourceType: ResourceType, constrainableRole: ResourceRole, synchronizer) = initPrivateTest
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      _,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
 
     val dummyUserInfo = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(dummyUserInfo, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), Set.empty, Set(constrainableRole.roleName), None)
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(constrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext)
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(constrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val constrained = synchronizer.isConstrainable(resource.fullyQualifiedId, accessPolicy)
     constrained shouldEqual false
   }
 
   it should "return false when the resource type is not constrainable" in {
-    val (dirDAO: DirectoryDAO,  _, constrainableService: ResourceService, _, _, _, _) = initPrivateTest
+    val (dirDAO: DirectoryDAO, _, constrainableService: ResourceService, _, _, _, _) = initPrivateTest
 
     val dummyUserInfo = Generator.genWorkbenchUserBoth.sample.get
     dirDAO.createUser(dummyUserInfo, samRequestContext).unsafeRunSync()
@@ -1039,10 +1807,35 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
 
     constrainableService.createResourceType(nonConstrainableResourceType, samRequestContext).unsafeRunSync()
 
-    val accessPolicyMap = Map(AccessPolicyName(nonConstrainableRole.roleName.value) -> AccessPolicyMembership(Set(dummyUserInfo.email), nonConstrainableRole.actions, Set(nonConstrainableRole.roleName), None))
-    val resource = runAndWait(constrainableService.createResource(nonConstrainableResourceType, ResourceId("rid"), accessPolicyMap, Set.empty, None, dummyUserInfo.id, samRequestContext))
+    val accessPolicyMap = Map(
+      AccessPolicyName(nonConstrainableRole.roleName.value) -> AccessPolicyMembership(
+        Set(dummyUserInfo.email),
+        nonConstrainableRole.actions,
+        Set(nonConstrainableRole.roleName),
+        None
+      )
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(
+        nonConstrainableResourceType,
+        ResourceId("rid"),
+        accessPolicyMap,
+        Set.empty,
+        None,
+        dummyUserInfo.id,
+        samRequestContext
+      )
+    )
 
-    val accessPolicy = runAndWait(constrainableService.overwritePolicy(nonConstrainableResourceType, AccessPolicyName("ap"), resource.fullyQualifiedId, AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None), samRequestContext))
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        nonConstrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembership(Set.empty, Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
 
     val constrained = synchronizer.isConstrainable(resource.fullyQualifiedId, accessPolicy)
     constrained shouldEqual false
@@ -1057,7 +1850,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGoogleProjectDAO = new MockGoogleProjectDAO
     val garbageOrgGoogleServicesConfig = TestSupport.googleServicesConfig.copy(terraGoogleOrgNumber = "garbage")
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, mockGoogleDirectoryDAO, null, null, null, mockGoogleIamDAO, null, mockGoogleProjectDAO, null, null, null, garbageOrgGoogleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      mockGoogleIamDAO,
+      null,
+      mockGoogleProjectDAO,
+      null,
+      null,
+      null,
+      garbageOrgGoogleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val defaultUser = Generator.genWorkbenchUserBoth.sample.get
 
@@ -1077,11 +1888,28 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGoogleProjectDAO = new MockGoogleProjectDAO {
-      override def getAncestry(projectName: String): Future[Seq[Ancestor]] = {
+      override def getAncestry(projectName: String): Future[Seq[Ancestor]] =
         Future.failed(new HttpResponseException.Builder(403, "Made up error message", new HttpHeaders()).build())
-      }
     }
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, dirDAO,  null, mockGoogleDirectoryDAO, null, null, null, mockGoogleIamDAO, null, mockGoogleProjectDAO, null, null, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      mockGoogleIamDAO,
+      null,
+      mockGoogleProjectDAO,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val defaultUser = Generator.genWorkbenchUserBoth.sample.get
 
@@ -1097,7 +1925,25 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     val mockGoogleNotificationPubSubDAO = new MockGooglePubSubDAO
     val topicName = "neat_topic"
     val notificationDAO = new PubSubNotificationDAO(mockGoogleNotificationPubSubDAO, topicName)
-    val googleExtensions = new GoogleExtensions(TestSupport.distributedLock, null,  null, null, mockGoogleNotificationPubSubDAO, null, null, null, null, null, null, notificationDAO, null, googleServicesConfig, petServiceAccountConfig, configResourceTypes, superAdminsGroup)
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      null,
+      null,
+      null,
+      mockGoogleNotificationPubSubDAO,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      notificationDAO,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
 
     val messages = Set(
       Notifications.GroupAccessRequestNotification(
@@ -1105,7 +1951,8 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
         WorkbenchGroupName("bobs_buds").value,
         Set(WorkbenchUserId("reply_to_address")),
         WorkbenchUserId("requesters_id")
-      ))
+      )
+    )
 
     googleExtensions.fireAndForgetNotifications(messages)
 
@@ -1114,7 +1961,6 @@ class GoogleExtensionSpec(_system: ActorSystem) extends TestKit(_system) with An
     messageLog should contain theSameElementsAs formattedMessages
   }
 
-  protected def clearDatabase(): Unit = {
+  protected def clearDatabase(): Unit =
     TestSupport.truncateAll
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMonitorSpec.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.mockito.MockitoSugar
-import org.mockito.ArgumentMatchers.{ eq => mockitoEq }
+import org.mockito.ArgumentMatchers.{eq => mockitoEq}
 
 import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers.any
@@ -22,12 +22,18 @@ import spray.json._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) with AnyFlatSpecLike with Matchers with TestSupport with MockitoSugar with BeforeAndAfterAll with Eventually {
+class GoogleGroupSyncMonitorSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with TestSupport
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with Eventually {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -41,15 +47,19 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")
-    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(groupToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext])).thenReturn(Future.successful(Map(groupToSyncEmail -> Seq.empty[SyncReportItem])))
+    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(groupToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext]))
+      .thenReturn(Future.successful(Map(groupToSyncEmail -> Seq.empty[SyncReportItem])))
 
     val policyToSyncEmail = WorkbenchEmail("testpolicy@example.com")
     val policyToSyncId = FullyQualifiedPolicyId(FullyQualifiedResourceId(ResourceTypeName("rt"), ResourceId("rid")), AccessPolicyName("pname"))
-    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(policyToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext])).thenReturn(Future.successful(Map(policyToSyncEmail -> Seq.empty[SyncReportItem])))
+    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(policyToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext]))
+      .thenReturn(Future.successful(Map(policyToSyncEmail -> Seq.empty[SyncReportItem])))
 
     val topicName = "testtopic"
     val subscriptionName = "testsub"
-    system.actorOf(GoogleGroupSyncMonitorSupervisor.props(10 milliseconds, 0 seconds, mockGooglePubSubDAO, topicName, subscriptionName, 1, mockGoogleExtensions))
+    system.actorOf(
+      GoogleGroupSyncMonitorSupervisor.props(10 milliseconds, 0 seconds, mockGooglePubSubDAO, topicName, subscriptionName, 1, mockGoogleExtensions)
+    )
 
     eventually {
       assert(mockGooglePubSubDAO.subscriptionsByName.contains(subscriptionName))
@@ -64,7 +74,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
     // try to use `Retrying[Future[T]]`, which gets weird when we're using mockito together with it.
     // Hence adding ascribing [Unit] explicitly here so that `eventually` will use `Retrying[Unit]`
     eventually[Unit] {
-      assertResult(2) { mockGooglePubSubDAO.acks.size() }
+      assertResult(2)(mockGooglePubSubDAO.acks.size())
       verify(mockGoogleExtensions, atLeastOnce).synchronizeGroupMembers(mockitoEq(groupToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext])
       verify(mockGoogleExtensions, atLeastOnce).synchronizeGroupMembers(mockitoEq(policyToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext])
       ()
@@ -78,11 +88,14 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
 
     val groupToSyncEmail = WorkbenchEmail("testgroup@example.com")
     val groupToSyncId = WorkbenchGroupName("testgroup")
-    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(groupToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext])).thenReturn(Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "not found"))))
+    when(mockGoogleExtensions.synchronizeGroupMembers(mockitoEq(groupToSyncId), any[Set[WorkbenchGroupIdentity]], any[SamRequestContext]))
+      .thenReturn(Future.failed(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "not found"))))
 
     val topicName = "testtopic"
     val subscriptionName = "testsub"
-    system.actorOf(GoogleGroupSyncMonitorSupervisor.props(10 milliseconds, 0 seconds, mockGooglePubSubDAO, topicName, subscriptionName, 1, mockGoogleExtensions))
+    system.actorOf(
+      GoogleGroupSyncMonitorSupervisor.props(10 milliseconds, 0 seconds, mockGooglePubSubDAO, topicName, subscriptionName, 1, mockGoogleExtensions)
+    )
 
     eventually {
       assert(mockGooglePubSubDAO.subscriptionsByName.contains(subscriptionName))
@@ -92,7 +105,7 @@ class GoogleGroupSyncMonitorSpec(_system: ActorSystem) extends TestKit(_system) 
     mockGooglePubSubDAO.publishMessages(topicName, Seq(groupToSyncId.toJson.compactPrint))
 
     eventually {
-      assertResult(1) { mockGooglePubSubDAO.acks.size() }
+      assertResult(1)(mockGooglePubSubDAO.acks.size())
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -15,10 +15,10 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
   val defaultUser = Generator.genWorkbenchUserBoth.sample.get
   val serviceAccountUser = Generator.genWorkbenchUserServiceAccount.sample.get
 
-  private val tosServiceEnabledV0 = new TosService(dirDAO,"example.com", TestSupport.tosConfig.copy(enabled = true, version = "0"))
+  private val tosServiceEnabledV0 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "0"))
   private val tosServiceEnabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true))
-  private val tosServiceEnabledV2 = new TosService(dirDAO,"example.com", TestSupport.tosConfig.copy(enabled = true, version = "2"))
-  private val tosServiceDisabled = new TosService(dirDAO,  "example.com", TestSupport.tosConfig.copy(enabled = false))
+  private val tosServiceEnabledV2 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2"))
+  private val tosServiceDisabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = false))
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -30,9 +30,8 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     TestSupport.truncateAll
   }
 
-  protected def clearDatabase(): Unit = {
+  protected def clearDatabase(): Unit =
     TestSupport.truncateAll
-  }
 
   "TosService" should "accept, get, and reject the ToS for a user" in {
     dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupportSpec.scala
@@ -22,7 +22,9 @@ class DatabaseSupportSpec extends AnyFreeSpec with Matchers with BeforeAndAfterE
     override protected val writeDbRef: DbReference = TestSupport.dbRef
     override protected val readDbRef: DbReference = TestSupport.dbRef
 
-    override def serializableWriteTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext, maxTries: Int = 3)(databaseFunction: DBSession => A)(implicit timer: Temporal[IO]): IO[A] =
+    override def serializableWriteTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext, maxTries: Int = 3)(
+        databaseFunction: DBSession => A
+    )(implicit timer: Temporal[IO]): IO[A] =
       super.serializableWriteTransaction(dbQueryName, samRequestContext, maxTries)(databaseFunction)
   }
 
@@ -47,15 +49,10 @@ class DatabaseSupportSpec extends AnyFreeSpec with Matchers with BeforeAndAfterE
     }
   }
 
-  /**
-    * This does some db stuff that causes a serialization failure.
-    * 1) insert a record
-    * 2) in serializable transaction A read the record
-    * 3) in transaction B update the record
-    * 4) in transaction A update the record
-    * A CyclicBarrier is used to make sure of the ordering between transactions A and B to force the serialization failure.
-    * In the case of a retry we only retry transaction A but the thread running B still needs to use the CyclicBarrier
-    * so the thread running A does not get stuck.
+  /** This does some db stuff that causes a serialization failure. 1) insert a record 2) in serializable transaction A read the record 3) in transaction B
+    * update the record 4) in transaction A update the record A CyclicBarrier is used to make sure of the ordering between transactions A and B to force the
+    * serialization failure. In the case of a retry we only retry transaction A but the thread running B still needs to use the CyclicBarrier so the thread
+    * running A does not get stuck.
     *
     * @param maxTries
     * @return


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-279

scalafmt plugin isnt maintained anymore and is kinda broke so it isnt working as expected. This pr gets fmt running on compile and check running on assembly. Look to first commit for actual changes and second commit for autofmt changes.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
