### PR TITLE
QA-2056: Implement GitHub Actions to set up webhooks for other event types

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
 
       - name: dispatch build to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: sam-build
           repo: broadinstitute/terra-github-workflows
@@ -80,7 +80,7 @@ jobs:
           echo '${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
@@ -101,9 +101,9 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: sam-smoke-tests
+          workflow: .github/workflows/sam-smoke-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
@@ -123,9 +123,9 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: sam-swat-tests
+          workflow: .github/workflows/sam-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
@@ -144,7 +144,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
 
       - name: dispatch build to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
         with:
           workflow: sam-build
           repo: broadinstitute/terra-github-workflows
@@ -80,7 +80,7 @@ jobs:
           echo '${{ needs.sam-build-tag-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
         with:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
@@ -101,9 +101,9 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
         with:
-          workflow: .github/workflows/sam-smoke-tests.yaml
+          workflow: sam-smoke-tests
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
@@ -123,9 +123,9 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
         with:
-          workflow: .github/workflows/sam-swat-tests.yaml
+          workflow: sam-swat-tests
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
@@ -144,7 +144,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
         with:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -17,7 +17,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - develop
+      - QA-2056
     paths-ignore:
       - 'README.md'
   workflow_dispatch:
@@ -72,6 +72,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    outputs:
+      provider-sha: ${{ steps.verification-test.outputs.provider-sha }}
 
     steps:
       - name: Checkout current code
@@ -131,7 +133,9 @@ jobs:
           cat pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
+        id: verification-test
         run: |
+          echo "provider-sha=${{ env.PROVIDER_SHA }}" >> $GITHUB_OUTPUT
           echo "env.CHECKOUT_BRANCH=${{ env.CHECKOUT_BRANCH }} # This should reflect the code branch this workflow runs on"
           echo "env.CHECKOUT_SHA=${{ env.CHECKOUT_SHA }}       # This should reflect the git hash of the branch this workflows runs on"
           echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This should reflect the provider branch for pact verification"
@@ -152,3 +156,17 @@ jobs:
                           -e PACT_BROKER_PASSWORD=${{ secrets.PACT_BROKER_PASSWORD }} \
                           sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 \
                           sbt "project pact4s" "testOnly *SamProviderSpec"
+
+  can-i-deploy: # We only need this if Sam makes a change
+    runs-on: ubuntu-latest
+    needs: [ verify-consumer-pact ]
+    steps:
+      - name: Dispatch to terra-github-workflows
+        if: ${{ inputs.pb-event-type == '' }}
+        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        with:
+          workflow: can-i-deploy.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/QA-2056
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "pacticipant": "leo-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}", "environment": "alpha" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
-          fetch_depth: 0
+          fetch-depth: 0
 
       - name: Extract branch
         id: extract-branch
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
-          fetch_depth: 0
+          fetch-depth: 0
           ref: ${{ env.PROVIDER_BRANCH }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -122,7 +122,7 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          $(git rev-parse ${{ inputs.provider-version-number }})
+          $(git rev-parse --remotes ${{ inputs.provider-version-number }})
 
       - name: Checkout current code
         uses: actions/checkout@v3

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -32,7 +32,7 @@ on:
         type: string
       provider-version-number:
         description: 'the provider version number for the verification result'
-        required: true
+        required: false
         type: string
       consumer-version-tags:
         description: 'the list of tag names for the most recent consumer version associated with the pact content, separated by ", "'
@@ -44,7 +44,7 @@ on:
         type: string
       provider-version-branch:
         description: 'the name of the branch for the provider version associated with the verification result'
-        required: true
+        required: false
         type: string
       consumer-labels:
         description: 'the list of labels for the consumer associated with the pact content, separated by ", "'
@@ -94,9 +94,11 @@ jobs:
           echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+          echo "BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
+          echo "GIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
-      - name: "This step will only run when the workflow is triggered by Pact Broker 'contract requiring verification published' event type"
-        if: ${{ inputs.pb-event-type == 'contract-requiring-verification-published' }}
+      - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
+        if: ${{ inputs.pb-event-type != '' }}
         run: |
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
@@ -105,15 +107,24 @@ jobs:
           echo "consumer-version-branch=${{ inputs.consumer-version-branch }}"
           echo "provider-version-branch=${{ inputs.provider-version-branch }}"
           echo "pact-url=${{ inputs.pact-url }}"
+          if [[ "${{ inputs.provider-version-branch }}" != "" ]]; then
+            echo "BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
+          fi
+          if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
+            echo "GIT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
+          fi
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
+          echo "${{ env.BRANCH }}
+          echo "${{ env.GIT_SHA }}
           docker run --rm -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
                           -e BRANCH=${{ steps.extract-branch.outputs.branch }} \
                           -e GIT_SHA_SHORT=${{ steps.extract-branch.outputs.sha_short }} \
+                          -e GIT_SHA=${{ steps.extract-branch.outputs.sha }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \
                           -e PACT_BROKER_USERNAME=${{ secrets.PACT_BROKER_USERNAME }} \
                           -e PACT_BROKER_PASSWORD=${{ secrets.PACT_BROKER_PASSWORD }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,6 +74,9 @@ jobs:
       id-token: 'write'
 
     steps:
+      - name: Checkout current code
+        uses: actions/checkout@v3
+
       - name: Extract branch
         id: extract-branch
         run: |
@@ -117,11 +120,12 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
+          git rev-parse ${{ inputs.provider-version-number }}
 
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.PROVIDER_SHA }}
+          ref: ${{ env.PROVIDER_BRANCH }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -21,7 +21,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - QA-2056
+      - develop
     paths-ignore:
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -1,11 +1,13 @@
 name: Verify consumer pacts
-# The purpose of this workflow is to verify Leo consumer contract using Pact framework.
+# The purpose of this workflow is to verify ANY consumer contract(s) dependent on Sam provider using Pact framework.
 #
-# The workflow fulfills Pact Broker Platinum described in https://docs.pact.io/pact_nirvana/step_6
+# The workflow meets Pact Broker's definition of *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
+# The can-i-deploy job has been added to this workflow to gate the merge of PRs into develop branch.
 #
-# This workflow can be triggered when
-# 1. Consumer makes a change (will verify only the changed pact, and publishes the verification results back to the broker)
-# 2. Provider makes a change (runs pact verification tests, publishes verification results. The pacts with recorded deployment would be verified during this job)
+# This workflow is triggered when
+#
+# 1. Consumer makes a change that results in a new pact published to Pact Broker (will verify ONLY the changed pact and publish the verification results back to the broker)
+# 2. Provider makes a change (runs verification tests against ALL DEPLOYED consumer pact versions and publishes corresponding verification results)
 #
 #
 # The workflow requires Pact broker credentials
@@ -19,7 +21,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - develop
+      - QA-2056
     paths-ignore:
       - 'README.md'
   workflow_dispatch:
@@ -168,6 +170,6 @@ jobs:
         with:
           workflow: can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/QA-2056
+          ref: refs/heads/develop
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -170,6 +170,6 @@ jobs:
         with:
           workflow: can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/develop
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,11 +74,6 @@ jobs:
       id-token: 'write'
 
     steps:
-      - name: Checkout current code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       - name: Extract branch
         id: extract-branch
         run: |
@@ -122,13 +117,13 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u
+          # git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u
 
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ env.PROVIDER_BRANCH }}
+          ref: ${{ env.PROVIDER_SHA }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -84,8 +84,8 @@ jobs:
             GITHUB_REF=refs/heads/${{ github.head_ref }}
             GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF=${{ github.ref }} # The Git Ref that this workflow runs on
+            GITHUB_SHA=${{ github.sha }} # The Git Sha that this workflow runs on
           else
             echo "Failed to extract branch information"
             exit 1
@@ -102,22 +102,24 @@ jobs:
         run: |
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
-          echo "consumer-version-number=${{ inputs.consumer-version-number }}"
-          echo "provider-version-number=${{ inputs.provider-version-number }}"
-          echo "consumer-version-branch=${{ inputs.consumer-version-branch }}"
-          echo "provider-version-branch=${{ inputs.provider-version-branch }}"
-          echo "pact-url=${{ inputs.pact-url }}"
+          echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
+          echo "provider-version-branch/provider-version-number=${{ inputs.provider-version-branch }}/${{ inputs.provider-version-number }}"
+          echo "pact-url=${{ inputs.pact-url }}" # Practically the provider-version-branch/provider-version-number is sufficient. It's included here in case future client supports it.
           if [[ "${{ inputs.provider-version-branch }}" != "" ]]; then
             echo "BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
           fi
           if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
             echo "GIT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
           fi
+          echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
+          echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
-          echo "${{ env.BRANCH }}
-          echo "${{ env.GIT_SHA }}
+          echo "${{ env.BRANCH }} # This should reflect the provider branch for pact verification
+          echo "${{ env.GIT_SHA }} # This should reflect the provider version for pact verification
+          echo "${{ env.CONSUMER_BRANCH }} # This should reflect the consumer branch for pact verification
+          echo "${{ env.CONSUMER_SHA }} # This should reflect the consumer version for pact verification
           docker run --rm -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
@@ -125,6 +127,8 @@ jobs:
                           -e BRANCH=${{ steps.extract-branch.outputs.branch }} \
                           -e GIT_SHA_SHORT=${{ steps.extract-branch.outputs.sha_short }} \
                           -e GIT_SHA=${{ steps.extract-branch.outputs.sha }} \
+                          -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
+                          -e CONSUMER_SHA=${{ env.CONSUMER_SHA }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \
                           -e PACT_BROKER_USERNAME=${{ secrets.PACT_BROKER_USERNAME }} \
                           -e PACT_BROKER_PASSWORD=${{ secrets.PACT_BROKER_PASSWORD }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -132,7 +132,6 @@ jobs:
             echo "PROVIDER_SHA=${{ env.CHECKOUT_SHA }}" >> $GITHUB_ENV
           fi
           git checkout ${{ env.CHECKOUT_BRANCH }}
-          cat pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         id: verification-test

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -111,6 +111,7 @@ jobs:
           if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
             echo "GIT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
           fi
+          echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
 
@@ -127,6 +128,7 @@ jobs:
                           -e BRANCH=${{ env.BRANCH }} \
                           -e GIT_SHA_SHORT=${{ steps.extract-branch.outputs.sha_short }} \
                           -e GIT_SHA=${{ env.GIT_SHA }} \
+                          -e CONSUMER_NAME=${{ env.CONSUMER_NAME }} \
                           -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
                           -e CONSUMER_SHA=${{ env.CONSUMER_SHA }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -17,7 +17,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - QA-2056
+      - develop
     paths-ignore:
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -122,7 +122,7 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          git rev-parse --all | grep ${{ inputs.provider-version-number }}) | sort -u
+          git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u
 
       - name: Checkout current code
         uses: actions/checkout@v3

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -1,7 +1,7 @@
 name: Verify consumer pacts
 # The purpose of this workflow is to verify ANY consumer contract(s) dependent on Sam provider using Pact framework.
 #
-# The workflow meets Pact Broker's definition of *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
+# The workflow meets the criteria of Pact Broker *Platinum* as described in https://docs.pact.io/pact_nirvana/step_6.
 # The can-i-deploy job has been added to this workflow to gate the merge of PRs into develop branch.
 #
 # This workflow is triggered when
@@ -168,7 +168,7 @@ jobs:
         if: ${{ inputs.pb-event-type == '' }}
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: can-i-deploy.yaml
+          workflow: .github/workflows/can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -2,6 +2,10 @@ name: Verify consumer pacts
 # The purpose of this workflow is to verify Leo consumer contract
 # using the Pact framework.
 #
+# This workflow can be triggered when
+# 1. Consumer makes a change (will verify only the changed pact, and publishes the verification results back to the broker)
+# 2. Provider makes a change (runs pact verification tests, publishes verification results. The pacts with recorded deployment would be verified during this job)
+
 # The workflow requires Pact broker credentials
 # - PACT_BROKER_USERNAME - the Pact Broker username
 # - PACT_BROKER_PASSWORD - the Pact Broker password
@@ -90,12 +94,12 @@ jobs:
             echo "Failed to extract branch information"
             exit 1
           fi
-          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
-          echo "BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
-          echo "GIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+          # echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
+          # echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          # echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          # echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
+          echo "PROVIDER_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
+          echo "PROVIDER_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
         if: ${{ inputs.pb-event-type != '' }}
@@ -104,12 +108,14 @@ jobs:
           echo "consumer-name=${{ inputs.consumer-name }}"
           echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
           echo "provider-version-branch/provider-version-number=${{ inputs.provider-version-branch }}/${{ inputs.provider-version-number }}"
-          echo "pact-url=${{ inputs.pact-url }}" # Practically the provider-version-branch/provider-version-number is sufficient. It's included here in case future client supports it.
+          # The consumer-version-branch/consumer-version-number is practically sufficient.
+          # The pact-url is included here in case future pact4s client supports it.
+          echo "pact-url=${{ inputs.pact-url }}"
           if [[ "${{ inputs.provider-version-branch }}" != "" ]]; then
-            echo "BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
+            echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
           fi
           if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
-            echo "GIT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
+            echo "PROVIDER_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
           fi
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
@@ -117,17 +123,16 @@ jobs:
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
-          echo "env.BRANCH=${{ env.BRANCH }} # This should reflect the provider branch for pact verification"
-          echo "env.GIT_SHA=${{ env.GIT_SHA }} # This should reflect the provider version for pact verification"
+          echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This should reflect the provider branch for pact verification"
+          echo "env.PROVIDER_SHA=${{ env.PROVIDER_SHA }}       # This should reflect the provider version for pact verification"
           echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} # This should reflect the consumer branch for pact verification"
-          echo "env.CONSUMER_SHA=${{ env.CONSUMER_SHA }} # This should reflect the consumer version for pact verification"
+          echo "env.CONSUMER_SHA=${{ env.CONSUMER_SHA }}       # This should reflect the consumer version for pact verification"
           docker run --rm -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
-                          -e BRANCH=${{ env.BRANCH }} \
-                          -e GIT_SHA_SHORT=${{ steps.extract-branch.outputs.sha_short }} \
-                          -e GIT_SHA=${{ env.GIT_SHA }} \
+                          -e PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} \
+                          -e PROVIDER_SHA=${{ env.PROVIDER_SHA }} \
                           -e CONSUMER_NAME=${{ env.CONSUMER_NAME }} \
                           -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
                           -e CONSUMER_SHA=${{ env.CONSUMER_SHA }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -96,10 +96,6 @@ jobs:
             echo "Failed to extract branch information"
             exit 1
           fi
-          # echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          # echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
-          # echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          # echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
           echo "CHECKOUT_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
           echo "CHECKOUT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
@@ -125,10 +121,10 @@ jobs:
 
       - name: Switch to appropriate branch
         run: |
-          if [[ -z "${{ env.PROVIDER_BRANCH }} ]]; then
+          if [[ -z "${{ env.PROVIDER_BRANCH }}" ]]; then
             echo "PROVIDER_BRANCH=${{ env.CHECKOUT_BRANCH }}" >> $GITHUB_ENV
           fi
-          if [[ -z "${{ env.PROVIDER_SHA }} ]]; then
+          if [[ -z "${{ env.PROVIDER_SHA }}" ]]; then
             echo "PROVIDER_SHA=${{ env.CHECKOUT_SHA }}" >> $GITHUB_ENV
           fi
           git checkout ${{ env.CHECKOUT_BRANCH }}

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -169,4 +169,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "leo-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}", "environment": "alpha" }'
+          inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}", "environment": "alpha" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -129,15 +129,9 @@ jobs:
           echo "$USE_PROVIDER_SHA"
           echo "USE_PROVIDER_SHA=$USE_PROVIDER_SHA" >> $GITHUB_ENV
 
-      - name: Checkout current code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ env.USE_PROVIDER_SHA }}
-
       - name: Sanity check
         run: |
-          git branch
+          git checkout ${{ env.USE_PROVIDER_SHA }}
           cat pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
 
       - name: Verify consumer pacts and publish verification status to Pact Broker

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       pb-event-type:
-        description: 'the PB event type that triggers this workflow'
+        description: 'the Pact Broker event type that triggers this workflow'
         required: true
         type: string
       consumer-name:
@@ -158,16 +158,16 @@ jobs:
                           sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 \
                           sbt "project pact4s" "testOnly *SamProviderSpec"
 
-  can-i-deploy: # We only need this if Sam makes a change
+  can-i-deploy: # The can-i-deploy job will run as a result of a Sam PR. It reports the pact verification statuses on all deployed environments.
     runs-on: ubuntu-latest
     needs: [ verify-consumer-pact ]
     steps:
       - name: Dispatch to terra-github-workflows
         if: ${{ inputs.pb-event-type == '' }}
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/QA-2056
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}", "environment": "alpha" }'
+          inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -135,6 +135,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.USE_PROVIDER_SHA }}
 
+      - name: Sanity check
+        run: |
+          git branch
+          cat pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
           echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This should reflect the provider branch for pact verification"

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -122,7 +122,7 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          $(git rev-parse --remotes ${{ inputs.provider-version-number }})
+          git rev-parse --all | grep ${{ inputs.provider-version-number }}) | sort -u
 
       - name: Checkout current code
         uses: actions/checkout@v3

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -116,17 +116,17 @@ jobs:
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
-          echo "${{ env.BRANCH }} # This should reflect the provider branch for pact verification
-          echo "${{ env.GIT_SHA }} # This should reflect the provider version for pact verification
-          echo "${{ env.CONSUMER_BRANCH }} # This should reflect the consumer branch for pact verification
-          echo "${{ env.CONSUMER_SHA }} # This should reflect the consumer version for pact verification
+          echo "env.BRANCH=${{ env.BRANCH }} # This should reflect the provider branch for pact verification"
+          echo "env.GIT_SHA=${{ env.GIT_SHA }} # This should reflect the provider version for pact verification"
+          echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} # This should reflect the consumer branch for pact verification"
+          echo "env.CONSUMER_SHA=${{ env.CONSUMER_SHA }} # This should reflect the consumer version for pact verification"
           docker run --rm -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
-                          -e BRANCH=${{ steps.extract-branch.outputs.branch }} \
+                          -e BRANCH=${{ env.BRANCH }} \
                           -e GIT_SHA_SHORT=${{ steps.extract-branch.outputs.sha_short }} \
-                          -e GIT_SHA=${{ steps.extract-branch.outputs.sha }} \
+                          -e GIT_SHA=${{ env.GIT_SHA }} \
                           -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
                           -e CONSUMER_SHA=${{ env.CONSUMER_SHA }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,6 +74,11 @@ jobs:
       id-token: 'write'
 
     steps:
+      - name: Checkout current code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Extract branch
         id: extract-branch
         run: |
@@ -101,6 +106,7 @@ jobs:
       - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
         if: ${{ inputs.pb-event-type != '' }}
         run: |
+          PROVIDER_FULL_SHA=""
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
           echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
@@ -113,17 +119,21 @@ jobs:
           fi
           if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
             echo "PROVIDER_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
+            PROVIDER_FULL_SHA=$(git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u)
+            echo "PROVIDER_FULL_SHA=$PROVIDER_FULL_SHA"
           fi
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          # git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u
+          USE_PROVIDER_SHA=$PROVIDER_FULL_SHA || $PROVIDER_SHA
+          echo "$USE_PROVIDER_SHA"
+          echo "USE_PROVIDER_SHA=$USE_PROVIDER_SHA" >> $GITHUB_ENV
 
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ env.PROVIDER_SHA }}
+          ref: ${{ env.USE_PROVIDER_SHA }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,9 +74,6 @@ jobs:
       id-token: 'write'
 
     steps:
-      - name: Checkout current code
-        uses: actions/checkout@v3
-
       - name: Extract branch
         id: extract-branch
         run: |
@@ -120,6 +117,11 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
+
+      - name: Checkout current code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.PROVIDER_SHA }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -1,11 +1,13 @@
 name: Verify consumer pacts
-# The purpose of this workflow is to verify Leo consumer contract
-# using the Pact framework.
+# The purpose of this workflow is to verify Leo consumer contract using Pact framework.
+#
+# The workflow fulfills Pact Broker Platinum described in https://docs.pact.io/pact_nirvana/step_6
 #
 # This workflow can be triggered when
 # 1. Consumer makes a change (will verify only the changed pact, and publishes the verification results back to the broker)
 # 2. Provider makes a change (runs pact verification tests, publishes verification results. The pacts with recorded deployment would be verified during this job)
-
+#
+#
 # The workflow requires Pact broker credentials
 # - PACT_BROKER_USERNAME - the Pact Broker username
 # - PACT_BROKER_PASSWORD - the Pact Broker password
@@ -17,7 +19,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - QA-2056
+      - develop
     paths-ignore:
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -100,13 +100,12 @@ jobs:
           # echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           # echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           # echo "branch=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_OUTPUT
-          echo "PROVIDER_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
-          echo "PROVIDER_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+          echo "CHECKOUT_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
+          echo "CHECKOUT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
       - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
         if: ${{ inputs.pb-event-type != '' }}
         run: |
-          PROVIDER_FULL_SHA=""
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
           echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
@@ -114,28 +113,31 @@ jobs:
           # The consumer-version-branch/consumer-version-number is practically sufficient.
           # The pact-url is included here in case future pact4s client supports it.
           echo "pact-url=${{ inputs.pact-url }}"
-          if [[ "${{ inputs.provider-version-branch }}" != "" ]]; then
+          if [[ ! -z "${{ inputs.provider-version-branch }}" ]]; then
             echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
           fi
-          if [[ "${{ inputs.provider-version-number }}" != "" ]]; then
+          if [[ ! -z "${{ inputs.provider-version-number }}" ]]; then
             echo "PROVIDER_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
-            PROVIDER_FULL_SHA=$(git rev-parse --all | grep ${{ inputs.provider-version-number }} | sort -u)
-            echo "PROVIDER_FULL_SHA=$PROVIDER_FULL_SHA"
           fi
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          USE_PROVIDER_SHA=$PROVIDER_FULL_SHA || $PROVIDER_SHA
-          echo "$USE_PROVIDER_SHA"
-          echo "USE_PROVIDER_SHA=$USE_PROVIDER_SHA" >> $GITHUB_ENV
 
-      - name: Sanity check
+      - name: Switch to appropriate branch
         run: |
-          git checkout ${{ env.USE_PROVIDER_SHA }}
+          if [[ -z "${{ env.PROVIDER_BRANCH }} ]]; then
+            echo "PROVIDER_BRANCH=${{ env.CHECKOUT_BRANCH }}" >> $GITHUB_ENV
+          fi
+          if [[ -z "${{ env.PROVIDER_SHA }} ]]; then
+            echo "PROVIDER_SHA=${{ env.CHECKOUT_SHA }}" >> $GITHUB_ENV
+          fi
+          git checkout ${{ env.CHECKOUT_BRANCH }}
           cat pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
 
       - name: Verify consumer pacts and publish verification status to Pact Broker
         run: |
+          echo "env.CHECKOUT_BRANCH=${{ env.CHECKOUT_BRANCH }} # This should reflect the code branch this workflow runs on"
+          echo "env.CHECKOUT_SHA=${{ env.CHECKOUT_SHA }}       # This should reflect the git hash of the branch this workflows runs on"
           echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This should reflect the provider branch for pact verification"
           echo "env.PROVIDER_SHA=${{ env.PROVIDER_SHA }}       # This should reflect the provider version for pact verification"
           echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} # This should reflect the consumer branch for pact verification"

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -17,7 +17,7 @@ on:
       - 'README.md'
   push:
     branches:
-      - develop
+      - QA-2056
     paths-ignore:
       - 'README.md'
   workflow_dispatch:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout current code
         uses: actions/checkout@v3
+        with:
+          fetch_depth: 0
 
       - name: Extract branch
         id: extract-branch
@@ -120,11 +122,12 @@ jobs:
           echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
           echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
-          git rev-parse ${{ inputs.provider-version-number }}
+          $(git rev-parse ${{ inputs.provider-version-number }})
 
       - name: Checkout current code
         uses: actions/checkout@v3
         with:
+          fetch_depth: 0
           ref: ${{ env.PROVIDER_BRANCH }}
 
       - name: Verify consumer pacts and publish verification status to Pact Broker

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -125,14 +125,18 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val branch: String = sys.env.getOrElse("BRANCH", "")
   lazy val gitShaShort: String = sys.env.getOrElse("GIT_SHA_SHORT", "")
   lazy val gitSha: String = sys.env.getOrElse("GIT_SHA", "")
+  lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
   lazy val consumerBranch: String = sys.env.getOrElse("CONSUMER_BRANCH", "")
   lazy val consumerSha: String = sys.env.getOrElse("CONSUMER_SHA", "")
 
+  println(consumerName)
+
   val consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
   consumerVersionSelectors.mainBranch
-  if (!consumerBranch.isBlank()) {
-    consumerVersionSelectors.branch(consumerBranch)
-  }
+  // if (!consumerBranch.isBlank()) {
+  //  println(consumerName)
+  //  consumerVersionSelectors.branch(consumerBranch, consumerName)
+  // }
 
   override def provider: ProviderInfoBuilder = ProviderInfoBuilder(
     name = "sam-provider",

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -137,6 +137,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
     case Some(s) if !s.isBlank() => consumerVersionSelectors = consumerVersionSelectors.branch(s, consumerName)
     case _ => None
   }
+  consumerVersionSelectors = consumerVersionSelectors.deployedOrReleased
 
   println(consumerVersionSelectors.toString)
 

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -131,8 +131,8 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
 
   println(consumerName)
 
-  val consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
-  consumerVersionSelectors.mainBranch
+  var consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
+  consumerVersionSelectors = consumerVersionSelectors.mainBranch
   // if (!consumerBranch.isBlank()) {
   //  println(consumerName)
   //  consumerVersionSelectors.branch(consumerBranch, consumerName)
@@ -145,7 +145,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .PactBrokerWithSelectors(
         brokerUrl = pactBrokerUrl
       )
-      .withConsumerVersionSelectors(ConsumerVersionSelectors.mainBranch)
+      .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -138,7 +138,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
     case _ => None
   }
 
-  println(consumerVersionSelectors)
+  println(consumerVersionSelectors.toString)
 
   // if (!consumerBranch.isBlank()) {
   //  println(consumerName)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -145,7 +145,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .PactBrokerWithSelectors(
         brokerUrl = pactBrokerUrl
       )
-      .withConsumerVersionSelectors(consumerVersionSelectors)
+      .withConsumerVersionSelectors(ConsumerVersionSelectors.mainBranch)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -129,10 +129,9 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val consumerSha: String = sys.env.getOrElse("CONSUMER_SHA", "")
 
   val consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
+  consumerVersionSelectors.mainBranch
   if (!consumerBranch.isBlank()) {
     consumerVersionSelectors.branch(consumerBranch)
-  } else {
-    consumerVersionSelectors.mainBranch
   }
 
   override def provider: ProviderInfoBuilder = ProviderInfoBuilder(

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -166,8 +166,8 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       providerVerificationOptions = Seq(
         ProviderVerificationOption.SHOW_STACKTRACE,
         // Exclude these Consumers from Pact Broker
-        ProviderVerificationOption.FILTER_CONSUMERS
-          .apply(Seq("Example App", "GoAdminService").toList)
+        // ProviderVerificationOption.FILTER_CONSUMERS
+        //  .apply(Seq("Example App", "GoAdminService").toList)
       ).toList,
       verificationTimeout = Some(10.seconds)
     )

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -134,8 +134,8 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   var consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
   // consumerVersionSelectors = consumerVersionSelectors.mainBranch
   // The following match condition basically says
-  // 1. If verification is triggered by consumer pact change, verifies only the changed pact.
-  // 2. For normal Sam workflow, verify all pact versions that have been deployed.
+  // 1. If verification is triggered by consumer pact change, verify only the changed pact.
+  // 2. For normal Sam PR, verify all consumer pacts in Pact Broker labelled with a deployed environment (alpha, dev, prod, staging).
   consumerBranch match {
     case Some(s) if !s.isBlank() => consumerVersionSelectors = consumerVersionSelectors.branch(s, consumerName)
     case _ => consumerVersionSelectors = consumerVersionSelectors.deployedOrReleased

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -122,9 +122,10 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val pactBrokerUrl: String = sys.env.getOrElse("PACT_BROKER_URL", "")
   lazy val pactBrokerUser: String = sys.env.getOrElse("PACT_BROKER_USERNAME", "")
   lazy val pactBrokerPass: String = sys.env.getOrElse("PACT_BROKER_PASSWORD", "")
+  // Provider branch, sha
   lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
-  // lazy val gitShaShort: String = sys.env.getOrElse("GIT_SHA_SHORT", "")
   lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
+  // Consumer name, bran, sha (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
   lazy val consumerBranch: Option[String] = sys.env.get("CONSUMER_BRANCH")
   // This matches the latest commit of the consumer branch that triggered the webhook event
@@ -132,6 +133,9 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
 
   var consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
   // consumerVersionSelectors = consumerVersionSelectors.mainBranch
+  // The following match condition basically says
+  // 1. If verification is triggered by consumer pact change, verifies only the changed pact.
+  // 2. For normal Sam workflow, verify all pact versions that have been deployed.
   consumerBranch match {
     case Some(s) if !s.isBlank() => consumerVersionSelectors = consumerVersionSelectors.branch(s, consumerName)
     case _ => consumerVersionSelectors = consumerVersionSelectors.deployedOrReleased

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -126,13 +126,20 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val gitShaShort: String = sys.env.getOrElse("GIT_SHA_SHORT", "")
   lazy val gitSha: String = sys.env.getOrElse("GIT_SHA", "")
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
-  lazy val consumerBranch: String = sys.env.getOrElse("CONSUMER_BRANCH", "")
+  lazy val consumerBranch: Option[String] = sys.env.get("CONSUMER_BRANCH")
   lazy val consumerSha: String = sys.env.getOrElse("CONSUMER_SHA", "")
 
   println(consumerName)
 
   var consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
   consumerVersionSelectors = consumerVersionSelectors.mainBranch
+  consumerBranch match {
+    case Some(s) if !s.isBlank() => consumerVersionSelectors = consumerVersionSelectors.branch(s, consumerName)
+    case _ => None
+  }
+
+  println(consumerVersionSelectors)
+
   // if (!consumerBranch.isBlank()) {
   //  println(consumerName)
   //  consumerVersionSelectors.branch(consumerBranch, consumerName)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -124,6 +124,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val pactBrokerPass: String = sys.env.getOrElse("PACT_BROKER_PASSWORD", "")
   lazy val branch: String = sys.env.getOrElse("BRANCH", "")
   lazy val gitShaShort: String = sys.env.getOrElse("GIT_SHA_SHORT", "")
+  lazy val gitSha: String = sys.env.getOrElse("GIT_SHA", "")
 
   override def provider: ProviderInfoBuilder = ProviderInfoBuilder(
     name = "sam-provider",
@@ -140,7 +141,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
     verifyPacts(
       providerBranch = if (branch.isEmpty) None else Some(Branch(branch)),
       publishVerificationResults = Some(
-        PublishVerificationResults(gitShaShort, ProviderTags(branch))
+        PublishVerificationResults(gitSha, ProviderTags(branch))
       ),
       providerVerificationOptions = Seq(
         ProviderVerificationOption.SHOW_STACKTRACE,

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -152,12 +152,6 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 
-  println(branch)
-  println(gitSha)
-  println(consumerName)
-  println(consumerBranch)
-  println(consumerSha)
-
   it should "Verify pacts" in {
     verifyPacts(
       providerBranch = if (branch.isEmpty) None else Some(Branch(branch)),

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -152,6 +152,12 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 
+  println(branch)
+  println(gitSha)
+  println(consumerName)
+  println(consumerBranch)
+  println(consumerSha)
+
   it should "Verify pacts" in {
     verifyPacts(
       providerBranch = if (branch.isEmpty) None else Some(Branch(branch)),

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -125,6 +125,15 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
   lazy val branch: String = sys.env.getOrElse("BRANCH", "")
   lazy val gitShaShort: String = sys.env.getOrElse("GIT_SHA_SHORT", "")
   lazy val gitSha: String = sys.env.getOrElse("GIT_SHA", "")
+  lazy val consumerBranch: String = sys.env.getOrElse("CONSUMER_BRANCH", "")
+  lazy val consumerSha: String = sys.env.getOrElse("CONSUMER_SHA", "")
+
+  val consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
+  if (!consumerBranch.isBlank()) {
+    consumerVersionSelectors.branch(consumerBranch)
+  } else {
+    consumerVersionSelectors.mainBranch
+  }
 
   override def provider: ProviderInfoBuilder = ProviderInfoBuilder(
     name = "sam-provider",
@@ -133,7 +142,7 @@ class SamProviderSpec extends AnyFlatSpec with ScalatestRouteTest with MockTestS
       .PactBrokerWithSelectors(
         brokerUrl = pactBrokerUrl
       )
-      .withConsumerVersionSelectors(ConsumerVersionSelectors.mainBranch)
+      .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
   ).withHost("localhost").withPort(8080)
 


### PR DESCRIPTION
Ticket: [QA-2056](https://broadworkbench.atlassian.net/browse/QA-2056)

What:

This PR comprises of the Provider CI required to meet the definition of *Platinum* as described in [https://docs.pact.io/pact_nirvana/step_6](https://docs.pact.io/pact_nirvana/step_6).

NOTE: Once we are comfortable with this new CI/CD, we will look into refactoring boilerplate code into `terra-github-workflows` to minimize pipeline related logic in the application repo. 

Why:

Meeting the *Platinum* standard means that this contract verification workflow can now be included in an automated end-to-end Independent Release process involving the following

1. automated verification of events related consumer pact changes
2. automated verification of Sam (as a provider) changes against consumer pacts on all deployed environments

How:

The magic that enables 1) is configured as webhook in the Pact Broker.
In addition, logic has been added to `SamProviderSpec` to support 1) and 2).

```
  consumerBranch match {
    case Some(s) if !s.isBlank() => consumerVersionSelectors = consumerVersionSelectors.branch(s, consumerName)
    case _ => consumerVersionSelectors = consumerVersionSelectors.deployedOrReleased
  }
```

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[QA-2056]: https://broadworkbench.atlassian.net/browse/QA-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ