### PR TITLE
new resource for wds-instance [AJ-598]

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -153,6 +153,7 @@ resourceTypes = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
+          wds-instance = ["owner"]
         }
       }
       application = {
@@ -167,6 +168,7 @@ resourceTypes = {
           controlled-user-shared-workspace-resource = ["editor", "writer", "reader"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           google-project = ["pet-creator"]
+          wds-instance = ["writer"]
         }
       }
       reader = {
@@ -175,6 +177,7 @@ resourceTypes = {
           controlled-user-shared-workspace-resource = ["reader"]
           controlled-application-shared-workspace-resource = ["reader"]
           google-project = ["pet-creator"]
+          wds-instance = ["reader"]
         }
       }
       discoverer = {
@@ -1250,6 +1253,38 @@ resourceTypes = {
       }
       user = {
         roleActions = ["list_resources"]
+      }
+    }
+    reuseIds = false
+  }
+  wds-instance = {
+    actionPatterns = {
+      read = {
+        description = "read data from this WDS instance"
+      }
+      write = {
+        description = "add, update, delete data in this WDS instance"
+      }
+      delete = {
+        description = "delete this WDS instance"
+      }
+      get_parent = {
+        description = "get the parent workspace of this WDS instance"
+      }
+      set_parent = {
+        description = "set the parent workspace of this WDS instance"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["set_parent", "delete", "write", "read", "get_parent"]
+      }
+      writer = {
+        roleActions = ["write", "read", "get_parent"]
+      }
+      reader = {
+        roleActions = ["read", "get_parent"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-598

Sets up a new resource type `wds-instance` to capture permissions for WDS instances, which run as apps behind Leo in Azure. `wds-instance` will inherit reader/writer/owner from a parent workspace.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
