### PR TITLE
[WOR-576] Replace "say" with "echo" to work around git secrets installation issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Secrets check
         run: |
+          sudo ln -s "$(which echo)" /usr/local/bin/say
           ./minnie-kenny.sh --force
           git secrets --scan-history
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-576

git has deleted `say`. The [PR](https://github.com/awslabs/git-secrets/pull/221) to fix the issue in git-secrets has not been merged. When it is merged, we can update the commit we use to pick up the change and delete this workaround.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
