### PR TITLE
ID-562 fixing deprecated command in github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
       ARTIFACTORY_USERNAME: ${{secrets.ARTIFACTORY_USERNAME}}
       ARTIFACTORY_PASSWORD: ${{secrets.ARTIFACTORY_PASSWORD}}
       SBT_OPTS: -Xmx3g
+      # https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - uses: actions/checkout@v2
@@ -83,11 +85,6 @@ jobs:
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action
         uses: coursier/cache-action@v5
-
-      - name: Extract branch name
-        shell: bash
-        run: echo "Branch:: $(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-        id: extractBranch
 
       - name: Generate java client
         id: generateJavaClient
@@ -102,5 +99,5 @@ jobs:
       - name: Publish java client as snapshot for PRs
         working-directory: codegen_java
         id: publishJavaClientSnapshot
-        if: ${{steps.extractBranch.outputs.branch != 'develop'}}
+        if: ${{ $BRANCH_NAME != 'develop' }}
         run: sbt "+ publish" -Dproject.isSnapshot=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "Branch:: $(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extractBranch
 
       - name: Generate java client


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-562

What:

Addresses Github Action Command deprecation:  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
