### PR TITLE
ID-363 let Sam host privacy policy in tandem with ToS

### DIFF
--- a/src/main/resources/tos/privacyPolicy-0.md
+++ b/src/main/resources/tos/privacyPolicy-0.md
@@ -1,0 +1,95 @@
+If there are any questions about privacy, please email [privacy@broadinstitute.org](mailto:privacy@broadinstitute.org).
+
+We keep your name, email and company so you can use our system.
+
+We place cookies on your browser to make our system faster.
+
+We may use your name and email to send you information about our system.
+
+You are responsible for maintaining the privacy of data you enter into our system. We keep your data very private on our cloud providers.
+
+We follow the laws of all the countries where we operate. We follow the laws of Europe, like GDPR. If you need more information, see the sections below.
+
+## Information Terra May Collect From You
+
+1. Our primary goals in collecting information are to provide genomic information management and analysis services to you, to improve our Site, features, content, and to run our business.
+
+    1. Genomic Information That You Voluntarily Provide
+
+        * Terra collects and stores the genomic sequence data (DNA, RNA, etc), derived from humans or other organisms, that you submit to the Site along with metadata and other information related to such sequence data. You agree to and accept full responsibility for obtaining all necessary permissions and informed consents from the donors of all samples from which your submitted sequence data is derived.
+
+    2. HIPAA, Protected Health Information, and the Clinical Compliance Features
+
+        * Terra is not a Covered Entity as that term is defined in the Health Insurance Portability and Accountability Act of 1996, as amended, and its related regulations (collectively, "HIPAA"). On occasion, Terra may agree in writing with a user to perform services for the user in the storing PHI. We recommend that such users enter into a formal agreement with Terra/Firecloud.
+
+        * Terra does offers clinical compliance features as part of its service ("Compliance Features") for users who wish to upload, store, or otherwise transfer PHI, as well as users who are using the Site in connection with their clinical operations. Users who desire to upload, store, or otherwise transfer PHI using the Site must implement all of the required Clinical Features and must enter a formal agreement with Firecloud stating that. The uploading, storing, or transferring of PHI using the Site by users that have not implemented the Clinical Features is strictly prohibited. You agree that, unless you have implemented the Clinical Features, you will not upload, store, or otherwise transfer PHI using the Site.
+
+        * You acknowledge that this may require you, in some instances, to anonymize sequence data prior to uploading it to the Site. You further agree to indemnify and hold harmless Terra of and from any and all claims, demands, losses, causes of action, damage, lawsuits, judgments, including attorneys' fees and costs, arising out of or relating to your uploading, storing, or transferring of PHI without having fully implemented the Clinical Features.
+
+    3. User Account Information/Personally Identifiable Information
+
+        * When you register with us through the Site and during your use of the Site, we will ask you for personally-identifiable information, which is information about you that can be used to contact or identify you ("Personal Information"), such as: your name, company or organization name, title, e-mail address, postal address, telephone number.
+
+    4. Cookies and Tracking Pixels
+
+        * We use cookies, tracking pixels, and other similar technologies to track activity on our Site and to enhance the functionality of our Site. Cookies are small data files that our web servers send to your browser and which get saved on the hard drive of the computer that you are using to access the Site. If you do not want to allow cookies on your computer, most browsers have a feature that allows you either to automatically decline cookies or to decline or accept particular cookies from particular web sites. If you choose to reject cookies from our Site, you may be unable to use certain Site services, features, and functionality. If you choose to accept cookies from us and our service providers, you are agreeing to let us and our service providers install cookies on your computer. To learn more about cookies, please visit [http://allaboutcookies.org](http://allaboutcookies.org/). Tracking pixels (also known as web beacons, action tags, or transparent GIF files) collect and store information about your visits to our Site, such as page visits, the duration of the visit, the specific link(s) that you clicked during your visit, and the address of the website from which you arrived at the Site.
+
+    5. User Software and Reference Data
+
+        * You may also be permitted to upload your own software and data, including reference genomes, to the Site in the course of using the Site. You agree to and accept full responsibility for obtaining all permissions, consents, and rights necessary for uploading and using any such software and data to and with the Site. The software you upload must comply with the Terra "Terms of Use Policy".
+
+2. How Your Information May be Used
+
+    1. We may use your Personal Information to improve our products and services, to ensure contact information is up to date and accurate, to improve our customer service, to reduce risk and prevent fraud, to provide you with a personalized experience on our Site and to communicate with you regarding new service features and related products and services provided by our partners, events, and other information and notices we believe you may find interesting or useful. We will not sell or provide your information to third parties for their own direct marketing purposes.
+
+    2. We use the automatic usage and other non-Personal Information collected to maintain, secure, and improve our Site, and to understand your interests when visiting our Site. We may generate statistical information regarding our user-base and use it to analyze our Site or business.
+
+3. With Whom May Terra Share Your Information?
+
+    1. Service Providers
+
+        * We may rely on various third-party service providers and contractors to provide services that support the Site and our operations, including, without limitation, maintenance of our databases, distribution of emails and newsletters on our behalf, data analysis, payment processing and other services of an administrative nature. Such third-parties may have access to your Personal Information for the purpose of performing the service for which they have been engaged.
+
+    2. Compliance with Laws and Law Enforcement
+
+        * Terra cooperates with government and law enforcement officials and private parties to enforce and comply with the law. We may disclose Personal Information and other user information when we, in our sole discretion, have reason to believe that disclosing this information is necessary to identify, contact, or bring legal action against someone who may (either intentionally or unintentionally) be causing injury to or interference with our rights or property, users of our Site, or anyone else who could be harmed by such activities. We may also disclose user information when we believe, in our sole discretion, that such disclosure is required by applicable law. We also may be required to disclose an individual’s personal information in response to a lawful request by public authorities, including to meet national security or law enforcement requirements.
+
+    3. Vendors and Service Providers
+
+        * We use [various third-party vendors and service providers](https://support.terra.bio/hc/en-us/articles/360039434212), such as Google Cloud and MixPanel, that assist us in providing the Platform. For example, we may use third-party vendors to store and authenticate account credentials, store and analyze system logs, send email communications, and for hosting and storing information collected through our Platform. We may need to share your information with these vendors and service providers to enable them to provide these services to us. These service providers and vendors are required to only use your information to provide their services to us and in a manner consistent with this Policy.
+
+4. Information You Share With Other Users; Forums
+
+    1. Our Site allows you to share the sequence data, reference genomes, and other information you submit to the Site with other users of the Site and third parties who are not users of the Site. Terra is not responsible for such other users' and third parties' use of your sequence data, reference genomes or other information. You understand and acknowledge that, if you choose to share the sequence data, reference genomes, or other information you submit to the Site with other users of the Site or third parties, such shared information might be copied or redistributed by other users and third parties. Even after you remove information from your account or delete your account, copies of that information may remain viewable elsewhere to the extent it has previously been shared with others.
+
+5. Links and Third Party Applications
+
+    1. On the Site, we may provide links to websites or applications maintained by third parties, which we believe you may find useful. Terra is not responsible for the privacy practices of these other websites or applications and we encourage you to review the privacy policies of each of those other websites or applications before using such websites and applications. If you click on these third-party links, these other websites or applications may place their own cookies or other files on your computer, collect data, or solicit Personal Information from you. Other websites and applications will have different policies and rules regarding the use or disclosure of the personal information you submit to them. We make no representation with regard to the policies or business practices of any websites or applications to which you connect through a link from this Site, and are not responsible for any material contained on, or any transactions that occur between you and any such website or application.
+
+6. Location
+
+    1. Broad Institute is a United States based company and therefore we must abide the laws and regulations of the United States as well as the other countries where we operate. By providing Personal Information and other information to this Site, you understand and consent to the collection, use, processing and transfer of such information to the United States and other countries or territories, which may not offer the same level of data protection as the country where you reside, in accordance with the terms of this Privacy Policy.
+
+7. General Data Privacy Regulation (GDPR)
+
+    1. Terra is compliant with the GDPR regulations as it becomes effective starting 25 May 2018. In the language of GDPR, Terra positions itself as a Data Processor or Subprocessor for our customers, who are either Data Controllers or Data Processors. As such, Terra is not liable for the provisions of GDPR that pertain to the Data Controllers. Terra’ obligations as a Data Processor include, but are not limited to the following:
+
+        * Terra shall follow the instructions of the Customer in the management of their data. Terra shall not opportunistically use or mine or use personal data that it is entrusted, aside from those mentioned elsewhere in this document or under the written instructions of the Customer.
+
+        * Terra shall obtain written permission from the Customer before engaging a subprocessor and assume liability for failures of the subprocessors to meet the requirements of GDPR.
+
+        * Upon request, Terra shall delete or return all personal data to the Customer at the end of the service contract.
+
+        * Terra shall enable and contribute to compliance audits conducted by the Customer’s controller or a competent representative of the controller.
+
+        * Terra shall take reasonable steps to secure data, such as encryption, stability and uptime, backup and disaster recovery, and regular security testing.
+
+        * Terra shall notify the Customer without undue delay upon learning of data breaches.
+
+        * Terra shall make every effort to restrict personal data transfer to a third country only if legal safeguards are obtained.
+
+        * Terra shall make the Data Protection Officer available address concerns or questions upon request.
+
+8. Privacy Policy Changes
+
+    1. This Privacy Policy may be updated periodically. We will notify you of any material changes to this Privacy Policy by posting the revised policy on the Site. You are advised to periodically review this page to ensure continuing familiarity with the most current version of our Privacy Policy. Any changes to our Privacy Policy will become effective upon our posting of the revised Privacy Policy on the Site. Use of the Site following such changes constitutes your acceptance of the revised Privacy Policy then in effect. You will be able to determine when this Privacy Policy was last revised by checking the "Last Updated" information that appears at the top of this page.

--- a/src/main/resources/tos/privacyPolicy-1.md
+++ b/src/main/resources/tos/privacyPolicy-1.md
@@ -366,6 +366,6 @@ We share Personal Data with the following categories of recipients:
 - If you have any questions about our privacy practices, you may contact
   us using the following email address: [privacy@broadinstitute.org](mailto:privacy@broadinstitute.org).
 
-- You may contact our Data Protection Officer at: \[ADD AS APPLICABLE\].
+- You may contact our Data Protection Officer at: [whedglon@broadinstitute.org](mailto:whedglon@broadinstitute.org).
 
-- You may contact our EU/UK Representative at: \[ADD AS APPLICABLE\].
+- You may contact our EU/UK Representative at: [whedglon@broadinstitute.org](mailto:whedglon@broadinstitute.org).

--- a/src/main/resources/tos/privacyPolicy-1.md
+++ b/src/main/resources/tos/privacyPolicy-1.md
@@ -1,0 +1,371 @@
+# Terra Platform Privacy Notice 
+
+Last Updated: October 20, 2022
+
+This Privacy Notice is supplied by The Broad Institute (“Broad,” “we,”
+“us” or “our”) and describes how Personal Data is collected and used by
+Broad via the Terra platform and all associated websites (including
+terra.bio) (”Terra”) developed by Verily, Microsoft and Broad (together
+with their affiliates, the “Collaborators”). This Privacy Notice applies
+only to the websites and other online properties that directly link to
+it, which we refer to herein as the “Services”.
+
+This Privacy Notice applies to Broad where Broad is the “controller” of
+your Personal Data, i.e., the entity that determines the purposes and
+means for processing such data. Broad may in some cases process Personal
+Data on behalf of users of Terra, such as where Users load Personal Data
+including genomics data to Terra. In that case, Broad is a “processor”
+with respect to such information, and you should refer to the user’s own
+privacy notices to receive additional information about their privacy
+practices.
+
+If you have any questions about Broad’s privacy practices, please
+email:
+
+[privacy@broadinstitute.org](mailto:privacy@broadinstitute.org).
+
+## 1. Personal Data We Collect
+
+When we use the term “Personal Data” we mean information that relates to
+a specific person, or that can be used to identify a specific person,
+such as a name or email address. In this Privacy Notice, we do not
+include Protected Health Information in the definition of Personal Data
+because, as discussed in Section 2 (Protected Health Information),
+Protected Health Information has different treatment under the Health
+Insurance Portability and Accountability Act of 1996, as amended, and
+its implementing regulations (“HIPAA”) and other applicable laws.
+“Protected Health Information” or “PHI” is individually identifiable
+health information that is protected by HIPAA.
+
+We collect and use Personal Data through your use of the Services in the
+following ways:
+
+***1.a User Account Information/Personally Identifiable Information***
+
+- When you register with us through the Services and during your use of
+  the Services, we will ask you for Personal Data such as: your name,
+  company or organization name, title, e-mail address, postal address,
+  telephone number.
+
+***1.b Information You Provide***
+
+- When you interact with the Services, you may supply certain Personal
+  Data, such as when you submit a request or post on the Community
+  Forum. The information will vary depending on your interactions, but
+  may include your name and email address and other information you
+  include in the body of your request, post, comment, or other
+  interaction.
+
+***1.c. Automatic Data Collection: Cookies and Similar Technologies***
+
+- When you use the Services, we automatically collect usage data such as
+  the IP address of the device or internet service you use to connect to
+  the Internet, browser type and version, operating system and platform,
+  and referring URLs, which may, in some instances, constitute Personal
+  Data (“Usage Data”).
+
+- We use cookies, tracking pixels, and other similar technologies to
+  track activity on our Services and to enhance the functionality of our
+  Services. Cookies are small data files that our web servers send to
+  your browser and which get saved on the hard drive of the computer
+  that you are using to access the Services. If you do not want to allow
+  cookies on your computer, most browsers have a feature that allows you
+  either to automatically decline cookies or to decline or accept
+  particular cookies from particular websites. If you choose to reject
+  cookies from our Services, you may be unable to use certain Services
+  features, and functionality. If you choose to accept cookies from us
+  and our service providers, you are agreeing to let us and our service
+  providers install cookies on your computer. To learn more about
+  cookies, please visit http://allaboutcookies.org. Tracking pixels
+  (also known as web beacons, action tags, or transparent GIF files)
+  collect and store information about your visits to our Services, such
+  as page visits, the duration of the visit, the specific link(s) that
+  you clicked during your visit, and the address of the website from
+  which you arrived at the Services.
+
+- We use Google Analytics to better understand how users interact with
+  our Services. To learn more about the use of Cookies by Google for
+  analytics and to exercise choice regarding those Cookies, please visit
+  the [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout).
+
+- Do Not Track (“DNT”) is a privacy preference that users can set in
+  certain web browsers. We are committed to providing you with
+  meaningful choices about the information collected on our website for
+  third-party purposes, and that is why we provide the variety of
+  opt-out mechanisms listed above. We do not currently use technology
+  that recognizes “do not track” signals from your Web browser.
+
+## 2. Protected Health Information
+
+- With respect to Terra, Broad is not a Covered Entity as that term is
+  defined under HIPAA. You may not use Terra to connect content that
+  includes PHI. You will anonymize or pseudonymize data prior to
+  connecting it to Terra.
+
+## 3. How Your Personal Data May be Used
+
+We use Personal Date as described below:
+
+- We may use your Personal Data to provide and improve Terra and our
+  other products and services, to ensure contact information is up to
+  date and accurate, to improve our customer service, to reduce risk and
+  prevent fraud, to provide you with a personalized experience on our
+  Services and to communicate with you regarding new service features
+  and related products and services provided by our Collaborators or
+  other partners, events, and other information and notices we believe
+  you may find interesting or useful. We will not sell or provide your
+  information to third parties other than the Collaborators for their
+  own direct marketing purposes.
+
+<!-- -->
+
+- We use Usage Data collected to provide, maintain, secure, and improve
+  our Services, and to understand your interests when visiting our
+  Services. We may generate statistical information regarding our
+  user-base and use it to analyze our Services or business.
+
+## 4. With Whom May Broad Share Your Personal Data?
+
+We share Personal Data with the following categories of recipients:
+
+*Service Providers*
+
+- We may rely on various third-party service providers and contractors
+  to provide services that support the Services and our operations,
+  including, without limitation, maintenance of our databases,
+  distribution of emails and newsletters on our behalf, data analysis,
+  payment processing and other services of an administrative nature.
+  Such third parties may have access to your Personal Data for the
+  purpose of performing the service for which they have been engaged.
+
+*Compliance with Laws and Law Enforcement*
+
+- Broad cooperates with government and law enforcement officials and
+  private parties to enforce and comply with the law. We may disclose
+  Personal Data and other user information when we, in our sole
+  discretion, have reason to believe that disclosing this information is
+  necessary to identify, contact, or bring legal action against someone
+  who may (either intentionally or unintentionally) be causing injury to
+  or interference with our rights or property, users of our Services, or
+  anyone else who could be harmed by such activities. We may also
+  disclose user information when we believe, in our sole discretion,
+  that such disclosure is required by applicable law. We also may be
+  required to disclose an individual’s Personal Data in response to a
+  lawful request by public authorities, including to meet national
+  security or law enforcement requirements.
+
+*Vendors and Service Providers*
+
+- We use various third-party [various third-party service
+  providers](https://support.terra.bio/hc/en-us/articles/360039434212),
+  such as Google Cloud and MixPanel, that assist us in providing Terra.
+  For example, we may use third-party vendors to store and authenticate
+  account credentials, store and analyze system logs, send email
+  communications, and for hosting and storing information collected
+  through our Platform. We may need to share your information with these
+  vendors and service providers to enable them to provide these services
+  to us. These service providers and vendors are required to only use
+  your information to provide their services to us and in a manner
+  consistent with this Policy.
+
+*Business Transactions*
+
+- If any of the Collaborators sell all or part of their business or
+  makes a sale or transfer of assets or is otherwise involved in a
+  merger or business transfer, the Collaborator may transfer your
+  Personal Data to a third party as part of that transaction.
+
+## 5. Information You Share With Other Users; Forums
+
+- Our Services allow you to share the sequence data, reference genomes,
+  and other information you submit to the Services with other users of
+  the Services and third parties who are not users of the Services.
+  Broad is not responsible for such other users' and third parties' use
+  of your sequence data, reference genomes or other information. You
+  understand and acknowledge that, if you choose to share the sequence
+  data, reference genomes, or other information you submit to the
+  Services with other users of the Services or third parties, such
+  shared information might be copied or redistributed by other users and
+  third parties. Even after you remove information from your account or
+  delete your account, copies of that information may remain viewable
+  elsewhere to the extent it has previously been shared with others.
+
+## 6. Links and Third Party Applications; Other Privacy Terms and Conditions
+
+- On the Services, we may provide links to websites or applications
+  maintained by third parties, which we believe you may find useful.
+  Broad is not responsible for the privacy practices of these other
+  websites or applications and we encourage you to review the privacy
+  policies of each of those other websites or applications before using
+  such websites and applications. If you click on these third-party
+  links, these other websites or applications may place their own
+  cookies or other files on your computer, collect data, or solicit
+  Personal Data from you. Other websites and applications will have
+  different policies and rules regarding the use or disclosure of the
+  Personal Data you submit to them. We make no representation with
+  regard to the policies or business practices of any websites or
+  applications to which you connect through a link from the Services,
+  and are not responsible for any material contained on, or any
+  transactions that occur between you and any such website or
+  application.
+
+- As a processor, Broad stores the genomic sequence data (DNA, RNA,
+  etc), derived from humans or other organisms, that you submit to the
+  Services along with metadata and other information related to such
+  sequence data. You agree to and accept full responsibility for
+  obtaining all necessary permissions and informed consents from the
+  donors of all samples from which your submitted sequence data is
+  derived.
+
+- You may also be permitted to upload your own software and data,
+  including reference genomes, to the Services in the course of using
+  the Services. You agree to and accept full responsibility for
+  obtaining all permissions, consents, and rights necessary for
+  uploading and using any such software and data to and with the
+  Services. The software you upload must comply with the Terra "Terms of
+  Use Policy".
+
+## 7. Children’s Privacy
+
+- We are committed to protecting privacy of young people using our
+  Services. We do not knowingly collect Personal Data on the Services
+  from children under age 13. We believe children should get their
+  parents’ or guardians’ consent before giving out any Personal Data. If
+  you become aware that we have collected Personal Data from a child
+  without parental consent, please notify us promptly. If we become
+  aware that a child under age 13 has provided us with Personal Data
+  without parental consent, we will take steps to remove it.
+
+## 8. Data Processed in the United States
+
+- Broad is a United States based company and therefore we must abide by
+  the laws and regulations of the United States. By providing Personal
+  Data and other information via the Services, you understand and
+  consent to the collection, use, processing and transfer of such
+  information to the United States, which may not offer the same level
+  of data protection as the country where you reside, in accordance with
+  the terms of this Privacy Policy. As described further in Section 9,
+  where required by applicable law, we have instituted suitable
+  safeguards to ensure the adequacy of the privacy protections in place
+  with respect to any data transfers.
+
+## 9. Notice to Individuals Located in the European Economic Area, United Kingdom, or Switzerland
+
+- Our processing of Personal Data about individuals located in the
+  European Economic Area, United Kingdom, and Switzerland may be within
+  the scope of the European Union’s General Data Protection Regulation
+  (EU Regulation 2016/679) (“EU GDPR”), its incorporation into the laws
+  of England and Wales, Scotland, and Northern Ireland by virtue of the
+  UK European Union (Withdrawal) Act 2018 and/or the Swiss Federal Act
+  on Data Protection, as applicable (together, the “GDPR”). This portion
+  of our Privacy Notice (the “GDPR Privacy Notice”) applies only to our
+  processing of Personal Data that is within the scope of the GDPR and
+  where we are a controller of your data, i.e., where the purpose and
+  means of processing your data is determined by us (“GDPR Processing
+  Activities”).
+
+- We rely on separate and overlapping bases to process your Personal
+  Data lawfully when acting as a controller. We will use the Personal
+  Data provided through or collected on the Services only for the
+  purposes described in this Privacy Notice. Our legal bases for
+  processing your Personal Data include providing you with the
+  information or services that you have requested, protecting your vital
+  interests, furthering our legitimate interests, and your consent, if
+  applicable.
+
+- Legitimate interests that we rely on in processing your Personal Data
+  include (i) improving and customizing the Services for you, (ii)
+  understanding how the Services are being used, (iii) exploring ways to
+  develop and grow our Services, (iv) ensuring the safety and security
+  of the Services, and (v) enhancing protection against fraud, spam,
+  harassment, intellectual property infringement, crime and security
+  risks. Without the ability to collect and process your Personal Data,
+  we would not be able to achieve those interests. We may also use your
+  Personal Data for purposes, including scientific research, that are
+  compatible with the purposes for which such data were initially
+  collected.
+
+- If our processing is based solely on consent, you have the right to
+  withdraw your consent. You may withdraw your consent by contacting us
+  as set forth in the “Contact Us” section below. Please note that, in
+  certain cases, we may continue to process your Personal Data after you
+  have withdrawn consent, if we have a legal basis to do so. For
+  example, we may retain certain information if we need to do so to
+  comply with an independent legal obligation, or if it is necessary to
+  do so to pursue our legitimate interest in keeping the Services safe
+  and secure, or if deleting the information would undermine the
+  integrity of a research study in which you are enrolled.
+
+- As described in Section 8, Broad is located in the United States. When
+  you enter your Personal Data through one of the Services, the data is
+  being transferred to, stored, and processed in the United States, and
+  could be transferred to, stored and processed in another country
+  outside of the EEA, UK or Switzerland. Please be aware that the United
+  States, and possibly other countries to which your Personal Data may
+  be transferred, have not been determined by the appropriate government
+  authorities to provide adequate safeguards for the protection of
+  Personal Data. However, Broad will take steps to maintain the privacy
+  of your Personal Data as described in this Privacy Notice. If Broad
+  transfers your Personal Data outside the EEA, UK, or Switzerland, we
+  will do so in reliance on mechanisms recognized under the GDPR. This
+  includes (i) transferring your Personal Data to countries that the
+  appropriate government authority has determined to provide adequate
+  data protection, (ii) obtaining your consent to transfer your Personal
+  Data after first informing you about the possible risks of such a
+  transfer, (iii) transferring your information where the transfer is
+  necessary to the performance of a contract between you and Broad or if
+  the transfer is necessary to the performance of a contract and the
+  contract was entered into in your interest, (iv) transferring your
+  information if necessary to establish, exercise or defend legal
+  claims, (v) transferring your Personal Data outside the EEA, UK, or
+  Switzerland to protect your vital interests; or (vi) transferring your
+  Personal Data pursuant to Standard Contractual Clauses. You may
+  request a copy of the Standard Contractual Clauses relevant to any
+  such transfer of your Personal Data by contacting us as set forth in
+  the “Contact Us” section below.
+
+- We will retain your Personal Data for as long as is necessary for the
+  purposes set out in this Privacy Notice (for example, if you have an
+  account, for as long as your account is active), subject to your
+  right, under certain circumstances, to have certain of your Personal
+  Data erased, as discussed in the next paragraph, unless a longer
+  period is required under applicable law or is needed to resolve
+  disputes or protect our legal rights.
+
+- If your Personal Data is processed for GDPR Processing Activities, you
+  have the right to (1) obtain a copy of the Personal Data Broad holds
+  about you in an easily accessible format and receive any details
+  required to be provided to you under applicable law, (2) correct or
+  update your Personal Data, if inaccurate, (3) limit collection and use
+  of your Personal Data under certain circumstances (for example, if you
+  think it is inaccurate), (4) request deletion of your Personal Data,
+  subject to Broad’s need to keep such data to comply with legal
+  requirements, to preserve the integrity of a research study, or to
+  allow itself to defend itself from legal claims, among other bases for
+  denying a request to delete, and (5) file a complaint with a data
+  protection authority. If you have questions about the processing of
+  your Personal Data or rights associated with your Personal Data, see
+  the section “Contact Us” below.
+
+## 10. Privacy Notice Changes
+
+- This Privacy Notice may be updated periodically. We will notify you of
+  any material changes to this Privacy Notice by posting the revised
+  policy on the Services. You are advised to periodically review this
+  page to ensure continuing familiarity with the most current version of
+  our Privacy Notice. Any changes to our Privacy Notice will become
+  effective upon our posting of the revised Privacy Notice on the
+  Services. Use of the Services following such changes constitutes your
+  acceptance of the revised Privacy Notice then in effect. You will be
+  able to determine when this Privacy Notice was last revised by
+  checking the “Last Updated” information that appears at the top of
+  this page.
+
+## 11. Contact Us
+
+- If you have any questions about our privacy practices, you may contact
+  us using the following email address: [privacy@broadinstitute.org](mailto:privacy@broadinstitute.org).
+
+- You may contact our Data Protection Officer at: \[ADD AS APPLICABLE\].
+
+- You may contact our EU/UK Representative at: \[ADD AS APPLICABLE\].

--- a/src/main/resources/tos/termsOfService-1.md
+++ b/src/main/resources/tos/termsOfService-1.md
@@ -1,196 +1,651 @@
+# Terra Platform Terms of Service
+
 Last Modified: October 13, 2022
 
-Certain terms (including capitalized terms) are defined in Section 13 (Definitions). 
+Effective Date: \[●\]
+
+Certain terms (including capitalized terms) are defined in Section 13
+(Definitions).
 
 ## 1. Introduction
 
-Thanks for using Terra! Terra is a platform developed by Verily, Microsoft and The Broad Institute that enables Users to curate and publish datasets, discover and access data, find and leverage tools, and collaborate with others. These Terms of Service apply to your use of Terra, as described in Section 2 and as operated by The Broad Institute.
+Thanks for using Terra! Terra is a platform developed by Verily,
+Microsoft and The Broad Institute that enables Users to curate and
+publish datasets, discover and access data, find and leverage tools, and
+collaborate with others. These Terms of Service apply to your use of
+Terra, as described in Section 2 and as operated by The Broad Institute.
 
-The mission of Terra is to enable the next generation of collaborative biomedical research by building an open platform that connects researchers to each other and to the datasets and tools they need to achieve scientific breakthroughs. The success of that mission depends on User contributions of Content, and so we encourage you to support this vibrant environment by making Content available for use and analysis by other Users.
+The mission of Terra is to enable the next generation of collaborative
+The mission of Terra is to enable the next generation of collaborative
+biomedical research by building an open platform that connects
+researchers to each other and to the datasets and tools they need to
+achieve scientific breakthroughs. The success of that mission depends on
+User contributions of Content, and so we encourage you to support this
+vibrant environment by making Content available for use and analysis by
+other Users.
 
-Your use of Terra requires that you agree to these Terms, which also include the Acceptable Use Policy and the Customer Security Requirements. Please read these materials carefully. If you are accessing Terra on behalf of a company or entity, you represent that you have the legal authority to enter into these Terms on that entity’s behalf and agree that we may also contact such entity if you violate these Terms or the Acceptable Use Policy or Customer Security Requirements. If you do not understand these Terms, or do not accept any part of them, then do not use Terra.
+Your use of Terra requires that you agree to these Terms, which also
+include the Acceptable Use Policy and the Customer Security
+Requirements. Please read these materials carefully. If you are
+accessing Terra on behalf of a company or entity, you represent that you
+have the legal authority to enter into these Terms on that entity’s
+behalf and agree that we may also contact such entity if you violate
+these Terms or the Acceptable Use Policy or Customer Security
+Requirements. If you do not understand these Terms, or do not accept any
+part of them, then do not use Terra.
 
 ## 2. Your Use of Terra
 
-**Non-Commercial Use**. Non-Commercial Users may use Terra for research, sharing reproducible research, developing scientific software tools, making data and scientific software tools available to the scientific community, teaching and educational activities, and/or sponsored research, regardless of the identity of the sponsor, provided that, for sponsored research: (i) the primary effect of such sponsorship is not to permit a commercial sponsor to profit from access to or use of Terra, (ii) a commercial sponsor is not permitted to access Terra except in an incidental manner in the course of such collaboration, and (iii) you do not access or use Terra to comply with the express directions of a commercial sponsor.
+**Non-Commercial Use.** Non-Commercial Users may use Terra for research,
+sharing reproducible research, developing scientific software tools,
+making data and scientific software tools available to the scientific
+community, teaching and educational activities, and/or sponsored
+research, regardless of the identity of the sponsor, provided that, for
+sponsored research: (i) the primary effect of such sponsorship is not to
+permit a commercial sponsor to profit from access to or use of Terra,
+(ii) a commercial sponsor is not permitted to access Terra except in an
+incidental manner in the course of such collaboration, and (iii) you do
+not access or use Terra to comply with the express directions of a
+commercial sponsor.
 
-If your employer has reached an enterprise level agreement with The Broad Institute governing your use of Terra, these terms will apply in areas where they are additional to that agreement but will not amend or supervene the governing enterprise level agreement.
+If your employer has reached an enterprise level agreement with The
+Broad Institute governing your use of Terra, these terms will apply in
+areas where they are additional to that agreement but will not amend or
+supervene the governing enterprise level agreement.
 
-**For-Profit Entities or other Commercial Use.** For-Profit Entities, and anyone making use of Terra that is not described in “Non-Commercial Use” above, may use Terra only under the terms of a Commercial Agreement with Microsoft or Verily, which will govern, or for the following limited circumstances:
+**For-Profit Entities or other Commercial Use.** For-Profit Entities,
+and anyone making use of Terra that is not described in “Non-Commercial
+Use” above, may use Terra only under the terms of a Commercial Agreement
+with Microsoft or Verily, which will govern, or for the following
+limited circumstances:
 
-1. Accessing specific Public Datasets via Terra to the extent that the owner of the Public Dataset has made such Public Dataset available to Users that include For-Profit Entities. If such owner has designated a specific purpose for such Public Dataset, a For-Profit Entity may use such Public Dataset only for such designated purpose. Access by a For-Profit Entity to Public Datasets through Terra under this exception may include using Terra to work across Public Datasets, but does not extend to working in connection with any data, information, material, documents, or other Content outside of a Public Dataset and the software and tools provided for use with a Public Dataset.
+1. Accessing specific Public Datasets via Terra to the extent that
+   the owner of the Public Dataset has made such Public Dataset available
+   to Users that include For-Profit Entities. If such owner has
+   designated a specific purpose for such Public Dataset, a For-Profit
+   Entity may use such Public Dataset only for such designated purpose.
+   Access by a For-Profit Entity to Public Datasets through Terra under
+   this exception may include using Terra to work across Public Datasets,
+   but does not extend to working in connection with any data,
+   information, material, documents, or other Content outside of a Public
+   Dataset and the software and tools provided for use with a Public
+   Dataset.
 
-2. Incidental access to Terra as part of a collaboration between a For-Profit Entity and a Non-Profit Entity.
+2. Incidental access to Terra as part of a collaboration between a
+   For-Profit Entity and a Non-Profit Entity.
 
 And/or
 
-3. If either Microsoft or Verily has approved you or your company to have an evaluation license, the limited use of Terra under these Terms for the sole purpose of evaluating whether to enter into a Commercial Agreement.
+3. If either Microsoft or Verily has approved you or your company
+   to have an evaluation license, the limited use of Terra under these
+   Terms for the sole purpose of evaluating whether to enter into a
+   Commercial Agreement.
 
-**Your Conduct.** Don’t misuse Terra. You may use Terra only as permitted by Law, including applicable export and re-export control laws and regulations, and in accordance with the Acceptable Use Policy. You are responsible for your conduct and your Content Connected to Terra. By accessing Terra, you acknowledge and agree that we may monitor your conduct, your use of Terra, and your Content to filter spam, viruses, and other malware, ensure interoperability, fix bugs and resolve problems, ensure compliance with these Terms, the Acceptable Use Policy, Customer Security Requirements, and Law, provide you with help desk services and support, and that our understanding of the way Users interact with Terra may be used to improve Terra. This analysis may occur when you Connect Content to Terra or access Content Connected to Terra. We may Remove or refuse to display Content that we reasonably believe is spam, viruses, or other malware, not interoperable, not in compliance with these Terms, the Acceptable Use Policy, Customer Security Requirements, or Law, or is used outside of a restriction on its use. If you request technical support, we may also use eyes on monitoring to provide you with such technical support. When using or accessing Content other than your Content, you agree to comply with all restrictions and controls imposed by the owner of that Content. Within Terra workspaces and repositories, owners have the ability to allow other users access, or remove and exclude users entirely. Further, for those granted access to a workspace or repository, the owner can assign roles that limit access and use rights in a range of ways and revoke access previously granted. Note, though, that where you have previously granted access, and allowed others to acquire copies of your Content or related Metadata, your revocation of future access will not pull back or retrieve Content or Metadata in the hands of others through previously granted access. Finally an owner may impose terms or restrictions through separate agreements with users. You may not access any data through Terra, or make any use of Terra functionality, other than access and use authorized by the owners, and may not try to defeat, disable, or otherwise avoid any technical mechanisms deployed within Terra to maintain or enforce any limitations on access or use.
+**Your Conduct.** Don’t misuse Terra. You may use Terra only as
+permitted by Law, including applicable export and re-export control laws
+and regulations, and in accordance with the Acceptable Use Policy. You
+are responsible for your conduct and your Content Connected to Terra. By
+accessing Terra, you acknowledge and agree that we may monitor your
+conduct, your use of Terra, and your Content to filter spam, viruses,
+and other malware, ensure interoperability, fix bugs and resolve
+problems, ensure compliance with these Terms, the Acceptable Use Policy,
+Customer Security Requirements, and Law, provide you with help desk
+services and support, and that our understanding of the way Users
+interact with Terra may be used to improve Terra. This analysis may
+occur when you Connect Content to Terra or access Content Connected to
+Terra. We may Remove or refuse to display Content that we reasonably
+believe is spam, viruses, or other malware, not interoperable, not in
+compliance with these Terms, the Acceptable Use Policy, Customer
+Security Requirements, or Law, or is used outside of a restriction on
+its use. If you request technical support, we may also use eyes on
+monitoring to provide you with such technical support. When using or
+accessing Content other than your Content, you agree to comply with all
+restrictions and controls imposed by the owner of that Content. Within
+Terra workspaces and repositories, owners have the ability to allow
+other users access, or remove and exclude users entirely. Further, for
+those granted access to a workspace or repository, the owner can assign
+roles that limit access and use rights in a range of ways and revoke
+access previously granted. Note, though, that where you have previously
+granted access, and allowed others to acquire copies of your Content or
+related Metadata, your revocation of future access will not pull back or
+retrieve Content or Metadata in the hands of others through previously
+granted access. Finally an owner may impose terms or restrictions
+through separate agreements with users. You may not access any data
+through Terra, or make any use of Terra functionality, other than access
+and use authorized by the owners, and may not try to defeat, disable, or
+otherwise avoid any technical mechanisms deployed within Terra to
+maintain or enforce any limitations on access or use.
 
-**Your Terra Account.** In order to use Terra, you will need to register for a Terra account using an account from a Compatible Cloud. You may not access Terra using group or shared accounts. The credentials used for authenticating to Terra must belong to a single individual and only that individual may use those credentials. To protect your Terra account, keep your password confidential. You are responsible for the activity that happens on or through your Terra account. Try not to reuse your Terra account password on third-party applications. If you learn of any unauthorized use of your password or Terra account, contact us immediately.
+**Your Terra Account.** In order to use Terra, you will need to register
+for a Terra account using an account from a Compatible Cloud. You may
+not access Terra using group or shared accounts. The credentials used
+for authenticating to Terra must belong to a single individual and only
+that individual may use those credentials. To protect your Terra
+account, keep your password confidential. You are responsible for the
+activity that happens on or through your Terra account. Try not to reuse
+your Terra account password on third-party applications. If you learn of
+any unauthorized use of your password or Terra account, contact us
+immediately.
 
-**Accessing a Government Website.** To the extent you have selected research data from certain U.S. Government sources, you acknowledge that the following terms apply: (1) Users are accessing a U.S. Government information system; (2) Information system usage may be monitored, recorded and subject to audit; (3) Unauthorized use of the information system is prohibited and subject to criminal and civil penalties; and (4) Use of the information system indicates consent to monitoring and recording.
+**Accessing a Government Website.** To the extent you have selected
+research data from certain U.S. Government sources, you acknowledge that
+the following terms apply: (1) Users are accessing a U.S. Government
+information system; (2) Information system usage may be monitored,
+recorded and subject to audit; (3) Unauthorized use of the information
+system is prohibited and subject to criminal and civil penalties; and
+(4) Use of the information system indicates consent to monitoring and
+recording.
 
-**Terra Security Requirements.** To use Terra, you must comply with any and all security requirements that we make available at [https://terra.bio/resources/security/](https://terra.bio/resources/security/) or such other location as we may notify you of, including in the Customer Security Requirements. Users must ensure that your Web browsers use Transport Layer Security (TLS) 1.2 (or higher). SSL and TLS must use a minimum of 256-bit encryption.
+**Terra Security Requirements.** To use Terra, you must comply with any
+and all security requirements that we make available at
+<https://terra.bio/resources/security/> or such other location as we may
+notify you of, including in the Customer Security Requirements. Users
+must ensure that your Web browsers use Transport Layer Security (TLS)
+1.2 (or higher). SSL and TLS must use a minimum of 256-bit encryption.
 
-**Announcements.** In connection with your use of Terra, we may send you service announcements, administrative messages, and other information. You may opt out of some of these communications.
+**Announcements.** In connection with your use of Terra, we may send you
+service announcements, administrative messages, and other information.
+You may opt out of some of these communications.
 
-**Retained Rights.** Using Terra does not give you ownership of any intellectual property rights in Terra or the Content you access. You may not use Content Connected to Terra unless you obtain permission from its owner or are otherwise permitted by Law. These Terms do not grant you the right to use any branding or logos used in Terra. Don’t remove, obscure, or alter any marks, designations, or legal notices displayed in or along with Terra.
+**Retained Rights.** Using Terra does not give you ownership of any
+intellectual property rights in Terra or the Content you access. You may
+not use Content Connected to Terra unless you obtain permission from its
+owner or are otherwise permitted by Law. These Terms do not grant you
+the right to use any branding or logos used in Terra. Don’t remove,
+obscure, or alter any marks, designations, or legal notices displayed in
+or along with Terra.
 
-**Age Restrictions.** In order to use Terra you must be 18 years of age or older, unless you are accessing Terra in connection with your activities using your account authorized by a Non-Profit Entity, in which case you must be 16 years of age or older.
+**Age Restrictions.** In order to use Terra you must be 18 years of age
+or older, unless you are accessing Terra in connection with your
+activities using your account authorized by a Non-Profit Entity, in
+which case you must be 16 years of age or older.
 
-**No Medical Advice.** Terra does not provide medical advice. All Content Connected to Terra is for informational purposes only and is not a substitute for professional medical advice or treatment. Always seek the advice of your physician or other qualified health provider with any questions you may have regarding your health. Never disregard professional medical advice or delay in seeking it because of something you have read on Terra. If you think you may have a medical emergency, call your doctor or 911 immediately. We do not recommend or endorse any specific tests, physicians, products, procedures, opinions, or other information that may be mentioned on Terra. Reliance on any information provided by us, available on Terra, or by other Users is solely at your own risk.
+**No Medical Advice.** Terra does not provide medical advice. All
+Content Connected to Terra is for informational purposes only and is not
+a substitute for professional medical advice or treatment. Always seek
+the advice of your physician or other qualified health provider with any
+questions you may have regarding your health. Never disregard
+professional medical advice or delay in seeking it because of something
+you have read on Terra. If you think you may have a medical emergency,
+call your doctor or 911 immediately. We do not recommend or endorse any
+specific tests, physicians, products, procedures, opinions, or other
+information that may be mentioned on Terra. Reliance on any information
+provided by us, available on Terra, or by other Users is solely at your
+own risk.
 
 ## 3. Content
 
-**Your Content.** Terra enables you to Connect and access Content. You are never required to Connect Content to Terra. You retain ownership of any intellectual property rights that you hold in that Content. You control who can access your Content Connected to Terra. Your Content will never be shared through Terra with any other User in violation of the access restrictions and assigned roles you establish for your Content.
+**Your Content.** Terra enables you to Connect and access Content. You
+are never required to Connect Content to Terra. You retain ownership of
+any intellectual property rights that you hold in that Content. You
+control who can access your Content Connected to Terra. Your Content
+will never be shared through Terra with any other User in violation of
+the access restrictions and assigned roles you establish for your
+Content.
 
-**Permitted Uses**.
+**Permitted Uses.** When you Connect Content to Terra, you give us a non-exclusive,
+royalty-free, worldwide license to use that Content for the limited
+purposes of (a) providing Terra and the Content Connected to Terra to
+you, (b) providing support to you in connection with your use of and
+access to Terra, (c) making your Content available to other Users
+authorized by you via Terra’s functionality for such purpose and
+supporting such access and use, each in accordance with the restrictions
+and roles established by you, (d) using Metadata to maintain, test and
+improve Terra, and (e) to comply with any Law. The license to your
+Metadata (but not your Content itself) continues even if you stop using
+Terra or Remove your Content. Your revocation of access previously
+granted to one or more users will cut off future access of those users
+to your Content through the accounts you control. If, though, you have
+previously permitted other users to copy Content to their own accounts,
+your revocation of access will not pull back the copied Content. Those
+users may have ongoing access to the copies you have previously
+permitted, and this use will be permitted under this license. We will
+never let any third party (other than a third party we engage to
+exercise our rights under these Terms, including operating Terra) access
+your Content without your permission, and will never access or use your
+Content (including letting our employees and other representatives
+access your Content) for any purpose not allowed by these Terms without
+a separate agreement between you and us. You agree that we may engage
+third parties to exercise our rights under these Terms, including
+operating Terra.
 
-When you Connect Content to Terra, you give us a non-exclusive, royalty-free, worldwide license to use that Content for the limited purposes of (a) providing Terra and the Content Connected to Terra to you, (b) providing support to you in connection with your use of and access to Terra, (c) making your Content available to other Users authorized by you via Terra’s functionality for such purpose and supporting such access and use, each in accordance with the restrictions and roles established by you, (d) using Metadata to maintain, test and improve Terra, and (e) to comply with any Law. The license to your Metadata (but not your Content itself) continues even if you stop using Terra or Remove your Content. Your revocation of access previously granted to one or more users will cut off future access of those users to your Content through the accounts you control. If, though, you have previously permitted other users to copy Content to their own accounts, your revocation of access will not pull back the copied Content. Those users may have ongoing access to the copies you have previously permitted, and this use will be permitted under this license. We will never let any third party (other than a third party we engage to exercise our rights under these Terms, including operating Terra) access your Content without your permission, and will never access or use your Content (including letting our employees and other representatives access your Content) for any purpose not allowed by these Terms without a separate agreement between you and us. You agree that we may engage third parties to exercise our rights under these Terms, including operating Terra.
+Terra provides certain functionality that will allow You to restrict
+access to workspaces and repositories, and, within a workspace or
+repository, assign Users roles that may have limited access to data or
+certain functionalities. You are solely responsible for the
+configuration, setting and use of these functionalities. Terra will not
+manage, review or otherwise correct any errors You may make in how these
+functionalities are configured, set or used. You are also responsible
+for ensuring you have the rights to Connect your Content, share your
+Content with any Users, and allow Users to access or use your Content in
+accordance with any applicable regulation, any contractual or other
+legal duties you may have, and in compliance with any proprietary rights
+any third parties may have in your Content. Finally, You are responsible
+for keeping backups of your Content. We take no responsibility for your
+Content and do not and will not provide any back-up, archive, or
+restoration functionality.
 
-Terra provides certain functionality that will allow You to restrict access to workspaces and repositories, and, within a workspace or repository, assign Users roles that may have limited access to data or certain functionalities. You are solely responsible for the configuration, setting and use of these functionalities. Terra will not manage, review or otherwise correct any errors You may make in how these functionalities are configured, set or used. You are also responsible for ensuring you have the rights to Connect your Content, share your Content with any Users, and allow Users to access or use your Content in accordance with any applicable regulation, any contractual or other legal duties you may have, and in compliance with any proprietary rights any third parties may have in your Content. Finally, You are responsible for keeping backups of your Content. We take no responsibility for your Content and do not and will not provide any back-up, archive, or restoration functionality.
+We have no obligation to review Content Connected to Terra, so please
+don’t assume that we do. We understand the importance of the
+confidentiality of your Content, including where applicable that your
+Content may be protected by law, such as by a Certificate of
+Confidentiality. If no exception at Law (for example, a Certificate of
+Confidentiality) applies, and we determine we are required by Law to do
+so, we may make any Content Connected to Terra available to a court,
+regulatory agency, or other government entity, including in connection
+with subpoenas, investigations, inquiries, examinations, or audits.
+Where the Law permits, we will use reasonable efforts to notify you
+before making any Content available to a court, agency or other
+government entity.
 
-We have no obligation to review Content Connected to Terra, so please don’t assume that we do. We understand the importance of the confidentiality of your Content, including where applicable that your Content may be protected by law, such as by a Certificate of Confidentiality. If no exception at Law (for example, a Certificate of Confidentiality) applies, and we determine we are required by Law to do so, we may make any Content Connected to Terra available to a court, regulatory agency, or other government entity, including in connection with subpoenas, investigations, inquiries, examinations, or audits. Where the Law permits, we will use reasonable efforts to notify you before making any Content available to a court, agency or other government entity.
+**Feedback.** We welcome you to provide ideas, suggestions, and other
+feedback about Terra! There is no requirement that you provide us any
+feedback. If you do provide any ideas, suggestions, or other feedback
+about Terra, you grant us a perpetual, irrevocable, royalty-free,
+sublicensable, transferable, non-exclusive, worldwide right and license
+to use that feedback for any lawful purposes.
 
-**Feedback. **We welcome you to provide ideas, suggestions, and other feedback about Terra! There is no requirement that you provide us any feedback. If you do provide any ideas, suggestions, or other feedback about Terra, you grant us a perpetual, irrevocable, royalty-free, sublicensable, transferable, non-exclusive, worldwide right and license to use that feedback for any lawful purposes.
+**Terra Community Forum.** You may use your Terra account to access the
+Terra Community Forum. By accessing the Terra Community Forum you agree
+that the Terra Community Guidelines will cover your use of the Terra
+Community Forum
 
-**Terra Community Forum**. You may use your Terra account to access the Terra Community Forum. By accessing the Terra Community Forum you agree that the Terra Community Guidelines will cover your use of the Terra Community Forum
+**External Links, Third Party Products and Services.** Your use of Terra
+is possible using repositories and computing resources of third party
+services, including as may be offered by The Broad institute, Microsoft
+Verily or their respective affiliates. In addition, Terra may provide
+links that are maintained or controlled by external organizations. The
+listing of links are not an endorsement of information, products, or
+services, and do not imply a direct association between Terra and the
+operators of the outside resource links. Products and services that
+provide additional services or functions for use with Terra (including
+from The Broad Institute, Microsoft and Verily) are made available under
+a separate agreement. Your use of such additional products and services
+is subject to those separate agreements.
 
-**External Links, Third Party Products and Services**. Your use of Terra is possible using repositories and computing resources of third party services, including as may be offered by The Broad institute, Microsoft Verily or their respective affiliates. In addition, Terra may provide links that are maintained or controlled by external organizations. The listing of links are not an endorsement of information, products, or services, and do not imply a direct association between Terra and the operators of the outside resource links. Products and services that provide additional services or functions for use with Terra (including from The Broad Institute, Microsoft and Verily) are made available under a separate agreement. Your use of such additional products and services is subject to those separate agreements.
+If you access Terra using your Azure account, you must enter into a
+separate agreement for Azure. Microsoft makes Azure available directly
+and through Microsoft Cloud Solution Providers. Your use of Azure is
+always subject to the Microsoft Universal License Terms for Online
+Services. Your agreements with Microsoft, and not these Terms, will
+apply to your use of Azure. Microsoft and Azure are registered
+trademarks of Microsoft Corporation. All rights reserved.
 
-If you access Terra using your Azure account, you must enter into a separate agreement for Azure. Microsoft makes Azure available directly and through Microsoft Cloud Solution Providers. Your use of Azure is always subject to the Microsoft Universal License Terms for Online Services. Your agreements with Microsoft, and not these Terms, will apply to your use of Azure. Microsoft and Azure are registered trademarks of Microsoft Corporation. All rights reserved.
+If you access Terra using your Google Cloud Platform account, the terms
+of your separate agreement for Google Cloud Platform will apply to your
+use of Google Cloud Platform. Your agreements with Google or an
+authorized reseller of Google Cloud Platform services, and not these
+Terms, will apply to your use of GCP. Verily is a registered trademark
+of Verily Life Sciences LLC. All rights reserved.
 
-If you access Terra using your Google Cloud Platform account, the terms of your separate agreement for Google Cloud Platform will apply to your use of Google Cloud Platform. Your agreements with Google or an authorized reseller of Google Cloud Platform services, and not these Terms, will apply to your use of GCP. Verily is a registered trademark of Verily Life Sciences LLC. All rights reserved.
-
-**Customized Features from Partners.** Some Users are also collaborators with whom The Broad Institute works to develop custom experiences that leverage the Terra system infrastructure. Depending on the features, the Users providing customized features may have additional responsibilities, and additional terms or agreements may be required to deploy or use such features.
+**Customized Features from Partners.** Some Users are also collaborators
+with whom The Broad Institute works to develop custom experiences that
+leverage the Terra system infrastructure. Depending on the features, the
+Users providing customized features may have additional
+responsibilities, and additional terms or agreements may be required to
+deploy or use such features.
 
 ## 4. Privacy Protection
 
-Our Privacy Policy explains how we treat your personal data and protect your privacy when you use Terra. Any information submitted on Terra is subject to our Privacy Policy, the terms of which are incorporated herein by this reference. Please review our [Privacy Policy](https://app.terra.bio/#privacy) to understand our practices. By using Terra, you have read, understood, and agree to the terms of the Privacy Policy, and you agree that we may retrieve, use, and disclose your personal data in accordance with the Privacy Policy.
+Our Privacy Policy explains how we treat your personal data and protect
+your privacy when you use Terra. Any information submitted on Terra is
+subject to our Privacy Policy, the terms of which are incorporated
+herein by this reference. Please review our [Privacy
+Policy](https://terra.bio/about/privacy/) to understand our practices.
+By using Terra, you have read, understood, and agree to the terms of the
+Privacy Policy, and you agree that we may retrieve, use, and disclose
+your personal data in accordance with the Privacy Policy.
 
-To the extent you access Terra using an Azure account, Microsoft processes your personal data in Azure as described in the [Microsoft Universal License Terms for Online Services](https://www.microsoft.com/licensing/terms/product/ForOnlineServices/all), including, as applicable, the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement).
+To the extent you access Terra using an Azure account, Microsoft
+processes your personal data in Azure as described in the Microsoft
+Universal License Terms for Online Services, including, as applicable,
+the <u>Microsoft Privacy Statement</u>.
 
-To the extent you access Terra using a Google Cloud Platform account, the terms of your separate agreement with Google will apply to the processing of your personal data in Google Cloud Platform. To the extent you access Terra through a Verily product or offering, the terms of your separate agreement with Verily will apply to the processing of your personal data through such Verily product or offering.
+To the extent you access Terra using a Google Cloud Platform account,
+the terms of your separate agreement with Google will apply to the
+processing of your personal data in Google Cloud Platform. To the extent
+you access Terra through a Verily product or offering, the terms of your
+separate agreement with Verily will apply to the processing of your
+personal data through such Verily product or offering.
 
-**Compliance with Data Protection Laws** You may not use Terra to Connect Content that includes PHI. You will anonymize or pseudonymize data prior to Connecting it to Terra. To the extent not prohibited by Law, you further agree to indemnify and hold harmless us, Microsoft, and Verily from any and all claims, demands, losses, causes of action, damage, lawsuits, judgments, including attorneys' fees and costs, arising out of or relating to your Connecting Content that includes PHI or personal data to Terra in violation of these Terms.
+**Compliance with Data Protection Laws.** You may not use Terra to
+Connect Content that includes PHI. You will anonymize or pseudonymize
+data prior to Connecting it to Terra. To the extent not prohibited by
+Law, you further agree to indemnify and hold harmless us, Microsoft, and
+Verily from any and all claims, demands, losses, causes of action,
+damage, lawsuits, judgments, including attorneys' fees and costs,
+arising out of or relating to your Connecting Content that includes PHI
+or personal data to Terra in violation of these Terms.
 
-To the extent you Connect or access Content in Terra that is protected under GDPR, you and we agree that the Data Protection Addendum describes how we are processing any applicable personal data included in your Content.
+To the extent you Connect or access Content in Terra that is protected
+under GDPR, you and we agree that the Data Protection Addendum describes
+how we are processing any applicable personal data included in your
+Content.
 
 ## 5. Copyright Protection
 
-We respond to notices of alleged copyright infringement and terminate accounts of repeat infringers according to the process set out in the U.S. Digital Millennium Copyright Act and related regulations, as updated from time to time.
+We respond to notices of alleged copyright infringement and terminate
+accounts of repeat infringers according to the process set out in the
+U.S. Digital Millennium Copyright Act and related regulations, as
+updated from time to time.
 
-We provide information to help copyright holders manage their intellectual property online. If you think somebody is violating your copyrights and want to notify us, please review the Copyright Policies & Procedures.
+We provide information to help copyright holders manage their
+intellectual property online. If you think somebody is violating your
+copyrights and want to notify us, please review the Copyright Policies &
+Procedures.
 
 ## 6. Software and Tools
 
-Terra has been developed and is available under an open source license and is intended to be interoperable with Compatible Clouds. In addition to the foundational open code, we may make various software and tools available through Terra. We may add, change, or remove such software and tools at any time in our sole discretion. Subject to any other applicable terms and conditions, we give you a personal, worldwide, royalty-free, non-assignable and non-exclusive license to use these tools. Third parties may also provide software and tools for use with Terra, and your use of such third party tools is subject to the terms on which they are made available.
+Terra has been developed and is available under an open source license
+and is intended to be interoperable with Compatible Clouds. In addition
+to the foundational open code, we may make various software and tools
+available through Terra. We may add, change, or remove such software and
+tools at any time in our sole discretion. Subject to any other
+applicable terms and conditions, we give you a personal, worldwide,
+royalty-free, non-assignable and non-exclusive license to use these
+tools. Third parties may also provide software and tools for use with
+Terra, and your use of such third party tools is subject to the terms on
+which they are made available.
 
-Some third party incorporated software used in Terra may be offered under open source licenses. We will make the terms of those licenses available to you. There may be provisions in the open source license that expressly override some of these Terms only with regard to the specific software associated with such provisions. To the extent not permitted under the applicable open source license, you may not copy, modify, distribute, sell, or lease any part of Terra or included tools, nor may you reverse engineer or attempt to extract the source code of those tools, unless Laws prohibit those restrictions or you have our written permission.
+Some third party incorporated software used in Terra may be offered
+under open source licenses. We will make the terms of those licenses
+available to you. There may be provisions in the open source license
+that expressly override some of these Terms only with regard to the
+specific software associated with such provisions. To the extent not
+permitted under the applicable open source license, you may not copy,
+modify, distribute, sell, or lease any part of Terra or included tools,
+nor may you reverse engineer or attempt to extract the source code of
+those tools, unless Laws prohibit those restrictions or you have our
+written permission.
 
 ## 7. Modifying and Terminating Use of Terra
 
-**Changes to Terra.** While we have no obligation to maintain or update Terra, we are constantly changing and improving Terra. We may make performance or security improvements, change functionalities or features, or make changes to comply with Law or to prevent illegal activities on, or abuse of, our systems. Your continued use of Terra constitutes acceptance of any updates to these Terms. There may be times when we will need to make changes to Terra without giving notice. These will be limited to instances where we need to take action to ensure the security and operability of the service, prevent abuse or where we must act to meet legal requirements.
+**Changes to Terra.** While we have no obligation to maintain or update
+Terra, we are constantly changing and improving Terra. We may make
+performance or security improvements, change functionalities or
+features, or make changes to comply with Law or to prevent illegal
+activities on, or abuse of, our systems. Your continued use of Terra
+constitutes acceptance of any updates to these Terms. There may be times
+when we will need to make changes to Terra without giving notice. These
+will be limited to instances where we need to take action to ensure the
+security and operability of the service, prevent abuse or where we must
+act to meet legal requirements.
 
-**Suspension and Termination.** You can stop using Terra at any time, although we’ll be sad to see you go. You may Remove your Content at any time. We may suspend or permanently disable your access to Terra without notice for any reason in our sole discretion, including if: (1) you materially or repeatedly violate these Terms or the Acceptable Use Policy or Customer Security Requirements; or (2) you are using Terra in a manner that could cause us legal liability.
+**Suspension and Termination.** You can stop using Terra at any time,
+although we’ll be sad to see you go. You may Remove your Content at any
+time. We may suspend or permanently disable your access to Terra without
+notice for any reason in our sole discretion, including if: (1) you
+materially or repeatedly violate these Terms or the Acceptable Use
+Policy or Customer Security Requirements; or (2) you are using Terra in
+a manner that could cause us legal liability.
 
-If we suspend or disable your access to Terra, we have no obligation to return your Content to you, and may Remove your Content in our sole discretion.
+If we suspend or disable your access to Terra, we have no obligation to
+return your Content to you, and may Remove your Content in our sole
+discretion.
 
-**Discontinuation of Terra.** If we decide to discontinue Terra we will give you reasonable notice based on the circumstances, but may not be able to provide advance notice if we are required or advised to immediately discontinue Terra. During any advance notice period (if any), you will have the opportunity to Remove your Content from Terra. After the end of this advance notice (if any) period you will not be able to access your Content through Terra.
+**Discontinuation of Terra.** If we decide to discontinue Terra we will
+give you reasonable notice based on the circumstances, but may not be
+able to provide advance notice if we are required or advised to
+immediately discontinue Terra. During any advance notice period (if
+any), you will have the opportunity to Remove your Content from Terra.
+After the end of this advance notice (if any) period you will not be
+able to access your Content through Terra.
 
 ## 8. Our Warranties and Disclaimers
 
-We operate Terra using a reasonable level of skill and care and we hope that you will enjoy using Terra. But there are certain things that we don’t promise about Terra, including that Terra will change in any way or not change in any way. Other than as expressly stated, we do not make any commitments about the specific form, features, or functionality available through Terra, its reliability, availability, or ability to meet your needs. We may change the form, features, or functionality of Terra at any time in our sole discretion.
+We operate Terra using a reasonable level of skill and care and we hope
+that you will enjoy using Terra. But there are certain things that we
+don’t promise about Terra, including that Terra will change in any way
+or not change in any way. Other than as expressly stated, we do not make
+any commitments about the specific form, features, or functionality
+available through Terra, its reliability, availability, or ability to
+meet your needs. We may change the form, features, or functionality of
+Terra at any time in our sole discretion.
 
-# 9. Liability for Terra; Disclaimers and Limitations
+**9. Liability for Terra; Disclaimers and Limitations**
 
-You expressly understand and agree that your use of Terra, or any Content Connected to Terra, is at your own risk. We do not warrant that your access to Terra will be uninterrupted, problem-free, free of omissions, or error-free; nor make any warranty as to the results that may be obtained from Terra. We do not warrant that Terra or any Content Connected to Terra is safe to use or free from viruses or other malware. When you access Terra, your systems may be exposed to cybersecurity threats, including viruses and other malware. ALL PRODUCTS AND SERVICES OFFERED THROUGH TERRA ARE MADE AVAILABLE “AS IS” AND WE MAKE NO REPRESENTATIONS OF ANY KIND AS TO THE OPERATION OR USE OF TERRA. IN ADDITION WE SPECIFICALLY DISCLAIM ANY REPRESENTATION OR WARRANTY THAT SUCH PRODUCTS OR SERVICES WILL BE OR OPERATE IN A FASHION THAT IS ERROR FREE, BE AVAILABLE OR ‘UP’ AT ANY TIME, OR WILL OPERATE IN A FASHION THAT IS FIT FOR ANY SPECIFIC RESEARCH OR COMMERCIAL APPLICATION.
+You expressly understand and agree that your use of Terra, or any
+Content Connected to Terra, is at your own risk. We do not warrant that
+your access to Terra will be uninterrupted, problem-free, free of
+omissions, or error-free; nor make any warranty as to the results that
+may be obtained from Terra. We do not warrant that Terra or any Content
+Connected to Terra is safe to use or free from viruses or other malware.
+When you access Terra, your systems may be exposed to cybersecurity
+threats, including viruses and other malware. ALL PRODUCTS AND SERVICES
+OFFERED THROUGH TERRA ARE MADE AVAILABLE “AS IS” AND WE MAKE NO
+REPRESENTATIONS OF ANY KIND AS TO THE OPERATION OR USE OF TERRA. IN
+ADDITION WE SPECIFICALLY DISCLAIM ANY REPRESENTATION OR WARRANTY THAT
+SUCH PRODUCTS OR SERVICES WILL BE OR OPERATE IN A FASHION THAT IS ERROR
+FREE, BE AVAILABLE OR ‘UP’ AT ANY TIME, OR WILL OPERATE IN A FASHION
+THAT IS FIT FOR ANY SPECIFIC RESEARCH OR COMMERCIAL APPLICATION.
 
-In no event will we be liable for the incidental, indirect, special, punitive, exemplary, or consequential damages, arising out of your use of or inability to use Terra, including loss of revenue or anticipated profits, loss of goodwill, loss of data, computer failure or malfunction, or any and all other damages.
+In no event will we be liable for the incidental, indirect, special,
+punitive, exemplary, or consequential damages, arising out of your use
+of or inability to use Terra, including loss of revenue or anticipated
+profits, loss of goodwill, loss of data, computer failure or
+malfunction, or any and all other damages.
 
-The total liability of us and our suppliers and distributors to you, for any claims arising from or related to your use of Terra, including claims for breach of any express or implied warranties, is limited to the amount (if any) you paid us to use Terra during the twelve-month period immediately preceding the time of the claim. If you did not pay us any amount for the use of Terra during the twelve-month period immediately preceding the time of the claim, then the total liability of us and our suppliers and distributors to you for claims arising from or related to your use of Terra is limited to one hundred ($100) dollars.
+The total liability of us and our suppliers and distributors to you, for
+any claims arising from or related to your use of Terra, including
+claims for breach of any express or implied warranties, is limited to
+the amount (if any) you paid us to use Terra during the twelve-month
+period immediately preceding the time of the claim. If you did not pay
+us any amount for the use of Terra during the twelve month period
+immediately preceding the time of the claim, then the total liability of
+us and our suppliers and distributors to you for claims arising from or
+related to your use of Terra is limited to one hundred (\$100) dollars.
 
-Nothing in these Terms is intended to exclude or limit our liability, or that of our suppliers and distributors, for death or personal injury, fraud, fraudulent misrepresentation or any liability that cannot be excluded by Law.
+Nothing in these Terms is intended to exclude or limit our liability, or
+that of our suppliers and distributors, for death or personal injury,
+fraud, fraudulent misrepresentation or any liability that cannot be
+excluded by Law.
 
-Microsoft and Verily, who are development collaborators with the Broad Institute for Terra, and, in the case of Microsoft, a cloud service provider of one of the Compatible Clouds you may use with Terra, do not operate this version of Terra and do not make any warranties (whether express, implied or statutory) regarding Terra or Content Connected to Terra. In no event will Microsoft and/or Verily be responsible for any direct, incidental, indirect, special, punitive, exemplary, or consequential damages, arising out of your use of or inability to use Terra.
+Microsoft and Verily, who are development collaborators with the Broad
+Institute for Terra, and, in the case of Microsoft, a cloud service
+provider of one of the Compatible Clouds you may use with Terra, do not
+operate this version of Terra and do not make any warranties (whether
+express, implied or statutory) regarding Terra or Content Connected to
+Terra. In no event will Microsoft and/or Verily be responsible for any
+direct, incidental, indirect, special, punitive, exemplary, or
+consequential damages, arising out of your use of or inability to use
+Terra.
 
-## 10. Indemnification
+**10. Indemnification**
 
-To the extent permitted by Law, you agree to fully defend, indemnify and hold us, Microsoft, and Verily harmless from any third party claims arising from your use of Terra, including any claim arising from the Connecting or accessing of Content. Neither we, nor Microsoft or Verily, agree to indemnify you.
+To the extent permitted by Law, you agree to fully defend, indemnify and
+hold us, Microsoft, and Verily harmless from any third party claims
+arising from your use of Terra, including any claim arising from the
+Connecting or accessing of Content. Neither we, nor Microsoft or Verily,
+agree to indemnify you.
 
-## 11. Laws Governing these Terms
+**11. Laws Governing these Terms.**
 
-The laws of the Commonwealth of Massachusetts, U.S.A., excluding Massachusetts’s conflict of laws rules, will apply to any disputes arising out of or relating to these Terms or Terra.
+The laws of the Commonwealth of Massachusetts, U.S.A., excluding
+Massachusetts’s conflict of laws rules, will apply to any disputes
+arising out of or relating to these Terms or Terra.
 
-We reserve the right to seek temporary or preliminary injunctive relief (or an equivalent type of urgent legal relief) in any jurisdiction. You waive the right to seek any equitable or legal remedies to restrain the operation of Terra. The Terra [website](https://app.terra.bio) will provide contact information for our designated agent for notifications under these Terms or delivery of service of process.
+We reserve the right to seek temporary or preliminary injunctive relief
+(or an equivalent type of urgent legal relief) in any jurisdiction. You
+waive the right to seek any equitable or legal remedies to restrain the
+operation of Terra. The Terra [website](https://terra.bio/) will provide
+contact information for our designated agent for notifications under
+these Terms or delivery of service of process.
 
-In the event of a dispute arising from your use of Terra, you and we agree that we will first contact each other in an attempt to informally resolve the dispute. If the dispute is not resolved, then either you or we may submit the dispute to binding arbitration. You and we will mutually agree on a qualified arbitrator who will conduct the arbitration solely by telephone, online, or based on written submissions without any personal appearances by any parties or witnesses unless mutually agreed.
+In the event of a dispute arising from your use of Terra, you and we
+agree that we will first contact each other in an attempt to informally
+resolve the dispute. If the dispute is not resolved, then either you or
+we may submit the dispute to binding arbitration. You and we will
+mutually agree on a qualified arbitrator who will conduct the
+arbitration solely by telephone, online, or based on written submissions
+without any personal appearances by any parties or witnesses unless
+mutually agreed.
 
-Any judgment on the award rendered by the arbitrator will be binding on both you and us, final and unappealable and may be entered in any court of competent jurisdiction. The prevailing party will be entitled to recover its fees and costs incurred in connection with the arbitration, including reasonable attorneys’ fees. You acknowledge and accept these dispute resolution measures, and waive all right to litigate any disputes arising from these Terms in court, including waiver of any right to a jury trial or to participate in a class action suit against us.
+Any judgment on the award rendered by the arbitrator will be binding on
+both you and us, final and unappealable and may be entered in any court
+of competent jurisdiction. The prevailing party will be entitled to
+recover its fees and costs incurred in connection with the arbitration,
+including reasonable attorneys’ fees. You acknowledge and accept these
+dispute resolution measures, and waive all right to litigate any
+disputes arising from these Terms in court, including waiver of any
+right to a jury trial or to participate in a class action suit against
+us.
 
-## 12. About these Terms
+**12. About these Terms**
 
-We may modify these Terms, the Acceptable Use Policy, the Customer Security Requirements or any additional terms that apply to Terra or your use of Terra, for any reason, including to reflect changes to Terra or Laws or to enable us to meet our obligations. Any change to these Terms will be effective immediately upon our posting notice unless we state otherwise. You should look at the Terms regularly. We’ll post notice of modifications or additions to the Terms in Terra and will post prior notice of material changes to the Terms to you at **???** or such other location as we may notify you of.
+We may modify these Terms, the Acceptable Use Policy, the Customer
+Security Requirements or any additional terms that apply to Terra or
+your use of Terra, for any reason, including to reflect changes to Terra
+or Laws or to enable us to meet our obligations. Any change to these
+Terms will be effective immediately upon our posting notice unless we
+state otherwise. You should look at the Terms regularly. We’ll post
+notice of modifications or additions to the Terms in Terra and will post
+prior notice of material changes to the Terms to you at
+\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+notify you of.
 
-These Terms control the relationship between us and you. Microsoft, Verily, Google LLC, Alphabet Inc. and other entities that are or may become affiliates of the Broad Institute or the foregoing entities are not parties to these Terms, but are intended third party beneficiaries of these Terms, with a right to enforce these Terms directly against you. Otherwise, these Terms do not create any third party beneficiary rights.
+These Terms control the relationship between us and you. Microsoft,
+Verily, Google LLC, Alphabet Inc. and other entities that are or may
+become affiliates of the Broad Institute or the foregoing entities are
+not parties to these Terms, but are intended third party beneficiaries
+of these Terms, with a right to enforce these Terms directly against
+you. Otherwise, these Terms do not create any third party beneficiary
+rights.
 
-If you do not comply with these Terms, and we don’t take action right away, this doesn’t mean that we are waiving or giving up any rights that we may have (such as taking action in the future). If a particular term is not enforceable, this will not affect any other term.
+If you do not comply with these Terms, and we don’t take action right
+away, this doesn’t mean that we are waiving or giving up any rights that
+we may have (such as taking action in the future). If a particular term
+is not enforceable, this will not affect any other term.
 
-## 13. Definitions
+**13. Definitions**
 
-“Acceptable Use Policy” means our Acceptable Use Policy, available at <u>https://terra.bio/about/acceptable use-policy/</u> or such other location as we may notify you of.
+“Acceptable Use Policy” means our Acceptable Use Policy, available at
+<https://terra.bio/about/acceptable-use-policy/> or such other location
+as we may notify you of.
 
-“CCPA” means the California Consumer Protection Act, as amended, and its related regulations. “Cloud Identity” means a Microsoft Identity or Google Identity.
+“CCPA” means the California Consumer Protection Act, as amended, and its
+related regulations.
 
-“Compatible Cloud” means Microsoft Azure, Google Cloud Platform, or other cloud service providers as we may add to or remove from use with Terra at any time in our sole discretion.
+“Cloud Identity” means a Microsoft Identity or Google Identity.
 
-“Commercial Agreement” means a separately executed, legally binding written agreement between you or the entity on whose behalf you are accessing and using Terra (e.g., an enterprise agreement) and Microsoft or Verily, covering (among other things) your use of and access to Terra and your Content.
+“Compatible Cloud” means Microsoft Azure, Google Cloud Platform, or
+other cloud service providers as we may add to or remove from use with
+Terra at any time in our sole discretion.
 
-“Connect” means to connect, submit, share, send, create in or otherwise make Content available through Terra.
+“Commercial Agreement” means a separately executed, legally binding
+written agreement between you or the entity on whose behalf you are
+accessing and using Terra (e.g., an enterprise agreement) and Microsoft
+or Verily, covering (among other things) your use of and access to Terra
+and your Content.
 
-“Content” means any data, information, material, documents, or other content, including any related Metadata. “your Content” means Content that you Connect to Terra. For clarity, Content will not include other copies of the same information that is not Connected to Terra.
+“Connect” means to connect, submit, share, send, create in or otherwise
+make Content available through Terra.
 
-“Copyright Policies & Procedures” means our Copyright Policies & Procedures available at **???** or such other location as we may notify you of.
+“Content” means any data, information, material, documents, or other
+content, including any related Metadata. “your Content” means Content
+that you Connect to Terra. For clarity, Content will not include other
+copies of the same information that is not Connected to Terra.
 
-“Customer Security Requirements” means our Customer Security Requirements available at <u>https://terra.bio/about/customer-security-requirements/ </u>or such other location as we may notify you of.
+“Copyright Policies & Procedures” means our Copyright Policies &
+Procedures available at \[[●](https://app.terra.bio/#privacy)\] or such
+other location as we may notify you of.
 
-“Data Protection Addendum” means our Data Processing Terms available at **???** or such other location as we may notify you of.
+“Customer Security Requirements” means our Customer Security
+Requirements available at
+<https://terra.bio/about/customer-security-requirements/> or such other
+location as we may notify you of.
 
-“For-Profit Entity” means any individual, entity or organization other than a Non-Profit Entity, including any for-profit pharmaceutical, biotechnology, medical device, or food or cosmetics company.
+“Data Protection Addendum” means our Data Processing Terms available at
+\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+notify you of.
 
-“Google Identity” or “Google ID” means any of a gmail account, an organizationally-managed G Suite identity, or a Google Apps identity.
+“For-Profit Entity” means any individual, entity or organization other
+than a Non-Profit Entity, including any for-profit pharmaceutical,
+biotechnology, medical device, or food or cosmetics company.
 
-“HIPAA” means the Health Insurance Portability and Accountability Act of 1996, as amended, and its related regulations.
+“Google Identity” or “Google ID” means any of a gmail account, an
+organizationally-managed G Suite identity, or a Google Apps identity.
 
-“including” means “including, without limitation and without limiting the foregoing.”
+“HIPAA” means the Health Insurance Portability and Accountability Act of
+1996, as amended, and its related regulations.
 
-“Law” means all laws, regulations, court orders, frameworks, guidelines and standards applicable to your use of Terra (including all Content Connected to Terra), including HIPAA, CCPA, the U.S. Computer Fraud and Abuse Act, E.U. General Data Protection Regulation, U.S. Digital Millennium Copyright Act, the National Institute of Standards and Technology Cybersecurity Framework, and any similar laws in any other jurisdictions, any applicable ethical standards, and any applicable informed consent documents. Something is “illegal” if it violates any Law.
+“including” means “including, without limitation and without limiting
+the foregoing.”
 
-“Metadata” means information about a file or data object including the file size, number of rows, number of columns, column labels, and other descriptors that describe the format of the file or data object or about the behavior of a file or data object in a specific computer environment, such as the file’s level of compression or the latency to access, but does not include or mean the content of the file, including but not limited to any genotypic or phenotypic information contained in the Content.
+“Law” means all laws, regulations, court orders, frameworks, guidelines
+and standards applicable to your use of Terra (including all Content
+Connected to Terra), including HIPAA, CCPA, the U.S. Computer Fraud and
+Abuse Act, E.U. General Data Protection Regulation, U.S. Digital
+Millennium Copyright Act, the National Institute of Standards and
+Technology Cybersecurity Framework, and any similar laws in any other
+jurisdictions, any applicable ethical standards, and any applicable
+informed consent documents. Something is “illegal” if it violates any
+Law.
 
-“Microsoft” means Microsoft Corporation, located at One Microsoft Way, Redmond, Washington 98052.
+“Metadata” means information about a file or data object including the
+file size, number of rows, number of columns, column labels, and other
+descriptors that describe the format of the file or data object or about
+the behavior of a file or data object in a specific computer
+environment, such as the file’s level of compression or the latency to
+access, but does not include or mean the content of the file, including
+but not limited to any genotypic or phenotypic information contained in
+the Content.
 
-“Microsoft Identity” means a Microsoft account or an Azure Active Directory account for Microsoft Azure users
+“Microsoft” means Microsoft Corporation, located at One Microsoft Way,
+Redmond, Washington 98052.
 
-“Non-Commercial User” means a Non-Profit Entity (or person acting through or on behalf of a Non-Profit Entity) to the extent that it is carrying out research that does not involve the production or manufacture of products for sale or the offer for sale or performance of commercial services for a fee.
+“Microsoft Identity” means a Microsoft account or an Azure Active
+Directory account for Microsoft Azure users
 
-“Non-Profit Entity” means an entity that is (a) not a for-profit commercial business, such as any for-profit pharmaceutical, biotechnology, medical device, or food or cosmetics company, and (b) (i) if an entity organized in the United States, exempt from U.S. federal income tax under Section 501(a) of the Internal Revenue Code (for example, a 501(c)(3) or 501(c)(4) tax-exempt organization) or (ii) if an entity organized outside of the United States, that has equivalent tax exempt status under other applicable laws or that otherwise operates as a not-for-profit business. Non-Profit Entities may include, by way of example, educational institutions, research institutions, academic medical centers, and government entities that operate as a not-for-profit business.
+“Non-Commercial User” means a Non-Profit Entity (or person acting
+through or on behalf of a Non-Profit Entity) to the extent that it is
+carrying out research that does not involve the production or
+manufacture of products for sale or the offer for sale or performance of
+commercial services for a fee.
+
+“Non-Profit Entity” means an entity that is (a) not a for-profit
+commercial business, such as any for-profit pharmaceutical,
+biotechnology, medical device, or food or cosmetics company, and (b) (i)
+if an entity organized in the United States, exempt from U.S. federal
+income tax under Section 501(a) of the Internal Revenue Code (for
+example, a 501(c)(3) or 501(c)(4) tax-exempt organization) or (ii) if an
+entity organized outside of the United States, that has equivalent tax
+exempt status under other applicable laws or that otherwise operates as
+a not-for-profit business. Non-Profit Entities may include, by way of
+example, educational institutions, research institutions, academic
+medical centers, and government entities that operate as a
+not-for-profit business.
 
 “PHI” means protected health information, as defined in HIPAA.
 
-“Privacy Policy” means our Privacy Policy, available at [https://terra.bio/about/privacy/]() or such other location as we may notify you of.
+“Privacy Policy” means our Privacy Policy, available at
+<https://terra.bio/about/privacy/> or such other location as we may
+notify you of.
 
-“Public Dataset” means those datasets listed at **???** or such other location as we may notify you of. “Remove” means to cause Content to not be Connected to Terra.
+“Public Dataset” means those datasets listed at
+\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+notify you of.
 
-“Terms” means these legally binding Terms of Service, as may be amended by us from time to time. “Terra” means the Terra platform and all associated websites (including terra.bio).
+“Remove” means to cause Content to not be Connected to Terra.
 
+“Terms” means these legally binding Terms of Service, as may be amended
+by us from time to time.
 
-“The Broad Institute” means The Broad Institute, Inc., located at 415 Main St, Cambridge, MA 02142. “User” means any person who has authorized access to Terra, under all applicable terms and requirements.
+“Terra” means the Terra platform and all associated websites (including
+terra.bio).
 
-“you” means the person who accesses Terra under these Terms. If you are accessing or using Terra in your individual capacity, all references to “you” reference you as an individual. If you are accessing or using Terra on behalf of a company or other entity all references to “you” reference both you as an individual and that entity.
+“The Broad Institute” means The Broad Institute, Inc., located at 415
+Main St, Cambridge, MA 02142.
 
-“Verily” means Verily Life Sciences LLC, located at 269 East Grand Avenue, South San Francisco, CA 94080.
+“User” means any person who has authorized access to Terra, under all
+applicable terms and requirements.
 
-“we” “us” and similar terms means The Broad Institute.
+“you” means the person who accesses Terra under these Terms. If you are
+accessing or using Terra in your individual capacity, all references to
+“you” reference you as an individual. If you are accessing or using
+Terra on behalf of a company or other entity all references to “you”
+reference both you as an individual and that entity.
+
+“Verily” means Verily Life Sciences LLC, located at 269 East Grand
+Avenue, South San Francisco, CA 94080.
+
+“we”, “us” and similar terms means The Broad Institute.

--- a/src/main/resources/tos/termsOfService-1.md
+++ b/src/main/resources/tos/termsOfService-1.md
@@ -402,7 +402,7 @@ available through Terra, its reliability, availability, or ability to
 meet your needs. We may change the form, features, or functionality of
 Terra at any time in our sole discretion.
 
-**9. Liability for Terra; Disclaimers and Limitations**
+## 9. Liability for Terra; Disclaimers and Limitations
 
 You expressly understand and agree that your use of Terra, or any
 Content Connected to Terra, is at your own risk. We do not warrant that
@@ -450,7 +450,7 @@ direct, incidental, indirect, special, punitive, exemplary, or
 consequential damages, arising out of your use of or inability to use
 Terra.
 
-**10. Indemnification**
+## 10. Indemnification
 
 To the extent permitted by Law, you agree to fully defend, indemnify and
 hold us, Microsoft, and Verily harmless from any third party claims
@@ -458,7 +458,7 @@ arising from your use of Terra, including any claim arising from the
 Connecting or accessing of Content. Neither we, nor Microsoft or Verily,
 agree to indemnify you.
 
-**11. Laws Governing these Terms.**
+## 11. Laws Governing these Terms.
 
 The laws of the Commonwealth of Massachusetts, U.S.A., excluding
 Massachusetts’s conflict of laws rules, will apply to any disputes
@@ -490,7 +490,7 @@ disputes arising from these Terms in court, including waiver of any
 right to a jury trial or to participate in a class action suit against
 us.
 
-**12. About these Terms**
+## 12. About these Terms
 
 We may modify these Terms, the Acceptable Use Policy, the Customer
 Security Requirements or any additional terms that apply to Terra or
@@ -500,7 +500,7 @@ Terms will be effective immediately upon our posting notice unless we
 state otherwise. You should look at the Terms regularly. We’ll post
 notice of modifications or additions to the Terms in Terra and will post
 prior notice of material changes to the Terms to you at
-<https://support.terra.bio/hc/en-us/sections/4408251025563> or such other location as we may
+<https://app.terra.bio/#terms-of-service> or such other location as we may
 notify you of.
 
 These Terms control the relationship between us and you. Microsoft,
@@ -516,7 +516,7 @@ away, this doesn’t mean that we are waiving or giving up any rights that
 we may have (such as taking action in the future). If a particular term
 is not enforceable, this will not affect any other term.
 
-**13. Definitions**
+## 13. Definitions
 
 “Acceptable Use Policy” means our Acceptable Use Policy, available at
 <https://terra.bio/about/acceptable-use-policy/> or such other location
@@ -546,7 +546,7 @@ that you Connect to Terra. For clarity, Content will not include other
 copies of the same information that is not Connected to Terra.
 
 “Copyright Policies & Procedures” means our Copyright Policies &
-Procedures available at \[[●](https://app.terra.bio/#privacy)\] or such
+Procedures available at <https://support.terra.bio/hc/en-us/sections/4408251025563> or such
 other location as we may notify you of.
 
 “Customer Security Requirements” means our Customer Security

--- a/src/main/resources/tos/termsOfService-1.md
+++ b/src/main/resources/tos/termsOfService-1.md
@@ -500,7 +500,7 @@ Terms will be effective immediately upon our posting notice unless we
 state otherwise. You should look at the Terms regularly. We’ll post
 notice of modifications or additions to the Terms in Terra and will post
 prior notice of material changes to the Terms to you at
-\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+<https://support.terra.bio/hc/en-us/sections/4408251025563> or such other location as we may
 notify you of.
 
 These Terms control the relationship between us and you. Microsoft,
@@ -555,7 +555,7 @@ Requirements available at
 location as we may notify you of.
 
 “Data Protection Addendum” means our Data Processing Terms available at
-\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+<https://support.terra.bio/hc/en-us/articles/10860018891291> or such other location as we may
 notify you of.
 
 “For-Profit Entity” means any individual, entity or organization other
@@ -622,7 +622,7 @@ not-for-profit business.
 notify you of.
 
 “Public Dataset” means those datasets listed at
-\[[●](https://app.terra.bio/#privacy)\] or such other location as we may
+<https://support.terra.bio/hc/en-us/articles/10859572748827> or such other location as we may
 notify you of.
 
 “Remove” means to cause Content to not be Connected to Terra.

--- a/src/main/resources/tos/termsOfService-1.md
+++ b/src/main/resources/tos/termsOfService-1.md
@@ -291,7 +291,7 @@ Our Privacy Policy explains how we treat your personal data and protect
 your privacy when you use Terra. Any information submitted on Terra is
 subject to our Privacy Policy, the terms of which are incorporated
 herein by this reference. Please review our [Privacy
-Policy](https://terra.bio/about/privacy/) to understand our practices.
+Policy](https://app.terra.bio/#privacy) to understand our practices.
 By using Terra, you have read, understood, and agree to the terms of the
 Privacy Policy, and you agree that we may retrieve, use, and disclose
 your personal data in accordance with the Privacy Policy.
@@ -618,7 +618,7 @@ not-for-profit business.
 “PHI” means protected health information, as defined in HIPAA.
 
 “Privacy Policy” means our Privacy Policy, available at
-<https://terra.bio/about/privacy/> or such other location as we may
+<https://app.terra.bio/#privacy> or such other location as we may
 notify you of.
 
 “Public Dataset” means those datasets listed at

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -15,9 +15,18 @@ trait TermsOfServiceRoutes {
       path("text") {
         pathEndOrSingleSlash {
           get {
-            complete(tosService.getText)
+            complete(tosService.getTosText)
           }
         }
       }
-    }
+    } ~
+      pathPrefix("privacy") {
+        path("text") {
+          pathEndOrSingleSlash {
+            get {
+              complete(tosService.getPrivacyText)
+            }
+          }
+        }
+      }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -18,6 +18,7 @@ import scala.io.Source
 class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tosConfig: TermsOfServiceConfig)(implicit val executionContext: ExecutionContext)
     extends LazyLogging {
   val termsOfServiceFile = s"tos/termsOfService-${tosConfig.version}.md"
+  val privacyPolicyFile = s"tos/privacyPolicy-${tosConfig.version}.md"
 
   def acceptTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[Boolean]] =
     if (tosConfig.enabled) {
@@ -49,23 +50,31 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
     * @return
     *   terms of service text
     */
-  def getText: String = {
-    val tosFileStream =
+  def getText(file: String, prettyTitle: String): String = {
+    val fileStream =
       try {
-        logger.debug("Reading terms of service")
-        Source.fromResource(termsOfServiceFile)
+        logger.debug(s"Reading $prettyTitle")
+        Source.fromResource(file)
       } catch {
         case e: FileNotFoundException =>
-          logger.error("Terms Of Service file not found", e)
+          logger.error(s"$prettyTitle file not found", e)
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
         case e: IOException =>
-          logger.error("Failed to read Terms of Service fail due to IO exception", e)
+          logger.error(s"Failed to read $prettyTitle file due to IO exception", e)
           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, e))
       }
-    logger.debug("Terms of service file found")
+    logger.debug(s"$prettyTitle file found")
     try
-      tosFileStream.mkString
+      fileStream.mkString
     finally
-      tosFileStream.close
+      fileStream.close
+  }
+
+  def getPrivacyText: String = {
+    getText(privacyPolicyFile, "Privacy Policy")
+  }
+
+  def getTosText: String = {
+    getText(termsOfServiceFile, "Terms of Service")
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -70,11 +70,9 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
       fileStream.close
   }
 
-  def getPrivacyText: String = {
+  def getPrivacyText: String =
     getText(privacyPolicyFile, "Privacy Policy")
-  }
 
-  def getTosText: String = {
+  def getTosText: String =
     getText(termsOfServiceFile, "Terms of Service")
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
@@ -21,4 +21,15 @@ class TermsOfServiceRouteSpec extends AnyFlatSpec with Matchers with ScalatestRo
       }
     }
   }
+
+  "GET /privacy/text" should "return the privacy policy text" in {
+    val samRoutes = TestSamRoutes(Map.empty)
+    eventually {
+      Get("/privacy/text") ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[String].isEmpty shouldBe false
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-363

  \<Don't forget to include the ticket number in the PR title!\>

What:

Makes Sam host the Terra Privacy Policy as well as the Terms of Service.

Why:

The Terms of Service and Privacy are updated at the same time, and users need to accept the new bundle of documents before continuing to use Terra. Having Sam host both the Terms of Service and Privacy Policy means both can be updated at once with a single config change, meaning we don't need to coordinate UI and Sam PRs. It also means the Privacy Policy version is configurable per-environment, which is really useful for keeping prod and pre-prod on different versions.

How:

Just like the Terms of Service, the Privacy Policy is now kept in Sam's resources folder, and versioned. Sam now has the ability to serve up the text of the Privacy Policy, and the text served is based on Sam's configured Terms of Service version.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
