### PR TITLE
ID-442 Added unit tests in DeleteUserSpec for UserService.deleteUser …

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/SamApiSpec.scala
@@ -55,39 +55,6 @@ class SamApiSpec extends AnyFreeSpec with Matchers with ScalaFutures with CleanU
     Thurloe.keyValuePairs.deleteAll(subjectId)
   }
 
-  "Sam test utilities" - {
-    "should be idempotent for removal of user's registration" in {
-
-      // use a temp user because they should not be registered.  Remove them after!
-
-      val tempUser: Credentials = UserPool.chooseTemp
-      val tempAuthToken: AuthToken = tempUser.makeAuthToken()
-
-      // Register user if the user is not registered
-      val tempUserInfo = Sam.user.status()(tempAuthToken) match {
-        case Some(user) =>
-          logger.info(s"User ${user.userInfo.userEmail} was already registered.")
-          user.userInfo
-        case None =>
-          logger.info(s"User ${tempUser.email} does not yet exist! Registering user.")
-          Sam.user.registerSelf()(tempAuthToken)
-          Sam.user.status()(tempAuthToken).get.userInfo
-      }
-
-      tempUserInfo.userEmail shouldBe tempUser.email
-
-      // Remove user
-
-      removeUser(tempUserInfo.userSubjectId)
-      Sam.user.status()(tempAuthToken) shouldBe None
-
-      // OK to re-remove
-
-      removeUser(tempUserInfo.userSubjectId)
-      Sam.user.status()(tempAuthToken) shouldBe None
-    }
-  }
-
   "Sam" - {
     "should return terms of services with auth token" in {
       val anyUser: Credentials = UserPool.chooseAnyUser

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
@@ -107,6 +107,16 @@ case class MockDirectoryDaoBuilder() extends MockitoSugar {
     .when(mockedDirectoryDAO)
     .setUserAzureB2CId(any[WorkbenchUserId], any[AzureB2CId], any[SamRequestContext])
 
+  lenient()
+    .doReturn(IO(true))
+    .when(mockedDirectoryDAO)
+    .removeGroupMember(any[WorkbenchGroupIdentity], any[WorkbenchSubject], any[SamRequestContext])
+
+  lenient()
+    .doReturn(IO.unit)
+    .when(mockedDirectoryDAO)
+    .deleteUser(any[WorkbenchUserId], any[SamRequestContext])
+
   def withExistingUser(samUser: SamUser): MockDirectoryDaoBuilder = withExistingUsers(Set(samUser))
   def withExistingUsers(samUsers: Iterable[SamUser]): MockDirectoryDaoBuilder = {
     samUsers.toSet.foreach(makeUserExist)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.service
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import org.broadinstitute.dsde.workbench.model.{WorkbenchGroup, WorkbenchGroupIdentity}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchGroup, WorkbenchGroupIdentity, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -68,6 +68,12 @@ case class MockCloudExtensionsBuilder(directoryDAO: DirectoryDAO) extends Mockit
     .doReturn(Future.successful(()))
     .when(mockedCloudExtensions)
     .onGroupUpdate(any[Seq[WorkbenchGroupIdentity]], any[SamRequestContext])
+
+  lenient()
+    .doReturn(IO.unit)
+    .when(mockedCloudExtensions)
+    .onUserDelete(any[WorkbenchUserId], any[SamRequestContext])
+
 
   def withEnabledUser(samUser: SamUser): MockCloudExtensionsBuilder = withEnabledUsers(Set(samUser))
   def withEnabledUsers(samUsers: Iterable[SamUser]): MockCloudExtensionsBuilder = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
@@ -74,7 +74,6 @@ case class MockCloudExtensionsBuilder(directoryDAO: DirectoryDAO) extends Mockit
     .when(mockedCloudExtensions)
     .onUserDelete(any[WorkbenchUserId], any[SamRequestContext])
 
-
   def withEnabledUser(samUser: SamUser): MockCloudExtensionsBuilder = withEnabledUsers(Set(samUser))
   def withEnabledUsers(samUsers: Iterable[SamUser]): MockCloudExtensionsBuilder = {
     samUsers.foreach(makeUserAppearEnabled)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/DeleteUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/DeleteUserSpec.scala
@@ -1,0 +1,51 @@
+package org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, TestUserServiceBuilder}
+
+import scala.concurrent.ExecutionContextExecutor
+
+class DeleteUserSpec extends UserServiceTestTraits {
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+  val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
+
+  describe("When deleting") {
+    describe("an existing user") {
+      it("should be successful") {
+        // Arrange
+        val userWithBothIds = genWorkbenchUserBoth.sample.get
+        val userService = TestUserServiceBuilder()
+          .withAllUsersGroup(allUsersGroup)
+          .withEnabledUser(userWithBothIds)
+          .build
+
+        // Act
+        runAndWait(userService.deleteUser(userWithBothIds.id, samRequestContext))
+
+        // Assert
+        assert(true, "Deleting the user should succeed without throwing an exception.")
+      }
+    }
+    describe("user that does not exist") {
+      it("should be successful") {
+        // Arrange
+        val userWithBothIds = genWorkbenchUserBoth.sample.get
+        val userService = TestUserServiceBuilder()
+          .withAllUsersGroup(allUsersGroup)
+          .build
+
+        // Act
+        runAndWait(userService.deleteUser(userWithBothIds.id, samRequestContext))
+
+        // Assert
+        assert(true, "Deleting the user should succeed without throwing an exception.")
+      }
+    }
+  }
+
+
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/DeleteUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/DeleteUserSpec.scala
@@ -46,6 +46,4 @@ class DeleteUserSpec extends UserServiceTestTraits {
     }
   }
 
-
-
 }


### PR DESCRIPTION
…and deleted the corresponding automation/ test.

Ticket: https://broadworkbench.atlassian.net/browse/ID-442


What:
Removing automation test to speed up and reduce integrations. Wrote a corresponding unit test.

Why:

Reduce test complexity and run time.


---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
