### PR TITLE
[WOR-741] Allow spend-profile pet creators to add other users to the pet-creator policy

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1050,7 +1050,7 @@ resourceTypes = {
         roleActions = ["share_policy::owner", "read_policies", "alter_policies"]
       }
       pet-creator = {
-        roleActions = ["create-pet"]
+        roleActions = ["create-pet", "share_policy::pet-creator"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: [WOR-741](https://broadworkbench.atlassian.net/browse/WOR-741)

What:
Workspace owners that don't have access to the workspace's billing project still need to be able to compute and share the workspace with others. Rawls will add these owners (and writers) to the `spend-profile` resource's `pet-creator` policy (which has the `pet-creator` role) when they are added to the workspace. This will allow them to create Azure pets in that workspace. Adding the `share_policy::pet-creator` action to the `pet-creator` role will allow owners of the workspace that do not have access to the workspace's billing project to share the workspace with other users. Without this action, these owners will see 403s when trying to add new writers or owners to their workspace.

Why:
to run compute on azure

How:


---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[WOR-741]: https://broadworkbench.atlassian.net/browse/WOR-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ