### PR TITLE
try to stop sam from hammering google during quota issues

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -23,4 +23,5 @@
     <include file="changesets/20220628_distributed_lock.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220811_allow_leaving_column.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20221115_azure_managed_resource_group.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230203_last_quota_error.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230203_last_quota_error.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230203_last_quota_error.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="dvoet" id="last_quota_error">
+        <createTable tableName="SAM_LAST_QUOTA_ERROR">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="last_quota_error" type="timestamptz">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -113,7 +113,7 @@ object Boot extends IOApp with LazyLogging {
 
   private[sam] def createAppDependencies(appConfig: AppConfig)(implicit actorSystem: ActorSystem): cats.effect.Resource[IO, AppDependencies] =
     for {
-      (foregroundDirectoryDAO, foregroundAccessPolicyDAO, postgresDistributedLockDAO, azureManagedResourceGroupDAO) <- createDAOs(
+      (foregroundDirectoryDAO, foregroundAccessPolicyDAO, postgresDistributedLockDAO, azureManagedResourceGroupDAO, lastQuotaErrorDAO) <- createDAOs(
         appConfig,
         appConfig.samDatabaseConfig.samWrite,
         appConfig.samDatabaseConfig.samRead
@@ -121,7 +121,7 @@ object Boot extends IOApp with LazyLogging {
 
       // This special set of objects are for operations that happen in the background, i.e. not in the immediate service
       // of an api call (foreground). They are meant to partition resources so that background processes can't crowd our api calls.
-      (backgroundDirectoryDAO, backgroundAccessPolicyDAO, _, _) <- createDAOs(
+      (backgroundDirectoryDAO, backgroundAccessPolicyDAO, _, _, _) <- createDAOs(
         appConfig,
         appConfig.samDatabaseConfig.samBackground,
         appConfig.samDatabaseConfig.samBackground
@@ -141,7 +141,8 @@ object Boot extends IOApp with LazyLogging {
         backgroundDirectoryDAO,
         backgroundAccessPolicyDAO,
         postgresDistributedLockDAO,
-        googleSynchronizerExecutionContext
+        googleSynchronizerExecutionContext,
+        lastQuotaErrorDAO
       )
 
       oauth2Config <- cats.effect.Resource.eval(
@@ -172,7 +173,8 @@ object Boot extends IOApp with LazyLogging {
       backgroundDirectoryDAO: DirectoryDAO,
       backgroundAccessPolicyDAO: AccessPolicyDAO,
       postgresDistributedLockDAO: PostgresDistributedLockDAO[IO],
-      googleSynchronizerExecutionContext: ExecutionContext
+      googleSynchronizerExecutionContext: ExecutionContext,
+      lastQuotaErrorDAO: LastQuotaErrorDAO
   )(implicit actorSystem: ActorSystem): cats.effect.Resource[IO, CloudExtensionsInitializer] =
     appConfig.googleConfig match {
       case Some(config) =>
@@ -192,6 +194,7 @@ object Boot extends IOApp with LazyLogging {
           val cloudExtension = createGoogleCloudExt(
             foregroundAccessPolicyDAO,
             foregroundDirectoryDAO,
+            lastQuotaErrorDAO,
             config,
             resourceTypeMap,
             postgresDistributedLockDAO,
@@ -212,7 +215,7 @@ object Boot extends IOApp with LazyLogging {
       appConfig: AppConfig,
       writeDbConfig: DatabaseConfig,
       readDbConfig: DatabaseConfig
-  ): cats.effect.Resource[IO, (PostgresDirectoryDAO, AccessPolicyDAO, PostgresDistributedLockDAO[IO], AzureManagedResourceGroupDAO)] =
+  ): cats.effect.Resource[IO, (PostgresDirectoryDAO, AccessPolicyDAO, PostgresDistributedLockDAO[IO], AzureManagedResourceGroupDAO, LastQuotaErrorDAO)] =
     for {
       writeDbRef <- DbReference.resource(appConfig.liquibaseConfig, writeDbConfig)
       readDbRef <- DbReference.resource(appConfig.liquibaseConfig, readDbConfig)
@@ -221,11 +224,13 @@ object Boot extends IOApp with LazyLogging {
       accessPolicyDAO = new PostgresAccessPolicyDAO(writeDbRef, readDbRef)
       postgresDistributedLockDAO = new PostgresDistributedLockDAO[IO](writeDbRef, readDbRef, appConfig.distributedLockConfig)
       azureManagedResourceGroupDAO = new PostgresAzureManagedResourceGroupDAO(writeDbRef, readDbRef)
-    } yield (directoryDAO, accessPolicyDAO, postgresDistributedLockDAO, azureManagedResourceGroupDAO)
+      lastQuotaErrorDAO = new PostgresLastQuotaErrorDAO(writeDbRef, readDbRef)
+    } yield (directoryDAO, accessPolicyDAO, postgresDistributedLockDAO, azureManagedResourceGroupDAO, lastQuotaErrorDAO)
 
   private[sam] def createGoogleCloudExt(
       accessPolicyDAO: AccessPolicyDAO,
       directoryDAO: DirectoryDAO,
+      lastQuotaErrorDAO: LastQuotaErrorDAO,
       config: GoogleConfig,
       resourceTypeMap: Map[ResourceTypeName, ResourceType],
       distributedLock: PostgresDistributedLockDAO[IO],
@@ -234,7 +239,7 @@ object Boot extends IOApp with LazyLogging {
       adminConfig: AdminConfig
   )(implicit actorSystem: ActorSystem): GoogleExtensions = {
     val workspaceMetricBaseName = "google"
-    val googleDirDaos = createGoogleDirDaos(config, workspaceMetricBaseName)
+    val googleDirDaos = createGoogleDirDaos(config, workspaceMetricBaseName, lastQuotaErrorDAO)
     val googleDirectoryDAO = DelegatePool[GoogleDirectoryDAO](googleDirDaos)
     val googleIamDAO = new HttpGoogleIamDAO(
       config.googleServicesConfig.appName,
@@ -308,7 +313,7 @@ object Boot extends IOApp with LazyLogging {
     )
   }
 
-  private def createGoogleDirDaos(config: GoogleConfig, workspaceMetricBaseName: String)(implicit
+  private def createGoogleDirDaos(config: GoogleConfig, workspaceMetricBaseName: String, lastQuotaErrorDAO: LastQuotaErrorDAO)(implicit
       actorSystem: ActorSystem
   ): NonEmptyList[HttpGoogleDirectoryDAO] = {
     val serviceAccountJsons = config.googleServicesConfig.adminSdkServiceAccountPaths.map(_.map(path => Files.readAllLines(Paths.get(path)).asScala.mkString))
@@ -325,7 +330,15 @@ object Boot extends IOApp with LazyLogging {
       case Some(accounts) => accounts.map(account => Json(account, Option(config.googleServicesConfig.subEmail)))
     }
 
-    googleCredentials.map(credentials => new HttpGoogleDirectoryDAO(config.googleServicesConfig.appName, credentials, workspaceMetricBaseName))
+    googleCredentials.map(credentials =>
+      new CoordinatedBackoffHttpGoogleDirectoryDAO(
+        config.googleServicesConfig.appName,
+        credentials,
+        workspaceMetricBaseName,
+        lastQuotaErrorDAO,
+        backoffDuration = config.coordinatedAdminSdkBackoffDuration
+      )
+    )
   }
 
   private[sam] def createAppDependenciesWithSamRoutes(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -202,7 +202,11 @@ object AppConfig {
   def readConfig(config: Config): AppConfig = {
     val googleConfigOption = for {
       googleServices <- config.getAs[GoogleServicesConfig]("googleServices")
-    } yield GoogleConfig(googleServices, config.as[PetServiceAccountConfig]("petServiceAccount"))
+    } yield GoogleConfig(
+      googleServices,
+      config.as[PetServiceAccountConfig]("petServiceAccount"),
+      config.as[Option[Duration]]("coordinatedAdminSdkBackoffDuration")
+    )
 
     // TODO - https://broadinstitute.atlassian.net/browse/GAWB-3603
     // This should JUST get the value from "emailDomain", but for now we're keeping the backwards compatibility code to

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.nonEmptyListReader
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /** Created by mbemis on 8/17/17.
   */
@@ -95,4 +95,8 @@ object GoogleServicesConfig {
 
 final case class DefaultServiceAccountJsonPath(asString: String) extends AnyVal
 final case class ServiceAccountCredentialJson(defaultServiceAccountJsonPath: DefaultServiceAccountJsonPath)
-final case class GoogleConfig(googleServicesConfig: GoogleServicesConfig, petServiceAccountConfig: PetServiceAccountConfig)
+final case class GoogleConfig(
+    googleServicesConfig: GoogleServicesConfig,
+    petServiceAccountConfig: PetServiceAccountConfig,
+    coordinatedAdminSdkBackoffDuration: Option[Duration]
+)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LastQuotaErrorDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/LastQuotaErrorDAO.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import cats.effect.IO
+
+import scala.concurrent.duration.Duration
+
+trait LastQuotaErrorDAO {
+  def quotaErrorOccurredWithinDuration(duration: Duration): IO[Boolean]
+  def recordQuotaError(): IO[Int]
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresLastQuotaErrorDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresLastQuotaErrorDAO.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.sam.db.DbReference
+import org.broadinstitute.dsde.workbench.sam.db.tables.LastQuotaErrorTable
+import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
+import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory._
+
+import scala.concurrent.duration.Duration
+
+class PostgresLastQuotaErrorDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)
+    extends LastQuotaErrorDAO
+    with DatabaseSupport
+    with PostgresGroupDAO {
+
+  private val recordId = 1
+
+  override def quotaErrorOccurredWithinDuration(duration: Duration): IO[Boolean] =
+    readOnlyTransaction("quotaErrorOccurredWithinDuration", SamRequestContext()) { implicit session =>
+      val lqe = LastQuotaErrorTable.syntax("lqe")
+      // doing the date math and comparison within the query avoid possible timezone/skew problems between app and db
+      samsql"""select ${lqe.resultAll} from ${LastQuotaErrorTable as lqe} where
+              ${lqe.lastQuotaError} + ${duration.toMillis} * INTERVAL '1 milliseconds' > clock_timestamp()"""
+        .map(LastQuotaErrorTable.apply(lqe))
+        .single()
+        .apply()
+        .isDefined
+    }
+
+  override def recordQuotaError(): IO[Int] =
+    serializableWriteTransaction("recordQuotaError", SamRequestContext()) { implicit session =>
+      val lqeColumn = LastQuotaErrorTable.column
+      // note that this uses the clock_timestamp() postgres function instead of Instant.now()
+      // because this transaction could be retried and we want to record really now
+      // and not the time when the query was formulated
+      samsql"""insert into ${LastQuotaErrorTable.table}(${lqeColumn.id}, ${lqeColumn.lastQuotaError}) values($recordId, clock_timestamp())
+              on conflict (${lqeColumn.id}) do update
+              set ${lqeColumn.lastQuotaError} = EXCLUDED.${lqeColumn.lastQuotaError}
+            """.update().apply()
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
@@ -177,4 +177,10 @@ object SamTypeBinders {
     def apply(rs: ResultSet, label: String): BillingProfileId = BillingProfileId(rs.getString(label))
     def apply(rs: ResultSet, index: Int): BillingProfileId = BillingProfileId(rs.getString(index))
   }
+
+  implicit val lastQuotaErrorPKTypeBinder: TypeBinder[LastQuotaErrorPK] = new TypeBinder[LastQuotaErrorPK] {
+    def apply(rs: ResultSet, label: String): LastQuotaErrorPK = LastQuotaErrorPK(rs.getLong(label))
+    def apply(rs: ResultSet, index: Int): LastQuotaErrorPK = LastQuotaErrorPK(rs.getLong(index))
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/LastQuotaErrorTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/LastQuotaErrorTable.scala
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
+import scalikejdbc._
+
+import java.time.Instant
+
+final case class LastQuotaErrorPK(value: Long) extends DatabaseKey
+final case class LastQuotaErrorRecord(id: LastQuotaErrorPK, lastQuotaError: Instant)
+
+object LastQuotaErrorTable extends SQLSyntaxSupportWithDefaultSamDB[LastQuotaErrorRecord] {
+  override def tableName: String = "SAM_LAST_QUOTA_ERROR"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[LastQuotaErrorRecord])(rs: WrappedResultSet): LastQuotaErrorRecord = LastQuotaErrorRecord(
+    rs.get(e.id),
+    rs.timestamp(e.lastQuotaError).toInstant
+  )
+
+  def apply(o: SyntaxProvider[LastQuotaErrorRecord])(rs: WrappedResultSet): LastQuotaErrorRecord = apply(o.resultName)(rs)
+
+  def opt(m: SyntaxProvider[LastQuotaErrorRecord])(rs: WrappedResultSet): Option[LastQuotaErrorRecord] =
+    rs.longOpt(m.resultName.id).map(_ => LastQuotaErrorTable(m)(rs))
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAO.scala
@@ -1,0 +1,51 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import akka.actor.ActorSystem
+import cats.effect.unsafe.implicits.global
+import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
+import com.google.api.client.http.{HttpHeaders, HttpResponseException}
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates.whenUsageLimited
+import org.broadinstitute.dsde.workbench.google.HttpGoogleDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.LastQuotaErrorDAO
+
+import java.util.Collections
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{ExecutionContext, Future}
+
+class CoordinatedBackoffHttpGoogleDirectoryDAO(
+    appName: String,
+    googleCredentialMode: GoogleCredentialMode,
+    workbenchMetricBaseName: String,
+    lastQuotaErrorDAO: LastQuotaErrorDAO,
+    maxPageSize: Int = 200,
+    val backoffDuration: Option[Duration] = None
+)(implicit system: ActorSystem, executionContext: ExecutionContext)
+    extends HttpGoogleDirectoryDAO(appName, googleCredentialMode, workbenchMetricBaseName, maxPageSize) {
+
+  override def retryExponentially[T](pred: Predicate[Throwable], failureLogMessage: String)(op: () => Future[T])(implicit
+      executionContext: ExecutionContext
+  ): RetryableFuture[T] =
+    super.retryExponentially(pred, failureLogMessage) { () =>
+      lastQuotaErrorDAO.quotaErrorOccurredWithinDuration(backoffDuration.getOrElse(2 seconds)).unsafeToFuture().flatMap {
+        case true => Future.failed(usageLimitedException)
+        case false =>
+          op().recoverWith {
+            case t if whenUsageLimited(t) => lastQuotaErrorDAO.recordQuotaError().unsafeToFuture().flatMap(_ => Future.failed(t))
+          }
+      }
+    }
+
+  private[google] def usageLimitedException = {
+    val errorInfo = new GoogleJsonError.ErrorInfo()
+    errorInfo.setDomain("usageLimits")
+    errorInfo.setMessage("Sam in backoff mode, did not actually call google")
+    val googleJsonError = new GoogleJsonError()
+    googleJsonError.setCode(403)
+    googleJsonError.setErrors(Collections.singletonList(errorInfo))
+    new GoogleJsonResponseException(
+      new HttpResponseException.Builder(403, "403 Forbidden", new HttpHeaders()),
+      googleJsonError
+    )
+  }
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -158,7 +158,7 @@ db {
 }
 
 scalikejdbc.global.loggingSQLAndTime {
-  enabled = true, # switch this to true to print sql
+  enabled = false, # switch this to true to print sql
   singleLineMode = true, # switch this to false to see stack trace information about where sql was executed
   printUnprocessedStackTrace = false,
   stackTraceDepth= 15,

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -158,7 +158,7 @@ db {
 }
 
 scalikejdbc.global.loggingSQLAndTime {
-  enabled = false, # switch this to true to print sql
+  enabled = true, # switch this to true to print sql
   singleLineMode = true, # switch this to false to see stack trace information about where sql was executed
   printUnprocessedStackTrace = false,
   stackTraceDepth= 15,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -238,7 +238,8 @@ object TestSupport extends TestSupport {
           PetManagedIdentityTable,
           UserTable,
           AccessInstructionsTable,
-          GroupTable
+          GroupTable,
+          LastQuotaErrorTable
         )
 
         tables

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresLastQuotaErrorDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresLastQuotaErrorDAOSpec.scala
@@ -1,0 +1,43 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+
+class PostgresLastQuotaErrorDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach {
+  val dao = new PostgresLastQuotaErrorDAO(TestSupport.dbRef, TestSupport.dbRef)
+
+  override protected def beforeEach(): Unit =
+    TestSupport.truncateAll
+
+  "PostgresLastQuotaErrorDAO" - {
+    "quotaErrorOccurredWithinDuration" - {
+      "always returns false when no error" in {
+        dao.quotaErrorOccurredWithinDuration(0.seconds).unsafeRunSync() shouldBe false
+        dao.quotaErrorOccurredWithinDuration(10.seconds).unsafeRunSync() shouldBe false
+      }
+
+      "returns false when error outside duration" in {
+        dao.recordQuotaError().unsafeRunSync()
+        Thread.sleep(500)
+        dao.quotaErrorOccurredWithinDuration(100.millisecond).unsafeRunSync() shouldBe false
+      }
+
+      "returns true when error inside duration" in {
+        dao.recordQuotaError().unsafeRunSync()
+        dao.quotaErrorOccurredWithinDuration(100.millisecond).unsafeRunSync() shouldBe true
+      }
+    }
+
+    "recordQuotaError" - {
+      "does not fail on consecutive inserts" in {
+        dao.recordQuotaError().unsafeRunSync()
+        dao.recordQuotaError().unsafeRunSync()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAOSpec.scala
@@ -1,0 +1,78 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import akka.actor.ActorSystem
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities
+import org.broadinstitute.dsde.workbench.sam.dataAccess.LastQuotaErrorDAO
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+
+class CoordinatedBackoffHttpGoogleDirectoryDAOSpec extends AnyFreeSpec with Matchers {
+  implicit val system = ActorSystem("CoordinatedBackoffHttpGoogleDirectoryDAOSpec")
+
+  "CoordinatedBackoffHttpGoogleDirectoryDAO" - {
+    "retryExponentially" - {
+      "should not do the op when in backoff mode" in {
+        val lastQuotaErrorDAOMock = mock[LastQuotaErrorDAO]
+        when(lastQuotaErrorDAOMock.quotaErrorOccurredWithinDuration(any[Duration])).thenReturn(IO.pure(true))
+        val googleDao = new CoordinatedBackoffHttpGoogleDirectoryDAO("", null, "", lastQuotaErrorDAOMock)
+
+        val test = googleDao.retryExponentially(GoogleUtilities.RetryPredicates.whenUsageLimited) { () =>
+          Future(fail("op should not have been called"))
+        }
+
+        Await.result(test, Duration.Inf) match {
+          case Right(_) => fail("expected error")
+          case Left(errors) =>
+            errors.length shouldBe 7
+            errors.forall(_ == googleDao.usageLimitedException)
+        }
+      }
+
+      "records quota errors" in {
+        val lastQuotaErrorDAOMock = mock[LastQuotaErrorDAO]
+        when(lastQuotaErrorDAOMock.quotaErrorOccurredWithinDuration(any[Duration])).thenReturn(IO.pure(false))
+        when(lastQuotaErrorDAOMock.recordQuotaError()).thenReturn(IO.pure(1))
+        val googleDao = new CoordinatedBackoffHttpGoogleDirectoryDAO("", null, "", lastQuotaErrorDAOMock)
+
+        val test = googleDao.retryExponentially(_ => false) { () =>
+          Future.failed(googleDao.usageLimitedException)
+        }
+
+        Await.result(test, Duration.Inf) match {
+          case Right(_) => fail("expected error")
+          case Left(errors) =>
+            errors.length shouldBe 1
+            errors.forall(_ == googleDao.usageLimitedException)
+        }
+
+        verify(lastQuotaErrorDAOMock).recordQuotaError()
+      }
+
+      "should do the op when not in backoff mode" in {
+        val lastQuotaErrorDAOMock = mock[LastQuotaErrorDAO]
+        when(lastQuotaErrorDAOMock.quotaErrorOccurredWithinDuration(any[Duration])).thenReturn(IO.pure(false))
+        val googleDao = new CoordinatedBackoffHttpGoogleDirectoryDAO("", null, "", lastQuotaErrorDAOMock)
+
+        val expectedResult = "I did a thing"
+        val test = googleDao.retryExponentially(GoogleUtilities.RetryPredicates.whenUsageLimited) { () =>
+          Future.successful(expectedResult)
+        }
+
+        Await.result(test, Duration.Inf) match {
+          case Right((l, result)) =>
+            l shouldBe empty
+            result shouldBe expectedResult
+          case Left(errors) => fail("should not have had errors", errors.head)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-446

There are multiple instances of sam each with multiple threads doing google group things. When there is a quota error they all start hammering google with uncoordinated backoffs.

This tries to stop that using a database record saving the last time a quota error was encountered. If we want to make a google groups request within a configurable time (2s by default) after the last error, just don't do it and pretend kind of like we did and got the rate limit error. A little quick and dirty, it does so by overriding the `retryExponentially` function in the `HttpGoogleDirectoryDAO` to wrap operations with this desired feature.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
