### PR TITLE
use dumb terminal if no say function

### DIFF
--- a/minnie-kenny.sh
+++ b/minnie-kenny.sh
@@ -10,6 +10,11 @@ minnie_kenny_strict=0
 minnie_kenny_modify=0
 minnie_kenny_gitconfig="minnie-kenny.gitconfig"
 
+if ! which -s say; then
+  # Sometimes github actions doesn't have the say command, or a TERM. Setting TERM=dumb seems to get around this.
+  export TERM=dumb
+fi
+
 usage() {
   if [ ${minnie_kenny_quiet} -ne 1 ]; then
     cat <<USAGE >&2


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
We're getting [failures](https://github.com/broadinstitute/sam/actions/runs/3275431279/jobs/5390273230) in our tests when checking for git-secrets. Sometimes, the github action doesn't seem to have the `say` command. Andrew Herbst reports that `export TERM=dumb` seems to fix the problem, so making `minnie-kenny.sh` conditionally do that if `say` isn't defined should work around this issue. 
 
[Slack thread](https://broadinstitute.slack.com/archives/C03BCARP494/p1665766224753949)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
