### PR TITLE
ID-338 Don't fail on missing Azure config

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -153,14 +153,23 @@ object AppConfig {
     )
   }
 
-  implicit val azureServicesConfigReader: ValueReader[AzureServicesConfig] = ValueReader.relative { config =>
-    AzureServicesConfig(
-      config.as[Option[Boolean]]("azureEnabled"),
-      config.getString("managedAppClientId"),
-      config.getString("managedAppClientSecret"),
-      config.getString("managedAppTenantId"),
-      config.as[Seq[String]]("managedAppPlanIds")
-    )
+  implicit val azureServicesConfigReader: ValueReader[Option[AzureServicesConfig]] = ValueReader.relative { config =>
+    config
+      .getAs[Boolean]("azureEnabled")
+      .flatMap(azureEnabled =>
+        if (azureEnabled) {
+          Option(
+            AzureServicesConfig(
+              config.getString("managedAppClientId"),
+              config.getString("managedAppClientSecret"),
+              config.getString("managedAppTenantId"),
+              config.as[Seq[String]]("managedAppPlanIds")
+            )
+          )
+        } else {
+          None
+        }
+      )
   }
 
   implicit val prometheusConfig: ValueReader[PrometheusConfig] = ValueReader.relative { config =>
@@ -198,7 +207,7 @@ object AppConfig {
       termsOfServiceConfig = config.as[TermsOfServiceConfig]("termsOfService"),
       oidcConfig = config.as[OidcConfig]("oidc"),
       adminConfig = config.as[AdminConfig]("admin"),
-      azureServicesConfig = config.getAs[AzureServicesConfig]("azureServices"),
+      azureServicesConfig = config.as[Option[AzureServicesConfig]]("azureServices"),
       prometheusConfig = config.as[PrometheusConfig]("prometheus")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -207,7 +207,7 @@ object AppConfig {
       termsOfServiceConfig = config.as[TermsOfServiceConfig]("termsOfService"),
       oidcConfig = config.as[OidcConfig]("oidc"),
       adminConfig = config.as[AdminConfig]("admin"),
-      azureServicesConfig = config.as[Option[AzureServicesConfig]]("azureServices"),
+      azureServicesConfig = config.getAs[AzureServicesConfig]("azureServices"),
       prometheusConfig = config.as[PrometheusConfig]("prometheus")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 case class AzureServicesConfig(
-    azureEnabled: Option[Boolean],
     managedAppClientId: String,
     managedAppClientSecret: String,
     managedAppTenantId: String,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -20,7 +20,7 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   "AzureService" should "create a pet managed identity" taggedAs ConnectedTest in {
     val azureServicesConfig = appConfig.azureServicesConfig
 
-    assume(azureServicesConfig.flatMap(_.azureEnabled).exists(identity), "-- skipping Azure test")
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
 
     // create dependencies
     val directoryDAO = new PostgresDirectoryDAO(dbRef, dbRef)
@@ -91,7 +91,7 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   it should "get the billing profile id from the managed resource group" taggedAs ConnectedTest in {
     val azureServicesConfig = appConfig.azureServicesConfig
 
-    assume(azureServicesConfig.flatMap(_.azureEnabled).exists(identity), "-- skipping Azure test")
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
 
     // create dependencies
     val directoryDAO = new PostgresDirectoryDAO(dbRef, dbRef)


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/ID-338)

Looks like we didn't test if Sam would boot if the Azure configs are missing. This happens because Prod doesn't have Azure enabled. I've fixed the issue, and also removed the `azureEnabled` variable from the code, since it's not used for anything.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
