### PR TITLE
ID-181 and ID-228 Database resiliency to CloudSQL maintenance

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -12,7 +12,7 @@ import java.util.Date
 /** Created by dvoet on 5/26/17.
   */
 trait DirectoryDAO {
-  def checkStatus(samRequestContext: SamRequestContext): Boolean
+  def checkStatus(samRequestContext: SamRequestContext): IO[Boolean]
   def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup]
   def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]]
   def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -755,9 +755,10 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val isSessionValid = session.connection.isValid((2 seconds).toSeconds.intValue())
       val canQuery =
         sql"""SELECT 1 from ${UserTable}"""
-        .map(rs => rs.int(1))
-        .single()
-        .apply().nonEmpty
+          .map(rs => rs.int(1))
+          .single()
+          .apply()
+          .nonEmpty
 
       isSessionValid && canQuery
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/StatusService.scala
@@ -52,12 +52,12 @@ class StatusService(
   private def checkStatus(): Map[Subsystem, Future[SubsystemStatus]] =
     cloudExtensions.checkStatus + (Database -> checkDatabase().unsafeToFuture())
 
-  private def checkDatabase(): IO[SubsystemStatus] = IO {
+  private def checkDatabase(): IO[SubsystemStatus] = {
     logger.info("checking database connection")
-    if (directoryDAO.checkStatus(SamRequestContext()))
-      HealthMonitor.OkStatus
-    else
-      HealthMonitor.failedStatus("Postgres database connection invalid or timed out checking")
+    directoryDAO.checkStatus(SamRequestContext()).map {
+      case true => HealthMonitor.OkStatus
+      case false => HealthMonitor.failedStatus("Postgres database connection invalid or timed out checking")
+    }
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -297,7 +297,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     } yield users += user.id -> user.copy(azureB2CId = Option(b2CId))
   }
 
-  override def checkStatus(samRequestContext: SamRequestContext): Boolean = passStatusCheck
+  override def checkStatus(samRequestContext: SamRequestContext): IO[Boolean] = IO(passStatusCheck)
 
   override def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(users.values.find(_.googleSubjectId.contains(userId)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
@@ -119,7 +119,7 @@ case class MockDirectoryDaoBuilder() extends MockitoSugar {
 
   def withHealthyDatabase: MockDirectoryDaoBuilder = {
     lenient()
-      .doReturn(true)
+      .doReturn(IO(true))
       .when(mockedDirectoryDAO)
       .checkStatus(any[SamRequestContext])
     this
@@ -127,7 +127,7 @@ case class MockDirectoryDaoBuilder() extends MockitoSugar {
 
   def withUnhealthyDatabase: MockDirectoryDaoBuilder = {
     lenient()
-      .doReturn(false)
+      .doReturn(IO(false))
       .when(mockedDirectoryDAO)
       .checkStatus(any[SamRequestContext])
     this


### PR DESCRIPTION
Ticket: 
https://broadworkbench.atlassian.net/browse/ID-181
https://broadworkbench.atlassian.net/browse/ID-228

What:

This should merge into https://github.com/broadinstitute/sam/pull/1041

Adds a simple read query to the `DirectoryDAO.checkStatus` method in an attempt to make sure our connections are actually functional.  

Why:
Sometimes during CloudSQL maintenance, our db connections would get all messed up, but not to the point where Sam would be able to tell and it would restart itself.  Instead, it would do things like sit there with 1 connection in the pool that was _just_ functional enough to report as "valid" even though it was unusable.  For some reason, Sam wouldn't try to refresh the connection pool either.  

How:
This change should ensure that the Sam Status endpoint reports "NOT OK" if it is unable to run a simple query against the DB.  In this case, our k8s infrastructure should notice that Sam is unhealthy and attempt to restart it, which is precisely what an on-call engineer would be asked to do in the past when we got paged because Sam was not able to query the DB.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
