### PR TITLE
QA-2050: Add Consumer Version Selector to SamProviderSpec to select consumer pacts from default branch.

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -6,14 +6,9 @@ name: Verify consumer pacts
 # - PACT_BROKER_USERNAME - the Pact Broker username
 # - PACT_BROKER_PASSWORD - the Pact Broker password
 on:
-  pull_request:
-    branches:
-      - develop
-    paths-ignore:
-      - 'README.md'
   push:
     branches:
-      - develop
+      - QA-2050
     paths-ignore:
       - 'README.md'
 env:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -6,9 +6,14 @@ name: Verify consumer pacts
 # - PACT_BROKER_USERNAME - the Pact Broker username
 # - PACT_BROKER_PASSWORD - the Pact Broker password
 on:
+  pull_request:
+    branches:
+      - develop
+    paths-ignore:
+      - 'README.md'
   push:
     branches:
-      - QA-2050
+      - develop
     paths-ignore:
       - 'README.md'
 env:

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -134,6 +134,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .PactBrokerWithSelectors(
         brokerUrl = pactBrokerUrl
       )
+      .withConsumerVersionSelectors(ConsumerVersionSelectors.mainBranch)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 


### PR DESCRIPTION
Ticket: [QA-2050](https://broadworkbench.atlassian.net/browse/QA-2050)

What:

Choose Consumer Version Selectors based on branches / environment.

- The minimum pact that should be verified by Sam is the latest pact from the main line of development from the consumer (eg. { "mainBranch": true }). 

Why:

The `SamProviderSpec` should only verify Leo since it has a consumer pact published from default branch. 
The Consent pact should not be verified since it has not yet been published through its default branch.

How:

Add consumer version selector config to `SamProviderSpec`, this will bypass `Consent` pacts from PR branches.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[QA-2050]: https://broadworkbench.atlassian.net/browse/QA-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ