### PR TITLE
ID-402 Log SamUser object from Directives

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -28,13 +28,19 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
 
   def withActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture()
+      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture().map(samUser => {
+        logger.info(s"Handling request for active Sam User: $samUser")
+        samUser
+      })
     }
   }
 
   def withUserAllowInactive(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture()
+      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture().map(samUser => {
+        logger.info(s"Handling request for (in)active Sam User: $samUser")
+        samUser
+      })
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.server.directives.OnSuccessMagnet._
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.sam.util.AsyncLogging.IOWithLogging
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam.api.StandardSamUserDirectives._
@@ -72,7 +71,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
   }
 }
 
-object StandardSamUserDirectives extends LazyLogging {
+object StandardSamUserDirectives {
   val SAdomain: Regex = "(\\S+@\\S*gserviceaccount\\.com$)".r
   // UAMI == "User Assigned Managed Identity" in Azure
   val UamiPattern: Regex = "(^/subscriptions/\\S+/resourcegroups/\\S+/providers/Microsoft\\.ManagedIdentity/userAssignedIdentities/\\S+$)".r
@@ -82,7 +81,7 @@ object StandardSamUserDirectives extends LazyLogging {
   val googleIdFromAzureHeader = "OAUTH2_CLAIM_google_id"
   val managedIdentityObjectIdHeader = "OAUTH2_CLAIM_xms_mirid"
 
-  def getSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] = {
+  def getSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext): IO[SamUser] =
     oidcHeaders match {
       case OIDCHeaders(_, Left(googleSubjectId), WorkbenchEmail(SAdomain(_)), _, _) =>
         // If it's a PET account, we treat it as its owner
@@ -104,8 +103,6 @@ object StandardSamUserDirectives extends LazyLogging {
       case OIDCHeaders(_, Right(azureB2CId), _, _, _) =>
         loadUserMaybeUpdateAzureB2CId(azureB2CId, oidcHeaders.googleSubjectIdFromAzure, directoryDAO, samRequestContext)
     }
-  }.withInfoLogMessage()
-
 
   def getActiveSamUser(oidcHeaders: OIDCHeaders, directoryDAO: DirectoryDAO, tosService: TosService, samRequestContext: SamRequestContext): IO[SamUser] =
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -29,7 +29,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
   def withActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
       getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture().map(samUser => {
-        logger.info(s"Auth Headers: $oidcHeaders mapped to active user: $samUser")
+        logger.info(s"Handling request for active Sam User: $samUser")
         samUser
       })
     }
@@ -38,7 +38,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
   def withUserAllowInactive(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
       getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture().map(samUser => {
-        logger.info(s"Auth Headers: $oidcHeaders mapped to (in)active user: $samUser")
+        logger.info(s"Handling request for (in)active Sam User: $samUser")
         samUser
       })
     }
@@ -62,6 +62,10 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
       headerValueByName(emailHeader).as(WorkbenchEmail) &
       optionalHeaderValueByName(googleIdFromAzureHeader).map(_.map(GoogleSubjectId)) &
       optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId))).as(OIDCHeaders)
+      .map(oidcHeaders => {
+        logger.info(s"Auth Headers: $oidcHeaders")
+        oidcHeaders
+      })
 
   private def externalIdFromHeaders: Directive1[Either[GoogleSubjectId, AzureB2CId]] = headerValueByName(userIdHeader).map { idString =>
     Try(BigInt(idString)).fold(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -28,19 +28,19 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
 
   def withActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture().map(samUser => {
+      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture().map { samUser =>
         logger.info(s"Handling request for active Sam User: $samUser")
         samUser
-      })
+      }
     }
   }
 
   def withUserAllowInactive(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture().map(samUser => {
+      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture().map { samUser =>
         logger.info(s"Handling request for (in)active Sam User: $samUser")
         samUser
-      })
+      }
     }
   }
 
@@ -61,11 +61,12 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
       externalIdFromHeaders &
       headerValueByName(emailHeader).as(WorkbenchEmail) &
       optionalHeaderValueByName(googleIdFromAzureHeader).map(_.map(GoogleSubjectId)) &
-      optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId))).as(OIDCHeaders)
-      .map(oidcHeaders => {
+      optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId)))
+      .as(OIDCHeaders)
+      .map { oidcHeaders =>
         logger.info(s"Auth Headers: $oidcHeaders")
         oidcHeaders
-      })
+      }
 
   private def externalIdFromHeaders: Directive1[Either[GoogleSubjectId, AzureB2CId]] = headerValueByName(userIdHeader).map { idString =>
     Try(BigInt(idString)).fold(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -28,19 +28,19 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
 
   def withActiveUser(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture().map { samUser =>
-        logger.info(s"Handling request for active Sam User: $samUser")
-        samUser
-      }
+      getActiveSamUser(oidcHeaders, directoryDAO, tosService, samRequestContext).unsafeToFuture()
+    }.tmap { samUser =>
+      logger.info(s"Handling request for active Sam User: $samUser")
+      samUser
     }
   }
 
   def withUserAllowInactive(samRequestContext: SamRequestContext): Directive1[SamUser] = requireOidcHeaders.flatMap { oidcHeaders =>
     onSuccess {
-      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture().map { samUser =>
-        logger.info(s"Handling request for (in)active Sam User: $samUser")
-        samUser
-      }
+      getSamUser(oidcHeaders, directoryDAO, samRequestContext).unsafeToFuture()
+    }.tmap { samUser =>
+      logger.info(s"Handling request for (in)active Sam User: $samUser")
+      samUser
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-402

What:

For tracking and troubleshooting reasons, it is useful to log information from the request headers and match them to the corresponding user found in Sam

Why:

To help with troubleshooting and production support

How:

There are varied ways for pretty printing a case class.  This seemed the most straight forward for what we are trying to accomplish here.  

As for where to log, that was a little tricky because we want to make sure we always log the OIDCHeaders on pretty much every request that comes in.  This solution should do that and additionally log the corresponding user we load from the DB if one is found.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
