### PR TITLE
AJ-666: enable reuseids for wds-instance resource

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1353,7 +1353,7 @@ resourceTypes = {
         roleActions = ["read", "get_parent"]
       }
     }
-    reuseIds = false
+    reuseIds = true
   }
 }
 


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/AJ-666

**What:** enable `reuseIds = true` for the `wds-instance` resource.

**Why:** WDS allows end users to delete and re-create an instance (drop all data and start from scratch). Since the Sam resource id is the same as the instance id, this means we will delete and re-create the Sam resource.

Doug's comment:
> The change is simple but exiting deleted resources will remain preventing reuse of their ids. The reason this is a thing is if your resource is created in a special way that you don’t want the user to undo (e.g. auth domains). If they can delete the resource in sam they recreate it how they wish.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
