### PR TITLE
ID-321 Add ability to retry flaky tests

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFlatSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFlatSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam
 
-import org.scalatest.{Canceled, Failed, Outcome, Retries}
+import org.scalatest.{Exceptional, Outcome, Retries}
 import org.scalatest.flatspec.AnyFlatSpec
 
 trait RetryableAnyFlatSpec extends AnyFlatSpec with Retries {
@@ -13,8 +13,9 @@ trait RetryableAnyFlatSpec extends AnyFlatSpec with Retries {
   def withFixture(test: NoArgTest, count: Int): Outcome = {
     val outcome = super.withFixture(test)
     outcome match {
-      case Failed(_) | Canceled(_) =>
-        println(s"Test '${test.name}' failed on try $count.")
+      case Exceptional(ex) =>
+        println(s"Test '${test.name}' ${outcome.getClass.getSimpleName} on try $count.")
+        println(s"Test '${test.name}' ${outcome.getClass.getSimpleName} with: $ex")
         if (count >= retries) super.withFixture(test) else withFixture(test, count + 1)
       case other => other
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFlatSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFlatSpec.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.workbench.sam
+
+import org.scalatest.{Canceled, Failed, Outcome, Retries}
+import org.scalatest.flatspec.AnyFlatSpec
+
+trait RetryableAnyFlatSpec extends AnyFlatSpec with Retries {
+
+  val retries = 3
+
+  override def withFixture(test: NoArgTest): Outcome =
+    withFixture(test, 1)
+
+  def withFixture(test: NoArgTest, count: Int): Outcome = {
+    val outcome = super.withFixture(test)
+    outcome match {
+      case Failed(_) | Canceled(_) =>
+        println(s"Test '${test.name}' failed on try $count.")
+        if (count >= retries) super.withFixture(test) else withFixture(test, count + 1)
+      case other => other
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -14,14 +14,13 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.scalatest.AppendedClues
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
 /** Created by dvoet on 6/7/17.
   */
-class ResourceRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
+class ResourceRoutesSpec extends RetryableAnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with AppendedClues {
 
   val defaultUserInfo = TestSamRoutes.defaultUserInfo
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -15,12 +15,11 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport, model}
+import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFlatSpec, TestSupport, model}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.{any, argThat, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.AppendedClues
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import spray.json.DefaultJsonProtocol._
@@ -29,7 +28,7 @@ import spray.json.{JsBoolean, JsValue}
 import scala.concurrent.Future
 
 //TODO This test is flaky. It looks like the tests run too fast and cause some sort of timeout error or race condition
-class ResourceRoutesV2Spec extends AnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
+class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
 
   implicit val errorReportSource = ErrorReportSource("sam")
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -7,20 +7,19 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
-import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
+import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFlatSpec, TestSupport}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Database
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import org.mockito.ArgumentMatchers.{any, anyLong, anyString}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
 
-class StatusRouteSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
+class StatusRouteSpec extends RetryableAnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
 
   "GET /version" should "give 200 for ok" in {
     val samRoutes = TestSamRoutes(Map.empty)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.Generator._
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
+import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFlatSpec, TestSupport}
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -670,7 +670,7 @@ class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupp
 }
 
 @deprecated("this allows testing of deprecated functions, remove as part of CA-1783", "")
-class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec {
+class DeprecatedPolicyEvaluatorSpec extends PolicyEvaluatorServiceSpec with RetryableAnyFlatSpec {
   "listUserAccessPolicies" should "list user's access policies but not others" in {
     assume(databaseEnabled, databaseEnabledClue)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-321

I've added the ability to make a unit test suite retry failing tests up to 3 times. This is done by making the test suite extend the new `RetryableAnyFlatSpec` instead of `AnyFlatSpec`.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
