### PR TITLE
ID-586 Sam signs GS URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ sh docker/run-proxy.sh start
 ```shell
 sbt run
 ```
-Navigate to [Sam's (Proxy's) Swagger page](http://localhost:50443/)
+Navigate to [Sam's (Proxy's) Swagger page](https://local.broadinstitute.org:50443/#/)
 
 
 #### Debugging in IntelliJ

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -116,6 +116,7 @@ object MockTestSupport extends MockTestSupport {
         cloudKeyCache,
         notificationDAO,
         FakeGoogleKmsInterpreter,
+        FakeGoogleStorageInterpreter,
         googleServicesConfig,
         petServiceAccountConfig,
         resourceTypes,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,15 +11,15 @@ object Dependencies {
   val postgresDriverVersion = "42.5.0"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "abd44a6"
-  val workbenchUtilV = s"0.6-$workbenchLibV"
-  val workbenchUtil2V = s"0.2-$workbenchLibV"
-  val workbenchModelV = s"0.15-$workbenchLibV"
-  val workbenchGoogleV = s"0.22-$workbenchLibV"
-  val workbenchGoogle2V = s"0.25-$workbenchLibV"
-  val workbenchNotificationsV = s"0.3-$workbenchLibV"
-  val workbenchOauth2V = s"0.2-$workbenchLibV"
-  val workbenchOpenTelemetryV = s"0.3-$workbenchLibV"
+  val workbenchLibV = "6abbdd5d-SNAP"
+  val workbenchUtilV = s"0.7-$workbenchLibV"
+  val workbenchUtil2V = s"0.3-$workbenchLibV"
+  val workbenchModelV = s"0.17-$workbenchLibV"
+  val workbenchGoogleV = s"0.26-$workbenchLibV"
+  val workbenchGoogle2V = s"0.27-$workbenchLibV"
+  val workbenchNotificationsV = s"0.4-$workbenchLibV"
+  val workbenchOauth2V = s"0.3-$workbenchLibV"
+  val workbenchOpenTelemetryV = s"0.4-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.12-SNAPSHOT"
   val slf4jVersion = "2.0.6"
@@ -102,7 +102,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
   val workbenchGoogle2Tests: ModuleID =
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.123.28" % "test" // needed for mocking google cloud storage
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
   val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,8 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
   val workbenchGoogle2Tests: ModuleID =
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll (excludeWorkbenchUtil, excludeWorkbenchModel)
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
+  val googleStorageLocal: ModuleID =
+    "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
   val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val postgresDriverVersion = "42.5.0"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "6abbdd5d-SNAP"
+  val workbenchLibV = "1bab754"
   val workbenchUtilV = s"0.7-$workbenchLibV"
   val workbenchUtil2V = s"0.3-$workbenchLibV"
   val workbenchModelV = s"0.17-$workbenchLibV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,10 +92,10 @@ object Dependencies {
   // the name of the auto-value package changed from auto-value to auto-value-annotations so old libraries are not evicted
   // leading to merge errors during sbt assembly. At this time the old version of auto-value is pulled in through the google2
   // workbench-libs dependency so exclude auto-value from there
-  val excludGoogleAutoValue = ExclusionRule(organization = "com.google.auto.value", name = "auto-value")
+  val excludeGoogleAutoValue = ExclusionRule(organization = "com.google.auto.value", name = "auto-value")
   val excludeBouncyCastle = ExclusionRule("org.bouncycastle")
   val workbenchGoogle2: ModuleID =
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll (excludeWorkbenchModel, excludeWorkbenchUtil, excludGoogleAutoValue, excludeBouncyCastle)
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll (excludeWorkbenchModel, excludeWorkbenchUtil, excludeGoogleAutoValue, excludeBouncyCastle)
   val workbenchNotifications: ModuleID =
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
   val workbenchGoogleTests: ModuleID =

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -11,6 +11,8 @@ object Merging {
     case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
     case PathList("META-INF", "kotlin-result.kotlin_module") => MergeStrategy.first
+    case PathList("META-INF", "kotlin-stdlib.kotlin_module") => MergeStrategy.first
+    case PathList("META-INF", "kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
     case PathList("mozilla", "public-suffix-list.txt") => MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1096,6 +1096,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-codegen-request-body-name: scopes
+  /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob:
+    post:
+      tags:
+        - Google
+      summary: gets a signed URL for the given blob, signed by the Pet Service account of the calling user
+      operationId: getSignedUrlForBlob
+      parameters:
+        - name: project
+          in: path
+          description: Google project of the pet
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: bucketName and blobName of the object to get a signed URL for
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SignedUrlRequest'
+        required: true
+      responses:
+        200:
+          description: signed URL for the blob, signed by the Pet Service Account key
+          content:
+            application/json:
+              schema:
+                type: string
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/user/proxyGroup/{email}:
     get:
       tags:
@@ -2954,6 +2987,18 @@ components:
         - https://www.googleapis.com/auth/userinfo.profile
       items:
         type: string
+    SignedUrlRequest:
+      type: object
+      required:
+        - bucketName
+        - blobName
+      properties:
+        bucketName:
+          type: string
+          description: bucket of the blob
+        blobName:
+          type: string
+          description: path to the blob in the bucket
     CreateResourceRequest:
       required:
         - policies

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1100,7 +1100,9 @@ paths:
     post:
       tags:
         - Google
-      summary: gets a signed URL for the given blob, signed by the Pet Service account of the calling user
+      summary: Gets a signed URL for the given blob, signed by the Pet Service account of the calling user. 
+        The signed URL is active for 1 hour and scoped to the permissions of the signing Pet Service Account.
+        Sam will provide a signed URL for any object path, even if that object does not exist.
       operationId: getSignedUrlForBlob
       parameters:
         - name: project

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -287,6 +287,7 @@ object Boot extends IOApp with LazyLogging {
       googleKeyCache,
       notificationDAO,
       googleKms,
+      googleStorageNew,
       config.googleServicesConfig,
       config.petServiceAccountConfig,
       resourceTypeMap,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -141,6 +141,19 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                     }
                   }
                 } ~
+                pathPrefix("signedUrlForBlob") {
+                  post {
+                    entity(as[SignedUrlRequest]) { request =>
+                      complete {
+                        googleExtensions
+                          .getSignedUrl(samUser, GoogleProject(project), request.bucketName, request.blobName, samRequestContext)
+                          .map { signedUrl =>
+                            StatusCodes.OK -> JsString(signedUrl.toString)
+                          }
+                      }
+                    }
+                  }
+                } ~
                 pathEnd {
                   requireOneOfActionIfParentIsWorkspace(
                     FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -143,7 +143,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   }
                 } ~
                 pathPrefix("signedUrlForBlob") {
-                  requireOneOfActionIfParentIsWorkspace(
+                  requireOneOfAction(
                     FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
                     Set(SamResourceActions.createPet),
                     samUser.id,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
@@ -152,7 +153,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                       entity(as[SignedUrlRequest]) { request =>
                         complete {
                           googleExtensions
-                            .getSignedUrl(samUser, GoogleProject(project), request.bucketName, request.blobName, samRequestContext)
+                            .getSignedUrl(samUser, GoogleProject(project), GcsBucketName(request.bucketName), GcsBlobName(request.blobName), samRequestContext)
                             .map { signedUrl =>
                               StatusCodes.OK -> JsString(signedUrl.toString)
                             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -142,14 +142,21 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   }
                 } ~
                 pathPrefix("signedUrlForBlob") {
-                  post {
-                    entity(as[SignedUrlRequest]) { request =>
-                      complete {
-                        googleExtensions
-                          .getSignedUrl(samUser, GoogleProject(project), request.bucketName, request.blobName, samRequestContext)
-                          .map { signedUrl =>
-                            StatusCodes.OK -> JsString(signedUrl.toString)
-                          }
+                  requireOneOfActionIfParentIsWorkspace(
+                    FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project)),
+                    Set(SamResourceActions.createPet),
+                    samUser.id,
+                    samRequestContext
+                  ) {
+                    post {
+                      entity(as[SignedUrlRequest]) { request =>
+                        complete {
+                          googleExtensions
+                            .getSignedUrl(samUser, GoogleProject(project), request.bucketName, request.blobName, samRequestContext)
+                            .map { signedUrl =>
+                              StatusCodes.OK -> JsString(signedUrl.toString)
+                            }
+                        }
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -14,7 +14,9 @@ import com.google.rpc.Code
 import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
+import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.MessageRequest
 import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleKmsService, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.Notifications.Notification
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchGroupNameFormat
 import org.broadinstitute.dsde.workbench.model._
@@ -32,6 +34,7 @@ import org.broadinstitute.dsde.workbench.util.{FutureSupport, Retry}
 import spray.json._
 
 import java.io.ByteArrayInputStream
+import java.net.URL
 import java.util.Date
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -56,6 +59,7 @@ class GoogleExtensions(
     val googleKeyCache: GoogleKeyCache,
     val notificationDAO: NotificationDAO,
     val googleKms: GoogleKmsService[IO],
+    val googleStorageService: GoogleStorageService[IO],
     val googleServicesConfig: GoogleServicesConfig,
     val petServiceAccountConfig: PetServiceAccountConfig,
     val resourceTypes: Map[ResourceTypeName, ResourceType],
@@ -174,7 +178,7 @@ class GoogleExtensions(
   // The handler for the subscription will ultimately call GoogleExtensions.synchronizeGroupMembers, which will
   // do all the heavy lifting of creating the Google Group and adding members.
   override def publishGroup(id: WorkbenchGroupName): Future[Unit] =
-    googleGroupSyncPubSubDAO.publishMessages(googleServicesConfig.groupSyncPubSubConfig.topic, Seq(id.toJson.compactPrint))
+    googleGroupSyncPubSubDAO.publishMessages(googleServicesConfig.groupSyncPubSubConfig.topic, Seq(MessageRequest(id.toJson.compactPrint)))
 
   /*
     - managed groups and access policies are both "groups"
@@ -223,7 +227,7 @@ class GoogleExtensions(
       }
 
       // publish all the messages
-      _ <- IO.fromFuture(IO(publishMessages(messages.flatten)))
+      _ <- IO.fromFuture(IO(publishMessages(messages.flatten.map(MessageRequest(_)))))
 
       end <- clock.monotonic
 
@@ -258,7 +262,7 @@ class GoogleExtensions(
       // return messages for all the affected access policies and the original group we started with
     } yield constrainedResourceAccessPolicyIds.flatten.map(accessPolicyId => accessPolicyId.toJson.compactPrint)
 
-  private def publishMessages(messages: Seq[String]): Future[Unit] =
+  private def publishMessages(messages: Seq[MessageRequest]): Future[Unit] =
     googleGroupSyncPubSubDAO.publishMessages(googleServicesConfig.groupSyncPubSubConfig.topic, messages)
 
   override def onUserCreate(user: SamUser, samRequestContext: SamRequestContext): IO[Unit] = {
@@ -636,6 +640,14 @@ class GoogleExtensions(
       Subsystems.GoogleIam -> checkIam
     )
   }
+
+  def getSignedUrl(samUser: SamUser, project: GoogleProject, bucket: GcsBucketName, name: GcsBlobName, samRequestContext: SamRequestContext): IO[URL] =
+    for {
+      petServiceAccount <- createUserPetServiceAccount(samUser, project, samRequestContext)
+      petKey <- googleKeyCache.getKey(petServiceAccount)
+      serviceAccountCredentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(petKey.getBytes()))
+      url <- googleStorageService.getSignedBlobUrl(bucket, name, serviceAccountCredentials).compile.lastOrError
+    } yield url
 
   override val allSubSystems: Set[Subsystems.Subsystem] = Set(Subsystems.GoogleGroups, Subsystems.GooglePubSub, Subsystems.GoogleIam)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GooglePubSubMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GooglePubSubMonitor.scala
@@ -45,7 +45,7 @@ class GooglePubSubMonitor(
     */
   protected def init: IO[Unit] = for {
     _ <- IO.fromFuture(IO(pubSubDao.createTopic(config.topic)))
-    _ <- IO.fromFuture(IO(pubSubDao.createSubscription(config.topic, config.subscription)))
+    _ <- IO.fromFuture(IO(pubSubDao.createSubscription(config.topic, config.subscription, None)))
   } yield ()
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
 import monocle.macros.Lenses
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
@@ -74,6 +77,9 @@ object SamJsonSupport {
   implicit val CreateResourcePolicyResponseFormat = jsonFormat2(CreateResourcePolicyResponse.apply)
 
   implicit val CreateResourceResponseFormat = jsonFormat4(CreateResourceResponse.apply)
+
+  implicit val GcsBlobNameFormat = jsonFormat(GcsBlobName.apply _, "value")
+  implicit val SignedUrlRequestFormat = jsonFormat2(SignedUrlRequest.apply)
 }
 
 object RootPrimitiveJsonSupport {
@@ -302,6 +308,8 @@ object BasicWorkbenchGroup {
 @Lenses final case class ManagedGroupAccessInstructions(value: String) extends ValueObject
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
+
+@Lenses final case class SignedUrlRequest(bucketName: GcsBucketName, blobName: GcsBlobName)
 object SamUser {
   def apply(
       id: WorkbenchUserId,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -1,10 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
 import monocle.macros.Lenses
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
@@ -78,7 +75,6 @@ object SamJsonSupport {
 
   implicit val CreateResourceResponseFormat = jsonFormat4(CreateResourceResponse.apply)
 
-  implicit val GcsBlobNameFormat = jsonFormat(GcsBlobName.apply _, "value")
   implicit val SignedUrlRequestFormat = jsonFormat2(SignedUrlRequest.apply)
 }
 
@@ -309,7 +305,7 @@ object BasicWorkbenchGroup {
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 
-@Lenses final case class SignedUrlRequest(bucketName: GcsBucketName, blobName: GcsBlobName)
+@Lenses final case class SignedUrlRequest(bucketName: String, blobName: String)
 object SamUser {
   def apply(
       id: WorkbenchUserId,

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.workbench.sam
 
 import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount, ServiceAccountDisplayName, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam.api.StandardSamUserDirectives._
 import org.broadinstitute.dsde.workbench.sam.azure._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.LockDetails
@@ -108,6 +109,9 @@ object Generator {
 
   val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s${x.take(50)}")) // prepending `s` just so this won't be an empty string
   val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) // prepending `s` just so this won't be an empty string
+  val genGcsBucketName = Gen.listOfN(63, Gen.alphaChar).map(x => GcsBucketName(x.mkString))
+  val genGcsBlobName = Gen.alphaStr.flatMap(x => Gen.alphaStr.map(y => GcsBlobName(s"s$x/s$y")))
+
   val genWorkbenchSubject: Gen[WorkbenchSubject] = for {
     groupId <- genWorkbenchGroupName
     userId <- genWorkbenchUserId

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFreeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/RetryableAnyFreeSpec.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.workbench.sam
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.{Exceptional, Outcome, Retries}
+
+trait RetryableAnyFreeSpec extends AnyFreeSpec with Retries {
+
+  val retries = 3
+
+  override protected def withFixture(test: NoArgTest): Outcome =
+    withFixture(test, 1)
+
+  def withFixture(test: NoArgTest, count: Int): Outcome = {
+    val outcome = super.withFixture(test)
+    outcome match {
+      case Exceptional(ex) =>
+        println(s"Test '${test.name}' ${outcome.getClass.getSimpleName} on try $count.")
+        println(s"Test '${test.name}' ${outcome.getClass.getSimpleName} with: $ex")
+        if (count >= retries) super.withFixture(test) else withFixture(test, count + 1)
+      case other => other
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -127,6 +127,7 @@ object TestSupport extends TestSupport {
         cloudKeyCache,
         notificationDAO,
         FakeGoogleKmsInterpreter,
+        FakeGoogleStorageInterpreter,
         googleServicesConfig,
         petServiceAccountConfig,
         resourceTypes,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -10,9 +10,8 @@ import org.broadinstitute.dsde.workbench.sam.db.SamParameterBinderFactory._
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.matchers.TimeMatchers
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
+import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFreeSpec, TestSupport}
 import org.scalatest.Inside.inside
-import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 
@@ -20,7 +19,7 @@ import java.time.Instant
 import java.util.Date
 import scala.concurrent.duration._
 
-class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach with TimeMatchers with OptionValues {
+class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with BeforeAndAfterEach with TimeMatchers with OptionValues {
   val dao = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.dbRef)
   val policyDAO = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.dbRef)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -14,12 +14,14 @@ import org.broadinstitute.dsde.workbench.sam.Generator._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, genSamRoutes, _}
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes
 import org.broadinstitute.dsde.workbench.sam.config.GoogleServicesConfig
+import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchers.{eq => mockitoEq}
 import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -396,6 +398,20 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
     (user, samDependencies, createRoutes)
   }
 
+  def createMockGoogleIamDaoForSignedUrlTests: GoogleIamDAO = {
+    val googleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
+
+    lenient()
+      .doAnswer { (i: InvocationOnMock) =>
+        val email = i.getArgument[WorkbenchEmail](1)
+        val (keyId, keyJson) = RealKeyMockGoogleIamDAO.generateNewRealKey(email)
+        Future.successful(ServiceAccountKey(keyId, ServiceAccountPrivateKeyData(ServiceAccountPrivateKeyData(keyJson).encode), None, None))
+      }
+      .when(googleIamDAO)
+      .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
+
+    googleIamDAO
+  }
   def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String) = {
     val googleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
     val expectedJson = """{"json":"yes I am"}"""
@@ -420,6 +436,31 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
       .when(googleIamDAO.addServiceAccountUserRoleForUser(any[GoogleProject], any[WorkbenchEmail], any[WorkbenchEmail]))
       .thenReturn(Future.successful(()))
     (googleIamDAO, expectedJson)
+  }
+
+  def setupSignedUrlTest(): (SamUser, SamRoutes) = {
+    val googleIamDAO = new RealKeyMockGoogleIamDAO
+    val samUser = Generator.genWorkbenchUserGoogle.sample.get
+
+    val (user, samDeps, routes) = createTestUser(
+      configResourceTypes,
+      Some(googleIamDAO),
+      TestSupport.googleServicesConfig.copy(serviceAccountClientEmail = samUser.email, serviceAccountClientId = samUser.googleSubjectId.get.value),
+      user = samUser
+    )
+
+    samDeps.cloudExtensions
+      .asInstanceOf[GoogleExtensions]
+      .onBoot(
+        SamApplication(
+          samDeps.userService,
+          samDeps.resourceService,
+          samDeps.statusService,
+          new TosService(samDeps.directoryDAO, TestSupport.tosConfig)
+        )
+      )
+      .unsafeRunSync()
+    (user, routes)
   }
 
   def setupPetSATest(): (SamUser, SamRoutes, String) = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -5,8 +5,10 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -244,6 +246,14 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     // create a pet service account key
     Get(s"/api/google/v1/petServiceAccount/myproject/I-do-not-exist@foo.bar") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "POST /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob" should "200 with a signed url" in {
+    val (_, samRoutes, _) = setupPetSATest()
+    val blob = SignedUrlRequest(GcsBucketName("my-bucket"), GcsBlobName("my-folder/my-object.txt"))
+    Post(s"api/google/v1/user/petServiceAccount/myproject/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Success
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -5,10 +5,8 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import cats.effect.unsafe.implicits.global
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -251,7 +249,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
 
   "POST /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob" should "200 with a signed url" in {
     val (_, samRoutes) = setupSignedUrlTest()
-    val blob = SignedUrlRequest(GcsBucketName("my-bucket"), GcsBlobName("my-folder/my-object.txt"))
+    val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt")
     Post(s"/api/google/v1/user/petServiceAccount/myproject/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
       responseAs[String] should not be empty
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -248,10 +248,19 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   }
 
   "POST /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob" should "200 with a signed url" in {
-    val (_, samRoutes) = setupSignedUrlTest()
+    val (_, samRoutes, projectName) = setupSignedUrlTest()
     val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt")
-    Post(s"/api/google/v1/user/petServiceAccount/myproject/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
-      responseAs[String] should not be empty
+
+    Post(s"/api/google/v1/user/petServiceAccount/$projectName/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+      responseAs[String] should include("my-bucket/my-folder/my-object.txt")
+    }
+  }
+
+  it should "404 when the user doesn't have access to the project" in {
+    val (_, samRoutes, projectName) = setupSignedUrlTest()
+    val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt")
+    Post(s"/api/google/v1/user/petServiceAccount/not-$projectName/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -250,10 +250,10 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   }
 
   "POST /api/google/v1/user/petServiceAccount/{project}/signedUrlForBlob" should "200 with a signed url" in {
-    val (_, samRoutes, _) = setupPetSATest()
+    val (_, samRoutes) = setupSignedUrlTest()
     val blob = SignedUrlRequest(GcsBucketName("my-bucket"), GcsBlobName("my-folder/my-object.txt"))
-    Post(s"api/google/v1/user/petServiceAccount/myproject/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Success
+    Post(s"/api/google/v1/user/petServiceAccount/myproject/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+      responseAs[String] should not be empty
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.MessageRequest
 import org.broadinstitute.dsde.workbench.google.mock._
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
-import org.broadinstitute.dsde.workbench.google2.Generators.{genGcsBlobName, genGcsBucketName}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.model.Notifications.NotificationFormat
 import org.broadinstitute.dsde.workbench.model._
@@ -1241,31 +1240,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val service = new UserService(dirDAO, googleExtensions, Seq.empty, tosService)
 
     (googleExtensions, service, tosService)
-  }
-
-  "getSignedUrl" should "get a signed URL for GS Objects" in {
-    assume(databaseEnabled, databaseEnabledClue)
-
-    implicit val patienceConfig = PatienceConfig(1 second)
-    val (googleExtensions, service, tosService) = setupGoogleKeyCacheTests(true)
-
-    val createDefaultUser = Generator.genWorkbenchUserGoogle.sample.get
-    // create a user
-    val newUser = newUserWithAcceptedTos(service, tosService, createDefaultUser, samRequestContext)
-    newUser shouldBe UserStatus(
-      UserStatusDetails(createDefaultUser.id, createDefaultUser.email),
-      TestSupport.enabledMapTosAccepted
-    )
-
-    // create a pet service account
-    val googleProject = GoogleProject("testproject")
-
-    val bucketName = genGcsBucketName.sample.get
-    val blobName = genGcsBlobName.sample.get
-    runAndWait(FakeGoogleStorageInterpreter.createBlob(bucketName, blobName, "test".getBytes("UTF-8")).compile.drain)
-
-    val url = runAndWait(googleExtensions.getSignedUrl(createDefaultUser, googleProject, bucketName, blobName, samRequestContext))
-    url.getFile should startWith(s"/${bucketName.value}/${blobName.value}")
   }
 
   "GoogleKeyCache" should "create a service account key and return the same key when called again" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionSpec.scala
@@ -1,0 +1,130 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import cats.effect.IO
+import com.google.auth.oauth2.ServiceAccountCredentials
+import org.broadinstitute.dsde.workbench.RetryConfig
+import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleKmsService, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.sam.Generator.{
+  genFirecloudEmail,
+  genGcsBlobName,
+  genGcsBucketName,
+  genGoogleProject,
+  genPetServiceAccount,
+  genWorkbenchUserGoogle
+}
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresDistributedLockDAO}
+import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
+import org.broadinstitute.dsde.workbench.sam.model.{ResourceType, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.IdiomaticMockito
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, doReturn}
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.scalatest.{Inside, OptionValues}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.mockito.ArgumentMatchersSugar._
+import org.mockito.MockitoSugar.verify
+
+import java.net.URL
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration.TimeUnit
+
+class NewGoogleExtensionSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with TestSupport
+    with IdiomaticMockito
+    with ScalaFutures
+    with OptionValues
+    with Inside {
+
+  def this() = this(ActorSystem("NewGoogleExtensionSpec"))
+
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+  "GoogleExtensions.getSignedUrl" should "generate a signed URL for a GCS Object" in {
+    val newGoogleUser = genWorkbenchUserGoogle.sample.get
+    val googleProject = genGoogleProject.sample.get
+    val gcsBucket = genGcsBucketName.sample.get
+    val gcsBlob = genGcsBlobName.sample.get
+    val petServiceAccount = genPetServiceAccount.sample.get
+    val petServiceAccountKey = RealKeyMockGoogleIamDAO.generateNewRealKey(petServiceAccount.serviceAccount.email)._2
+    val expectedUrl = new URL("https", "localhost", 80, s"${gcsBucket.value}/${gcsBlob.value}")
+
+    val mockGoogleKeyCache = mock[GoogleKeyCache](RETURNS_SMART_NULLS)
+    val mockGoogleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+
+    lazy val petServiceAccountConfig = TestSupport.petServiceAccountConfig
+    lazy val googleServicesConfig = TestSupport.googleServicesConfig
+
+    val googleExtensions: GoogleExtensions = spy(
+      new GoogleExtensions(
+        mock[PostgresDistributedLockDAO[IO]](RETURNS_SMART_NULLS),
+        mock[DirectoryDAO](RETURNS_SMART_NULLS),
+        mock[AccessPolicyDAO](RETURNS_SMART_NULLS),
+        mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GoogleIamDAO](RETURNS_SMART_NULLS),
+        mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
+        mock[GoogleProjectDAO](RETURNS_SMART_NULLS),
+        mockGoogleKeyCache,
+        mock[NotificationDAO](RETURNS_SMART_NULLS),
+        mock[GoogleKmsService[IO]](RETURNS_SMART_NULLS),
+        mockGoogleStorageService,
+        googleServicesConfig,
+        petServiceAccountConfig,
+        Map.empty[ResourceTypeName, ResourceType],
+        genFirecloudEmail.sample.get
+      )
+    )
+
+    doReturn(IO.pure(petServiceAccount))
+      .when(googleExtensions)
+      .createUserPetServiceAccount(eqTo(newGoogleUser), eqTo(googleProject), any[SamRequestContext])
+
+    doReturn(IO.pure(petServiceAccountKey))
+      .when(mockGoogleKeyCache)
+      .getKey(eqTo(petServiceAccount))
+
+    doReturn(Stream.emit(expectedUrl))
+      .when(mockGoogleStorageService)
+      .getSignedBlobUrl(
+        any[GcsBucketName],
+        any[GcsBlobName],
+        any[ServiceAccountCredentials],
+        any[Option[TraceId]],
+        any[RetryConfig],
+        any[Long],
+        any[TimeUnit]
+      )
+
+    val signedUrl = runAndWait(googleExtensions.getSignedUrl(newGoogleUser, googleProject, gcsBucket, gcsBlob, samRequestContext))
+
+    signedUrl should be(expectedUrl)
+
+    verify(googleExtensions).createUserPetServiceAccount(eqTo(newGoogleUser), eqTo(googleProject), any[SamRequestContext])
+
+    verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
+
+    verify(mockGoogleStorageService).getSignedBlobUrl(
+      eqTo(gcsBucket),
+      eqTo(gcsBlob),
+      argThat((creds: ServiceAccountCredentials) => creds.getClientEmail.equals(petServiceAccount.serviceAccount.email.value)),
+      any[Option[TraceId]],
+      any[RetryConfig],
+      any[Long],
+      any[TimeUnit]
+    )
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -37,7 +37,7 @@ import java.net.URL
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.TimeUnit
 
-class NewGoogleExtensionSpec(_system: ActorSystem)
+class NewGoogleExtensionsSpec(_system: ActorSystem)
     extends TestKit(_system)
     with AnyFlatSpecLike
     with Matchers

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/mock/RealKeyMockGoogleIamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/mock/RealKeyMockGoogleIamDAO.scala
@@ -1,0 +1,86 @@
+package org.broadinstitute.dsde.workbench.sam.mock
+
+import com.google.auth.oauth2.ServiceAccountCredentials
+import com.google.gson.stream.{JsonReader, JsonWriter}
+import com.google.gson.{FieldNamingPolicy, GsonBuilder, TypeAdapter}
+import org.bouncycastle.jcajce.provider.asymmetric.rsa.BCRSAPrivateCrtKey
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openssl.jcajce.{JcaPEMWriter, JcaPKCS8Generator}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId, ServiceAccountPrivateKeyData}
+
+import java.io.StringWriter
+import java.nio.charset.StandardCharsets
+import java.security.{KeyPairGenerator, Security}
+import java.time.{Duration => JavaDuration, Instant}
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO.generateNewRealKey
+
+import java.util.{Base64, UUID}
+import scala.concurrent.Future
+import scala.util.Using
+
+object RealKeyMockGoogleIamDAO {
+
+  def generateNewRealKey(serviceAccountEmail: WorkbenchEmail): (ServiceAccountKeyId, String) = {
+    Security.addProvider(new BouncyCastleProvider)
+
+    // Create the public and private keys
+    val keyGen = KeyPairGenerator.getInstance("RSA", "BC")
+    keyGen.initialize(2048)
+    val pair = keyGen.genKeyPair()
+
+    val keyId = ServiceAccountKeyId(UUID.randomUUID().toString)
+    val serviceAccountCredentials = ServiceAccountCredentials
+      .newBuilder()
+      .setServiceAccountUser("testUser")
+      .setClientEmail(serviceAccountEmail.value)
+      .setClientId("12345678")
+      .setPrivateKey(pair.getPrivate)
+      .setPrivateKeyId(keyId.value)
+      .build()
+
+    val gson = new GsonBuilder()
+      .registerTypeAdapter(classOf[JavaDuration], new DurationAdapter)
+      .registerTypeAdapter(classOf[BCRSAPrivateCrtKey], new BCRSAPrivateCrtKeyAdapter)
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .create()
+    val keyJsonTree = gson.toJsonTree(serviceAccountCredentials)
+    keyJsonTree.getAsJsonObject.addProperty("type", "service_account")
+    (keyId, gson.toJson(keyJsonTree))
+  }
+
+  class DurationAdapter extends TypeAdapter[JavaDuration] {
+    override def write(writer: JsonWriter, value: JavaDuration): Unit =
+      writer.value(value.toMillis)
+
+    override def read(in: JsonReader): JavaDuration = throw new NotImplementedError("No reading here")
+  }
+
+  class BCRSAPrivateCrtKeyAdapter extends TypeAdapter[BCRSAPrivateCrtKey] {
+    override def write(writer: JsonWriter, value: BCRSAPrivateCrtKey): Unit = {
+      val sw = new StringWriter()
+      Using(new JcaPEMWriter(sw)) { pw =>
+        pw.writeObject(new JcaPKCS8Generator(value, null))
+      }
+      writer.value(sw.toString)
+    }
+
+    override def read(in: JsonReader): BCRSAPrivateCrtKey = throw new NotImplementedError("No reading here")
+  }
+}
+
+class RealKeyMockGoogleIamDAO extends MockGoogleIamDAO {
+
+  override def createServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[ServiceAccountKey] = {
+    val (keyId, keyJson) = generateNewRealKey(serviceAccountEmail)
+    val key = ServiceAccountKey(
+      keyId,
+      ServiceAccountPrivateKeyData(Base64.getEncoder.encodeToString(keyJson.getBytes(StandardCharsets.UTF_8))),
+      Some(Instant.now),
+      Some(Instant.now.plusSeconds(300))
+    )
+    serviceAccountKeys(serviceAccountEmail) += keyId -> key
+    Future.successful(key)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -10,13 +10,12 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, Direct
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.{Generator, RetryableAnyFlatSpec, TestSupport}
 import org.scalatest._
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PolicyEvaluatorServiceSpec extends AnyFlatSpec with Matchers with TestSupport with BeforeAndAfterEach {
+class PolicyEvaluatorServiceSpec extends RetryableAnyFlatSpec with Matchers with TestSupport with BeforeAndAfterEach {
   lazy val dirDAO: DirectoryDAO = new PostgresDirectoryDAO(TestSupport.dbRef, TestSupport.dbRef)
   lazy val policyDAO: AccessPolicyDAO = new PostgresAccessPolicyDAO(TestSupport.dbRef, TestSupport.dbRef)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-586


What:

Sam can now return signed URLs for GS Objects! 

Why:

Martha is getting retired, and Sam already handles service account keys. It makes sense for Sam to do this, and to not pass keys over the network to other systems.

How:

The first step was to modify [workbench-libs](https://github.com/broadinstitute/workbench-libs/pull/1336) to create signed URLs for gs blobs. Then, I wired that into Sam and wrote tests.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
