### PR TITLE
QA-2048: Set up a webhook between Leo consumer and Sam provider.

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
     paths-ignore: ['**.md']
+  workflow_dispatch:
 
 jobs:
   sam-build-tag-publish-job:

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -9,7 +9,6 @@ on:
     branches:
       - develop
     paths-ignore: ['**.md']
-  workflow_dispatch:
 
 jobs:
   sam-build-tag-publish-job:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -17,6 +17,59 @@ on:
     paths-ignore:
       - 'README.md'
   workflow_dispatch:
+    inputs:
+      pb-event-type:
+        description: 'the PB event type that triggers this workflow'
+        required: true
+        type: string
+      consumer-name:
+        description: 'the consumer name'
+        required: true
+        type: string
+      consumer-version-number:
+        description: 'the version number of the most recent consumer version associated with the pact content'
+        required: true
+        type: string
+      provider-version-number:
+        description: 'the provider version number for the verification result'
+        required: true
+        type: string
+      consumer-version-tags:
+        description: 'the list of tag names for the most recent consumer version associated with the pact content, separated by ", "'
+        required: true
+        type: string
+      provider-version-tags:
+        description: 'the list of tag names for the provider version associated with the verification result, separated by ", "'
+        required: true
+        type: string
+      consumer-version-branch:
+        description: 'the name of the branch for most recent consumer version associated with the pact content'
+        required: true
+        type: string
+      provider-version-branch:
+        description: 'the name of the branch for the provider version associated with the verification result'
+        required: true
+        type: string
+      consumer-labels:
+        description: 'the list of labels for the consumer associated with the pact content, separated by ", "'
+        required: true
+        type: string
+      provider-labels:
+        description: 'the list of labels for the provider associated with the pact content, separated by ", "'
+        required: true
+        type: string
+      github-verification-status:
+        description: 'the verification status using the correct keywords for posting to the the Github commit status API'
+        required: true
+        type: string
+      pact-url:
+        description: 'the "permalink" URL to the newly published pact (the URL specifying the consumer version URL, rather than the "/latest" format'
+        required: true
+        type: string
+      verification-result-url:
+        description: 'the URL to the relevant verification result'
+        required: true
+        type: string
 env:
   PACT_BROKER_URL: https://pact-broker.dsp-eng-tools.broadinstitute.org
 
@@ -49,6 +102,11 @@ jobs:
           echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+
+      - name: "This step will only run when the workflow is triggered by Pact Broker 'contract requiring verification published' event type"
+        if: ${{ inputs.pb-event-type == 'contract-requiring-verification-published' }}
+        run: |
+          echo ${{ inputs }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -16,6 +16,7 @@ on:
       - develop
     paths-ignore:
       - 'README.md'
+  workflow_dispatch:
 env:
   PACT_BROKER_URL: https://pact-broker.dsp-eng-tools.broadinstitute.org
 

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -38,10 +38,6 @@ on:
         description: 'the list of tag names for the most recent consumer version associated with the pact content, separated by ", "'
         required: true
         type: string
-      provider-version-tags:
-        description: 'the list of tag names for the provider version associated with the verification result, separated by ", "'
-        required: true
-        type: string
       consumer-version-branch:
         description: 'the name of the branch for most recent consumer version associated with the pact content'
         required: true
@@ -58,18 +54,11 @@ on:
         description: 'the list of labels for the provider associated with the pact content, separated by ", "'
         required: true
         type: string
-      github-verification-status:
-        description: 'the verification status using the correct keywords for posting to the the Github commit status API'
-        required: true
-        type: string
       pact-url:
         description: 'the "permalink" URL to the newly published pact (the URL specifying the consumer version URL, rather than the "/latest" format'
         required: true
         type: string
-      verification-result-url:
-        description: 'the URL to the relevant verification result'
-        required: true
-        type: string
+
 env:
   PACT_BROKER_URL: https://pact-broker.dsp-eng-tools.broadinstitute.org
 


### PR DESCRIPTION
Ticket: [QA-2048](https://broadworkbench.atlassian.net/browse/QA-2048)

**What**

This ticket added a `workflow_dispatch` to `verify_consumer_pacts.yml` with following input parameters provided by the dispatcher.

```
      pb-event-type:
        description: 'the PB event type that triggers this workflow'
        required: true
        type: string
      consumer-name:
        description: 'the consumer name'
        required: true
        type: string
      consumer-version-number:
        description: 'the version number of the most recent consumer version associated with the pact content'
        required: true
        type: string
      provider-version-number:
        description: 'the provider version number for the verification result'
        required: true
        type: string
      consumer-version-tags:
        description: 'the list of tag names for the most recent consumer version associated with the pact content, separated by ", "'
        required: true
        type: string
      consumer-version-branch:
        description: 'the name of the branch for most recent consumer version associated with the pact content'
        required: true
        type: string
      provider-version-branch:
        description: 'the name of the branch for the provider version associated with the verification result'
        required: true
        type: string
      consumer-labels:
        description: 'the list of labels for the consumer associated with the pact content, separated by ", "'
        required: true
        type: string
      provider-labels:
        description: 'the list of labels for the provider associated with the pact content, separated by ", "'
        required: true
        type: string
      pact-url:
        description: 'the "permalink" URL to the newly published pact (the URL specifying the consumer version URL, rather than the "/latest" format'
        required: true
        type: string
```

**Why**

Whenever a consumer publish a contract, the Pact Broker will use an algorithm to determine whether it should trigger provider verification tests. The algorithm is captured by the PB event type `contract-requiring-verification-published`. 

**How**

The PB will pass the event type and parameters defined in the **What** section as payload to trigger the `Sam` `verify_consumer_pacts.yml` workflow.

In this PR, we are setting up the input parameters as placeholders in `verify_consumer_pacts.yml`. 

In a follow up ticket, we will use these parameters to drive the verification tests. For example, we can use `provider-version` and `provider-version-branch` info to check out the proper Sam version to run tests. By default, tests will always run against default branch `develop'. The additional parameters make this workflow more flexible.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[QA-2048]: https://broadworkbench.atlassian.net/browse/QA-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ