### PR TITLE
Enable Pact Broker pending feature QA-2070

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -40,9 +40,6 @@ class SamProviderSpec
     with LazyLogging
     with MockitoSugar {
 
-  // Provider tags. For use with Pact Broker Pending feature
-  val providerTags = List("develop", "main")
-
   // The default login user
   val defaultSamUser: SamUser = Generator.genWorkbenchUserBoth.sample.get.copy(enabled = true)
   val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(defaultSamUser.id), WorkbenchEmail("all_users@fake.com"))
@@ -201,7 +198,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
-      .withPendingPactsEnabled(ProviderTags.fromList(providerTags).get)
+      .withPendingPactsEnabled(ProviderTags(branch))
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -129,6 +129,8 @@ class SamProviderSpec
   // Provider branch, sha
   lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
   lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
+  println("gitSha")
+  println(gitSha)
   // Consumer name, bran, sha (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
   lazy val consumerBranch: Option[String] = sys.env.get("CONSUMER_BRANCH")
@@ -198,7 +200,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
-      .withPendingPactsEnabled(ProviderTags(branch))
+      .withPendingPactsEnabled(ProviderTags(gitSha))
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -128,8 +128,6 @@ class SamProviderSpec
   lazy val pactBrokerPass: String = sys.env.getOrElse("PACT_BROKER_PASSWORD", "")
   // Provider branch, sha
   lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
-  println("branch=")
-  println(branch)
   lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
   // Consumer name, bran, sha (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
@@ -200,7 +198,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
-      .withPendingPactsEnabled(ProviderTags("develop", "iv-pact4s-enable-pending"))
+      .withPendingPactsEnabled(ProviderTags("develop"))
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -128,6 +128,8 @@ class SamProviderSpec
   lazy val pactBrokerPass: String = sys.env.getOrElse("PACT_BROKER_PASSWORD", "")
   // Provider branch, sha
   lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
+  println("branch=")
+  println(branch)
   lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
   // Consumer name, bran, sha (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -198,6 +198,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
+      .withPendingPacts(true)
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -40,6 +40,9 @@ class SamProviderSpec
     with LazyLogging
     with MockitoSugar {
 
+  // Provider tags. For use with Pact Broker Pending feature
+  val providerTags = List("develop", "main")
+
   // The default login user
   val defaultSamUser: SamUser = Generator.genWorkbenchUserBoth.sample.get.copy(enabled = true)
   val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(defaultSamUser.id), WorkbenchEmail("all_users@fake.com"))
@@ -198,7 +201,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
-      .withPendingPactsEnabled(ProviderTags("develop"))
+      .withPendingPactsEnabled(ProviderTags.fromList(providerTags).get)
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -200,7 +200,7 @@ class SamProviderSpec
       )
       .withConsumerVersionSelectors(consumerVersionSelectors)
       .withAuth(BasicAuth(pactBrokerUser, pactBrokerPass))
-      .withPendingPacts(true)
+      .withPendingPactsEnabled(ProviderTags("develop", "iv-pact4s-enable-pending"))
   ).withHost("localhost")
     .withPort(8080)
     // .withRequestFiltering(requestFilter)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -129,8 +129,6 @@ class SamProviderSpec
   // Provider branch, sha
   lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
   lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
-  println("gitSha")
-  println(gitSha)
   // Consumer name, bran, sha (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
   lazy val consumerBranch: Option[String] = sys.env.get("CONSUMER_BRANCH")


### PR DESCRIPTION
Enable Pact Broker pending feature.

The pending feature is enabled for the **current** branch of the provider triggered by the verification workflow.

The pending feature works as follows, consult [https://docs.pact.io/go/pending](https://docs.pact.io/go/pending) for more details.

- If a consumer pact has **previously** been successfully verified by a version of `sam-provider` from **current** branch and If this verification fails, it will fail the build.

- If the consumer pact is in **pending** state for this version of `sam-provider` **because** a **successful** verification result for a version of `sam-provider` from current branch **has not yet been published**. If this verification fails, it **will not** cause the overall build to fail.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
