### PR TITLE
ID-407 Don't allow new users to use API

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -52,10 +52,8 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
   def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean =
     !tosConfig.enabled || // ToS is disabled
       (tosConfig.isGracePeriodEnabled && user.acceptedTosVersion.isDefined) || // There is a grace period, and the user has accepted some form of the ToS
-      user.acceptedTosVersion.contains(tosConfig.version) ||  // No grace period, but user has accepted the current ToS version
+      user.acceptedTosVersion.contains(tosConfig.version) || // No grace period, but user has accepted the current ToS version
       StandardSamUserDirectives.SAdomain.matches(user.email.value) // The user is a Service Account
-
-
 
   /** Get the terms of service text and send it to the caller
     * @return

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -50,9 +50,12 @@ class TosService(val directoryDao: DirectoryDAO, val appsDomain: String, val tos
   /** If grace period enabled, don't check ToS, return true If ToS disabled, return true Otherwise return true if user has accepted ToS, or is a service account
     */
   def isTermsOfServiceStatusAcceptable(user: SamUser): Boolean =
-    tosConfig.isGracePeriodEnabled || !tosConfig.enabled || user.acceptedTosVersion.contains(tosConfig.version) || StandardSamUserDirectives.SAdomain.matches(
-      user.email.value
-    )
+    !tosConfig.enabled || // ToS is disabled
+      (tosConfig.isGracePeriodEnabled && user.acceptedTosVersion.isDefined) || // There is a grace period, and the user has accepted some form of the ToS
+      user.acceptedTosVersion.contains(tosConfig.version) ||  // No grace period, but user has accepted the current ToS version
+      StandardSamUserDirectives.SAdomain.matches(user.email.value) // The user is a Service Account
+
+
 
   /** Get the terms of service text and send it to the caller
     * @return

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
@@ -163,14 +163,14 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
       }
   }
 
-  it should "pass if user has rejected terms of service within grace period" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
+  it should "fail if user has rejected terms of service within grace period" in forAll(genWorkbenchUserAzure, genOAuth2BearerToken) { (user, token) =>
     val services = directives(tosConfig = TestSupport.tosConfig.copy(enabled = true, isGracePeriodEnabled = true))
     val headers = createRequiredHeaders(Right(user.azureB2CId.get), user.email, token)
     services.directoryDAO.createUser(user.copy(enabled = true), samRequestContext).unsafeRunSync()
     services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
-        status shouldBe StatusCodes.OK
+        status shouldBe StatusCodes.Unauthorized
       }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -19,6 +19,7 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
   private val tosServiceEnabledV0 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "0"))
   private val tosServiceEnabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true))
   private val tosServiceEnabledV2 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2"))
+  private val tosServiceGracePeriodEnabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2", isGracePeriodEnabled = true))
   private val tosServiceDisabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = false))
 
   override protected def beforeAll(): Unit = {
@@ -52,15 +53,7 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     assertResult(expected = false, s"getTosStatus(${defaultUser.id}) should have returned false")(actual = getTosStatusResultRejected.get)
   }
 
-  it should "exclude service accounts from ToS checks" in {
-    assume(databaseEnabled, databaseEnabledClue)
-
-    dirDAO.createUser(serviceAccountUser, samRequestContext).unsafeRunSync()
-
-    tosServiceEnabledV0.isTermsOfServiceStatusAcceptable(serviceAccountUser) should be(true)
-  }
-
-  it should "accept new version of ToS" in {
+  it should "allow users to accept new version of ToS" in {
     assume(databaseEnabled, databaseEnabledClue)
 
     dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
@@ -72,5 +65,39 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
     tosServiceEnabledV2.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(false)
     tosServiceEnabledV2.acceptTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
     tosServiceEnabledV2.getTosStatus(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Option(true)
+  }
+
+  "TosService.isTermsOfServiceStatusAcceptable" should "allow all requests to the API if TOS is disabled" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
+    tosServiceDisabled.isTermsOfServiceStatusAcceptable(defaultUser) should be(true)
+  }
+
+  it should "not allow users who have never accepted a ToS version to use the API, even with a grace period enabled" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
+    tosServiceGracePeriodEnabled.isTermsOfServiceStatusAcceptable(defaultUser) should be(false)
+  }
+
+  it should "allow users that have accepted a previous ToS version to use the API when the grace period is enabled" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
+    dirDAO.acceptTermsOfService(defaultUser.id, "1", samRequestContext).unsafeRunSync()
+    val userAcceptedPreviousVersion = dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync().orNull
+    tosServiceGracePeriodEnabled.isTermsOfServiceStatusAcceptable(userAcceptedPreviousVersion) should be(true)
+  }
+
+  it should "not allow users that have accepted a previous ToS to use the API without a grace period" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    dirDAO.createUser(defaultUser, samRequestContext).unsafeRunSync()
+    dirDAO.acceptTermsOfService(defaultUser.id, "1", samRequestContext).unsafeRunSync()
+    val userAcceptedPreviousVersion = dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync().orNull
+    tosServiceEnabledV2.isTermsOfServiceStatusAcceptable(userAcceptedPreviousVersion) should be(false)
+  }
+
+  it should "exclude service accounts from ToS checks" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    dirDAO.createUser(serviceAccountUser, samRequestContext).unsafeRunSync()
+    tosServiceEnabledV0.isTermsOfServiceStatusAcceptable(serviceAccountUser) should be(true)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -19,7 +19,8 @@ class TosServiceSpec extends AnyFlatSpec with TestSupport with BeforeAndAfterAll
   private val tosServiceEnabledV0 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "0"))
   private val tosServiceEnabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true))
   private val tosServiceEnabledV2 = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2"))
-  private val tosServiceGracePeriodEnabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2", isGracePeriodEnabled = true))
+  private val tosServiceGracePeriodEnabled =
+    new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = true, version = "2", isGracePeriodEnabled = true))
   private val tosServiceDisabled = new TosService(dirDAO, "example.com", TestSupport.tosConfig.copy(enabled = false))
 
   override protected def beforeAll(): Unit = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-407

What:

As a new Terra user, I should not be able to use Sam's APIs without accepting the Terms of Service, even during a grace period. If I'm an existing user, I should be able to use Sam's APIs with a previously-accepted version of the Terms of Service during a grace period. If I'm an existing user and have not accepted the current Terms of Service version and there is no grace period, I should not be able to use Sam's APIs.

Why:

We've never actually enabled a grace period in prod, so we missed the "As a new Terra user, I should not be able to use Sam's APIs without accepting the Terms of Service, even during a grace period" case. This PR fixes that.

How:

Simple making the `isTermsOfServiceStatusAcceptable` method check that a user has accepted some ToS version if there's a grace period, instead of just checking that there's a grace period.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
