### PR TITLE
[WOR-741] Let sharers of the spend-profile pet-creator policy read the policy

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1044,13 +1044,13 @@ resourceTypes = {
         descendantRoles = {
           landing-zone = ["user"]
         }
-        roleActions = ["link", "share_policy::user", "share_policy::pet-creator", "add_child", "create-pet"]
+        roleActions = ["link", "share_policy::user", "share_policy::pet-creator", "read_policy::pet-creator", "add_child", "create-pet"]
       }
       admin = {
         roleActions = ["share_policy::owner", "read_policies", "alter_policies"]
       }
       pet-creator = {
-        roleActions = ["create-pet", "share_policy::pet-creator"]
+        roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: [WOR-741](https://broadworkbench.atlassian.net/browse/WOR-741)

-  Immediately after sharing a policy in BPM, it tries to read the policy to return the updated policy to the caller. BPM's attempt to read the policy fails and displays the error to the user which isn't great. Adding this action to the pet-creator role will prevent that error from surfacing

  \<Don't forget to include the ticket number in the PR title!\>

What:

  \<For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).\>

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[WOR-741]: https://broadworkbench.atlassian.net/browse/WOR-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ