### PR TITLE
ID-360 Add timing metrics to resource endpoints.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.google.{
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageInterpreter, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
-import org.broadinstitute.dsde.workbench.openTelemetry.{OpenTelemetryMetrics, OpenTelemetryMetricsInterpreter}
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.sam.api.{SamRoutes, StandardSamUserDirectives}
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.AdminConfig
@@ -315,7 +315,7 @@ object Boot extends IOApp with LazyLogging {
       directoryDAO: PostgresDirectoryDAO,
       azureManagedResourceGroupDAO: AzureManagedResourceGroupDAO,
       oauth2Config: OpenIDConnectConfiguration
-  )(implicit actorSystem: ActorSystem, openTelemetry: OpenTelemetryMetricsInterpreter[IO]): AppDependencies = {
+  )(implicit actorSystem: ActorSystem, openTelemetry: OpenTelemetryMetrics[IO]): AppDependencies = {
     val resourceTypeMap = config.resourceTypes.map(rt => rt.name -> rt).toMap
     val policyEvaluatorService = PolicyEvaluatorService(config.emailDomain, resourceTypeMap, accessPolicyDAO, directoryDAO)
     val resourceService = new ResourceService(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.config.LiquibaseConfig
 import org.broadinstitute.dsde.workbench.sam.model.RootPrimitiveJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.{CreateResourcePolicyResponse, CreateResourceResponse, _}
+import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.DefaultJsonProtocol._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -16,7 +16,7 @@ import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
-import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetricsInterpreter
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureRoutes, AzureService}
@@ -44,7 +44,7 @@ abstract class SamRoutes(
     val system: ActorSystem,
     val materializer: Materializer,
     val executionContext: ExecutionContext,
-    val openTelemetry: OpenTelemetryMetricsInterpreter[IO]
+    val openTelemetry: OpenTelemetryMetrics[IO]
 ) extends LazyLogging
     with ResourceRoutes
     with UserRoutes

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -94,16 +94,15 @@ class ResourceService(
     * @param samUser
     * @return
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Resource] =
-    openTelemetry.time("api.v1.resource.createDefault.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
-      val ownerRole = resourceType.roles
-        .find(_.roleName == resourceType.ownerRoleName)
-        .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
-      val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-        AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None)
-      )
-      createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
-    }
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Resource] = {
+    val ownerRole = resourceType.roles
+      .find(_.roleName == resourceType.ownerRoleName)
+      .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
+    val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
+      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None)
+    )
+    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
+  }
 
   /** Validates the resource first and if any validations fail, an exception is thrown with an error report that describes what failed. If validations pass,
     * then the Resource should be persisted.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -4,20 +4,20 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.Applicative
 import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.audit.SamAuditModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.audit._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.broadinstitute.dsde.workbench.sam.util.{API_TIMING_DURATION_BUCKET, SamRequestContext}
 
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 /** Created by mbemis on 5/22/17.
   */
@@ -29,8 +29,10 @@ class ResourceService(
     private val cloudExtensions: CloudExtensions,
     val emailDomain: String,
     private val allowedAdminEmailDomains: Set[String]
-)(implicit val executionContext: ExecutionContext)
+)(implicit val executionContext: ExecutionContext, val openTelemetry: OpenTelemetryMetrics[IO])
     extends LazyLogging {
+
+  private val openTelemetryTags: Map[String, String] = Map("endpoint" -> "createResource")
 
   private[service] case class ValidatableAccessPolicy(
       policyName: AccessPolicyName,
@@ -92,15 +94,16 @@ class ResourceService(
     * @param samUser
     * @return
     */
-  def createResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Resource] = {
-    val ownerRole = resourceType.roles
-      .find(_.roleName == resourceType.ownerRoleName)
-      .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
-    val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
-      AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None)
-    )
-    createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
-  }
+  def createResource(resourceType: ResourceType, resourceId: ResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Resource] =
+    openTelemetry.time("api.v1.resource.createDefault.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      val ownerRole = resourceType.roles
+        .find(_.roleName == resourceType.ownerRoleName)
+        .getOrElse(throw new WorkbenchException(s"owner role ${resourceType.ownerRoleName} does not exist in $resourceType"))
+      val defaultPolicies: Map[AccessPolicyName, AccessPolicyMembership] = Map(
+        AccessPolicyName(ownerRole.roleName.value) -> AccessPolicyMembership(Set(samUser.email), Set.empty, Set(ownerRole.roleName), None, None)
+      )
+      createResource(resourceType, resourceId, defaultPolicies, Set.empty, None, samUser.id, samRequestContext)
+    }
 
   /** Validates the resource first and if any validations fail, an exception is thrown with an error report that describes what failed. If validations pass,
     * then the Resource should be persisted.
@@ -120,28 +123,29 @@ class ResourceService(
       parentOpt: Option[FullyQualifiedResourceId],
       userId: WorkbenchUserId,
       samRequestContext: SamRequestContext
-  ): IO[Resource] = {
-    logger.info(s"Creating new `${resourceType.name}` with resourceId: `${resourceId}`")
-    makeValidatablePolicies(policiesMap, samRequestContext).flatMap { policies =>
-      validateCreateResource(resourceType, resourceId, policies, authDomain, userId, parentOpt, samRequestContext).flatMap {
-        case Seq() =>
-          for {
-            persisted <- persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)
+  ): IO[Resource] =
+    openTelemetry.time("api.v1.resource.create.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      logger.info(s"Creating new `${resourceType.name}` with resourceId: `${resourceId}`")
+      makeValidatablePolicies(policiesMap, samRequestContext).flatMap { policies =>
+        validateCreateResource(resourceType, resourceId, policies, authDomain, userId, parentOpt, samRequestContext).flatMap {
+          case Seq() =>
+            for {
+              persisted <- persistResource(resourceType, resourceId, policies, authDomain, parentOpt, samRequestContext)
 
-            _ <- AuditLogger.logAuditEventIO(
-              samRequestContext,
-              ResourceEvent(ResourceCreated, FullyQualifiedResourceId(resourceType.name, resourceId), parentOpt.map(ResourceChange))
-            )
+              _ <- AuditLogger.logAuditEventIO(
+                samRequestContext,
+                ResourceEvent(ResourceCreated, FullyQualifiedResourceId(resourceType.name, resourceId), parentOpt.map(ResourceChange))
+              )
 
-            changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId), LazyList.empty, persisted.accessPolicies)
+              changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId), LazyList.empty, persisted.accessPolicies)
 
-            _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq: _*)
-          } yield persisted
-        case errorReports: Seq[ErrorReport] =>
-          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports))
+              _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq: _*)
+            } yield persisted
+          case errorReports: Seq[ErrorReport] =>
+            throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports))
+        }
       }
     }
-  }
 
   /** This method only persists the resource and then overwrites/creates the policies for that resource. Be very careful if calling this method directly because
     * it will not validate the resource or its policies. If you want to create a Resource, use createResource() which will also perform critical validations
@@ -160,7 +164,7 @@ class ResourceService(
       authDomain: Set[WorkbenchGroupName],
       parentOpt: Option[FullyQualifiedResourceId],
       samRequestContext: SamRequestContext
-  ) = {
+  ) = openTelemetry.time("api.v1.resource.persist.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
     val accessPolicies = policies.map(constructAccessPolicy(resourceType, resourceId, _, public = false)) // can't set public at create time
     accessPolicyDAO.createResource(Resource(resourceType.name, resourceId, authDomain, accessPolicies = accessPolicies, parent = parentOpt), samRequestContext)
   }
@@ -296,18 +300,20 @@ class ResourceService(
   //      preventing a new Resource with the same ID from being created
   // Resources with children cannot be deleted and will throw a 400.
   @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy
-  def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[Unit] =
-    for {
-      _ <- checkNoChildren(resource, samRequestContext).unsafeToFuture()
+  def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
+    openTelemetry.time("api.v1.resource.delete.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        _ <- checkNoChildren(resource, samRequestContext)
 
-      // remove from cloud first so a failure there does not leave sam in a bad state
-      _ <- cloudDeletePolicies(resource, samRequestContext)
+        // remove from cloud first so a failure there does not leave sam in a bad state
+        _ <- cloudDeletePolicies(resource, samRequestContext)
 
-      _ <- accessPolicyDAO.deleteAllResourcePolicies(resource, samRequestContext).unsafeToFuture()
-      _ <- maybeDeleteResource(resource, samRequestContext).unsafeToFuture()
+        _ <- accessPolicyDAO.deleteAllResourcePolicies(resource, samRequestContext)
+        _ <- maybeDeleteResource(resource, samRequestContext)
 
-      _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceDeleted, resource)).unsafeToFuture()
-    } yield ()
+        _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceDeleted, resource))
+      } yield ()
+    }
 
   /** Check if a resource has any children. If so, then throw a 400. */
   def checkNoChildren(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
@@ -329,11 +335,11 @@ class ResourceService(
       _ <- accessPolicyDAO.deletePolicy(policyId, samRequestContext)
     } yield ()
 
-  def cloudDeletePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Future[LazyList[AccessPolicy]] =
+  def cloudDeletePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicy]] =
     for {
-      policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource, samRequestContext).unsafeToFuture()
-      _ <- Future.traverse(policiesToDelete) { policy =>
-        cloudExtensions.onGroupDelete(policy.email)
+      policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource, samRequestContext)
+      _ <- policiesToDelete.traverse { policy =>
+        IO.fromFuture(IO(cloudExtensions.onGroupDelete(policy.email)))
       }
     } yield policiesToDelete
 
@@ -348,8 +354,10 @@ class ResourceService(
         } yield ()
     }
 
-  def listUserResourceRoles(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): Future[Set[ResourceRoleName]] =
-    accessPolicyDAO.listUserResourceRoles(resource, samUser.id, samRequestContext).unsafeToFuture()
+  def listUserResourceRoles(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): IO[Set[ResourceRoleName]] =
+    openTelemetry.time("api.v1.resource.listUserRoles.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      accessPolicyDAO.listUserResourceRoles(resource, samUser.id, samRequestContext)
+    }
 
   /** Overwrites an existing policy (keyed by resourceType/resourceId/policyName), saves a new one if it doesn't exist yet
     * @param resourceType
@@ -366,15 +374,17 @@ class ResourceService(
       policyMembership: AccessPolicyMembership,
       samRequestContext: SamRequestContext
   ): IO[AccessPolicy] =
-    for {
-      policy <- makeCreatablePolicy(policyName, policyMembership, samRequestContext)
-      _ <- validatePolicy(resourceType, policy).map {
-        case Some(errorReport) =>
-          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "You have specified an invalid policy", errorReport))
-        case None =>
-      }
-      overwrittenPolicy <- createOrUpdatePolicy(FullyQualifiedPolicyId(resource, policyName), policy, samRequestContext)
-    } yield overwrittenPolicy
+    openTelemetry.time("api.v1.resource.overwritePolicy.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        policy <- makeCreatablePolicy(policyName, policyMembership, samRequestContext)
+        _ <- validatePolicy(resourceType, policy).map {
+          case Some(errorReport) =>
+            throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "You have specified an invalid policy", errorReport))
+          case None =>
+        }
+        overwrittenPolicy <- createOrUpdatePolicy(FullyQualifiedPolicyId(resource, policyName), policy, samRequestContext)
+      } yield overwrittenPolicy
+    }
 
   /** Overwrites an existing admin policy, saves a new one if it doesn't exist yet.
     */
@@ -412,23 +422,25 @@ class ResourceService(
     * @return
     */
   def overwritePolicyMembers(policyId: FullyQualifiedPolicyId, membersList: Set[WorkbenchEmail], samRequestContext: SamRequestContext): IO[Unit] =
-    mapEmailsToSubjects(membersList, samRequestContext).flatMap { emailsToSubjects =>
-      validateMemberEmails(emailsToSubjects) match {
-        case Some(error) => IO.raiseError(new WorkbenchExceptionWithErrorReport(error.copy(statusCode = Option(StatusCodes.BadRequest))))
-        case None =>
-          val newMembers = emailsToSubjects.values.flatten.toSet
-          accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext).flatMap { originalPolicies =>
-            originalPolicies.find(_.id == policyId) match {
-              case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"policy $policyId does not exist")))
-              case Some(existingPolicy) =>
-                Applicative[IO].whenA(existingPolicy.members != newMembers) {
-                  for {
-                    _ <- accessPolicyDAO.overwritePolicyMembers(policyId, newMembers, samRequestContext)
-                    _ <- onPolicyUpdate(policyId, originalPolicies, samRequestContext)
-                  } yield ()
-                }
+    openTelemetry.time("api.v1.resource.overwritePolicyMembers.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      mapEmailsToSubjects(membersList, samRequestContext).flatMap { emailsToSubjects =>
+        validateMemberEmails(emailsToSubjects) match {
+          case Some(error) => IO.raiseError(new WorkbenchExceptionWithErrorReport(error.copy(statusCode = Option(StatusCodes.BadRequest))))
+          case None =>
+            val newMembers = emailsToSubjects.values.flatten.toSet
+            accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext).flatMap { originalPolicies =>
+              originalPolicies.find(_.id == policyId) match {
+                case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"policy $policyId does not exist")))
+                case Some(existingPolicy) =>
+                  Applicative[IO].whenA(existingPolicy.members != newMembers) {
+                    for {
+                      _ <- accessPolicyDAO.overwritePolicyMembers(policyId, newMembers, samRequestContext)
+                      _ <- onPolicyUpdate(policyId, originalPolicies, samRequestContext)
+                    } yield ()
+                  }
+              }
             }
-          }
+        }
       }
     }
 
@@ -443,7 +455,7 @@ class ResourceService(
       policyIdentity: FullyQualifiedPolicyId,
       policy: ValidatableAccessPolicy,
       samRequestContext: SamRequestContext
-  ): IO[AccessPolicy] = {
+  ): IO[AccessPolicy] = openTelemetry.time("api.v1.resource.createOrUpdatePolicy.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
     val workbenchSubjects = policy.emailsToSubjects.values.flatten.toSet ++
       policy.memberPolicies.getOrElse(Set.empty).map(p => FullyQualifiedPolicyId(FullyQualifiedResourceId(p.resourceTypeName, p.resourceId), p.policyName))
     accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext).flatMap { originalPolicies =>
@@ -501,7 +513,7 @@ class ResourceService(
       resourceId: FullyQualifiedResourceId,
       samUser: SamUser,
       samRequestContext: SamRequestContext
-  ): IO[List[Boolean]] =
+  ): IO[List[Boolean]] = openTelemetry.time("api.v1.resource.leaveResource.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
     accessPolicyDAO.listAccessPolicies(resourceId, samRequestContext) flatMap { policiesForResource =>
       val policiesForUser = policiesForResource.filter(_.members.contains(samUser.id)).toSet
       val publicPoliciesForResource = policiesForResource.filter(_.public).toSet
@@ -529,6 +541,7 @@ class ResourceService(
         removeSubjectFromPolicy(policy.id, samUser.id, samRequestContext)
       }
     }
+  }
 
   /** Validates a policy in the context of a ResourceType. When validating the policy, we want to collect each entity that was problematic and report that back
     * using ErrorReports
@@ -628,27 +641,31 @@ class ResourceService(
     } yield ()
 
   def addSubjectToPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
-    subject match {
-      case subject: FullyQualifiedPolicyId if policyIdentity.resource.resourceTypeName.equals(ManagedGroupService.managedGroupTypeName) =>
-        // https://broadworkbench.atlassian.net/browse/CA-257
-        // this case was prevented as a performance enhancement in the dark days before Postgres, does it still apply?
-        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Access policies cannot be added to managed groups.")))
-      case _ =>
-        for {
-          originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
-          _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
-          policyChanged <- directoryDAO.addGroupMember(policyIdentity, subject, samRequestContext)
-          _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
-        } yield policyChanged
+    openTelemetry.time("api.v1.resource.addSubjectToPolicy.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      subject match {
+        case _: FullyQualifiedPolicyId if policyIdentity.resource.resourceTypeName.equals(ManagedGroupService.managedGroupTypeName) =>
+          // https://broadworkbench.atlassian.net/browse/CA-257
+          // this case was prevented as a performance enhancement in the dark days before Postgres, does it still apply?
+          IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Access policies cannot be added to managed groups.")))
+        case _ =>
+          for {
+            originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
+            _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
+            policyChanged <- directoryDAO.addGroupMember(policyIdentity, subject, samRequestContext)
+            _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
+          } yield policyChanged
+      }
     }
 
   def removeSubjectFromPolicy(policyIdentity: FullyQualifiedPolicyId, subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =
-    for {
-      originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
-      _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
-      policyChanged <- directoryDAO.removeGroupMember(policyIdentity, subject, samRequestContext)
-      _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
-    } yield policyChanged
+    openTelemetry.time("api.v1.resource.removeSubjectFromPolicy.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
+        _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
+        policyChanged <- directoryDAO.removeGroupMember(policyIdentity, subject, samRequestContext)
+        _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
+      } yield policyChanged
+    }
 
   def failWhenPolicyNotExists(policies: Iterable[AccessPolicy], policyId: FullyQualifiedPolicyId): IO[Unit] =
     IO.raiseUnless(policies.exists(_.id == policyId)) {
@@ -672,9 +689,11 @@ class ResourceService(
   }
 
   def listResourcePolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyResponseEntry]] =
-    accessPolicyDAO.listAccessPolicyMemberships(resource, samRequestContext).map { policiesWithMembership =>
-      policiesWithMembership.map { policyWithMembership =>
-        AccessPolicyResponseEntry(policyWithMembership.policyName, policyWithMembership.membership, policyWithMembership.email)
+    openTelemetry.time("api.v1.resource.listResourcePolicies.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      accessPolicyDAO.listAccessPolicyMemberships(resource, samRequestContext).map { policiesWithMembership =>
+        policiesWithMembership.map { policyWithMembership =>
+          AccessPolicyResponseEntry(policyWithMembership.policyName, policyWithMembership.membership, policyWithMembership.email)
+        }
       }
     }
 
@@ -713,9 +732,11 @@ class ResourceService(
   private def generateGroupEmail() = WorkbenchEmail(s"policy-${UUID.randomUUID}@$emailDomain")
 
   def isPublic(resourceAndPolicyName: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Boolean] =
-    accessPolicyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).flatMap {
-      case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found")))
-      case Some(accessPolicy) => IO.pure(accessPolicy.public)
+    openTelemetry.time("api.v1.resource.isPublic.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      accessPolicyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).flatMap {
+        case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found")))
+        case Some(accessPolicy) => IO.pure(accessPolicy.public)
+      }
     }
 
   /** Sets the public field of a policy. Raises an error if the policy has an auth domain and public == true. Triggers update to Google Group upon successfully
@@ -728,37 +749,41 @@ class ResourceService(
     * @return
     */
   def setPublic(policyId: FullyQualifiedPolicyId, public: Boolean, samRequestContext: SamRequestContext): IO[Unit] =
-    for {
-      authDomain <- accessPolicyDAO.loadResourceAuthDomain(policyId.resource, samRequestContext)
-      _ <- authDomain match {
-        case LoadResourceAuthDomainResult.ResourceNotFound =>
-          IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"ResourceId ${policyId.resource} not found.")))
-        case LoadResourceAuthDomainResult.Constrained(_) =>
-          // resources with auth domains logically can't have public policies but also technically allowing them poses a problem
-          // because the logic for public resources is different. However, sharing with the auth domain should have the
-          // exact same effect as making a policy public: anyone in the auth domain can access.
-          if (public)
-            IO.raiseError(
-              new WorkbenchExceptionWithErrorReport(
-                ErrorReport(StatusCodes.BadRequest, "Cannot make auth domain protected resources public. Share directly with auth domain groups instead.")
+    openTelemetry.time("api.v1.resource.setPublic.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        authDomain <- accessPolicyDAO.loadResourceAuthDomain(policyId.resource, samRequestContext)
+        _ <- authDomain match {
+          case LoadResourceAuthDomainResult.ResourceNotFound =>
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"ResourceId ${policyId.resource} not found.")))
+          case LoadResourceAuthDomainResult.Constrained(_) =>
+            // resources with auth domains logically can't have public policies but also technically allowing them poses a problem
+            // because the logic for public resources is different. However, sharing with the auth domain should have the
+            // exact same effect as making a policy public: anyone in the auth domain can access.
+            if (public)
+              IO.raiseError(
+                new WorkbenchExceptionWithErrorReport(
+                  ErrorReport(StatusCodes.BadRequest, "Cannot make auth domain protected resources public. Share directly with auth domain groups instead.")
+                )
               )
-            )
-          else IO.unit
-        case LoadResourceAuthDomainResult.NotConstrained =>
-          for {
-            originalPolicies <- accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext)
-            policyChanged <- accessPolicyDAO.setPolicyIsPublic(policyId, public, samRequestContext)
-            _ <- onPolicyUpdateIfChanged(policyId, originalPolicies, samRequestContext)(policyChanged)
-          } yield ()
-      }
-    } yield ()
+            else IO.unit
+          case LoadResourceAuthDomainResult.NotConstrained =>
+            for {
+              originalPolicies <- accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext)
+              policyChanged <- accessPolicyDAO.setPolicyIsPublic(policyId, public, samRequestContext)
+              _ <- onPolicyUpdateIfChanged(policyId, originalPolicies, samRequestContext)(policyChanged)
+            } yield ()
+        }
+      } yield ()
+    }
 
   def listAllFlattenedResourceUsers(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[UserIdInfo]] =
-    for {
-      accessPolicies <- accessPolicyDAO.listAccessPolicies(resourceId, samRequestContext)
-      members <- accessPolicies.toList.parTraverse(accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id, samRequestContext))
-      workbenchUsers = members.flatten.toSet
-    } yield workbenchUsers.map(_.toUserIdInfo)
+    openTelemetry.time("api.v1.resource.listAllFlattenedResourceUsers.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        accessPolicies <- accessPolicyDAO.listAccessPolicies(resourceId, samRequestContext)
+        members <- accessPolicies.toList.parTraverse(accessPolicy => accessPolicyDAO.listFlattenedPolicyMembers(accessPolicy.id, samRequestContext))
+        workbenchUsers = members.flatten.toSet
+      } yield workbenchUsers.map(_.toUserIdInfo)
+    }
 
   @throws(classOf[WorkbenchExceptionWithErrorReport]) // Necessary to make Mockito happy
   def getResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[FullyQualifiedResourceId]] =
@@ -769,39 +794,43 @@ class ResourceService(
     * https://docs.google.com/document/d/10qGxsV9BeM6-N_Zk27_JIayE509B8LUQBGiGrqB0taY/edit#heading=h.dxz6xjtnz9la
     */
   def setResourceParent(childResource: FullyQualifiedResourceId, parentResource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
-    for {
-      authDomain <- accessPolicyDAO.loadResourceAuthDomain(childResource, samRequestContext)
-      _ <- authDomain match {
-        case LoadResourceAuthDomainResult.NotConstrained =>
-          for {
-            _ <- accessPolicyDAO.setResourceParent(childResource, parentResource, samRequestContext)
-            _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
-          } yield ()
-        case LoadResourceAuthDomainResult.Constrained(_) =>
-          IO.raiseError(
-            new WorkbenchExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest, "Cannot set the parent for a constrained resource")
+    openTelemetry.time("api.v1.resource.setResourceParent.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        authDomain <- accessPolicyDAO.loadResourceAuthDomain(childResource, samRequestContext)
+        _ <- authDomain match {
+          case LoadResourceAuthDomainResult.NotConstrained =>
+            for {
+              _ <- accessPolicyDAO.setResourceParent(childResource, parentResource, samRequestContext)
+              _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
+            } yield ()
+          case LoadResourceAuthDomainResult.Constrained(_) =>
+            IO.raiseError(
+              new WorkbenchExceptionWithErrorReport(
+                ErrorReport(StatusCodes.BadRequest, "Cannot set the parent for a constrained resource")
+              )
             )
-          )
-        case LoadResourceAuthDomainResult.ResourceNotFound =>
-          IO.raiseError(
-            new WorkbenchExceptionWithErrorReport(
-              ErrorReport(StatusCodes.NotFound, "Resource not found")
+          case LoadResourceAuthDomainResult.ResourceNotFound =>
+            IO.raiseError(
+              new WorkbenchExceptionWithErrorReport(
+                ErrorReport(StatusCodes.NotFound, "Resource not found")
+              )
             )
-          )
-      }
-    } yield ()
+        }
+      } yield ()
+    }
 
   def deleteResourceParent(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Boolean] =
-    for {
-      maybeOldParent <- accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
-      _ <- maybeOldParent.traverse { oldParent =>
-        for {
-          _ <- accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
-          _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
-        } yield ()
-      }
-    } yield maybeOldParent.isDefined
+    openTelemetry.time("api.v1.resource.deleteResourceParent.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+      for {
+        maybeOldParent <- accessPolicyDAO.getResourceParent(resourceId, samRequestContext)
+        _ <- maybeOldParent.traverse { oldParent =>
+          for {
+            _ <- accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
+            _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
+          } yield ()
+        }
+      } yield maybeOldParent.isDefined
+    }
 
   def listResourceChildren(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] =
     accessPolicyDAO.listResourceChildren(resourceId, samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -141,7 +141,7 @@ class ResourceService(
               _ <- AuditLogger.logAuditEventIO(samRequestContext, changeEvents.toSeq: _*)
             } yield persisted
           case errorReports: Seq[ErrorReport] =>
-            throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports))
+            IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Cannot create resource", errorReports)))
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -163,7 +163,7 @@ class ResourceService(
       authDomain: Set[WorkbenchGroupName],
       parentOpt: Option[FullyQualifiedResourceId],
       samRequestContext: SamRequestContext
-  ) = openTelemetry.time("api.v1.resource.persist.time", API_TIMING_DURATION_BUCKET, openTelemetryTags) {
+  ) = {
     val accessPolicies = policies.map(constructAccessPolicy(resourceType, resourceId, _, public = false)) // can't set public at create time
     accessPolicyDAO.createResource(Resource(resourceType.name, resourceId, authDomain, accessPolicies = accessPolicies, parent = parentOpt), samRequestContext)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/package.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.dsde.workbench.sam
 
+import scala.concurrent.duration._
+
 package object util {
+  val API_TIMING_DURATION_BUCKET: List[FiniteDuration] = List(10 millis, 100 millis, 500 millis, 1 second, 2 seconds, 5 seconds)
 
   /** Takes a list of pairs and returns a map grouped by the first element with values of lists of the second
     * @param list

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -56,7 +56,7 @@ trait TestSupport {
   implicit val openTelemetry: OpenTelemetryMetricsInterpreter[IO] = mock[OpenTelemetryMetricsInterpreter[IO]](RETURNS_SMART_NULLS)
 
   when(
-    openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[Unit]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
+    openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
   ).thenAnswer(invocation => invocation.getArgument[IO[Unit]](3))
 
   val samRequestContext = SamRequestContext()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -20,7 +20,13 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, MockAccessPolicyDAO, MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDistributedLockDAO}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{
+  AccessPolicyDAO,
+  MockAccessPolicyDAO,
+  MockAzureManagedResourceGroupDAO,
+  MockDirectoryDAO,
+  PostgresDistributedLockDAO
+}
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
@@ -55,7 +61,9 @@ trait TestSupport {
   implicit val eqWorkbenchException: Eq[WorkbenchException] = (x: WorkbenchException, y: WorkbenchException) => x.getMessage == y.getMessage
   implicit val openTelemetry: OpenTelemetryMetricsInterpreter[IO] = mock[OpenTelemetryMetricsInterpreter[IO]](RETURNS_SMART_NULLS)
 
-  when(openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])).thenReturn(IO.unit)
+  when(
+    openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
+  ).thenReturn(IO.unit)
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -57,7 +57,7 @@ trait TestSupport {
 
   when(
     openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
-  ).thenAnswer(invocation => invocation.getArgument[IO[Unit]](3))
+  ).thenAnswer(invocation => invocation.getArgument[IO[_]](3))
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -57,7 +57,7 @@ trait TestSupport {
 
   when(
     openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[Unit]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
-  ).thenReturn(IO.unit)
+  ).thenAnswer(invocation => invocation.getArgument[IO[Unit]](3))
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -56,8 +56,8 @@ trait TestSupport {
   implicit val openTelemetry: OpenTelemetryMetricsInterpreter[IO] = mock[OpenTelemetryMetricsInterpreter[IO]](RETURNS_SMART_NULLS)
 
   when(
-    openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
-  ).thenReturn(IO.pure(()))
+    openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[Unit]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
+  ).thenReturn(IO.unit)
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.workbench.sam
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import cats.effect.IO
+import cats.ApplicativeError
+import cats.effect.{IO, Temporal}
 import cats.effect.unsafe.implicits.global
 import cats.kernel.Eq
 import com.typesafe.config.ConfigFactory
@@ -19,13 +20,7 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{
-  AccessPolicyDAO,
-  MockAccessPolicyDAO,
-  MockAzureManagedResourceGroupDAO,
-  MockDirectoryDAO,
-  PostgresDistributedLockDAO
-}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, MockAccessPolicyDAO, MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDistributedLockDAO}
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
@@ -33,7 +28,8 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.mockito.Mockito.RETURNS_SMART_NULLS
+import org.mockito.ArgumentMatchers.{any, anyList, anyLong, anyString}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, when}
 import org.scalatest.Tag
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.matchers.should.Matchers
@@ -58,6 +54,8 @@ trait TestSupport {
   implicit val futureTimeout = Timeout(Span(10, Seconds))
   implicit val eqWorkbenchException: Eq[WorkbenchException] = (x: WorkbenchException, y: WorkbenchException) => x.getMessage == y.getMessage
   implicit val openTelemetry: OpenTelemetryMetricsInterpreter[IO] = mock[OpenTelemetryMetricsInterpreter[IO]](RETURNS_SMART_NULLS)
+
+  when(openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])).thenReturn(IO.unit)
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.workbench.sam
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import cats.ApplicativeError
-import cats.effect.{IO, Temporal}
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Temporal}
 import cats.kernel.Eq
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
@@ -20,13 +20,7 @@ import org.broadinstitute.dsde.workbench.sam.api._
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig._
 import org.broadinstitute.dsde.workbench.sam.config._
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{
-  AccessPolicyDAO,
-  MockAccessPolicyDAO,
-  MockAzureManagedResourceGroupDAO,
-  MockDirectoryDAO,
-  PostgresDistributedLockDAO
-}
+import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
@@ -34,7 +28,7 @@ import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.mockito.ArgumentMatchers.{any, anyList, anyLong, anyString}
+import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{RETURNS_SMART_NULLS, when}
 import org.scalatest.Tag
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -63,7 +57,7 @@ trait TestSupport {
 
   when(
     openTelemetry.time(anyString(), any[List[FiniteDuration]], any[Map[String, String]])(any[IO[_]])(any[Temporal[IO]], any[ApplicativeError[IO, Throwable]])
-  ).thenReturn(IO.unit)
+  ).thenReturn(IO.pure(()))
 
   val samRequestContext = SamRequestContext()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -10,7 +10,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetricsInterpreter
+import org.broadinstitute.dsde.workbench.openTelemetry.{FakeOpenTelemetryMetricsInterpreter, OpenTelemetryMetrics}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
 import org.broadinstitute.dsde.workbench.sam.api.ManagedGroupRoutesSpec._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
@@ -18,11 +18,9 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
-import org.mockito.Mockito.RETURNS_SMART_NULLS
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.mockito.MockitoSugar.mock
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext
@@ -751,7 +749,7 @@ object ManagedGroupRoutesSpec {
   ): TestSamRoutes = {
     val directoryDAO = new MockDirectoryDAO()
     val policyDao = new MockAccessPolicyDAO(resourceTypeMap, directoryDAO)
-    implicit val openTelemetry: OpenTelemetryMetricsInterpreter[IO] = mock[OpenTelemetryMetricsInterpreter[IO]](RETURNS_SMART_NULLS)
+    implicit val openTelemetry: OpenTelemetryMetrics[IO] = FakeOpenTelemetryMetricsInterpreter
     val samRoutes = TestSamRoutes(resourceTypeMap, policyAccessDAO = Some(policyDao), maybeDirectoryDAO = Some(directoryDAO))
 
     policyDao.createResource(resource, samRequestContext).unsafeRunSync()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -25,8 +25,6 @@ import org.scalatestplus.mockito.MockitoSugar
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsBoolean, JsValue}
 
-import scala.concurrent.Future
-
 //TODO This test is flaky. It looks like the tests run too fast and cause some sort of timeout error or race condition
 class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
 
@@ -1824,7 +1822,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     }
 
     if (actionsOnChild.contains(SamResourceActions.delete)) {
-      when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext])).thenReturn(Future.unit)
+      when(samRoutes.resourceService.deleteResource(mockitoEq(childResource), any[SamRequestContext])).thenReturn(IO.unit)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -33,7 +33,6 @@ class StatusRouteSpec extends RetryableAnyFlatSpec with Matchers with ScalatestR
   }
 
   "GET /status" should "give 200 for ok" in {
-    when(openTelemetry.incrementCounter(anyString(), anyLong(), any[Map[String, String]])).thenReturn(IO.unit)
     val samRoutes = TestSamRoutes(Map.empty)
     implicit val patienceConfig = PatienceConfig(timeout = 1 second)
     eventually {
@@ -45,7 +44,6 @@ class StatusRouteSpec extends RetryableAnyFlatSpec with Matchers with ScalatestR
   }
 
   it should "give 500 for not ok" in {
-    when(openTelemetry.incrementCounter(anyString(), anyLong(), any[Map[String, String]])).thenReturn(IO.unit)
     val directoryDAO = new MockDirectoryDAO(passStatusCheck = false)
     val policyDAO = new MockAccessPolicyDAO(directoryDAO)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StatusRouteSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.sam.api
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.TestSupport.googleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -11,8 +10,6 @@ import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFlatSpec, T
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Database
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
-import org.mockito.ArgumentMatchers.{any, anyLong, anyString}
-import org.mockito.Mockito.when
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -8,11 +8,11 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
-import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetricsInterpreter
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{googleServicesConfig, samRequestContext}
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, _}
+import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.{adminAddMember, adminReadPolicies, adminRemoveMember}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
@@ -40,7 +40,7 @@ class TestSamRoutes(
     override val system: ActorSystem,
     override val materializer: Materializer,
     override val executionContext: ExecutionContext,
-    override val openTelemetry: OpenTelemetryMetricsInterpreter[IO]
+    override val openTelemetry: OpenTelemetryMetrics[IO]
 ) extends SamRoutes(
       resourceService,
       userService,
@@ -77,7 +77,7 @@ class TestSamTosEnabledRoutes(
     override val system: ActorSystem,
     override val materializer: Materializer,
     override val executionContext: ExecutionContext,
-    override val openTelemetry: OpenTelemetryMetricsInterpreter[IO]
+    override val openTelemetry: OpenTelemetryMetrics[IO]
 ) extends SamRoutes(
       resourceService,
       userService,
@@ -153,7 +153,7 @@ object TestSamRoutes {
       cloudExtensions: Option[CloudExtensions] = None,
       adminEmailDomains: Option[Set[String]] = None,
       crlService: Option[CrlService] = None
-  )(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext, openTelemetry: OpenTelemetryMetricsInterpreter[IO]) = {
+  )(implicit system: ActorSystem, materializer: Materializer, executionContext: ExecutionContext, openTelemetry: OpenTelemetryMetrics[IO]) = {
     val dbRef = TestSupport.dbRef
     val resourceTypesWithAdmin = resourceTypes + (resourceTypeAdmin.name -> resourceTypeAdmin)
     // need to make sure MockDirectoryDAO and MockAccessPolicyDAO share the same groups

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -2480,7 +2480,7 @@ class ResourceServiceSpec
     val resource = Resource(defaultResourceType.name, genResourceId.sample.get, Set.empty)
     policyDAO.createResource(resource, samRequestContext).unsafeRunSync()
 
-    runAuditLogTest(IO.fromFuture(IO(service.deleteResource(resource.fullyQualifiedId, samRequestContext))), List(ResourceDeleted), tryTwice = false)
+    runAuditLogTest(service.deleteResource(resource.fullyQualifiedId, samRequestContext), List(ResourceDeleted), tryTwice = false)
   }
 
   it should "be called on createResource" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-360

What:

Adding openapi timing metrics to sam resource endpoints so that we can get some visibility into which endpoints are slow and when.

Why:

To get more visibility into how sam behaves in production, should help with debugging etc.

How:

The bulk of the changes are in one file. I wrapped each endpoint in a openTelemetry.time call, which requires an IO so I also had to do a little refactoring. In particular I want feedback on naming metrics. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
