### PR TITLE
TOAZ-224 store MRG coordinates in sam

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,6 +124,8 @@ object Dependencies {
 
   val cloudResourceLib: ModuleID =
     "bio.terra" % "terra-cloud-resource-lib" % crlVersion excludeAll (excludeGoogleCloudResourceManager, excludeJerseyCore, excludeJerseyMedia, excludeSLF4J)
+  val azureManagedApplications: ModuleID =
+    "com.azure.resourcemanager" % "azure-resourcemanager-managedapplications" % "1.0.0-beta.1"
 
   // was included transitively before, now explicit
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.15"
@@ -174,6 +176,7 @@ object Dependencies {
     scalikeCoreConfig,
     scalikeCoreTest,
     postgres,
-    cloudResourceLib
+    cloudResourceLib,
+    azureManagedApplications
   ) ++ openCensusDependencies
 }

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -22,4 +22,5 @@
     <include file="changesets/20220524_pet_user_assigned_managed_identity.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220628_distributed_lock.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220811_allow_leaving_column.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221115_azure_managed_resource_group.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20221115_azure_managed_resource_group.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20221115_azure_managed_resource_group.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="dvoet" id="azure_managed_resource_group">
+        <createTable tableName="SAM_AZURE_MANAGED_RESOURCE_GROUP">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="subscription_id" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="managed_resource_group_name" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="billing_profile_id" type="VARCHAR">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="SAM_AZURE_MANAGED_RESOURCE_GROUP"
+                             columnNames="tenant_id,subscription_id,managed_resource_group_name"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1022,6 +1022,9 @@ resourceTypes = {
       "view_journal" = {
         description = "View a spend profile's journal entries"
       }
+      "set_managed_resource_group" = {
+        description = "Associate this spend profile to an Azure managed resource group"
+      }
     }
     ownerRoleName = "owner"
     roles = {
@@ -1029,7 +1032,7 @@ resourceTypes = {
         descendantRoles = {
           landing-zone = ["owner"]
         }
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "add_child", "list_children", "view_journal"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "read_policies", "add_child", "list_children", "view_journal", "set_managed_resource_group"]
       }
       user = {
         descendantRoles = {

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -177,6 +177,17 @@ azureServices {
   managedAppClientId = ${?AZURE_MANAGED_APP_CLIENT_ID}
   managedAppClientSecret = ${?AZURE_MANAGED_APP_CLIENT_SECRET}
   managedAppTenantId = ${?AZURE_MANAGED_APP_TENANT_ID}
-  managedAppPlanIds = ["terra-dev", "terra-workspace-dev-plan"]
+  managedAppPlans = [
+    {
+        name = "terra-dev"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
+    }
+    {
+        name = "terra-workspace-dev-plan"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
+    }
+  ]
 }
 

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1207,8 +1207,168 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/billingProfile/{billingProfileId}/managedResourceGroup:
+    post:
+      tags:
+        - Azure
+      summary: associates billing profile id to managed resource group coordinates
+      operationId: createManagedResourceGroup
+      parameters:
+        - name: billingProfileId
+          in: path
+          description: billing profile id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The details of the managed resource group in which to create the pet
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ManagedResourceGroupCoordinates'
+        required: true
+      responses:
+        201:
+          description: Successfully created managed resource group
+          content: { }
+        400:
+          description: Invalid or incomplete request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: Caller does not have permission to the managed resource group or it cannot be found or is otherwise invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Caller does not have permission to the billing profile or it does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: Managed resource group and/or billing profile already has an association
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/user/petManagedIdentity/{billingProfileId}:
+    post:
+      tags:
+        - Azure
+      summary: gets or creates a pet managed identity for the calling user
+      operationId: getPetManagedIdentityInBillingProfile
+      parameters:
+        - name: billingProfileId
+          in: path
+          description: billing profile id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
+      responses:
+        200:
+          description: Successfully retrieved resource without creating it
+          content:
+            application/json:
+              schema:
+                type: string
+        201:
+          description: Successfully created resource
+          content:
+            application/json:
+              schema:
+                type: string
+        400:
+          description: billing profile is not associated to managed resource group, call createManagedResourceGroup
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Caller does not have access to billing profile or it does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/petManagedIdentity/{billingProfileId}/{userEmail}:
+    post:
+      tags:
+        - Azure
+      summary: gets or creates a pet managed identity for the specified user, get_pet_managed_identity
+        action on cloud-extension/azure required
+      operationId: getPetManagedIdentityInBillingProfileForUser
+      parameters:
+        - name: billingProfileId
+          in: path
+          description: billing profile id
+          required: true
+          schema:
+            type: string
+        - name: userEmail
+          in: path
+          description: User's email address
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
+      responses:
+        200:
+          description: Successfully retrieved resource without creating it
+          content:
+            application/json:
+              schema:
+                type: string
+        201:
+          description: Successfully created resource
+          content:
+            application/json:
+              schema:
+                type: string
+        400:
+          description: billing profile is not associated to managed resource group, call createManagedResourceGroup
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: User does not have access to billing profile or it does not exist or caller does not have get_pet_managed_identity permission on cloud-extension/azure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/azure/v1/user/petManagedIdentity:
     post:
+      deprecated: true
       tags:
         - Azure
       summary: gets or creates a pet managed identity for the calling user
@@ -1250,6 +1410,7 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
   /api/azure/v1/petManagedIdentity/{userEmail}:
     post:
+      deprecated: true
       tags:
         - Azure
       summary: gets or creates a pet managed identity for the specified user, get_pet_managed_identity
@@ -3233,6 +3394,25 @@ components:
           type: boolean
           description: true if the user is in their proxy group
       description: ""
+    ManagedResourceGroupCoordinates:
+      required:
+        - tenantId
+        - subscriptionId
+        - managedResourceGroupName
+      type: object
+      properties:
+        tenantId:
+          type: string
+          description: the Azure tenant id (UUID)
+          example: 0cb7a640-45a2-4ed6-be9f-63519f86e04b
+        subscriptionId:
+          type: string
+          description: the Azure subscription id (UUID)
+          example: 3efc5bdf-be0e-44e7-b1d7-c08931e3c16c
+        managedResourceGroupName:
+          type: string
+          description: the name of the Azure managed resource group
+          example: my-managed-resource-group
     GetOrCreatePetManagedIdentityRequest:
       required:
         - tenantId

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1261,114 +1261,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /api/azure/v1/user/petManagedIdentity/{billingProfileId}:
-    post:
-      tags:
-        - Azure
-      summary: gets or creates a pet managed identity for the calling user
-      operationId: getPetManagedIdentityInBillingProfile
-      parameters:
-        - name: billingProfileId
-          in: path
-          description: billing profile id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          'application/json':
-            schema:
-              type: object
-      responses:
-        200:
-          description: Successfully retrieved resource without creating it
-          content:
-            application/json:
-              schema:
-                type: string
-        201:
-          description: Successfully created resource
-          content:
-            application/json:
-              schema:
-                type: string
-        400:
-          description: billing profile is not associated to managed resource group, call createManagedResourceGroup
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        404:
-          description: Caller does not have access to billing profile or it does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-  /api/azure/v1/petManagedIdentity/{billingProfileId}/{userEmail}:
-    post:
-      tags:
-        - Azure
-      summary: gets or creates a pet managed identity for the specified user, get_pet_managed_identity
-        action on cloud-extension/azure required
-      operationId: getPetManagedIdentityInBillingProfileForUser
-      parameters:
-        - name: billingProfileId
-          in: path
-          description: billing profile id
-          required: true
-          schema:
-            type: string
-        - name: userEmail
-          in: path
-          description: User's email address
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          'application/json':
-            schema:
-              type: object
-      responses:
-        200:
-          description: Successfully retrieved resource without creating it
-          content:
-            application/json:
-              schema:
-                type: string
-        201:
-          description: Successfully created resource
-          content:
-            application/json:
-              schema:
-                type: string
-        400:
-          description: billing profile is not associated to managed resource group, call createManagedResourceGroup
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        404:
-          description: User does not have access to billing profile or it does not exist or caller does not have get_pet_managed_identity permission on cloud-extension/azure
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
   /api/azure/v1/user/petManagedIdentity:
     post:
-      deprecated: true
       tags:
         - Azure
       summary: gets or creates a pet managed identity for the calling user
@@ -1398,10 +1292,10 @@ paths:
           content: { }
         403:
           description: Caller does not have permission to create a pet managed identity in the given managed resource group
-          content: { }
-        404:
-          description: Managed resource group does not exist
-          content: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           description: Internal Server Error
           content:
@@ -1410,7 +1304,6 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
   /api/azure/v1/petManagedIdentity/{userEmail}:
     post:
-      deprecated: true
       tags:
         - Azure
       summary: gets or creates a pet managed identity for the specified user, get_pet_managed_identity

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -133,7 +133,14 @@ object Boot extends IOApp with LazyLogging {
           extraAuthParams = Some("prompt=login")
         )
       )
-    } yield createAppDependenciesWithSamRoutes(appConfig, cloudExtensionsInitializer, foregroundAccessPolicyDAO, foregroundDirectoryDAO, azureManagedResourceGroupDAO, oauth2Config)(
+    } yield createAppDependenciesWithSamRoutes(
+      appConfig,
+      cloudExtensionsInitializer,
+      foregroundAccessPolicyDAO,
+      foregroundDirectoryDAO,
+      azureManagedResourceGroupDAO,
+      oauth2Config
+    )(
       actorSystem,
       openTelemetry
     )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -72,7 +72,7 @@ abstract class SamRoutes(
                   extensionRoutes(samUser, samRequestContextWithUser) ~
                   groupRoutes(samUser, samRequestContextWithUser) ~
                   apiUserRoutes(samUser, samRequestContextWithUser) ~
-                  azureRoutes(samUser, samRequestContext)
+                  azureRoutes(samUser, samRequestContextWithUser)
               }
             }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -28,6 +28,16 @@ final case class SubscriptionId(value: String) extends ValueObject
 final case class ManagedResourceGroupName(value: String) extends ValueObject
 final case class ManagedIdentityObjectId(value: String) extends ValueObject
 final case class ManagedIdentityDisplayName(value: String) extends ValueObject
+final case class BillingProfileId(value: String) extends ValueObject
+final case class ManagedResourceGroupCoordinates(
+    tenantId: TenantId,
+    subscriptionId: SubscriptionId,
+    managedResourceGroupName: ManagedResourceGroupName
+)
+final case class ManagedResourceGroup(
+    managedResourceGroupCoordinates: ManagedResourceGroupCoordinates,
+    billingProfileId: BillingProfileId
+)
 
 final case class GetOrCreatePetManagedIdentityRequest(tenantId: TenantId, subscriptionId: SubscriptionId, managedResourceGroupName: ManagedResourceGroupName)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -30,7 +30,9 @@ final case class SubscriptionId(value: String) extends ValueObject
 final case class ManagedResourceGroupName(value: String) extends ValueObject
 final case class ManagedIdentityObjectId(value: String) extends ValueObject
 final case class ManagedIdentityDisplayName(value: String) extends ValueObject
-final case class BillingProfileId(value: String) extends ValueObject
+final case class BillingProfileId(value: String) extends ValueObject {
+  def asResourceId = ResourceId(value)
+}
 final case class ManagedResourceGroupCoordinates(
     tenantId: TenantId,
     subscriptionId: SubscriptionId,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -39,7 +39,9 @@ final case class ManagedResourceGroup(
     billingProfileId: BillingProfileId
 )
 
-final case class GetOrCreatePetManagedIdentityRequest(tenantId: TenantId, subscriptionId: SubscriptionId, managedResourceGroupName: ManagedResourceGroupName)
+final case class GetOrCreatePetManagedIdentityRequest(tenantId: TenantId, subscriptionId: SubscriptionId, managedResourceGroupName: ManagedResourceGroupName) {
+  def toManagedResourceGroupCoordinates = ManagedResourceGroupCoordinates(tenantId, subscriptionId, managedResourceGroupName)
+}
 
 final case class PetManagedIdentityId(
     user: WorkbenchUserId,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -21,6 +21,8 @@ object AzureJsonSupport {
   implicit val petManagedIdentityIdFormat = jsonFormat4(PetManagedIdentityId.apply)
 
   implicit val petManagedIdentityFormat = jsonFormat3(PetManagedIdentity.apply)
+
+  implicit val managedResourceGroupCoordinatesFormat = jsonFormat3(ManagedResourceGroupCoordinates.apply)
 }
 
 final case class TenantId(value: String) extends ValueObject

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -86,7 +86,6 @@ trait AzureRoutes extends SecurityDirectives with LazyLogging {
 
     val maskNotFound = handleExceptions(ExceptionHandler {
       case withErrorReport: WorkbenchExceptionWithErrorReport if withErrorReport.errorReport.statusCode.contains(StatusCodes.NotFound) =>
-        logger.error("foo", withErrorReport)
         failWithForbidden
     })
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -6,16 +6,20 @@ import bio.terra.cloudres.azure.resourcemanager.msi.data.CreateUserAssignedManag
 import cats.effect.IO
 import com.azure.core.management.Region
 import com.azure.core.util.Context
-import com.azure.resourcemanager.resources.models.{GenericResource, ResourceGroup}
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
+import com.azure.resourcemanager.managedapplications.models.Application
+import com.azure.resourcemanager.resources.ResourceManager
+import com.azure.resourcemanager.resources.models.ResourceGroup
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchException, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.config.ManagedAppPlan
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{AzureManagedResourceGroupDAO, DirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.util.OpenCensusIOUtils._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import scala.jdk.CollectionConverters._
 
-class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
+class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO, azureManagedResourceGroupDAO: AzureManagedResourceGroupDAO) {
 
   // Static region in which to create all managed identities.
   // Managed identities are regional resources in Azure but they can be used across
@@ -25,6 +29,28 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
 
   // Tag on the MRG to specify the Sam billing-profile id
   private val billingProfileTag = "terra.billingProfileId"
+
+  private val managedAppValidationFailure = new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden,
+    "Specified manged resource group invalid. Possible reasons include resource group does not exist, it is not " +
+      "associated to an application, the application's plan is not supported or the user is not listed as authorized."))
+
+  def createManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Unit] = {
+    for {
+      _ <- validateManagedResourceGroup(managedResourceGroup.managedResourceGroupCoordinates, samRequestContext)
+
+      existingByCoords <- azureManagedResourceGroupDAO.getManagedResourceGroupByCoordinates(managedResourceGroup.managedResourceGroupCoordinates, samRequestContext)
+      _ <- IO.raiseWhen(existingByCoords.isDefined)(
+        new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"managed resource group ${managedResourceGroup.managedResourceGroupCoordinates} already exists"))
+      )
+
+      existingByBillingProfile <- azureManagedResourceGroupDAO.getManagedResourceGroupByBillingProfileId(managedResourceGroup.billingProfileId, samRequestContext)
+      _ <- IO.raiseWhen(existingByBillingProfile.isDefined)(
+        new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, s"managed resource group for ${managedResourceGroup.billingProfileId} already exists"))
+      )
+
+      _ <- azureManagedResourceGroupDAO.insertManagedResourceGroup(managedResourceGroup, samRequestContext)
+    } yield ()
+  }
 
   /** Looks up a pet managed identity from the database, or creates it if one does not exist.
     */
@@ -54,7 +80,7 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
       samRequestContext: SamRequestContext
   ): IO[(PetManagedIdentity, Boolean)] =
     for {
-      _ <- validateManagedResourceGroup(request)
+      _ <- validateManagedResourceGroup(request.toManagedResourceGroupCoordinates, samRequestContext, false)
       manager <- crlService.buildMsiManager(request.tenantId, request.subscriptionId)
       petName = toManagedIdentityNameFromUser(user)
       context = managedIdentityContext(request, petName)
@@ -90,43 +116,71 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO) {
       mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
     } yield mrg.toOption.flatMap(getBillingProfileFromTag)
 
-  /** Validates a managed resource group. This is only called at managed identity creation time. Algorithm:
-    *   1. Resolve the MRG in Azure 2. Get the managed app id from the MRG 3. Resolve the managed app as the publisher 4. Get the managed app "plan" id 4.
-    *      Validate the plan id matches the configured value
+  /** Validates a managed resource group. Algorithm:
+    *   1. Resolve the MRG in Azure
+    *   2. Get the managed app id from the MRG
+    *   3. Resolve the managed app
+    *   4. Get the managed app "plan" name and publisher
+    *   5. Validate the plan name and publisher matches a configured value
+    *   6. Validate that the caller is on the list of authorized users for the app
     */
-  private def validateManagedResourceGroup(request: GetOrCreatePetManagedIdentityRequest): IO[Unit] =
+  private def validateManagedResourceGroup(mrgCoords: ManagedResourceGroupCoordinates, samRequestContext: SamRequestContext, validateUser: Boolean = true): IO[Unit] = {
+    traceIOWithContext("validateManagedResourceGroup", samRequestContext) { _ =>
+      for {
+        resourceManager <- crlService.buildResourceManager(mrgCoords.tenantId, mrgCoords.subscriptionId)
+        mrg <- lookupMrg(mrgCoords, resourceManager)
+        appManager <- crlService.buildApplicationManager(mrgCoords.tenantId, mrgCoords.subscriptionId)
+        appsInSubscription <- IO(appManager.applications().list().asScala)
+        managedApp <- IO.fromOption(appsInSubscription.find(_.managedResourceGroupId() == mrg.id()))(managedAppValidationFailure)
+        plan <- validatePlan(managedApp, crlService.getManagedAppPlans)
+        _ <- if (validateUser) validateAuthorizedAppUser(managedApp, plan, samRequestContext) else IO.unit
+      } yield ()
+    }
+  }
+
+  /**
+    * The users authorized to setup a managed application are stored as a comma separated list of email addresses
+    * in the parameters of the application. The azure api is java so this code needs to deal with possible nulls
+    * and java Maps. Also the application parameters are untyped, fun.
+    * @param app
+    * @param plan
+    * @param samRequestContext
+    * @return
+    */
+  private def validateAuthorizedAppUser(app: Application, plan: ManagedAppPlan, samRequestContext: SamRequestContext): IO[Unit] = {
+    val authorizedUsersValue = for {
+      parametersObj <- Option(app.parameters()) if parametersObj.isInstanceOf[java.util.Map[_, _]]
+      parametersMap = parametersObj.asInstanceOf[java.util.Map[_, _]]
+      paramValuesObj <- Option(parametersMap.get(plan.authorizedUserKey)) if paramValuesObj.isInstanceOf[java.util.Map[_, _]]
+      paramValues = paramValuesObj.asInstanceOf[java.util.Map[_, _]]
+      authorizedUsersValue <- Option(paramValues.get("value"))
+    } yield authorizedUsersValue.toString
+
     for {
-      resourceManager <- crlService.buildResourceManager(request.tenantId, request.subscriptionId)
-      mrg <- IO(resourceManager.resourceGroups().getByName(request.managedResourceGroupName.value)).attempt
-      managedByOpt = mrg.toOption.flatMap(getManagedBy)
-      managedBy <- IO.fromOption(managedByOpt)(
-        new WorkbenchExceptionWithErrorReport(
-          ErrorReport(
-            StatusCodes.Forbidden,
-            s"Validation failed: could not retrieve managed app for managed resource group ${request.managedResourceGroupName.value}"
-          )
-        )
+      authorizedUsersString <- IO.fromOption(authorizedUsersValue)(managedAppValidationFailure)
+      user <- IO.fromOption(samRequestContext.samUser)(
+        // this exception is different from the others because it is a coding bug, the user should always be present here
+        new WorkbenchException("user is missing in call to validateAuthorizedAppUser")
       )
-      managedApp <- IO(resourceManager.genericResources().getById(managedBy)).attempt
-      planIdOpt = managedApp.toOption.flatMap(getPlanId)
-      planId <- IO.fromOption(planIdOpt)(
-        new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: could not retrieve plan for managed app"))
-      )
-      _ <- IO.raiseUnless(crlService.getManagedAppPlanIds.contains(planId))(
-        new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "Validation failed: wrong managed app plan"))
-      )
+      authorizedUsers = authorizedUsersString.split(",").map(_.trim.toLowerCase)
+      _ <- IO.raiseUnless(authorizedUsers.contains(user.email.value.toLowerCase))(managedAppValidationFailure)
     } yield ()
+  }
 
-  /** Null-safe get managedBy field from a ResourceGroup. */
-  private def getManagedBy(mrg: ResourceGroup): Option[String] =
-    for {
-      im <- Option(mrg.innerModel())
-      mb <- Option(im.managedBy())
-    } yield mb
+  private def validatePlan(managedApp: Application, allPlans: Seq[ManagedAppPlan]) = {
+    val maybePlan = for {
+      applicationPlan <- Option(managedApp.plan())
+      matchingPlan <- allPlans.find(p => p.name == applicationPlan.name() && p.publisher == applicationPlan.publisher())
+    } yield matchingPlan
 
-  /** Null-safe get planId from a resource. */
-  private def getPlanId(resource: GenericResource): Option[String] =
-    Option(resource.plan()).map(_.name())
+    IO.fromOption(maybePlan)(managedAppValidationFailure)
+  }
+
+  private def lookupMrg(mrgCoords: ManagedResourceGroupCoordinates, resourceManager: ResourceManager) = {
+    IO(resourceManager.resourceGroups().getByName(mrgCoords.managedResourceGroupName.value)).handleErrorWith {
+      case t: Throwable => IO.raiseError(managedAppValidationFailure)
+    }
+  }
 
   /** Null-safe get billing profile tag from a ResourceGroup. */
   private def getBillingProfileFromTag(mrg: ResourceGroup): Option[ResourceId] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/CrlService.scala
@@ -6,9 +6,10 @@ import cats.effect.IO
 import com.azure.core.management.AzureEnvironment
 import com.azure.core.management.profile.AzureProfile
 import com.azure.identity.{ClientSecretCredential, ClientSecretCredentialBuilder}
+import com.azure.resourcemanager.managedapplications.ApplicationManager
 import com.azure.resourcemanager.msi.MsiManager
 import com.azure.resourcemanager.resources.ResourceManager
-import org.broadinstitute.dsde.workbench.sam.config.AzureServicesConfig
+import org.broadinstitute.dsde.workbench.sam.config.{AzureServicesConfig, ManagedAppPlan}
 
 /** Service class for interacting with Terra Cloud Resource Library (CRL). See: https://github.com/DataBiosphere/terra-cloud-resource-lib
   *
@@ -29,7 +30,12 @@ class CrlService(config: AzureServicesConfig) {
     IO(Defaults.crlConfigure(clientConfig, ResourceManager.configure()).authenticate(credential, profile).withSubscription(subscriptionId.value))
   }
 
-  def getManagedAppPlanIds: Seq[String] = config.managedAppPlanIds
+  def buildApplicationManager(tenantId: TenantId, subscriptionId: SubscriptionId): IO[ApplicationManager] = {
+    val (credential, profile) = getCredentialAndProfile(tenantId, subscriptionId)
+    IO(ApplicationManager.authenticate(credential, profile))
+  }
+
+  def getManagedAppPlans: Seq[ManagedAppPlan] = config.managedAppPlans
 
   private def getCredentialAndProfile(tenantId: TenantId, subscriptionId: SubscriptionId): (ClientSecretCredential, AzureProfile) = {
     val credential = new ClientSecretCredentialBuilder()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -153,6 +153,10 @@ object AppConfig {
     )
   }
 
+  implicit val azureManagedAppPlanReader: ValueReader[ManagedAppPlan] = ValueReader.relative { config =>
+    ManagedAppPlan(config.getString("name"), config.getString("publisher"), config.getString("authorizedUserKey"))
+  }
+
   implicit val azureServicesConfigReader: ValueReader[Option[AzureServicesConfig]] = ValueReader.relative { config =>
     config
       .getAs[Boolean]("azureEnabled")
@@ -163,7 +167,7 @@ object AppConfig {
               config.getString("managedAppClientId"),
               config.getString("managedAppClientSecret"),
               config.getString("managedAppTenantId"),
-              config.as[Seq[String]]("managedAppPlanIds")
+              config.as[Seq[ManagedAppPlan]]("managedAppPlans")
             )
           )
         } else {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AzureServicesConfig.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
+case class ManagedAppPlan(name: String, publisher: String, authorizedUserKey: String)
 case class AzureServicesConfig(
     managedAppClientId: String,
     managedAppClientSecret: String,
     managedAppTenantId: String,
-    managedAppPlanIds: Seq[String]
+    managedAppPlans: Seq[ManagedAppPlan]
 ) {}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AzureManagedResourceGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AzureManagedResourceGroupDAO.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.sam.azure.{BillingProfileId, ManagedResourceGroup, ManagedResourceGroupCoordinates}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+trait AzureManagedResourceGroupDAO {
+  def insertManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Int]
+  def getManagedResourceGroupByBillingProfileId(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Option[ManagedResourceGroup]]
+  def getManagedResourceGroupByCoordinates(
+      managedResourceGroupCoordinates: ManagedResourceGroupCoordinates,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ManagedResourceGroup]]
+  def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Int]
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAO.scala
@@ -1,0 +1,93 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.sam._
+import org.broadinstitute.dsde.workbench.sam.azure.{BillingProfileId, ManagedResourceGroup, ManagedResourceGroupCoordinates}
+import org.broadinstitute.dsde.workbench.sam.db.{DbReference, PSQLStateExtensions}
+import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory.SqlInterpolationWithSamBinders
+import org.broadinstitute.dsde.workbench.sam.db.tables.{AzureManagedResourceGroupRecord, AzureManagedResourceGroupTable}
+import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
+import org.postgresql.util.PSQLException
+
+import scala.util.{Failure, Try}
+
+class PostgresAzureManagedResourceGroupDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)
+    extends AzureManagedResourceGroupDAO
+    with DatabaseSupport {
+
+  override def insertManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Int] =
+    serializableWriteTransaction("insertManagedResourceGroup", samRequestContext) { implicit session =>
+      val mrgTableColumn = AzureManagedResourceGroupTable.column
+      val insertGroupQuery =
+        samsql"""insert into ${AzureManagedResourceGroupTable.table} (${mrgTableColumn.tenantId}, ${mrgTableColumn.subscriptionId}, ${mrgTableColumn.managedResourceGroupName}, ${mrgTableColumn.billingProfileId})
+           values (${managedResourceGroup.managedResourceGroupCoordinates.tenantId}, ${managedResourceGroup.managedResourceGroupCoordinates.subscriptionId}, ${managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName}, ${managedResourceGroup.billingProfileId})"""
+      Try {
+        insertGroupQuery.update().apply()
+      }.recoverWith {
+        case duplicateException: PSQLException if duplicateException.getSQLState == PSQLStateExtensions.UNIQUE_VIOLATION =>
+          Failure(
+            new WorkbenchExceptionWithErrorReport(
+              ErrorReport(StatusCodes.Conflict, s"Coordinates or billing profile of ${managedResourceGroup} already exists", duplicateException)
+            )
+          )
+      }.get
+    }
+
+  override def getManagedResourceGroupByBillingProfileId(
+      billingProfileId: BillingProfileId,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ManagedResourceGroup]] =
+    readOnlyTransaction("getManagedResourceGroupByBillingProfileId", samRequestContext) { implicit session =>
+      val mrg = AzureManagedResourceGroupTable.syntax("mrg")
+
+      samsql"""select ${mrg.result.*}
+              from ${AzureManagedResourceGroupTable as mrg}
+              where ${mrg.billingProfileId} = ${billingProfileId}"""
+        .map(AzureManagedResourceGroupTable.apply(mrg))
+        .single()
+        .apply()
+        .map(toManagedResourceGroup)
+    }
+
+  override def getManagedResourceGroupByCoordinates(
+      mrgCoords: ManagedResourceGroupCoordinates,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ManagedResourceGroup]] =
+    readOnlyTransaction("getManagedResourceGroupByCoordinates", samRequestContext) { implicit session =>
+      val mrg = AzureManagedResourceGroupTable.syntax("mrg")
+
+      samsql"""select ${mrg.result.*}
+              from ${AzureManagedResourceGroupTable as mrg}
+              where ${mrg.tenantId} = ${mrgCoords.tenantId}
+              and ${mrg.subscriptionId} = ${mrgCoords.subscriptionId}
+              and ${mrg.managedResourceGroupName} = ${mrgCoords.managedResourceGroupName}"""
+        .map(AzureManagedResourceGroupTable.apply(mrg))
+        .single()
+        .apply()
+        .map(toManagedResourceGroup)
+    }
+
+  private def toManagedResourceGroup(result: AzureManagedResourceGroupRecord) =
+    ManagedResourceGroup(
+      ManagedResourceGroupCoordinates(
+        result.tenantId,
+        result.subscriptionId,
+        result.managedResourceGroupName
+      ),
+      result.billingProfileId
+    )
+
+  override def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Int] =
+    serializableWriteTransaction("deleteManagedResourceGroup", samRequestContext) { implicit session =>
+      val mrg = AzureManagedResourceGroupTable.syntax("mrg")
+
+      samsql"""delete
+              from ${AzureManagedResourceGroupTable as mrg}
+              where ${mrg.billingProfileId} = ${billingProfileId}"""
+        .map(AzureManagedResourceGroupTable.apply(mrg))
+        .update()
+        .apply()
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
@@ -3,7 +3,14 @@ package org.broadinstitute.dsde.workbench.sam.db
 import java.sql.ResultSet
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.model.{GoogleSubjectId, WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityDisplayName, ManagedIdentityObjectId, ManagedResourceGroupName, SubscriptionId, TenantId}
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  BillingProfileId,
+  ManagedIdentityDisplayName,
+  ManagedIdentityObjectId,
+  ManagedResourceGroupName,
+  SubscriptionId,
+  TenantId
+}
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import scalikejdbc.TypeBinder
@@ -159,5 +166,15 @@ object SamTypeBinders {
   implicit val managedIdentityDisplayNameTypeBinder: TypeBinder[ManagedIdentityDisplayName] = new TypeBinder[ManagedIdentityDisplayName] {
     def apply(rs: ResultSet, label: String): ManagedIdentityDisplayName = ManagedIdentityDisplayName(rs.getString(label))
     def apply(rs: ResultSet, index: Int): ManagedIdentityDisplayName = ManagedIdentityDisplayName(rs.getString(index))
+  }
+
+  implicit val ManagedResourceGroupPKTypeBinder: TypeBinder[ManagedResourceGroupPK] = new TypeBinder[ManagedResourceGroupPK] {
+    def apply(rs: ResultSet, label: String): ManagedResourceGroupPK = ManagedResourceGroupPK(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): ManagedResourceGroupPK = ManagedResourceGroupPK(rs.getLong(index))
+  }
+
+  implicit val BillingProfileIdTypeBinder: TypeBinder[BillingProfileId] = new TypeBinder[BillingProfileId] {
+    def apply(rs: ResultSet, label: String): BillingProfileId = BillingProfileId(rs.getString(label))
+    def apply(rs: ResultSet, index: Int): BillingProfileId = BillingProfileId(rs.getString(index))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AzureManagedResourceGroupTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/AzureManagedResourceGroupTable.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.sam.azure._
+import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
+import scalikejdbc._
+
+final case class ManagedResourceGroupPK(value: Long) extends DatabaseKey
+final case class AzureManagedResourceGroupRecord(
+    id: ManagedResourceGroupPK,
+    tenantId: TenantId,
+    subscriptionId: SubscriptionId,
+    managedResourceGroupName: ManagedResourceGroupName,
+    billingProfileId: BillingProfileId
+)
+
+object AzureManagedResourceGroupTable extends SQLSyntaxSupportWithDefaultSamDB[AzureManagedResourceGroupRecord] {
+  override def tableName: String = "SAM_AZURE_MANAGED_RESOURCE_GROUP"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[AzureManagedResourceGroupRecord])(rs: WrappedResultSet): AzureManagedResourceGroupRecord = AzureManagedResourceGroupRecord(
+    rs.get(e.id),
+    rs.get(e.tenantId),
+    rs.get(e.subscriptionId),
+    rs.get(e.managedResourceGroupName),
+    rs.get(e.billingProfileId)
+  )
+
+  def apply(p: SyntaxProvider[AzureManagedResourceGroupRecord])(rs: WrappedResultSet): AzureManagedResourceGroupRecord = apply(p.resultName)(rs)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -97,6 +97,7 @@ object SamResourceActions {
   val adminAddMember = ResourceAction("admin_add_member")
   val adminRemoveMember = ResourceAction("admin_remove_member")
   val link = ResourceAction("link")
+  val setManagedResourceGroup = ResourceAction("set_managed_resource_group")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -101,7 +101,7 @@ testStuff = {
   azure {
     tenantId = "0cb7a640-45a2-4ed6-be9f-63519f86e04b"
     subscriptionId = "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"
-    managedResourceGroupName = "mrg-terra-integration-test-20211118"
+    managedResourceGroupName = "mrg-terra-dev-previ-20220930130036"
   }
 }
 

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -30,10 +30,10 @@ object Generator {
   val genExternalId: Gen[Either[GoogleSubjectId, AzureB2CId]] = Gen.either(genGoogleSubjectId, genAzureB2CId)
   val genServiceAccountSubjectId: Gen[ServiceAccountSubjectId] = genGoogleSubjectId.map(x => ServiceAccountSubjectId(x.value))
   val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s" + x))
-  val genTenantId: Gen[TenantId] = Gen.alphaStr.map(TenantId)
-  val genSubscriptionId: Gen[SubscriptionId] = Gen.alphaStr.map(SubscriptionId)
+  val genTenantId: Gen[TenantId] = Gen.uuid.map(_.toString).map(TenantId)
+  val genSubscriptionId: Gen[SubscriptionId] = Gen.uuid.map(_.toString).map(SubscriptionId)
   val genManagedResourceGroupName: Gen[ManagedResourceGroupName] = Gen.alphaStr.map(ManagedResourceGroupName)
-  val genBillingProfileId: Gen[BillingProfileId] = Gen.alphaStr.map(BillingProfileId)
+  val genBillingProfileId: Gen[BillingProfileId] = Gen.uuid.map(_.toString).map(BillingProfileId)
 
   val genManagedResourceGroupCoordinates: Gen[ManagedResourceGroupCoordinates] = for {
     tenantId <- genTenantId

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -7,8 +7,17 @@ import org.broadinstitute.dsde.workbench.sam.api.StandardSamUserDirectives._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.scalacheck._
 import SamResourceActions._
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  BillingProfileId,
+  ManagedResourceGroup,
+  ManagedResourceGroupCoordinates,
+  ManagedResourceGroupName,
+  SubscriptionId,
+  TenantId
+}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.LockDetails
 import org.broadinstitute.dsde.workbench.sam.service.UserService
+
 import scala.concurrent.duration._
 
 object Generator {
@@ -21,6 +30,21 @@ object Generator {
   val genExternalId: Gen[Either[GoogleSubjectId, AzureB2CId]] = Gen.either(genGoogleSubjectId, genAzureB2CId)
   val genServiceAccountSubjectId: Gen[ServiceAccountSubjectId] = genGoogleSubjectId.map(x => ServiceAccountSubjectId(x.value))
   val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s" + x))
+  val genTenantId: Gen[TenantId] = Gen.alphaStr.map(TenantId)
+  val genSubscriptionId: Gen[SubscriptionId] = Gen.alphaStr.map(SubscriptionId)
+  val genManagedResourceGroupName: Gen[ManagedResourceGroupName] = Gen.alphaStr.map(ManagedResourceGroupName)
+  val genBillingProfileId: Gen[BillingProfileId] = Gen.alphaStr.map(BillingProfileId)
+
+  val genManagedResourceGroupCoordinates: Gen[ManagedResourceGroupCoordinates] = for {
+    tenantId <- genTenantId
+    subscriptionId <- genSubscriptionId
+    mrgName <- genManagedResourceGroupName
+  } yield ManagedResourceGroupCoordinates(tenantId, subscriptionId, mrgName)
+
+  val genManagedResourceGroup: Gen[ManagedResourceGroup] = for {
+    mrgCoords <- genManagedResourceGroupCoordinates
+    billingProfileId <- genBillingProfileId
+  } yield ManagedResourceGroup(mrgCoords, billingProfileId)
 
   // normally the current time in millis is used to create a WorkbenchUserId but too many users are created
   // during tests that collisions happen despite randomness built into UserService.genWorkbenchUserId

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -236,6 +236,7 @@ object TestSupport extends TestSupport {
           GroupMemberTable,
           GroupMemberFlatTable,
           PetServiceAccountTable,
+          AzureManagedResourceGroupTable,
           PetManagedIdentityTable,
           UserTable,
           AccessInstructionsTable,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -19,7 +19,7 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, MockAccessPolicyDAO, MockDirectoryDAO, PostgresDistributedLockDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, MockAccessPolicyDAO, MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDistributedLockDAO}
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
@@ -148,7 +148,7 @@ object TestSupport extends TestSupport {
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, tosConfig.copy(enabled = tosEnabled))
-    val azureService = new AzureService(MockCrlService(), directoryDAO)
+    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO)
     SamDependencies(
       mockResourceService,
       policyEvaluatorService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -19,7 +19,13 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, MockAccessPolicyDAO, MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDistributedLockDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{
+  AccessPolicyDAO,
+  MockAccessPolicyDAO,
+  MockAzureManagedResourceGroupDAO,
+  MockDirectoryDAO,
+  PostgresDistributedLockDAO
+}
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetricsInter
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{googleServicesConfig, samRequestContext}
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess._
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, _}
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.{adminAddMember, adminReadPolicies, adminRemoveMember}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -184,7 +184,7 @@ object TestSamRoutes {
     mockResourceService.initResourceTypes(samRequestContext).unsafeRunSync()
 
     val mockStatusService = new StatusService(directoryDAO, cloudXtns, dbRef)
-    val azureService = new AzureService(crlService.getOrElse(MockCrlService()), directoryDAO)
+    val azureService = new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO)
     new TestSamRoutes(
       mockResourceService,
       policyEvaluatorService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -9,6 +9,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.config.ManagedAppPlan
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicyMembership, SamResourceTypes, SamUser}
 import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
@@ -70,8 +71,8 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 403 if user has access to the billing profile but the MRG could not be validated" in {
     // Change the managed app plan
     val mockCrlService = MockCrlService()
-    when(mockCrlService.getManagedAppPlanIds)
-      .thenReturn(Seq("some-other-plan", "yet-another-plan"))
+    when(mockCrlService.getManagedAppPlans)
+      .thenReturn(Seq(ManagedAppPlan("some-other-plan", "publisher", "auth"), ManagedAppPlan("yet-another-plan", "publisher", "auth")))
     val samRoutes = genSamRoutes(crlService = Some(mockCrlService))
 
     // User has no access

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -203,7 +203,10 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   "POST /api/azure/v1/billingProfile/{billingProfileId}/managedResourceGroup" should "successfully create a managed resource group" in {
     val samRoutes = genSamRoutes()
     val request = ManagedResourceGroupCoordinates(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
-    Post(s"/api/azure/v1/billingProfile/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/managedResourceGroup", request) ~> samRoutes.route ~> check {
+    Post(
+      s"/api/azure/v1/billingProfile/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/managedResourceGroup",
+      request
+    ) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.Created
     }
@@ -212,7 +215,10 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   it should "return 404 if the user does not have access to the billing profile" in {
     val samRoutes = genSamRoutes(createSpendProfile = false)
     val request = ManagedResourceGroupCoordinates(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
-    Post(s"/api/azure/v1/billingProfile/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/managedResourceGroup", request) ~> samRoutes.route ~> check {
+    Post(
+      s"/api/azure/v1/billingProfile/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/managedResourceGroup",
+      request
+    ) ~> samRoutes.route ~> check {
       handled shouldBe true
       status shouldEqual StatusCodes.NotFound
       contentType shouldEqual ContentTypes.`application/json`

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -9,6 +9,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
 import org.broadinstitute.dsde.workbench.sam.azure.AzureJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.azure.MockCrlService.mockSamSpendProfileResource
 import org.broadinstitute.dsde.workbench.sam.config.ManagedAppPlan
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicyMembership, SamResourceTypes, SamUser}
@@ -24,8 +25,35 @@ import scala.concurrent.duration._
 class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport with MockitoSugar {
   implicit val timeout = RouteTestTimeout(15.seconds.dilated)
 
-  "POST /api/azure/v1/user/petManagedIdentity" should "successfully create a pet managed identity" in {
+  "POST /api/azure/v1/user/petManagedIdentity" should "successfully create a pet managed identity using MRG in db" in {
     val samRoutes = genSamRoutes()
+
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(
+      s"/api/azure/v1/billingProfile/${mockSamSpendProfileResource.resourceId.value}/managedResourceGroup",
+      request.toManagedResourceGroupCoordinates
+    ) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+    }
+
+    // Create a pet managed identity, should return 201 created
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+
+    // Create again, should return 200
+    Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  it should "successfully create a pet managed identity using MRG Azure tag for backwards compatibility" in {
+    val samRoutes = genSamRoutes(crlService = Option(MockCrlService(includeBillingProfileTag = true)))
 
     // Create a pet managed identity, should return 201 created
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
@@ -43,19 +71,19 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     }
   }
 
-  it should "return 404 if the MRG does not exist" in {
+  it should "return 403 if the MRG does not exist" in {
     val samRoutes = genSamRoutes()
 
     // Non-existent MRG
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), ManagedResourceGroupName("non-existent-mrg"))
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
-      status shouldEqual StatusCodes.NotFound
+      status shouldEqual StatusCodes.Forbidden
       contentType shouldEqual ContentTypes.`application/json`
     }
   }
 
-  it should "return 404 if the MRG exists but the user does not have access to the billing profile" in {
+  it should "return 403 if the MRG exists but the user does not have access to the billing profile" in {
     // Don't create spend-profile resource
     val samRoutes = genSamRoutes(createSpendProfile = false)
 
@@ -63,7 +91,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
     Post("/api/azure/v1/user/petManagedIdentity", request) ~> samRoutes.route ~> check {
       handled shouldBe true
-      status shouldEqual StatusCodes.NotFound
+      status shouldEqual StatusCodes.Forbidden
       contentType shouldEqual ContentTypes.`application/json`
     }
   }
@@ -84,8 +112,36 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     }
   }
 
-  "POST /api/azure/v1/petManagedIdentity/{email}" should "successfully create a pet managed identity for a user" in {
+  "POST /api/azure/v1/petManagedIdentity/{email}" should "successfully create a pet managed identity for a user using MRG in db" in {
     val samRoutes = genSamRoutes()
+    val newUser = createSecondUser(samRoutes)
+
+    val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
+    Post(
+      s"/api/azure/v1/billingProfile/${mockSamSpendProfileResource.resourceId.value}/managedResourceGroup",
+      request.toManagedResourceGroupCoordinates
+    ) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+    }
+
+    // Create a pet managed identity, should return 201 created
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.Created
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+
+    // Create again, should return 200
+    Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
+      handled shouldBe true
+      status shouldEqual StatusCodes.OK
+      contentType shouldEqual ContentTypes.`application/json`
+    }
+  }
+
+  it should "successfully create a pet managed identity for a user using MRG Azure tag for backwards compatibility" in {
+    val samRoutes = genSamRoutes(crlService = Option(MockCrlService(includeBillingProfileTag = true)))
     val newUser = createSecondUser(samRoutes)
 
     // Create a pet managed identity for the second user, should return 201 created
@@ -139,7 +195,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
     val request = GetOrCreatePetManagedIdentityRequest(TenantId("some-tenant"), SubscriptionId("some-sub"), MockCrlService.mockMrgName)
     Post(s"/api/azure/v1/petManagedIdentity/${newUser.email.value}", request) ~> samRoutes.route ~> check {
       handled shouldBe true
-      status shouldEqual StatusCodes.NotFound
+      status shouldEqual StatusCodes.Forbidden
       contentType shouldEqual ContentTypes.`application/json`
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.ConnectedTest
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
 import org.scalatest.concurrent.ScalaFutures
@@ -28,7 +28,7 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val tosService = new TosService(directoryDAO, googleServicesConfig.appsDomain, tosConfig)
     val userService = new UserService(directoryDAO, NoExtensions, Seq.empty, tosService)
     val azureTestConfig = config.getConfig("testStuff.azure")
-    val azureService = new AzureService(crlService, directoryDAO)
+    val azureService = new AzureService(crlService, directoryDAO, new MockAzureManagedResourceGroupDAO)
 
     // create user
     val defaultUser = genWorkbenchUserAzure.sample.get
@@ -97,7 +97,7 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val directoryDAO = new PostgresDirectoryDAO(dbRef, dbRef)
     val azureTestConfig = config.getConfig("testStuff.azure")
     val crlService = new CrlService(azureServicesConfig.get)
-    val azureService = new AzureService(crlService, directoryDAO)
+    val azureService = new AzureService(crlService, directoryDAO, new MockAzureManagedResourceGroupDAO)
 
     // build request
     val tenantId = TenantId(azureTestConfig.getString("tenantId"))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.{ConnectedTest, Generator}
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDirectoryDAO}
-import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, UserStatus, UserStatusDetails}
+import org.broadinstitute.dsde.workbench.sam.model.{UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
@@ -110,11 +110,11 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val request = GetOrCreatePetManagedIdentityRequest(tenantId, subscriptionId, managedResourceGroupName)
 
     // call getBillingProfileId
-    val res = azureService.getBillingProfileId(request).unsafeRunSync()
+    val res = azureService.getBillingProfileId(request, samRequestContext).unsafeRunSync()
 
     // should return a billing profile id
     res shouldBe defined
-    res.get shouldBe ResourceId("de38969d-f41b-4b80-99ba-db481e6db1cf")
+    res.get shouldBe BillingProfileId("de38969d-f41b-4b80-99ba-db481e6db1cf")
   }
 
   "createManagedResourceGroup" should "create a managed resource group" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -1,12 +1,16 @@
 package org.broadinstitute.dsde.workbench.sam.azure
 
+import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.sam.ConnectedTest
+import com.azure.resourcemanager.managedapplications.models.Plan
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.sam.{ConnectedTest, Generator}
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, PostgresDirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -110,6 +114,189 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     // should return a billing profile id
     res shouldBe defined
-    res.get shouldBe ResourceId("wm-default-spend-profile-id")
+    res.get shouldBe ResourceId("de38969d-f41b-4b80-99ba-db481e6db1cf")
+  }
+
+  "createManagedResourceGroup" should "create a managed resource group" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val svc =
+      new AzureService(MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName), new MockDirectoryDAO(), mockMrgDAO)
+
+    svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    mockMrgDAO.mrgs should contain(managedResourceGroup)
+  }
+
+  it should "create a managed resource group IN AZURE" taggedAs ConnectedTest in {
+    val azureServicesConfig = appConfig.azureServicesConfig
+
+    assume(azureServicesConfig.isDefined, "-- skipping Azure test")
+
+    // create dependencies
+    val crlService = new CrlService(azureServicesConfig.get)
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val azureService = new AzureService(crlService, new MockDirectoryDAO(), mockMrgDAO)
+
+    // build request
+    val azureTestConfig = config.getConfig("testStuff.azure")
+    val managedResourceGroup = ManagedResourceGroup(
+      ManagedResourceGroupCoordinates(
+        TenantId(azureTestConfig.getString("tenantId")),
+        SubscriptionId(azureTestConfig.getString("subscriptionId")),
+        ManagedResourceGroupName(azureTestConfig.getString("managedResourceGroupName"))
+      ),
+      BillingProfileId("de38969d-f41b-4b80-99ba-db481e6db1cf")
+    )
+
+    val user = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("rtitlefireclouddev@gmail.com")))
+
+    azureService.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    mockMrgDAO.mrgs should contain(managedResourceGroup)
+  }
+
+  it should "Conflict when MRG coordinates already exist" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val svc =
+      new AzureService(MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName), new MockDirectoryDAO(), mockMrgDAO)
+
+    mockMrgDAO.insertManagedResourceGroup(managedResourceGroup.copy(billingProfileId = BillingProfileId("no the same")), samRequestContext).unsafeRunSync()
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Conflict when MRG billing project already exist" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val svc =
+      new AzureService(MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName), new MockDirectoryDAO(), mockMrgDAO)
+
+    mockMrgDAO
+      .insertManagedResourceGroup(
+        managedResourceGroup
+          .copy(managedResourceGroupCoordinates = managedResourceGroup.managedResourceGroupCoordinates.copy(tenantId = TenantId("other tenant"))),
+        samRequestContext
+      )
+      .unsafeRunSync()
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Forbidden when MRG does not exist in Azure" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val svc = new AzureService(MockCrlService(user), new MockDirectoryDAO(), mockMrgDAO)
+
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Forbidden when MRG is not associated to an Application" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val crlService = MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName)
+    val svc = new AzureService(crlService, new MockDirectoryDAO(), mockMrgDAO)
+
+    val mockApplication = crlService
+      .buildApplicationManager(
+        managedResourceGroup.managedResourceGroupCoordinates.tenantId,
+        managedResourceGroup.managedResourceGroupCoordinates.subscriptionId
+      )
+      .unsafeRunSync()
+      .applications()
+      .list()
+      .asScala
+      .head
+    when(mockApplication.managedResourceGroupId()).thenReturn("something else")
+
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Forbidden when an Application does not have an accepted Plan name" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val crlService = MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName)
+    val svc = new AzureService(crlService, new MockDirectoryDAO(), mockMrgDAO)
+
+    val mockApplication = crlService
+      .buildApplicationManager(
+        managedResourceGroup.managedResourceGroupCoordinates.tenantId,
+        managedResourceGroup.managedResourceGroupCoordinates.subscriptionId
+      )
+      .unsafeRunSync()
+      .applications()
+      .list()
+      .asScala
+      .head
+    when(mockApplication.plan())
+      .thenReturn(new Plan().withName(MockCrlService.defaultManagedAppPlan.name).withPublisher("other publisher"))
+
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Forbidden when an Application does not have an accepted Plan publisher" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val crlService = MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName)
+    val svc = new AzureService(crlService, new MockDirectoryDAO(), mockMrgDAO)
+
+    val mockApplication = crlService
+      .buildApplicationManager(
+        managedResourceGroup.managedResourceGroupCoordinates.tenantId,
+        managedResourceGroup.managedResourceGroupCoordinates.subscriptionId
+      )
+      .unsafeRunSync()
+      .applications()
+      .list()
+      .asScala
+      .head
+    when(mockApplication.plan())
+      .thenReturn(new Plan().withName("other name").withPublisher(MockCrlService.defaultManagedAppPlan.publisher))
+
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
+  }
+
+  it should "Forbidden when user is not authorized for Application" in {
+    val user = Generator.genWorkbenchUserAzure.sample
+    val managedResourceGroup = Generator.genManagedResourceGroup.sample.get
+    val mockMrgDAO = new MockAzureManagedResourceGroupDAO
+    val svc =
+      new AzureService(MockCrlService(user, managedResourceGroup.managedResourceGroupCoordinates.managedResourceGroupName), new MockDirectoryDAO(), mockMrgDAO)
+
+    val err = intercept[WorkbenchExceptionWithErrorReport] {
+      svc
+        .createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user.map(_.copy(email = WorkbenchEmail("other@email.com")))))
+        .unsafeRunSync()
+    }
+    err.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    mockMrgDAO.mrgs should not contain managedResourceGroup
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/MockCrlService.scala
@@ -1,18 +1,22 @@
 package org.broadinstitute.dsde.workbench.sam.azure
 
 import cats.effect.IO
+import com.azure.core.http.rest.PagedIterable
 import com.azure.core.management.Region
 import com.azure.core.util.Context
+import com.azure.resourcemanager.managedapplications.ApplicationManager
+import com.azure.resourcemanager.managedapplications.models.{Application, Applications, Plan}
 import com.azure.resourcemanager.msi.MsiManager
 import com.azure.resourcemanager.msi.models.{Identities, Identity}
 import com.azure.resourcemanager.msi.models.Identity.DefinitionStages
 import com.azure.resourcemanager.resources.ResourceManager
 import com.azure.resourcemanager.resources.fluent.models.ResourceGroupInner
-import com.azure.resourcemanager.resources.models.{GenericResource, GenericResources, Plan, ResourceGroup, ResourceGroups}
-import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, SamResourceTypes}
+import com.azure.resourcemanager.resources.models.{ResourceGroup, ResourceGroups}
+import org.broadinstitute.dsde.workbench.sam.config.ManagedAppPlan
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, SamResourceTypes, SamUser}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, when}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.jdk.CollectionConverters._
@@ -20,11 +24,13 @@ import scala.jdk.CollectionConverters._
 object MockCrlService extends MockitoSugar {
   val mockMrgName = ManagedResourceGroupName("test-mrg")
   val mockSamSpendProfileResource = FullyQualifiedResourceId(SamResourceTypes.spendProfile, ResourceId("test-spend-profile"))
-  val mockPlanName = "mock-plan"
+  val mockPlan = ManagedAppPlan("mock-plan", "mock-publisher", "mock-auth-user-key")
 
-  def apply() = {
-    val mockCrlService = mock[CrlService]
+  def apply(user: Option[SamUser] = None) = {
+    val mockCrlService = mock[CrlService](RETURNS_SMART_NULLS)
     val mockRm = mockResourceManager
+    val mockAppMgr = mockApplicationManager(user)
+
     when(mockCrlService.buildResourceManager(any[TenantId], any[SubscriptionId]))
       .thenReturn(IO.pure(mockRm))
 
@@ -32,84 +38,99 @@ object MockCrlService extends MockitoSugar {
     when(mockCrlService.buildMsiManager(any[TenantId], any[SubscriptionId]))
       .thenReturn(IO.pure(mockMsi))
 
-    when(mockCrlService.getManagedAppPlanIds)
-      .thenReturn(Seq(mockPlanName))
+    when(mockCrlService.getManagedAppPlans)
+      .thenReturn(Seq(mockPlan))
+
+    when(mockCrlService.buildApplicationManager(any[TenantId], any[SubscriptionId]))
+      .thenReturn(IO.pure(mockAppMgr))
 
     mockCrlService
   }
 
   private def mockResourceManager: ResourceManager = {
     // Mock get resource group
-    val mockResourceGroupInner = mock[ResourceGroupInner]
+    val mockResourceGroupInner = mock[ResourceGroupInner](RETURNS_SMART_NULLS)
     when(mockResourceGroupInner.managedBy())
       .thenReturn("terra")
 
-    val mockResourceGroup = mock[ResourceGroup]
+    val mockResourceGroup = mock[ResourceGroup](RETURNS_SMART_NULLS)
     when(mockResourceGroup.tags())
       .thenReturn(Map("terra.billingProfileId" -> mockSamSpendProfileResource.resourceId.value).asJava)
     when(mockResourceGroup.innerModel())
       .thenReturn(mockResourceGroupInner)
+    when(mockResourceGroup.id())
+      .thenReturn(mockMrgName.value)
 
-    val mockResourceGroups = mock[ResourceGroups]
+    val mockResourceGroups = mock[ResourceGroups](RETURNS_SMART_NULLS)
     when(mockResourceGroups.getByName(anyString))
       .thenThrow(new RuntimeException("resource group not found"))
     when(mockResourceGroups.getByName(ArgumentMatchers.eq(mockMrgName.value)))
       .thenReturn(mockResourceGroup)
 
-    // Mock get managed app
-    val mockPlan = mock[Plan]
-    when(mockPlan.name())
-      .thenReturn(mockPlanName)
-
-    val mockGenericResource = mock[GenericResource]
-    when(mockGenericResource.plan())
-      .thenReturn(mockPlan)
-
-    val mockGenericResources = mock[GenericResources]
-    when(mockGenericResources.getById(anyString))
-      .thenReturn(mockGenericResource)
-
     // Mock resource manager
-    val mockResourceManager = mock[ResourceManager]
+    val mockResourceManager = mock[ResourceManager](RETURNS_SMART_NULLS)
     when(mockResourceManager.resourceGroups())
       .thenReturn(mockResourceGroups)
-    when(mockResourceManager.genericResources())
-      .thenReturn(mockGenericResources)
 
     mockResourceManager
   }
 
   private def mockMsiManager: MsiManager = {
     // Mock create identity
-    val mockIdentity = mock[Identity]
+    val mockIdentity = mock[Identity](RETURNS_SMART_NULLS)
     when(mockIdentity.name())
       .thenReturn("mock-uami")
     when(mockIdentity.id())
       .thenReturn("tenant/sub/mrg/uami")
 
-    val createIdentityStage3 = mock[DefinitionStages.WithCreate]
+    val createIdentityStage3 = mock[DefinitionStages.WithCreate](RETURNS_SMART_NULLS)
     when(createIdentityStage3.create(any[Context]))
       .thenReturn(mockIdentity)
     when(createIdentityStage3.withTags(any[java.util.Map[String, String]]))
       .thenReturn(createIdentityStage3)
 
-    val createIdentityStage2 = mock[DefinitionStages.WithGroup]
+    val createIdentityStage2 = mock[DefinitionStages.WithGroup](RETURNS_SMART_NULLS)
     when(createIdentityStage2.withExistingResourceGroup(anyString))
       .thenReturn(createIdentityStage3)
 
-    val createIdentityStage1 = mock[DefinitionStages.Blank]
+    val createIdentityStage1 = mock[DefinitionStages.Blank](RETURNS_SMART_NULLS)
     when(createIdentityStage1.withRegion(any[Region]()))
       .thenReturn(createIdentityStage2)
 
-    val mockIdentities = mock[Identities]
+    val mockIdentities = mock[Identities](RETURNS_SMART_NULLS)
     when(mockIdentities.define(anyString))
       .thenReturn(createIdentityStage1)
 
     // Mock MsiManager
-    val mockMsiManager = mock[MsiManager]
+    val mockMsiManager = mock[MsiManager](RETURNS_SMART_NULLS)
     when(mockMsiManager.identities())
       .thenReturn(mockIdentities)
 
     mockMsiManager
+  }
+
+  private def mockApplicationManager(user: Option[SamUser]): ApplicationManager = {
+    val appParameters = user.map(u => Map[String, Map[String, String]](mockPlan.authorizedUserKey -> Map("value" -> u.email.value)).view.mapValues(_.asJava).toMap.asJava)
+    val mockApplication = mock[Application](RETURNS_SMART_NULLS)
+    when(mockApplication.managedResourceGroupId())
+      .thenReturn(mockMrgName.value)
+    when(mockApplication.plan())
+      .thenReturn(new Plan().withName(mockPlan.name).withPublisher(mockPlan.publisher))
+    when(mockApplication.parameters())
+      .thenReturn(appParameters.orNull)
+
+    val mockApplicationIterator = mock[PagedIterable[Application]](RETURNS_SMART_NULLS)
+    when(mockApplicationIterator.iterator())
+      .thenReturn(List(mockApplication).iterator.asJava)
+
+    val mockApplications = mock[Applications](RETURNS_SMART_NULLS)
+    when(mockApplications.list())
+      .thenReturn(mockApplicationIterator)
+
+    val mockAppMgr = mock[ApplicationManager](RETURNS_SMART_NULLS)
+    when(mockAppMgr.applications())
+      .thenReturn(mockApplications)
+
+    mockAppMgr
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAzureManagedResourceGroupDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAzureManagedResourceGroupDAO.scala
@@ -8,19 +8,21 @@ import scala.collection.mutable
 
 class MockAzureManagedResourceGroupDAO extends AzureManagedResourceGroupDAO {
   val mrgs = new mutable.HashSet[ManagedResourceGroup]
-  override def insertManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Int] = {
+  override def insertManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Int] =
     IO(mrgs += managedResourceGroup).map(_ => 1)
-  }
 
-  override def getManagedResourceGroupByBillingProfileId(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Option[ManagedResourceGroup]] = {
+  override def getManagedResourceGroupByBillingProfileId(
+      billingProfileId: BillingProfileId,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ManagedResourceGroup]] =
     IO(mrgs.find(_.billingProfileId == billingProfileId))
-  }
 
-  override def getManagedResourceGroupByCoordinates(managedResourceGroupCoordinates: ManagedResourceGroupCoordinates, samRequestContext: SamRequestContext): IO[Option[ManagedResourceGroup]] = {
+  override def getManagedResourceGroupByCoordinates(
+      managedResourceGroupCoordinates: ManagedResourceGroupCoordinates,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ManagedResourceGroup]] =
     IO(mrgs.find(_.managedResourceGroupCoordinates == managedResourceGroupCoordinates))
-  }
 
-  override def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Int] = {
+  override def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Int] =
     IO(mrgs.filterInPlace(_.billingProfileId != billingProfileId)).map(_ => 1)
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAzureManagedResourceGroupDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAzureManagedResourceGroupDAO.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.sam.azure.{BillingProfileId, ManagedResourceGroup, ManagedResourceGroupCoordinates}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import scala.collection.mutable
+
+class MockAzureManagedResourceGroupDAO extends AzureManagedResourceGroupDAO {
+  val mrgs = new mutable.HashSet[ManagedResourceGroup]
+  override def insertManagedResourceGroup(managedResourceGroup: ManagedResourceGroup, samRequestContext: SamRequestContext): IO[Int] = {
+    IO(mrgs += managedResourceGroup).map(_ => 1)
+  }
+
+  override def getManagedResourceGroupByBillingProfileId(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Option[ManagedResourceGroup]] = {
+    IO(mrgs.find(_.billingProfileId == billingProfileId))
+  }
+
+  override def getManagedResourceGroupByCoordinates(managedResourceGroupCoordinates: ManagedResourceGroupCoordinates, samRequestContext: SamRequestContext): IO[Option[ManagedResourceGroup]] = {
+    IO(mrgs.find(_.managedResourceGroupCoordinates == managedResourceGroupCoordinates))
+  }
+
+  override def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Int] = {
+    IO(mrgs.filterInPlace(_.billingProfileId != billingProfileId)).map(_ => 1)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAOSpec.scala
@@ -1,0 +1,76 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.model.WorkbenchExceptionWithErrorReport
+import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
+import org.broadinstitute.dsde.workbench.sam.azure.{BillingProfileId, TenantId}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class PostgresAzureManagedResourceGroupDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach with PropertyBasedTesting with TestSupport {
+  val dao = new PostgresAzureManagedResourceGroupDAO(TestSupport.dbRef, TestSupport.dbRef)
+
+  override protected def beforeEach(): Unit =
+    TestSupport.truncateAll
+
+  "PostgresAzureManagedResourceGroupDAO" - {
+    "insert, query and delete" in forAll(Generator.genManagedResourceGroup) { mrg =>
+      val backgroundMrg = mrg.copy(
+        mrg.managedResourceGroupCoordinates.copy(tenantId = TenantId(mrg.managedResourceGroupCoordinates.tenantId.value + "_other")),
+        BillingProfileId(mrg.billingProfileId.value + "other")
+      )
+
+      // insert a background record to make sure our queries are not accidentally without restriction
+      dao.insertManagedResourceGroup(backgroundMrg, samRequestContext).unsafeRunSync() shouldBe 1
+
+      // mrg should not be there yet
+      dao.getManagedResourceGroupByCoordinates(mrg.managedResourceGroupCoordinates, samRequestContext).unsafeRunSync() shouldBe None
+      dao.getManagedResourceGroupByBillingProfileId(mrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe None
+
+      // insert mrg
+      dao.insertManagedResourceGroup(mrg, samRequestContext).unsafeRunSync() shouldBe 1
+
+      // should be able to query
+      dao.getManagedResourceGroupByCoordinates(mrg.managedResourceGroupCoordinates, samRequestContext).unsafeRunSync() shouldBe Some(mrg)
+      dao.getManagedResourceGroupByBillingProfileId(mrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe Some(mrg)
+
+      // delete background mrg
+      dao.deleteManagedResourceGroup(backgroundMrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe 1
+
+      // verify did not delete mrg by mistake
+      dao.getManagedResourceGroupByCoordinates(mrg.managedResourceGroupCoordinates, samRequestContext).unsafeRunSync() shouldBe Some(mrg)
+      dao.getManagedResourceGroupByBillingProfileId(mrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe Some(mrg)
+
+      // delete mrg
+      dao.deleteManagedResourceGroup(mrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe 1
+
+      // verify deletes
+      dao.getManagedResourceGroupByCoordinates(mrg.managedResourceGroupCoordinates, samRequestContext).unsafeRunSync() shouldBe None
+      dao.getManagedResourceGroupByBillingProfileId(mrg.billingProfileId, samRequestContext).unsafeRunSync() shouldBe None
+    }
+
+    "insertManagedResourceGroup" - {
+      "detect duplicate coordinates" in forAll(Generator.genManagedResourceGroup) { mrg =>
+        val dupCoords = mrg.copy(billingProfileId = BillingProfileId(mrg.billingProfileId.value + "other"))
+        dao.insertManagedResourceGroup(mrg, samRequestContext).unsafeRunSync() shouldBe 1
+        val error = intercept[WorkbenchExceptionWithErrorReport] {
+          dao.insertManagedResourceGroup(dupCoords, samRequestContext).unsafeRunSync()
+        }
+        error.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
+      }
+
+      "detect duplicate billing profile" in forAll(Generator.genManagedResourceGroup) { mrg =>
+        val dupBilling = mrg.copy(managedResourceGroupCoordinates =
+          mrg.managedResourceGroupCoordinates.copy(tenantId = TenantId(mrg.managedResourceGroupCoordinates.tenantId.value + "_other"))
+        )
+        dao.insertManagedResourceGroup(mrg, samRequestContext).unsafeRunSync() shouldBe 1
+        val error = intercept[WorkbenchExceptionWithErrorReport] {
+          dao.insertManagedResourceGroup(dupBilling, samRequestContext).unsafeRunSync()
+        }
+        error.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAzureManagedResourceGroupDAOSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.model.WorkbenchExceptionWithErrorReport
+import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
 import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
 import org.broadinstitute.dsde.workbench.sam.azure.{BillingProfileId, TenantId}
 import org.scalatest.BeforeAndAfterEach
@@ -17,6 +18,8 @@ class PostgresAzureManagedResourceGroupDAOSpec extends AnyFreeSpec with Matchers
 
   "PostgresAzureManagedResourceGroupDAO" - {
     "insert, query and delete" in forAll(Generator.genManagedResourceGroup) { mrg =>
+      assume(databaseEnabled, databaseEnabledClue)
+
       val backgroundMrg = mrg.copy(
         mrg.managedResourceGroupCoordinates.copy(tenantId = TenantId(mrg.managedResourceGroupCoordinates.tenantId.value + "_other")),
         BillingProfileId(mrg.billingProfileId.value + "other")
@@ -53,6 +56,8 @@ class PostgresAzureManagedResourceGroupDAOSpec extends AnyFreeSpec with Matchers
 
     "insertManagedResourceGroup" - {
       "detect duplicate coordinates" in forAll(Generator.genManagedResourceGroup) { mrg =>
+        assume(databaseEnabled, databaseEnabledClue)
+
         val dupCoords = mrg.copy(billingProfileId = BillingProfileId(mrg.billingProfileId.value + "other"))
         dao.insertManagedResourceGroup(mrg, samRequestContext).unsafeRunSync() shouldBe 1
         val error = intercept[WorkbenchExceptionWithErrorReport] {
@@ -62,6 +67,8 @@ class PostgresAzureManagedResourceGroupDAOSpec extends AnyFreeSpec with Matchers
       }
 
       "detect duplicate billing profile" in forAll(Generator.genManagedResourceGroup) { mrg =>
+        assume(databaseEnabled, databaseEnabledClue)
+
         val dupBilling = mrg.copy(managedResourceGroupCoordinates =
           mrg.managedResourceGroupCoordinates.copy(tenantId = TenantId(mrg.managedResourceGroupCoordinates.tenantId.value + "_other"))
         )


### PR DESCRIPTION
Ticket: [TOAZ-224](https://broadworkbench.atlassian.net/browse/TOAZ-224)

See the ticket for details pls. Note that the old way of using tags on the MRG is remaining intact for backwards compatibility. Look to a future PR to remove that and migrate pre-existing pet identities. 

Also note that I did not implement a new API to get a pet in the interest of not having to change external dependencies. I think the new api in the ticket looks nicer but the billing profile id might not be readily available and we know that the mrg coordinates are.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
