### PR TITLE
[WOR-777] give read_spend_report to spend-profile owners

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1073,6 +1073,9 @@ resourceTypes = {
       "create-pet" = {
         description = "create pet identity using this spend profile"
       }
+      "read_spend_report" = {
+        description = "read spend report for this spend profile"
+      }
     }
     ownerRoleName = "owner"
     roles = {
@@ -1080,7 +1083,7 @@ resourceTypes = {
         descendantRoles = {
           landing-zone = ["owner"]
         }
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::pet-creator", "read_policies", "add_child", "list_children", "view_journal", "set_managed_resource_group", "create-pet"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::pet-creator", "read_policies", "add_child", "list_children", "view_journal", "set_managed_resource_group", "create-pet", "read_spend_report"]
       }
       user = {
         descendantRoles = {


### PR DESCRIPTION
Ticket: [WOR-777](https://broadworkbench.atlassian.net/browse/WOR-777)

What:
Add new `read_spend_report` action to `owner` `spend-profile` role. BPM will check this permission before returning spend report data for billing profiles (see https://github.com/DataBiosphere/terra-billing-profile-manager/pull/147)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[WOR-777]: https://broadworkbench.atlassian.net/browse/WOR-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ