### PR TITLE
[WOR-641] Bump okhttp client to see if it fixes clientside stream res…

### DIFF
--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -13,8 +13,8 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.24",
-      "com.squareup.okhttp3" % "okhttp" % "4.9.1",
-      "com.squareup.okhttp3" % "logging-interceptor" % "4.9.1",
+      "com.squareup.okhttp3" % "okhttp" % "4.9.3",
+      "com.squareup.okhttp3" % "logging-interceptor" % "4.9.3",
       "com.google.code.gson" % "gson" % "2.8.6",
       "org.apache.commons" % "commons-lang3" % "3.10",
       {{#openApiNullable}}

--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -13,8 +13,8 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.24",
-      "com.squareup.okhttp3" % "okhttp" % "4.9.3",
-      "com.squareup.okhttp3" % "logging-interceptor" % "4.9.3",
+      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+      "com.squareup.okhttp3" % "logging-interceptor" % "4.10.0",
       "com.google.code.gson" % "gson" % "2.8.6",
       "org.apache.commons" % "commons-lang3" % "3.10",
       {{#openApiNullable}}


### PR DESCRIPTION
Ticket: WOR-641 https://broadworkbench.atlassian.net/browse/WOR-641
Rawls swat tests are failing fairly regularly in the Auth Domain spec. As part of those tests, we are creating a temporary billing project; The rawls logs for one of the failed runs surfaced this error:

```
2022-12-05 08:16:36.276 EST
3org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(rawls,Sam call to syncPolicy failed with error 'okhttp3.internal.http2.StreamResetException: stream was reset: CANCEL',Some(200 OK),ArraySeq(ErrorReport(rawls,stream was reset: CANCEL,None,ArraySeq(),ArraySeq(okhttp3.internal.http2.Http2Stream$FramingSource.read(Http2Stream.kt:358), okhttp3.internal.connection.Exchange$ResponseBodySource.read(Exchange.kt:276), okio.RealBufferedSource.read(RealBufferedSource.kt:189), okio.ForwardingSource.read(ForwardingSource.kt:29), org.broadinstitute.dsde.workbench.client.sam.ProgressResponseBody$1.read(ProgressResponseBody.java:62), okio.RealBufferedSource.read(RealBufferedSource.kt:189), okio.RealBufferedSource.exhausted(RealBufferedSource.kt:197), okio.GzipSource.read(GzipSource.kt:88), okio.Buffer.writeAll(Buffer.kt:1642), okio.RealBufferedSource.readString(RealBufferedSource.kt:95), okhttp3.ResponseBody.string(ResponseBody.kt:187), org.broadinstitute.dsde.workbench.client.sam.ApiClient.deserialize(ApiClient.java:923), org.broadinstitute.dsde.workbench.client.sam.ApiClient.handleResponse(ApiClient.java:1148), org.broadinstitute.dsde.workbench.client.sam.ApiClient$1.onResponse(ApiClient.java:1111), okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519), java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source), java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source), java.base/java.lang.Thread.run(Unknown Source)),Some(class okhttp3.internal.http2.StreamResetException))),ArraySeq(org.broadinstitute.dsde.workbench.client.sam.ApiClient.deserialize(ApiClient.java:927), org.broadinstitute.dsde.workbench.client.sam.ApiClient.handleResponse(ApiClient.java:1148), org.broadinstitute.dsde.workbench.client.sam.ApiClient$1.onResponse(ApiClient.java:1111), okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519), java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source), java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source), java.base/java.lang.Thread.run(Unknown Source)),None)
4	at org.broadinstitute.dsde.rawls.dataaccess.HttpSamDAO$SamApiCallback.onFailure(HttpSamDAO.scala:93)
5	at org.broadinstitute.dsde.workbench.client.sam.ApiClient$1.onResponse(ApiClient.java:1113)
6	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
7	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
8	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
9	at java.base/java.lang.Thread.run(Unknown Source)
```

The okhttp release notes for 4.9.3 make mention of a [fix](https://square.github.io/okhttp/changelogs/changelog_4x/#version-493) for unwanted stream resets. It's unclear if this will in fact fix the issue, but it seems like it's worth a try.

What:

* Upgrades to the latest 4.x okhttp client

Why:

see the "what" section

How:
* Bumps the okhttp version in the build.sbt.mustache -- I _think_ that's the correct place to increment the version but I'd appreciate a more experience sam expert's 👁️ .

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
