### PR TITLE
ZEBRA-54: Add Zebrafish MCT Resource Types

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1358,6 +1358,70 @@ resourceTypes = {
     }
     reuseIds = true
   }
+  mct_mapping = {
+    actionPatterns = {
+      own = {
+        description = "perform owner actions on the resource"
+      }
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      write = {
+        description = "perform writer actions on the resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "own", "write"]
+      }
+      editor = {
+        roleActions = ["write", "share_policy::editor"]
+      }
+    }
+    reuseIds = false
+  }
+  mct_target = {
+    actionPatterns = {
+      own = {
+        description = "perform owner actions on the resource"
+      }
+      delete = {
+        description = "delete this resource"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this resource"
+      }
+      write = {
+        description = "perform writer actions on the resource"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this resource"
+      }
+      "share_policy::editor" = {
+        description = "change the membership of the editor policy for this resource"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "own", "write"]
+      }
+      editor = {
+        roleActions = ["write", "share_policy::editor"]
+      }
+    }
+    reuseIds = false
+  }
 }
 
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1385,7 +1385,7 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "own", "write"]
       }
       editor = {
-        roleActions = ["write", "share_policy::editor"]
+        roleActions = ["write"]
       }
     }
     reuseIds = false
@@ -1417,7 +1417,7 @@ resourceTypes = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::editor", "own", "write"]
       }
       editor = {
-        roleActions = ["write", "share_policy::editor"]
+        roleActions = ["write"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: [ZEBRA-54](https://broadworkbench.atlassian.net/browse/ZEBRA-54)

What:

Zebrafish is a service that is being developed by a consultant (Manifold) in partnership with the Broad Institute. For now, code is in a private repo run by Manifold, and JIRA is a Manifold account (linked anyway above).

Part of Zebrafish is the Mapping Curation Tool (MCT). This is a user interface that helps define mappings between data sets and a target schema. The point is ingesting data into TDR with the given target schema (project led by the DSP Data Ingest team).

Why:

In order to run within the Terra security perimeter and have SAM be the source of truth for authorization, we need to represent MCT resources in SAM. There are two resource types to protect:

- `mct_mapping`
    - this is the configuration for transforming the source dataset to the target schema
- `mct_target`
    - this is the target schema itself
    - over time, the tool may be used for different target schemas 
   
These resources are very simple. They are essentially documents in the application's database. These documents should be publicly readable. We just need to protect owner and editor access to these documents. The documents aren't subdivided, so it's as simple as being able to write or not write, etc.

The point of this PR is defining those resource types. The definitions are copied from `controlled-user-shared-workspace-resource` since that resource type had the required actions and roles.

I prefixed the resource types with `mct_` for clarity/specificity, but that was just a guess at a naming convention, I can use whatever naming scheme is preferred.

How:

MCT resource types defined in `reference.conf`

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[ZEBRA-54]: https://broadworkbench.atlassian.net/browse/ZEBRA-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ