### PR TITLE
[WOR-739] Add prod offer

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -179,6 +179,11 @@ azureServices {
   managedAppTenantId = ${?AZURE_MANAGED_APP_TENANT_ID}
   managedAppPlans = [
     {
+        name = "terra-prod"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = authorizedTerraUser
+    }
+    {
         name = "terra-dev"
         publisher = "thebroadinstituteinc1615909626976"
         authorizedUserKey = authorizedTerraUser


### PR DESCRIPTION
The configs in `src/main/resources` may be clobbering the desired production settings. Adding them here until we can get the config extracted to the desired ENV vars. 