### PR TITLE
[DR-2839] Expand datarepo configuration to support DUOS user sync

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -935,17 +935,23 @@ resourceTypes = {
   }
   datarepo = {
     actionPatterns = {
-      create_dataset = {
+      "create_dataset" = {
         description = "Has permission to create a dataset"
       }
-      configure = {
+      "configure" = {
         description = "Edit and read the live configuration on a datarepo instance"
+      }
+      "sync_duos_users" = {
+        description = "Can sync a DUOS dataset's authorized users to TDR-managed Firecloud groups"
       }
       "share_policy::admin" = {
         description = "Can grant and revoke a users' admin permission"
       }
       "share_policy::steward" = {
         description = "Can grant and revoke a users' steward permission"
+      }
+      "share_policy::duos_user_syncer" = {
+        description = "Can grant and revoke a users' ability to sync DUOS users to Firecloud groups"
       }
       "read_policies" = {
         description = "Can read policies"
@@ -969,10 +975,14 @@ resourceTypes = {
     ownerRoleName = "admin"
     roles = {
       admin = {
-        roleActions = ["list_jobs", "delete_jobs", "delete", "share_policy::steward", "share_policy::admin", "read_policies", "alter_policies", "configure"]
+        roleActions = ["list_jobs", "delete_jobs", "delete", "share_policy::steward", "share_policy::admin", "share_policy::duos_user_syncer", "read_policies", "alter_policies", "configure"]
+        includedRoles = ["duos_user_syncer"]
       }
       steward = {
         roleActions = ["list_jobs", "delete_jobs", "create_dataset", "share_policy::steward", "read_policy::steward"]
+      }
+      duos_user_syncer = {
+        roleActions = ["sync_duos_users"]
       }
     }
     reuseIds = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -976,12 +976,12 @@ resourceTypes = {
     roles = {
       admin = {
         roleActions = ["list_jobs", "delete_jobs", "delete", "share_policy::steward", "share_policy::admin", "share_policy::duos_user_syncer", "read_policies", "alter_policies", "configure"]
-        includedRoles = ["duos_user_syncer"]
+        includedRoles = ["duos_integration_admin"]
       }
       steward = {
         roleActions = ["list_jobs", "delete_jobs", "create_dataset", "share_policy::steward", "read_policy::steward"]
       }
-      duos_user_syncer = {
+      duos_integration_admin = {
         roleActions = ["sync_duos_users"]
       }
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2839

What:

 If a user is a TDR Admin or holds new TDR role `duos_integration_admin`, they will be able to sync the members of TDR-managed Firecloud groups with the latest DUOS dataset authorized users.

Why:

TDR work in-flight exposes this sync functionality within a new endpoint, and our first draft checks for an unrelated action currently held only by TDR Admins: https://github.com/DataBiosphere/jade-data-repo/blob/e9f09ed0fc69c1e2b4a892e34b9e8df1c613d81e/src/main/java/bio/terra/app/controller/DuosApiController.java#L51-L54

Besides being brittle and unclear in the event of a user missing permissions, we'd like to allow more users beyond TDR Admins to be allowed to trigger these syncs (such as Jonathan, TDR and DUOS PM). 

How:

Expanded the `datarepo` resource configuration to add a new role `duos_integration_admin` with action `sync_duos_users`.  The existing `admin` role includes this new role. 

---

**PR checklist**

- [X] (N/A) I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
