### PR TITLE
[IA-4012] give kubernetes-app resource workspace inheritance

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -619,7 +619,7 @@ resourceTypes = {
         roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
         includedRoles = ["pet-creator"]
       }
-      pet-creator = {x
+      pet-creator = {
         roleActions = ["create-pet"]
       }
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -156,6 +156,7 @@ resourceTypes = {
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           wds-instance = ["owner"]
+          kubernetes-app = ["creator", "manager"]
           kubernetes-app-shared = ["owner", "user"]
         }
       }
@@ -172,6 +173,7 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           google-project = ["pet-creator"]
           wds-instance = ["writer"]
+          kubernetes-app = ["manager"]
           kubernetes-app-shared = ["user"]
         }
       }
@@ -182,6 +184,7 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["reader"]
           google-project = ["pet-creator"]
           wds-instance = ["reader"]
+          kubernetes-app = ["manager"]
           kubernetes-app-shared = ["user"]
         }
       }
@@ -616,7 +619,7 @@ resourceTypes = {
         roleActions = ["launch_notebook_cluster", "create_persistent_disk", "create_kubernetes_app", "add_child"]
         includedRoles = ["pet-creator"]
       }
-      pet-creator = {
+      pet-creator = {x
         roleActions = ["create-pet"]
       }
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -156,7 +156,7 @@ resourceTypes = {
           controlled-user-private-workspace-resource = ["deleter"]
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           wds-instance = ["owner"]
-          kubernetes-app = ["creator", "manager"]
+          kubernetes-app = ["manager"]
           kubernetes-app-shared = ["owner", "user"]
         }
       }
@@ -173,7 +173,6 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["writer", "reader"]
           google-project = ["pet-creator"]
           wds-instance = ["writer"]
-          kubernetes-app = ["manager"]
           kubernetes-app-shared = ["user"]
         }
       }
@@ -184,7 +183,6 @@ resourceTypes = {
           controlled-application-shared-workspace-resource = ["reader"]
           google-project = ["pet-creator"]
           wds-instance = ["reader"]
-          kubernetes-app = ["manager"]
           kubernetes-app-shared = ["user"]
         }
       }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-4012

What:

Give app permission inheritance from Workspace in addition to the Google Project. This will enable a better user experience with V2 apps.

Why:

 This way the behavior of the `kubernetes-app` resource will be similar to the new `kubernetes-app-shared` resource. 
https://github.com/broadinstitute/sam/pull/965

We want to keep the inheritance from the Google project for now to avoid any breaking change or need for a migration quite yet on legacy apps.

How:

Creator and manager roles both inherit from the workspace owner, while the manager role also inherit from the workspace reader and writer roles.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
