### PR TITLE
ID-360 Add timing metrics user service.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -111,7 +111,7 @@ class GoogleGroupSynchronizer(
             case group: WorkbenchGroupIdentity => directoryDAO.loadSubjectEmail(group, samRequestContext).unsafeToFuture()
 
             // use proxy group email instead of user's actual email
-            case userSubjectId: WorkbenchUserId => googleExtensions.getUserProxy(userSubjectId)
+            case userSubjectId: WorkbenchUserId => googleExtensions.getUserProxy(userSubjectId).unsafeToFuture()
 
             // not sure why this next case would happen but if a petSA is in a group just use its email
             case petSA: PetServiceAccountId => directoryDAO.loadSubjectEmail(petSA, samRequestContext).unsafeToFuture()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import cats.implicits.catsSyntaxApplicativeError
 import org.broadinstitute.dsde.workbench.model.Notifications.Notification
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -35,19 +35,19 @@ trait CloudExtensions {
 
   def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit]
 
-  def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): IO[Unit]
 
-  def getUserStatus(user: SamUser): Future[Boolean]
+  def getUserStatus(user: SamUser): IO[Boolean]
 
-  def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): IO[Unit]
 
-  def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): IO[Unit]
 
-  def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit]
+  def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
 
   def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean]
 
-  def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): Future[Option[WorkbenchEmail]]
+  def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
 
   def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit
 
@@ -59,7 +59,7 @@ trait CloudExtensions {
 
   def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext)(implicit
       executionContext: ExecutionContext
-  ): Future[WorkbenchGroup]
+  ): IO[WorkbenchGroup]
 }
 
 trait CloudExtensionsInitializer {
@@ -78,20 +78,20 @@ trait NoExtensions extends CloudExtensions {
 
   override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] = Future.successful(())
 
-  override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
-  override def getUserStatus(user: SamUser): Future[Boolean] = Future.successful(true)
+  override def getUserStatus(user: SamUser): IO[Boolean] = IO.pure(true)
 
-  override def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserEnable(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
-  override def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserDisable(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
-  override def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
+  override def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
   override def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
 
-  override def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): Future[Option[WorkbenchEmail]] =
-    Future.successful(Option(userEmail))
+  override def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
+    IO.pure(Option(userEmail))
 
   override def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit = ()
 
@@ -103,11 +103,11 @@ trait NoExtensions extends CloudExtensions {
 
   override def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext)(implicit
       executionContext: ExecutionContext
-  ): Future[WorkbenchGroup] = {
+  ): IO[WorkbenchGroup] = {
     val allUsersGroup =
       BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set.empty, WorkbenchEmail(s"GROUP_${CloudExtensions.allUsersGroupName.value}@$emailDomain"))
     for {
-      createdGroup <- directoryDAO.createGroup(allUsersGroup, samRequestContext = samRequestContext).unsafeToFuture() recover {
+      createdGroup <- directoryDAO.createGroup(allUsersGroup, samRequestContext = samRequestContext) recover {
         case e: WorkbenchExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) => allUsersGroup
       }
     } yield createdGroup

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
@@ -195,7 +195,7 @@ class AdminResourceTypesRoutesSpec extends AnyFlatSpec with Matchers with TestSu
           Set(),
           samRequestContext
         )
-        _ <- IO.fromFuture(IO(samRoutes.userService.createUser(testUser1, samRequestContext)))
+        _ <- samRoutes.userService.createUser(testUser1, samRequestContext)
       } yield ()
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
 import cats.implicits.toFoldableOps
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.resourceTypeAdmin
@@ -51,7 +50,7 @@ class AdminResourcesRoutesSpec extends AnyFlatSpec with Matchers with TestSuppor
       val routes = TestSamRoutes(resources, user = requester)
       for {
         _ <- (admin +: users).toSet.toList.filterNot(_ == requester).traverse_ { user =>
-          IO.fromFuture(IO(routes.userService.createUser(user, samRequestContext)))
+          routes.userService.createUser(user, samRequestContext)
         }
         _ <- routes.resourceService.createPolicy(
           FullyQualifiedPolicyId(defaultAdminResourceId, defaultAdminPolicyName),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -123,7 +123,7 @@ class ManagedGroupRoutesV1Spec extends AnyFlatSpec with ScalaFutures with Matche
     assertCreateGroup(samRoutes = samRoutes)
     assertGetGroup(samRoutes = samRoutes)
 
-    samRoutes.userService.createUser(newGuy, samRequestContext).futureValue
+    samRoutes.userService.createUser(newGuy, samRequestContext).unsafeRunSync()
 
     setGroupMembers(samRoutes, Set(newGuy.email), expectedStatus = StatusCodes.Created)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -54,7 +54,7 @@ class ResourceRoutesSpec extends RetryableAnyFlatSpec with Matchers with Scalate
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
-    mockUserService.createUser(defaultUserInfo, samRequestContext)
+    mockUserService.createUser(defaultUserInfo, samRequestContext).unsafeRunSync()
 
     new TestSamRoutes(
       mockResourceService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -58,7 +58,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
-    mockUserService.createUser(samUser, samRequestContext)
+    mockUserService.createUser(samUser, samRequestContext).unsafeRunSync()
 
     new TestSamRoutes(
       mockResourceService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutesSpec.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestDuration
-import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.sam.TestSupport.configResourceTypes
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes
@@ -313,7 +312,7 @@ class AzureRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest 
   private def createSecondUser(samRoutes: TestSamRoutes, addToSpendProfile: Boolean = true): SamUser = {
     val newUser = Generator.genWorkbenchUserGoogle.sample.get
     // wait for Future to complete by converting to IO
-    IO.fromFuture(IO(samRoutes.userService.createUser(newUser, samRequestContext))).unsafeRunSync()
+    samRoutes.userService.createUser(newUser, samRequestContext).unsafeRunSync()
     if (addToSpendProfile) {
       Put(
         s"/api/resources/v2/${SamResourceTypes.spendProfile.value}/${MockCrlService.mockSamSpendProfileResource.resourceId.value}/policies/owner/memberEmails/${newUser.email.value}"

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -1,15 +1,14 @@
 package org.broadinstitute.dsde.workbench.sam.azure
 
 import akka.http.scaladsl.model.StatusCodes
-import cats.effect.IO
 import com.azure.resourcemanager.managedapplications.models.Plan
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.sam.{ConnectedTest, Generator}
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserAzure
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAzureManagedResourceGroupDAO, MockDirectoryDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.service.{NoExtensions, TosService, UserService}
+import org.broadinstitute.dsde.workbench.sam.{ConnectedTest, Generator}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -36,7 +35,7 @@ class AzureServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     // create user
     val defaultUser = genWorkbenchUserAzure.sample.get
-    val userStatus = IO.fromFuture(IO(userService.createUser(defaultUser, samRequestContext))).unsafeRunSync()
+    val userStatus = userService.createUser(defaultUser, samRequestContext).unsafeRunSync()
     userStatus shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
 
     // user should exist in postgres

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/DisableUsersMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/DisableUsersMonitorSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.google
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.{UserStatus, UserStatusDetails}
@@ -10,13 +11,13 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.sam.{PropertyBasedTesting, TestSupport}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatestplus.mockito.MockitoSugar
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class DisableUsersMonitorSpec(_system: ActorSystem)
@@ -60,7 +61,7 @@ class DisableUsersMonitorSpec(_system: ActorSystem)
     }
     when(userService.disableUser(mockitoEq(userId), any[SamRequestContext]))
       .thenReturn(
-        Future.successful(
+        IO.pure(
           Some(
             UserStatus(
               UserStatusDetails(userId, userEmail),
@@ -92,7 +93,7 @@ class DisableUsersMonitorSpec(_system: ActorSystem)
     eventually {
       assert(mockGooglePubSubDAO.subscriptionsByName.contains(subscriptionName))
     }
-    when(userService.disableUser(mockitoEq(userId), any[SamRequestContext])).thenReturn(Future.successful(None))
+    when(userService.disableUser(mockitoEq(userId), any[SamRequestContext])).thenReturn(IO.pure(None))
 
     mockGooglePubSubDAO.publishMessages(topicName, Seq(userId.value))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -395,7 +395,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     ) = initPetTest
 
     // create a user
-    val newUser = service.createUser(defaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(defaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
 
     // create a pet service account
@@ -486,7 +486,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val serviceAccount = mockGoogleIamDAO.createServiceAccount(googleProject, saName, saDisplayName).futureValue
     // create a user
 
-    val newUser = service.createUser(defaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(defaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
 
     // create a pet service account
@@ -509,7 +509,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     ) = initPetTest
 
     // create a user
-    val newUser = service.createUser(defaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(defaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
 
     // create a pet service account
@@ -964,7 +964,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     when(mockGoogleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
     when(mockGoogleDirectoryDAO.lockedDownGroupSettings).thenCallRealMethod()
 
-    googleExtensions.onUserCreate(user, samRequestContext).futureValue
+    googleExtensions.onUserCreate(user, samRequestContext).unsafeRunSync()
 
     val lockedDownGroupSettings = Option(mockGoogleDirectoryDAO.lockedDownGroupSettings)
     verify(mockGoogleDirectoryDAO).createGroup(user.email.value, proxyEmail, lockedDownGroupSettings)
@@ -1213,7 +1213,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
-    val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(createDefaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(
       UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
       Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
@@ -1238,7 +1238,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
-    val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(createDefaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(
       UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
       Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)
@@ -1275,7 +1275,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
     // create a user
-    val newUser = service.createUser(createDefaultUser, samRequestContext).futureValue
+    val newUser = service.createUser(createDefaultUser, samRequestContext).unsafeRunSync()
     newUser shouldBe UserStatus(
       UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
       Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -459,7 +459,7 @@ class UserServiceSpec
     newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true))
 
     // get user status id info (both subject ids and email)
-    val info = service.getUserIdInfoFromEmail(defaultUser.email, samRequestContext).futureValue
+    val info = service.getUserIdInfoFromEmail(defaultUser.email, samRequestContext).unsafeRunSync()
     info shouldBe Right(Some(UserIdInfo(defaultUser.id, defaultUser.email, Some(defaultUser.googleSubjectId.get))))
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-360

What:

Adding openapi timing metrics to sam user endpoints so that we can get some visibility into which endpoints are slow and when.

Why:

To get more visibility into how sam behaves in production, should help with debugging etc.

How:

I wrapped each user service call in a openTelemetry.time call, which requires an IO so I also had to do a little refactoring. 

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
