### PR TITLE
WOR-595: add missing actions to roles

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -514,11 +514,14 @@ resourceTypes = {
       read_policies = {
         description = "view all policies and policy details for this workflow-collection"
       }
+      list_children = {
+        description = "list child resources"
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "add", "view", "abort", "get_cost", "update", "alter_policies", "read_policies"]
+        roleActions = ["delete", "add", "view", "abort", "get_cost", "update", "alter_policies", "read_policies", "list_children"]
       }
       reader = {
         roleActions = ["view", "get_cost"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -514,14 +514,11 @@ resourceTypes = {
       read_policies = {
         description = "view all policies and policy details for this workflow-collection"
       }
-      list_children = {
-        description = "list child resources"
-      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "add", "view", "abort", "get_cost", "update", "alter_policies", "read_policies", "list_children"]
+        roleActions = ["delete", "add", "view", "abort", "get_cost", "update", "alter_policies", "read_policies"]
       }
       reader = {
         roleActions = ["view", "get_cost"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -596,6 +596,9 @@ resourceTypes = {
       add_child = {
         description = "add child to google project"
       }
+      list_children = {
+        description = "list child resources"
+      }
       create-pet = {
         description = "create a pet service account in this google-project"
       }
@@ -610,7 +613,7 @@ resourceTypes = {
         }
       }
       notebook-user = {
-        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
+        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "list_children"]
         includedRoles = ["pet-creator"]
       }
       pet-creator = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -606,14 +606,14 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "list_children"]
         includedRoles = ["notebook-user", "pet-creator"]
         descendantRoles = {
           kubernetes-app = ["manager"]
         }
       }
       notebook-user = {
-        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child", "list_children"]
+        roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
         includedRoles = ["pet-creator"]
       }
       pet-creator = {


### PR DESCRIPTION
Ticket: [WOR-595](https://broadworkbench.atlassian.net/browse/WOR-595)

What:
Adding list_children to the google-project notebook-user role
~~Adding list_children to the workflow-collection owner role~~

Why:
Allows for validation before deleting a workspace that the workspace does not contain any resources that will cause deletion to fail

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
Link returns 404