### PR TITLE
Ignore generated credentials from google-github-actions/auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ automation/src/test/resources/
 codegen_java/*
 !codegen_java/project
 !codegen_java/templates
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2410
<Put notes here to help reviewer understand this PR>
adds a gitignore for gha json tokens.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
