### PR TITLE
[DR-2736] Snapshot custodians, readers can export_snapshot

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1197,13 +1197,13 @@ resourceTypes = {
         roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot"]
       }
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer"]
       }
       reader = {
-        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer"]
+        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot"]
       }
       admin = {
         roleActions = ["read_policies", "share_policy::steward", "alter_policies"]


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/DR-2736

**What:**

TDR Snapshot custodians and readers are now permitted to initiate the first step of a snapshot's export-by-copy to a Terra workspace: https://data.terra.bio/swagger-ui.html#/snapshots/exportSnapshot

**Why:**

Initially, TDR would check that a caller held `read_data` action on the snapshot to export it, but that check was incomplete given the permission syncing taking place in the second step of the export process (import to workspace).  The caller also needed the `share_policy::reader` action.

Snapshot readers would then successfully initiate the first step but see the import to workspace fail due to a missing `share_policy::reader` permission.

To avoid permitting the first step of an operation that would ultimately fail, we introduced a new `export_snapshot` action and granted it to stewards, which held both necessary actions.  (That custodians were not granted this action too was an oversight.)

We check for this permission before allowing a snapshot export in the [backend](https://github.com/DataBiosphere/jade-data-repo/blob/a9634d254c9e3caa3d7ce5f60408226b7dfb583b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java#L178).  The button to trigger a snapshot export in the [frontend](https://github.com/DataBiosphere/jade-data-repo-ui/pull/1161) is presently enabled for stewards only.

In the time since, Analysis Journeys has introduced a flag to specify whether or not permissions should be synced, so TDR UI will be able to enable imports for readers without the permission sync: https://docs.google.com/document/d/1yPHH03s-xW6W2SHBfjeGql2qnt2StgVtwVxkODXRWE4/edit#heading=h.w9spxp8w7kqh

**How:**

Granted `export_snapshot` action to `datasnapshot` `custodian` and `reader` roles.

---

**PR checklist**

- [X] (N/A) I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
