### PR TITLE
[DDO-2787] Allow Sam to be passed environment variables with periods in them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,14 @@ ENV GIT_MODEL_HASH $GIT_MODEL_HASH
 RUN mkdir /sam
 COPY ./sam*.jar /sam
 # Add Sam as a service (it will start when the container starts)
-CMD java $JAVA_OPTS -jar $(find /sam -name 'sam*.jar')
+# 1. “Exec” form of CMD necessary to avoid “shell” form’s `sh` stripping 
+#    environment variables with periods in them, often used in DSP for Lightbend 
+#    config.
+# 2. Handling $JAVA_OPTS is necessary as long as firecloud-develop or the app’s 
+#    chart tries to set it. Apps that use devops’s foundation subchart don’t need 
+#    to handle this.
+# 3. The jar’s location and naming scheme in the filesystem is required by preflight 
+#    liquibase migrations in some app charts. Apps that expose liveness endpoints 
+#    may not need preflight liquibase migrations.
+# We use the “exec” form with `bash` to accomplish all of the above.
+CMD ["/bin/bash", "-c", "java $JAVA_OPTS -jar $(find /sam -name 'sam*.jar')"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2787

What:

Allows Sam to be passed environment variables with periods in them.

Why:

Lightbend config expects folks to configure array fields by passing environment variables with periods in them.

How:

Use `bash` instead of the implicit `sh` for the Dockerfile's CMD.

Like https://github.com/DataBiosphere/leonardo/pull/3291

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

> No API changes!

- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket

> Appsec said this was reasonable and didn't require approval
