### PR TITLE
[WOR-637] Add MRG DELETE endpoint and associated tests

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1261,6 +1261,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+    delete:
+      tags:
+        - Azure
+      summary: Deletes the managed resource group coordinates associated with the billing profile id
+      operationId: deleteManagedResourceGroup
+      parameters:
+        - name: billingProfileId
+          in: path
+          description: billing profile id
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Successfully deleted managed resource group
+          content: { }
+        403:
+          description: You do not have permission to perform this action on the resource
+          content: { }
+        404:
+          description: Resource does not exist
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
   /api/azure/v1/user/petManagedIdentity:
     post:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -71,7 +71,19 @@ trait AzureRoutes extends SecurityDirectives with LazyLogging {
                     }
                   }
                 }
-              }
+              } ~
+                delete {
+                  requireAction(
+                    FullyQualifiedResourceId(SamResourceTypes.spendProfile, ResourceId(billingProfileId)),
+                    SamResourceActions.delete,
+                    samUser.id,
+                    samRequestContext
+                  ) {
+                    complete {
+                      service.deleteManagedResourceGroup(BillingProfileId(billingProfileId), samRequestContext).map(_ => StatusCodes.NoContent)
+                    }
+                  }
+                }
             }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureService.scala
@@ -69,6 +69,20 @@ class AzureService(crlService: CrlService, directoryDAO: DirectoryDAO, azureMana
       _ <- azureManagedResourceGroupDAO.insertManagedResourceGroup(managedResourceGroup, samRequestContext)
     } yield ()
 
+  /** Delete the managed resource group for a given billing profile
+    */
+  def deleteManagedResourceGroup(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Unit] =
+    for {
+      existing <- azureManagedResourceGroupDAO.getManagedResourceGroupByBillingProfileId(billingProfileId, samRequestContext)
+      _ <- IO.raiseWhen(existing.isEmpty)(
+        new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"managed resource group for profile ${billingProfileId} not found"))
+      )
+      _ <- azureManagedResourceGroupDAO.deleteManagedResourceGroup(
+        billingProfileId,
+        samRequestContext
+      )
+    } yield {}
+
   /** Looks up a pet managed identity from the database, or creates it if one does not exist.
     */
   def getOrCreateUserPetManagedIdentity(


### PR DESCRIPTION
Ticket: [Integrate BPM with new Sam API to store MRG coordinates](https://broadworkbench.atlassian.net/browse/WOR-637)

What:

Adds the ability to delete a managed resource group from a billing profile. This is a follow-on to #911 .


Why:

When an Azure  billing profile is deleted, we should remove the associated managed resource group record so it can be reused later. If we don't do this, a subsequent billing profile that attempts to use the same MRG will get a 409 and fail out. 

 
How:

* Adds a DELETE endpoint at `/api/azure/v1/billingProfile/{billingProfileId}/managedResourceGroup`,
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
