### PR TITLE
ID-360 Add timing metrics to managed groups service.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -312,8 +312,8 @@ class GoogleExtensions(
       _ <- withProxyEmail(userId)(email => IO.fromFuture(IO(googleDirectoryDAO.deleteGroup(email))))
     } yield ()
 
-  override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] =
-    googleDirectoryDAO.deleteGroup(groupEmail)
+  override def onGroupDelete(groupEmail: WorkbenchEmail): IO[Unit] =
+    IO.fromFuture(IO(googleDirectoryDAO.deleteGroup(groupEmail)))
 
   def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] =
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -33,7 +33,7 @@ trait CloudExtensions {
 
   def onGroupUpdate(groupIdentities: Seq[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): Future[Unit]
 
-  def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit]
+  def onGroupDelete(groupEmail: WorkbenchEmail): IO[Unit]
 
   def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): IO[Unit]
 
@@ -76,7 +76,7 @@ trait NoExtensions extends CloudExtensions {
 
   override def onGroupUpdate(groupIdentities: Seq[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): Future[Unit] = Future.successful(())
 
-  override def onGroupDelete(groupEmail: WorkbenchEmail): Future[Unit] = Future.successful(())
+  override def onGroupDelete(groupEmail: WorkbenchEmail): IO[Unit] = IO.unit
 
   override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -330,7 +330,7 @@ class ResourceService(
     for {
       policyEmailOpt <- directoryDAO.loadSubjectEmail(policyId, samRequestContext)
       policyEmail = policyEmailOpt.getOrElse(throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "policy not found")))
-      _ <- IO.fromFuture(IO(cloudExtensions.onGroupDelete(policyEmail)))
+      _ <- cloudExtensions.onGroupDelete(policyEmail)
       _ <- accessPolicyDAO.deletePolicy(policyId, samRequestContext)
     } yield ()
 
@@ -338,7 +338,7 @@ class ResourceService(
     for {
       policiesToDelete <- accessPolicyDAO.listAccessPolicies(resource, samRequestContext)
       _ <- policiesToDelete.traverse { policy =>
-        IO.fromFuture(IO(cloudExtensions.onGroupDelete(policy.email)))
+        cloudExtensions.onGroupDelete(policy.email)
       }
     } yield policiesToDelete
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -998,6 +998,8 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     when(mockDirectoryDAO.deleteGroup(testPolicy.id, samRequestContext)).thenReturn(IO.unit)
 
+    when(mockGoogleDirectoryDAO.deleteGroup(testPolicy.email)).thenReturn(Future.successful(()))
+
     googleExtensions.onGroupDelete(testPolicy.email).unsafeRunSync()
 
     verify(mockGoogleDirectoryDAO).deleteGroup(testPolicy.email)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -998,7 +998,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     when(mockDirectoryDAO.deleteGroup(testPolicy.id, samRequestContext)).thenReturn(IO.unit)
 
-    googleExtensions.onGroupDelete(testPolicy.email)
+    googleExtensions.onGroupDelete(testPolicy.email).unsafeRunSync()
 
     verify(mockGoogleDirectoryDAO).deleteGroup(testPolicy.email)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.service
 
 import akka.http.scaladsl.model.StatusCodes
+import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
@@ -200,7 +201,7 @@ class ManagedGroupServiceSpec
 
     val groupEmail = WorkbenchEmail(resourceId.value + "@" + testDomain)
     val mockGoogleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
-    when(mockGoogleExtensions.onGroupDelete(groupEmail)).thenReturn(Future.successful(()))
+    when(mockGoogleExtensions.onGroupDelete(groupEmail)).thenReturn(IO.unit)
     when(mockGoogleExtensions.publishGroup(WorkbenchGroupName(resourceId.value))).thenReturn(Future.successful(()))
     val managedGroupService = new ManagedGroupService(resourceService, null, resourceTypeMap, policyDAO, dirDAO, mockGoogleExtensions, testDomain)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-360

 What:

Adding openapi timing metrics to sam user endpoints so that we can get some visibility into which endpoints are slow and when.

Why:

To get more visibility into how sam behaves in production, should help with debugging etc.

How:

I wrapped each user service call in a openTelemetry.time call, which requires an IO so I also had to do a little refactoring.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://broadinstitute.github.io/dsp-appsec-security-risk-assessment/) and attached the result to the JIRA ticket
