### PR TITLE
[IA-4013] adding a kubernetes-app-shared resource

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -156,6 +156,7 @@ resourceTypes = {
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           wds-instance = ["owner"]
+          kubernetes-app-shared = ["owner", "user"]
         }
       }
       application = {
@@ -171,6 +172,7 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           google-project = ["pet-creator"]
           wds-instance = ["writer"]
+          kubernetes-app-shared = ["user"]
         }
       }
       reader = {
@@ -180,6 +182,7 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["reader"]
           google-project = ["pet-creator"]
           wds-instance = ["reader"]
+          kubernetes-app-shared = ["user"]
         }
       }
       discoverer = {
@@ -809,6 +812,44 @@ resourceTypes = {
       }
       manager = {
         roleActions = ["delete", "status", "read_policies"]
+      }
+    }
+    reuseIds = false
+  }
+  kubernetes-app-shared = {
+    actionPatterns = {
+      delete = {
+        description = "delete kubernetes application"
+      }
+      connect = {
+        description = "connect to kubernetes application"
+      }
+      update = {
+        description = "update kubernetes application"
+      }
+      status = {
+        description = "view details and configuration of the kubernetes application"
+      }
+      stop = {
+        description = "stop kubernetes application"
+      }
+      start = {
+        description = "start kubernetes application"
+      }
+      read_policies = {
+        description = "view all policies and policy details for the kubernetes application"
+      }
+      set_parent = {
+        description = "set parent of kubernetes app"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "connect", "update", "status", "stop", "start", "read_policies", "set_parent"]
+      }
+      user = {
+        roleActions = ["connect", "status"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-3911

What:

Adds a kubernetes-app-shared sam resources to enable leonardo to create shared apps. See design doc: https://docs.google.com/document/d/1Qqljdgnzojca-8xVdpYZaEWBZs0htf59JA5Yfbeg8po/edit#heading=h.nwloytsh75t7

Why:

 The new user role will be able to connect to the URL of the shared app

How:

A new resource has been added to the `reference.conf` file with the new owner and user roles that inherit from the workspace roles

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
