### PR TITLE
[DR-2839] Update references to datarepo's renamed duos_user_syncer role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -950,8 +950,8 @@ resourceTypes = {
       "share_policy::steward" = {
         description = "Can grant and revoke a users' steward permission"
       }
-      "share_policy::duos_user_syncer" = {
-        description = "Can grant and revoke a users' ability to sync DUOS users to Firecloud groups"
+      "share_policy::duos_integration_admin" = {
+        description = "Can grant and revoke a users' DUOS integration admin permission"
       }
       "read_policies" = {
         description = "Can read policies"
@@ -975,7 +975,7 @@ resourceTypes = {
     ownerRoleName = "admin"
     roles = {
       admin = {
-        roleActions = ["list_jobs", "delete_jobs", "delete", "share_policy::steward", "share_policy::admin", "share_policy::duos_user_syncer", "read_policies", "alter_policies", "configure"]
+        roleActions = ["list_jobs", "delete_jobs", "delete", "share_policy::steward", "share_policy::admin", "share_policy::duos_integration_admin", "read_policies", "alter_policies", "configure"]
         includedRoles = ["duos_integration_admin"]
       }
       steward = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2839

This is a follow-on bugfix from https://github.com/broadinstitute/sam/pull/907 - I renamed our new `datarepo` role from `duos_user_syncer` to `duos_integration_admin` in the PR's second commit, but forgot to update the `share_policies::<role>` role and its references to match.  Without an exact match, we can't manage the DUOS integration admin policy's members.

---

**PR checklist**

- [X] (N/A) I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
