### PR TITLE
TOAZ-258: Add admin getArbitraryPet endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -875,6 +875,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/google/v1/petServiceAccount/{userEmail}/key:
+    get:
+      tags:
+        - Google
+      summary: gets a key for the user's arbitrary pet service account, get_pet_private_key action on cloud-extension/google required
+      operationId: getUserArbitraryPetServiceAccountKey
+      parameters:
+        - name: userEmail
+          in: path
+          description: User's email address
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: json format key for a pet service account, see https://cloud.google.com/iam/docs/creating-managing-service-account-keys
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: caller has some access to cloud-extension/google but not to
+            the get_pet_private_key action
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: user does not exist or caller does not have any access to cloud-extension/google
+            resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/user/petServiceAccount/{project}:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -429,6 +429,16 @@ class GoogleExtensions(
       getAccessTokenUsingJson(key, scopes)
     }
 
+  def getArbitraryPetServiceAccountKey(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[String]] =
+    for {
+      subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
+      key <- subject match {
+        case Some(userId: WorkbenchUserId) =>
+          IO.fromFuture(IO(getArbitraryPetServiceAccountKey(SamUser(userId, None, userEmail, None, false, None), samRequestContext))).map(Option(_))
+        case _ => IO.none
+      }
+    } yield key
+
   def getArbitraryPetServiceAccountKey(user: SamUser, samRequestContext: SamRequestContext): Future[String] =
     getDefaultServiceAccountForShellProject(user, samRequestContext)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-258

Leo (and potentially other services) have a need for the `arbitrary pet` feature of Sam. However, the [existing API](https://sam.dsde-dev.broadinstitute.org/#/Google/getArbitraryPetServiceAccountKey) only operates on the calling user. We want the ability to get an arbitrary pet for a _provided_ user email, similar to [this API](https://sam.dsde-dev.broadinstitute.org/#/Google/getUserPetServiceAccountKey).

This PR adds that API. I tested it with Leonardo on a BEE. Any feedback appreciated.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
