### PR TITLE
PF-2712: Patch additional groups in an auth domain

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -100,6 +100,9 @@ resourceTypes = {
       "read_auth_domain" = {
         description = "view the auth domain of the workspace"
       }
+      "update_auth_domain" = {
+        description = "update the groups in the auth domain of the workspace"
+      }
       "create_controlled_user_private" = {
         description = "create controlled, user-owned private resources in the workspace"
       }
@@ -150,7 +153,7 @@ resourceTypes = {
         includedRoles = ["owner"]
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "update_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status"]
         # Workspace Manager also maintains a mapping of workspace roles to controlled resource roles. If you change this mapping, check that service's mapping as well.
         descendantRoles = {
           google-project = ["owner"]

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1675,11 +1675,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-    post:
+    patch:
       tags:
         - Resources
       summary: Update the groups in the Auth Domain for a resource
-      operationId: postAuthDomainV2
+      operationId: patchAuthDomainV2
       parameters:
         - name: resourceTypeName
           in: path

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1675,6 +1675,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+    put:
+      tags:
+        - Resources
+      summary: Update the groups in the Auth Domain for a resource
+      operationId: putAuthDomainV2
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        204:
+          description: Successfully updated domains
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/resources/v2/{resourceTypeName}/{resourceId}/allUsers:
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1675,11 +1675,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-    put:
+    post:
       tags:
         - Resources
       summary: Update the groups in the Auth Domain for a resource
-      operationId: putAuthDomainV2
+      operationId: postAuthDomainV2
       parameters:
         - name: resourceTypeName
           in: path

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -366,7 +366,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
 
   def putResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireAction(resource, SamResourceActions.alterPolicies, samUser.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.readAuthDomain, samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchGroupName]]) { authDomains =>
           complete(resourceService.setResourceAuthDomain(resource, authDomains, samRequestContext).map { response =>
             StatusCodes.OK -> response

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -149,7 +149,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                   pathPrefix("authDomain") {
                     pathEndOrSingleSlash {
                       getResourceAuthDomain(resource, samUser, samRequestContext) ~
-                        postResourceAuthDomain(resource, samUser, samRequestContext)
+                        patchResourceAuthDomain(resource, samUser, samRequestContext)
                     }
                   } ~
                   pathPrefix("roles") {
@@ -364,8 +364,8 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
       }
     }
 
-  def postResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
-    post {
+  def patchResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
+    patch {
       requireAction(resource, SamResourceActions.updateAuthDomain, samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchGroupName]]) { authDomains =>
           complete(resourceService.setResourceAuthDomain(resource, authDomains, samUser.id, samRequestContext).map { response =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -366,7 +366,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
 
   def putResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     put {
-      requireAction(resource, SamResourceActions.readAuthDomain, samUser.id, samRequestContext) {
+      requireAction(resource, SamResourceActions.updateAuthDomain, samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchGroupName]]) { authDomains =>
           complete(resourceService.setResourceAuthDomain(resource, authDomains, samRequestContext).map { response =>
             StatusCodes.OK -> response

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -148,7 +148,8 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                   } ~
                   pathPrefix("authDomain") {
                     pathEndOrSingleSlash {
-                      getResourceAuthDomain(resource, samUser, samRequestContext)
+                      getResourceAuthDomain(resource, samUser, samRequestContext) ~
+                        putResourceAuthDomain(resource, samUser, samRequestContext)
                     }
                   } ~
                   pathPrefix("roles") {
@@ -360,6 +361,17 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
         complete(resourceService.loadResourceAuthDomain(resource, samRequestContext).map { response =>
           StatusCodes.OK -> response
         })
+      }
+    }
+
+  def putResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
+    put {
+      requireAction(resource, SamResourceActions.alterPolicies, samUser.id, samRequestContext) {
+        entity(as[Set[WorkbenchGroupName]]) { authDomains =>
+          complete(resourceService.setResourceAuthDomain(resource, authDomains, samRequestContext).map { response =>
+            StatusCodes.OK -> response
+          })
+        }
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -149,7 +149,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                   pathPrefix("authDomain") {
                     pathEndOrSingleSlash {
                       getResourceAuthDomain(resource, samUser, samRequestContext) ~
-                        putResourceAuthDomain(resource, samUser, samRequestContext)
+                        postResourceAuthDomain(resource, samUser, samRequestContext)
                     }
                   } ~
                   pathPrefix("roles") {
@@ -364,11 +364,11 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
       }
     }
 
-  def putResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
-    put {
+  def postResourceAuthDomain(resource: FullyQualifiedResourceId, samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
+    post {
       requireAction(resource, SamResourceActions.updateAuthDomain, samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchGroupName]]) { authDomains =>
-          complete(resourceService.setResourceAuthDomain(resource, authDomains, samRequestContext).map { response =>
+          complete(resourceService.setResourceAuthDomain(resource, authDomains, samUser.id, samRequestContext).map { response =>
             StatusCodes.OK -> response
           })
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -368,7 +368,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
     patch {
       requireAction(resource, SamResourceActions.updateAuthDomain, samUser.id, samRequestContext) {
         entity(as[Set[WorkbenchGroupName]]) { authDomains =>
-          complete(resourceService.setResourceAuthDomain(resource, authDomains, samUser.id, samRequestContext).map { response =>
+          complete(resourceService.addResourceAuthDomain(resource, authDomains, samUser.id, samRequestContext).map { response =>
             StatusCodes.OK -> response
           })
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -21,7 +21,7 @@ trait AccessPolicyDAO {
 
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LoadResourceAuthDomainResult]
 
-  def setResourceAuthDomain(
+  def addResourceAuthDomain(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -21,6 +21,12 @@ trait AccessPolicyDAO {
 
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LoadResourceAuthDomainResult]
 
+  def setResourceAuthDomain(
+      resource: FullyQualifiedResourceId,
+      authDomains: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[LoadResourceAuthDomainResult]
+
   def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(
       groupId: WorkbenchGroupIdentity,
       samRequestContext: SamRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -25,7 +25,7 @@ trait AccessPolicyDAO {
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[LoadResourceAuthDomainResult]
+  ): IO[Unit]
 
   def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(
       groupId: WorkbenchGroupIdentity,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -520,19 +520,6 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
     insertAuthDomainQuery.update().apply()
   }
 
-  private def removeExtraAuthDomainGroupsFromResource(resourcePK: ResourcePK, authDomainGroupPKs: Seq[GroupPK])(implicit session: DBSession): Unit = {
-    val a = AuthDomainTable.syntax("a")
-
-    if (authDomainGroupPKs.nonEmpty) {
-      samsql"""delete from ${AuthDomainTable as a}
-        where ${a.resourceId} = ${resourcePK}
-        and ${a.groupId} not in (${authDomainGroupPKs})""".update().apply()
-    } else {
-      samsql"""delete from ${AuthDomainTable as a}
-        where ${a.resourceId} = ${resourcePK}""".update().apply()
-    }
-  }
-
   /** Queries the database for the PK of the resource and throws an error if it does not exist
     * @param resourceId
     * @return
@@ -613,7 +600,6 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       if (authDomainPks.nonEmpty) {
         insertAuthDomainsForResource(resourcePK, authDomainPks)
       }
-      removeExtraAuthDomainGroupsFromResource(resourcePK, authDomainPks)
     }
 
   override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -589,6 +589,19 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       }
     }
 
+  override def setResourceAuthDomain(
+      resource: FullyQualifiedResourceId,
+      authDomains: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[LoadResourceAuthDomainResult] = {
+    serializableWriteTransaction("setResourceAuthDomain", samRequestContext) { implicit session =>
+      val authDomainPks = queryForGroupPKs(authDomains.map(identity))
+      val resourcePk = loadResourcePK(resource)
+      insertAuthDomainsForResource(resourcePk, authDomainPks)
+    }
+    loadResourceAuthDomain(resource, samRequestContext)
+  }
+
   override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(
       groupId: WorkbenchGroupIdentity,
       samRequestContext: SamRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -589,12 +589,12 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       }
     }
 
-  override def setResourceAuthDomain(
+  override def addResourceAuthDomain(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
   ): IO[Unit] =
-    serializableWriteTransaction("setResourceAuthDomain", samRequestContext) { implicit session =>
+    serializableWriteTransaction("addResourceAuthDomain", samRequestContext) { implicit session =>
       val resourcePK = loadResourcePK(resource)
       val authDomainPks = queryForGroupPKs(authDomains.map(identity))
       if (authDomainPks.nonEmpty) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -593,13 +593,12 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[LoadResourceAuthDomainResult] = {
-    serializableWriteTransaction("setResourceAuthDomain", samRequestContext) { implicit session =>
+  ): IO[Unit] = {
+    serializableWriteTransaction("removeAuthDomainFromResource", samRequestContext) { implicit session =>
+      val resourcePK = loadResourcePK(resource)
       val authDomainPks = queryForGroupPKs(authDomains.map(identity))
-      val resourcePk = loadResourcePK(resource)
-      insertAuthDomainsForResource(resourcePk, authDomainPks)
+      insertAuthDomainsForResource(resourcePK, authDomainPks)
     }
-    loadResourceAuthDomain(resource, samRequestContext)
   }
 
   override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -593,13 +593,12 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[Unit] = {
+  ): IO[Unit] =
     serializableWriteTransaction("removeAuthDomainFromResource", samRequestContext) { implicit session =>
       val resourcePK = loadResourcePK(resource)
       val authDomainPks = queryForGroupPKs(authDomains.map(identity))
       insertAuthDomainsForResource(resourcePK, authDomainPks)
     }
-  }
 
   override def listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(
       groupId: WorkbenchGroupIdentity,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -100,6 +100,7 @@ object SamResourceActions {
   val setAccessInstructions = ResourceAction("set_access_instructions")
   val setPublic = ResourceAction("set_public")
   val readAuthDomain = ResourceAction("read_auth_domain")
+  val updateAuthDomain = ResourceAction("update_auth_domain")
   val testAnyActionAccess = ResourceAction("test_any_action_access")
   val getParent = ResourceAction("get_parent")
   val setParent = ResourceAction("set_parent")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -275,12 +275,11 @@ class ResourceService(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[Set[WorkbenchGroupName]] = {
+  ): IO[Set[WorkbenchGroupName]] =
     for {
       _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains, samRequestContext)
       authDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield authDomains
-  }
 
   @VisibleForTesting
   def createPolicy(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -277,10 +277,10 @@ class ResourceService(
       samRequestContext: SamRequestContext
   ): IO[Set[WorkbenchGroupName]] = {
     for {
-      currentDomains <- loadResourceAuthDomain(resource, samRequestContext)
-      _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains.diff(currentDomains), samRequestContext)
-      updatedDomains <- loadResourceAuthDomain(resource, samRequestContext)
-    } yield updatedDomains
+      _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains, samRequestContext)
+    } yield ()
+
+    loadResourceAuthDomain(resource, samRequestContext)
   }
 
   @VisibleForTesting

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -275,13 +275,13 @@ class ResourceService(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[Set[WorkbenchGroupName]] =
-    // check EnvVariable/Feature Flag allows auth domain changes.
+  ): IO[Set[WorkbenchGroupName]] = {
     for {
       currentDomains <- loadResourceAuthDomain(resource, samRequestContext)
       _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains.diff(currentDomains), samRequestContext)
       updatedDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield updatedDomains
+  }
 
   @VisibleForTesting
   def createPolicy(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -271,6 +271,18 @@ class ResourceService(
         }
       )
 
+  def setResourceAuthDomain(
+      resource: FullyQualifiedResourceId,
+      authDomains: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[Set[WorkbenchGroupName]] =
+    // check EnvVariable/Feature Flag allows auth domain changes.
+    for {
+      currentDomains <- loadResourceAuthDomain(resource, samRequestContext)
+      _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains.diff(currentDomains), samRequestContext)
+      updatedDomains <- loadResourceAuthDomain(resource, samRequestContext)
+    } yield updatedDomains
+
   @VisibleForTesting
   def createPolicy(
       policyIdentity: FullyQualifiedPolicyId,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -279,10 +279,10 @@ class ResourceService(
   ): IO[Set[WorkbenchGroupName]] =
     for {
       resourceType <- getResourceType(resource.resourceTypeName)
-      policies <- listResourcePolicies(resource, samRequestContext)
       _ <- validateAuthDomain(resourceType.get, authDomains, userId, samRequestContext)
-      _ <- cloudExtensions.onGroupUpdate(policies.map(p => FullyQualifiedPolicyId(resource, p.policyName)), samRequestContext)
+      policies <- listResourcePolicies(resource, samRequestContext)
       _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains, samRequestContext)
+      _ <- cloudExtensions.onGroupUpdate(policies.map(p => FullyQualifiedPolicyId(resource, p.policyName)), samRequestContext)
       authDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield authDomains
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -271,7 +271,7 @@ class ResourceService(
         }
       )
 
-  def setResourceAuthDomain(
+  def addResourceAuthDomain(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       userId: WorkbenchUserId,
@@ -281,7 +281,7 @@ class ResourceService(
       resourceType <- getResourceType(resource.resourceTypeName)
       _ <- validateAuthDomain(resourceType.get, authDomains, userId, samRequestContext)
       policies <- listResourcePolicies(resource, samRequestContext)
-      _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains, samRequestContext)
+      _ <- accessPolicyDAO.addResourceAuthDomain(resource, authDomains, samRequestContext)
       _ <- cloudExtensions.onGroupUpdate(policies.map(p => FullyQualifiedPolicyId(resource, p.policyName)), samRequestContext)
       authDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield authDomains

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -278,9 +278,8 @@ class ResourceService(
   ): IO[Set[WorkbenchGroupName]] = {
     for {
       _ <- accessPolicyDAO.setResourceAuthDomain(resource, authDomains, samRequestContext)
-    } yield ()
-
-    loadResourceAuthDomain(resource, samRequestContext)
+      authDomains <- loadResourceAuthDomain(resource, samRequestContext)
+    } yield authDomains
   }
 
   @VisibleForTesting

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -1689,7 +1689,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
         .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
     )
 
-    Post(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
+    Patch(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] shouldEqual Set(authDomain, authDomain2)
     }
@@ -1724,7 +1724,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
         .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
     )
 
-    Post(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
+    Patch(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -1689,7 +1689,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
         .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
     )
 
-    Put(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
+    Post(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] shouldEqual Set(authDomain, authDomain2)
     }
@@ -1724,7 +1724,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
         .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
     )
 
-    Put(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
+    Post(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -1667,8 +1667,8 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     val authDomain2 = "authDomain2"
     val resourceType = ResourceType(
       ResourceTypeName("rt"),
-      Set(SamResourceActionPatterns.readAuthDomain, SamResourceActionPatterns.use),
-      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction))),
+      Set(SamResourceActionPatterns.readAuthDomain, SamResourceActionPatterns.use, SamResourceActionPatterns.alterPolicies),
+      Set(ResourceRole(ResourceRoleName("owner"), Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction, SamResourceActions.alterPolicies))),
       ResourceRoleName("owner")
     )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType, managedGroupResourceType.name -> managedGroupResourceType))
@@ -1680,7 +1680,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     val policiesMap = Map(
       AccessPolicyName("ap") -> AccessPolicyMembership(
         Set(defaultUserInfo.email),
-        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction),
+        Set(SamResourceActions.readAuthDomain, ManagedGroupService.useAction, SamResourceActions.alterPolicies),
         Set(ResourceRoleName("owner"))
       )
     )
@@ -1689,17 +1689,10 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
         .createResource(resourceType, resourceId, policiesMap, Set(WorkbenchGroupName(authDomain)), None, defaultUserInfo.id, samRequestContext)
     )
 
-    val result = runAndWait(
-      samRoutes.resourceService
-        .setResourceAuthDomain(FullyQualifiedResourceId(resourceType.name, resourceId), Set(WorkbenchGroupName(authDomain2)), samRequestContext)
-    );
-    result.map(n => n.value) shouldEqual Set(authDomain, authDomain2)
-    /*
     Put(s"/api/resources/v2/${resourceType.name}/${resourceId.value}/authDomain", Array(authDomain2)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[Set[String]] shouldEqual Set(authDomain, authDomain2)
     }
-     */
   }
 
   private def initManagedGroupResourceType(): ResourceType = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -118,6 +118,7 @@ object TestSamRoutes {
 
     val use = ResourceActionPattern("use", "", true)
     val readAuthDomain = ResourceActionPattern("read_auth_domain", "", true)
+    val updateAuthDomain = ResourceActionPattern("update_auth_domain", "", true)
 
     val testActionAccess = ResourceActionPattern("test_action_access::.+", "", false)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -80,6 +80,17 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       }
     }
 
+  override def setResourceAuthDomain(
+      resource: FullyQualifiedResourceId,
+      authDomains: Set[WorkbenchGroupName],
+      samRequestContext: SamRequestContext
+  ): IO[LoadResourceAuthDomainResult] = {
+    val resourceToUpdateOpt = resources.get(resource)
+    val updatedAuthDomains = resourceToUpdateOpt.map(res => res.authDomain).get ++ authDomains
+    resourceToUpdateOpt.map(resourceToUpdate => resources += resource -> resourceToUpdate.copy(authDomain = updatedAuthDomains))
+    loadResourceAuthDomain(resource, samRequestContext)
+  }
+
   override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {
     val resourceToRemoveOpt = resources.get(resource)
     resourceToRemoveOpt.map(resourceToRemove => resources += resource -> resourceToRemove.copy(authDomain = Set.empty))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -80,7 +80,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       }
     }
 
-  override def setResourceAuthDomain(
+  override def addResourceAuthDomain(
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -84,11 +84,12 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       resource: FullyQualifiedResourceId,
       authDomains: Set[WorkbenchGroupName],
       samRequestContext: SamRequestContext
-  ): IO[LoadResourceAuthDomainResult] = {
+  ): IO[Unit] = {
     val resourceToUpdateOpt = resources.get(resource)
     val updatedAuthDomains = resourceToUpdateOpt.map(res => res.authDomain).get ++ authDomains
-    resourceToUpdateOpt.map(resourceToUpdate => resources += resource -> resourceToUpdate.copy(authDomain = updatedAuthDomains))
-    loadResourceAuthDomain(resource, samRequestContext)
+    IO {
+      resourceToUpdateOpt.map(resourceToUpdate => resources += resource -> resourceToUpdate.copy(authDomain = updatedAuthDomains))
+    }
   }
 
   override def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] = IO {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -475,7 +475,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
       }
     }
 
-    "setResourceAuthDomain" - {
+    "addResourceAuthDomain" - {
       "ZeroToOneGroups" in {
         assume(databaseEnabled, databaseEnabledClue)
 
@@ -488,7 +488,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         val resourceWithoutAuthDomain = Resource(resourceType.name, ResourceId("authDomainResource"), Set.empty)
         dao.createResource(resourceWithoutAuthDomain, samRequestContext).unsafeRunSync() shouldEqual resourceWithoutAuthDomain
 
-        dao.setResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, Set(authDomainGroupName1), samRequestContext).unsafeRunSync()
+        dao.addResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, Set(authDomainGroupName1), samRequestContext).unsafeRunSync()
 
         dao.loadResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, samRequestContext).unsafeRunSync() match {
           case Constrained(authDomain) => authDomain.toList should contain theSameElementsAs Set(authDomainGroupName1)
@@ -512,7 +512,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(resourceWithoutAuthDomain, samRequestContext).unsafeRunSync() shouldEqual resourceWithoutAuthDomain
 
         dao
-          .setResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, Set(authDomainGroupName1, authDomainGroupName2), samRequestContext)
+          .addResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, Set(authDomainGroupName1, authDomainGroupName2), samRequestContext)
           .unsafeRunSync()
 
         dao.loadResourceAuthDomain(resourceWithoutAuthDomain.fullyQualifiedId, samRequestContext).unsafeRunSync() match {
@@ -537,7 +537,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(resourceWithoutAuthDomain, samRequestContext).unsafeRunSync() shouldEqual resourceWithoutAuthDomain
 
         dao
-          .setResourceAuthDomain(
+          .addResourceAuthDomain(
             resourceWithoutAuthDomain.fullyQualifiedId,
             Set(authDomainGroupName1, authDomainGroupName2, authDomainGroupName1),
             samRequestContext


### PR DESCRIPTION
Ticket: PF-2712

What: Adds a PATCH endpoint to add groups to an auth domain on a resource.

Why: For the idea of data collections - if we want to import from a data collection into a workspace then the protections set on that data collection should carry over/apply to the workspace as well. 

How: The PATCH endpoint will take in a list of groups for the auth domain. We'll do a diff on that list with the existing groups and add in the missing groups to the auth domain. We don't currently support removing as that has some other considerations.

---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
