### PR TITLE
[WOR-735] Do not set managed app config in base sam.conf

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -177,17 +177,5 @@ azureServices {
   managedAppClientId = ${?AZURE_MANAGED_APP_CLIENT_ID}
   managedAppClientSecret = ${?AZURE_MANAGED_APP_CLIENT_SECRET}
   managedAppTenantId = ${?AZURE_MANAGED_APP_TENANT_ID}
-  managedAppPlans = [
-    {
-        name = "terra-dev"
-        publisher = "thebroadinstituteinc1615909626976"
-        authorizedUserKey = authorizedTerraUser
-    }
-    {
-        name = "terra-workspace-dev-plan"
-        publisher = "thebroadinstituteinc1615909626976"
-        authorizedUserKey = authorizedTerraUser
-    }
-  ]
 }
 

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -177,5 +177,17 @@ azureServices {
   managedAppClientId = ${?AZURE_MANAGED_APP_CLIENT_ID}
   managedAppClientSecret = ${?AZURE_MANAGED_APP_CLIENT_SECRET}
   managedAppTenantId = ${?AZURE_MANAGED_APP_TENANT_ID}
+  managedAppPlans = [
+    {
+        name = "terra-dev"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
+    }
+    {
+        name = "terra-workspace-dev-plan"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
+    }
+  ]
 }
 

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -177,22 +177,5 @@ azureServices {
   managedAppClientId = ${?AZURE_MANAGED_APP_CLIENT_ID}
   managedAppClientSecret = ${?AZURE_MANAGED_APP_CLIENT_SECRET}
   managedAppTenantId = ${?AZURE_MANAGED_APP_TENANT_ID}
-  managedAppPlans = [
-    {
-        name = "terra-dev"
-        publisher = "thebroadinstituteinc1615909626976"
-        authorizedUserKey = authorizedTerraUser
-    }
-    {
-        name = "terra-workspace-dev-plan"
-        publisher = "thebroadinstituteinc1615909626976"
-        authorizedUserKey = authorizedTerraUser
-    },
-    {
-        name = "terra-prod"
-        publisher = "thebroadinstituteinc1615909626976"
-        authorizedUserKey = authorizedTerraUser
-    }
-  ]
 }
 

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -187,6 +187,11 @@ azureServices {
         name = "terra-workspace-dev-plan"
         publisher = "thebroadinstituteinc1615909626976"
         authorizedUserKey = authorizedTerraUser
+    },
+    {
+        name = "terra-prod"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
     }
   ]
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-735

## What:
We are not getting the correct config for azure managed app plans in production and are thus unable to create azure billing profiles.

## Why:

 In my testing, I believe this is down to two things:
1. We are using the wrong key name (`managedPlanIds` vs `managedAppPlans`) (should be fixed in this [`firecloud-develop` PR](https://github.com/broadinstitute/firecloud-develop/pull/3219/files)).
2. The default config in the [base sam.conf](https://github.com/broadinstitute/sam/blob/develop/src/main/resources/sam.conf#L180) overrides any prod configuration. 

I _believe_ this is due to the way sam loads configs, as documented [in this comment](https://github.com/broadinstitute/sam/blob/77e4d0f9f1aa15e4ce57a6f384029beb2b888ce0/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala#L183-L200), but I'd appreciate confirmation from an Identiteam'er.

In my testing, even when I set the correct key name + values in `config/sam.conf` as in the referenced `firecloud-develop` PR, I was still getting the dev values. Removing the `managedAppPlans` key + value entirely in the base conf resolves the issue. _However_, that causes the create bee workflow to fail out, I _think_ due to a chicken and egg situation -- once the `firecloud-develop` PR merges, I will re-run swat against this to verify.


## How:

Removes the base `managedAppPlans` value which I believe should allow the per-env configs to be loaded in.
