### PR TITLE
ID-336 Service Accounts do not need to accept ToS

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -103,7 +103,7 @@ object StandardSamUserDirectives {
       user <- getSamUser(oidcHeaders, directoryDAO, samRequestContext)
     } yield {
       // service account users do not need to accept ToS
-      val tosStatusAcceptable = tosService.isTermsOfServiceStatusAcceptable(user) || SAdomain.matches(user.email.value)
+      val tosStatusAcceptable = tosService.isTermsOfServiceStatusAcceptable(user)
       if (!tosStatusAcceptable) {
         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Unauthorized, "User has not accepted the terms of service."))
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -41,7 +41,9 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
   /** If grace period enabled, don't check ToS, return true If ToS disabled, return true Otherwise return true if user has accepted ToS, or is a service account
     */
   def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean =
-    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version) || StandardSamUserDirectives.SAdomain.matches(user.email.value)
+    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version) || StandardSamUserDirectives.SAdomain.matches(
+      user.email.value
+    )
 
   /** Get the terms of service text and send it to the caller
     * @return

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.api.StandardSamUserDirectives
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.errorReportSource
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -37,10 +38,10 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
       directoryDao.loadUser(userId, samRequestContext).map(_.map(_.acceptedTosVersion.contains(tosConfig.version)))
     } else IO.none
 
-  /** If grace period enabled, don't check ToS, return true If ToS disabled, return true Otherwise return true if user has accepted ToS
+  /** If grace period enabled, don't check ToS, return true If ToS disabled, return true Otherwise return true if user has accepted ToS, or is a service account
     */
   def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean =
-    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version)
+    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version) || StandardSamUserDirectives.SAdomain.matches(user.email.value)
 
   /** Get the terms of service text and send it to the caller
     * @return

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -52,6 +52,14 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     assertResult(expected = false, s"getTosStatus(${defaultUser.id}) should have returned false")(actual = getTosStatusResultRejected.get)
   }
 
+  it should "exclude service accounts from ToS checks" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    dirDAO.createUser(serviceAccountUser, samRequestContext).unsafeRunSync()
+
+    tosServiceEnabledV0.isTermsOfServiceStatusAcceptable(serviceAccountUser) should be(true)
+  }
+
   it should "accept new version of ToS" in {
     assume(databaseEnabled, databaseEnabledClue)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-336
Enabling ToS all-of-a-sudden meant that Service Accounts needed to accept the ToS! This causes tests to fail, and causes all sorts of issues. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
