### PR TITLE
[DR-2730] Add view_journal action for TDR

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1004,6 +1004,9 @@ resourceTypes = {
       "list_children" = {
         description = "list child resources"
       }
+      "view_journal" = {
+        description = "View a spend profile's journal entries"
+      }
     }
     ownerRoleName = "owner"
     roles = {
@@ -1011,7 +1014,7 @@ resourceTypes = {
         descendantRoles = {
           landing-zone = ["owner"]
         }
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "add_child", "list_children"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "add_child", "list_children", "view_journal"]
       }
       user = {
         descendantRoles = {
@@ -1098,11 +1101,14 @@ resourceTypes = {
       update_passport_identifier = {
         description = "Can update a dataset's passport identifier (e.g. PHS ID)"
       }
+      view_journal = {
+        description = "View dataset journal entries"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal"]
       }
       custodian = {
         roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
@@ -1166,11 +1172,14 @@ resourceTypes = {
       export_snapshot = {
         description = "Export snapshot to a Terra workspace"
       }
+      view_journal = {
+        description = "View datasnapshot journal entries"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal"]
       }
       custodian = {
         roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]


### PR DESCRIPTION
Adds the view_journal action for TDR:

- dataset stewards
- datasnapshot stewards
- spend-profile owners

Ticket: [DR-2730](https://broadworkbench.atlassian.net/browse/DR-2730)
As part of a feature to create journal entries that document when specific actions were taken in TDR, this PR adds support for an action (view_journal) to read journal entires written about three resource types: datasets, datasnapshots, and spend-profiles.

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [404] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
