### PR TITLE
ID-343 fixing column defaults

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230328_add_date_columns_to_user.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230328_add_date_columns_to_user.xml
@@ -6,19 +6,32 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
   <changeSet logicalFilePath="dummy" author="kfeldman" id="add_date_columns_to_user_table">
+
     <addColumn tableName="sam_user">
-      <column name="created_at" type="timestamp with time zone">
+      <!-- Default value initially set to set a default create_at date for all existing records -->
+      <column name="created_at" type="timestamp with time zone" defaultValue="1970-01-01 00:00:00-00">
         <constraints nullable="false"/>
       </column>
     </addColumn>
+    <!-- Once the column is created and the default value is set for existing records, we drop the defaultValue
+         attribute entirely for new records going forward.  In other words, we want all new records to have a created_at
+         date specified -->
+    <dropDefaultValue tableName="sam_user" columnName="created_at"/>
+
     <addColumn tableName="sam_user">
       <column name="registered_at" type="timestamp with time zone">
       </column>
     </addColumn>
+
     <addColumn tableName="sam_user">
-      <column name="updated_at" type="timestamp with time zone">
+      <!-- Default value initially set to set a default updated_at date for all existing records -->
+      <column name="updated_at" type="timestamp with time zone" defaultValue="1970-01-01 00:00:00-00">
         <constraints nullable="false"/>
       </column>
     </addColumn>
+    <!-- Once the column is created and the default value is set for existing records, we drop the defaultValue
+         attribute entirely for new records going forward -->
+    <dropDefaultValue tableName="sam_user" columnName="updated_at"/>
+
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-343

What:

When we added the liquibase migrations before, we forgot to accommodate for existing records.  This change creates new columns with `default` values specified for all the records in the database.  Then it immediately drops the `default` value attribute on those columns so that if users try to insert a new record without specifying a value for these columns they will get an error, which is the behavior we want. 

Why:

Sometimes, in databases, they have data.  

How:

See the "why" - I'm not retyping it, but you can re-read it :) 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
