### PR TITLE
ID-549 Artifactory Proxy Resolver

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,6 +10,10 @@ import sbtassembly.AssemblyPlugin.autoImport._
 object Settings {
   lazy val artifactory = "https://artifactory.broadinstitute.org/artifactory/"
 
+  val proxyResolvers = List(
+    "internal-maven-proxy" at artifactory + "maven-central"
+  )
+
   lazy val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
     "artifactory-snapshots" at artifactory + "libs-snapshot"
@@ -65,7 +69,7 @@ object Settings {
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
       organization := "org.broadinstitute.dsde.workbench",
       scalaVersion := "2.13.10",
-      resolvers ++= commonResolvers,
+      resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,
       scalacOptions ++= commonCompilerSettings,
       Compile / compile := (Compile / compile).dependsOn(Compile / scalafmtAll).value,
       Compile / compile := (Compile / compile).dependsOn(Compile / scalafmtSbt).value


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-549

What:

Make Sam use Artifactory as a proxy resolver so that we cache packages from Maven just in case they disappear.

Why:

The `sbt-assembly` plugin temporarily disappeared from Maven last week, causing the Sam Build to fail. If we were caching it, the build would not have failed.

How:

Make Sam look at our internal artifactory before anything else.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
