### PR TITLE
Parameterize landing zone ID reuse - (again)

### DIFF
--- a/env/local.env
+++ b/env/local.env
@@ -34,5 +34,5 @@ export TOS_ENABLED="true"
 export TOS_GRACE_PERIOD_ENABLED="true"
 export TOS_URL="app.terra.bio/#terms-of-service"
 export TOS_VERSION="0"
-
 export SAM_LOG_APPENDER="Console-Standard"
+export LANDINGZONES_REUSE_IDS=false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1324,7 +1324,7 @@ resourceTypes = {
         roleActions = ["list_resources"]
       }
     }
-    reuseIds = false
+    reuseIds = ${?LANDINGZONES_REUSE_IDS}
   }
   wds-instance = {
     actionPatterns = {

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -192,3 +192,9 @@ prometheus {
 oidc {
   oidcClientId = "0"
 }
+
+resourceTypes {
+  landing-zone = {
+    reuseIds = false
+  }
+}


### PR DESCRIPTION
(this is a revert of a revert, now that terra-helmfile is the official source of truth for sam configs in all environments)

Ticket: https://broadworkbench.atlassian.net/browse/WOR-844

What:
Conditionally allow the reuse of Sam landing zone resource IDs.

Why:
We want to be able to reuse landing zone Sam resource IDs during Azure end-to-end tests. This will greatly simplify the test setup+teardown code as we will not need to conditionally guard against 409s in our application code when creating landing zones. We will also be able to tear down landing zones more easily.

How:

Adjusted the reference.conf file to pull the resourceTypes.landing-zone.reuseIds configuration value from an environment variable.
Note this means that the environment variable will need to be set externally via helmfile or Sam will fail to bootstrap. https://github.com/broadinstitute/terra-helmfile/pull/3886 in terra-helmfile will need to land first to ensure the var is set. Once this merges I will undraft and ensure all tests pass (they are failing in bees right now due to the lack of this env var).
PR checklist

 I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, especially if they're breaking changes
 I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket