### PR TITLE
ID-242 Updating comments that describe how configs are loaded

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -176,15 +176,12 @@ object AppConfig {
     PrometheusConfig(config.getInt("endpointPort"))
   }
 
-  /**
-    * Loads all the configs for the Sam App.  All values defined in `src/main/resources/sam.conf` will take precedence
-    * over any other configs.  In this way, we can still use configs rendered by `firecloud-develop` that render to
-    * `config/sam.conf` if we want.  To do so, you must render `config/sam.conf` and then do not populate ENV variables
-    * for `src/main/resources/sam.conf`.
+  /** Loads all the configs for the Sam App. All values defined in `src/main/resources/sam.conf` will take precedence over any other configs. In this way, we
+    * can still use configs rendered by `firecloud-develop` that render to `config/sam.conf` if we want. To do so, you must render `config/sam.conf` and then do
+    * not populate ENV variables for `src/main/resources/sam.conf`.
     *
-    * The ENV variables that you need to populate can be found in `src/main/resources/sam.conf` variable substitutions.
-    * To run Sam locally, you can `source env/local.env` and all required ENV variables will be populated with with
-    * default values.
+    * The ENV variables that you need to populate can be found in `src/main/resources/sam.conf` variable substitutions. To run Sam locally, you can `source
+    * env/local.env` and all required ENV variables will be populated with with default values.
     */
   def load: AppConfig = {
     // Start by parsing sam config files (like 'sam.conf') from wherever they live on the classpath

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -175,13 +175,25 @@ object AppConfig {
   implicit val prometheusConfig: ValueReader[PrometheusConfig] = ValueReader.relative { config =>
     PrometheusConfig(config.getInt("endpointPort"))
   }
+
+  /**
+    * Loads all the configs for the Sam App.  All values defined in `src/main/resources/sam.conf` will take precedence
+    * over any other configs.  In this way, we can still use configs rendered by `firecloud-develop` that render to
+    * `config/sam.conf` if we want.  To do so, you must render `config/sam.conf` and then do not populate ENV variables
+    * for `src/main/resources/sam.conf`.
+    *
+    * The ENV variables that you need to populate can be found in `src/main/resources/sam.conf` variable substitutions.
+    * To run Sam locally, you can `source env/local.env` and all required ENV variables will be populated with with
+    * default values.
+    */
   def load: AppConfig = {
-    // We need to manually parse and resolve the env.conf file.
-    // ConfigFactory.load automatically pulls in the default reference.conf,
-    // which then ends up overriding any conf files provided as java options.
-    // We need to get _just_ the contents of env.conf so that normal overriding can occur.
+    // Start by parsing sam config files (like 'sam.conf') from wherever they live on the classpath
     val samConfig = ConfigFactory.parseResourcesAnySyntax("sam").resolve()
+    // Load any other configs on the classpath following: https://github.com/lightbend/config#standard-behavior
+    // This is where things like `src/main/resources/reference.conf` will get loaded
     val config = ConfigFactory.load()
+    // Combine the two sets of configs.  If a value is defined in both sets of configs, the ones in `samConfig` will
+    // take precedence over those in `config`
     val combinedConfig = samConfig.withFallback(config)
     AppConfig.readConfig(combinedConfig)
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-242

What:
The comments on this method before were outdated and not really all that helpful.  

Why:
Other projects will be referencing this code when they break away from firecloud-develop and we want them to understand the how and why of why we load configs the way we do now.

How:
I rewrote the comments and moved some comments around to hopefully make it easier to understand what the code is doing and how to use it.  

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
