### PR TITLE
Add owner as included role to project-owner (WOR-522).

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -144,7 +144,8 @@ resourceTypes = {
         roleActions = ["read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader"]
       }
       project-owner = {
-        # This role is used for display purposes, but otherwise grants the same actions as the owner role.
+        # This role is used for display purposes and to prevent owners from removing project-owners,
+        # but otherwise grants the same actions as the owner role on workspaces.
         roleActions = []
         includedRoles = ["owner"]
       }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -144,8 +144,9 @@ resourceTypes = {
         roleActions = ["read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader"]
       }
       project-owner = {
-        # this role is used for display purposes but does not confer additional actions, use in conjunction with owner role
+        # This role is used for display purposes, but otherwise grants the same actions as the owner role.
         roleActions = []
+        includedRoles = ["owner"]
       }
       owner = {
         roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-522

**What:**

Make the workspace `project-owner` role inherit the `owner` role.

**Why:**

Currently the `project-owner` role is [always granted together](https://github.com/broadinstitute/rawls/blob/9a7cc501a421895742c9df12bedd7fae9cb4e738/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L3277) with the owner role for GCP workspaces. Apparently this was done because the `project-owner` role predated `includedRoles` being introduced in Sam.

We would like to add the `project-owner` role to Azure workspaces, where policy/role creation is done in Workspace Manager. Unfortunately Workspace Manager has built in a [1-to-1 assumption](https://github.com/DataBiosphere/terra-workspace-manager/blob/31e1606d9e7e6799b13d679e0a5654780ee10019/service/src/main/java/bio/terra/workspace/service/iam/model/WsmIamRole.java#L59) between roles and policies that does not easily extend to being able to assign both `project-owner` and `owner` roles to the `project-owner` policy; in fact WSM, conflates policies and roles together.

I went down the path of trying to change this 1-to-1 assumption in WSM, but it quickly became complicated. Talking with @marctalbott , it seems that a more natural way to get the behavior we desire is to have the `project-owner` role include the `owner` role.

@marctalbott did some sleuthing and found that there aren’t any cases in prod where the `project-owner` role is granted without the `owner` role. (Marc added that there are confusingly some project-owner workspace policies in Sam that don’t have the project-owner role but do have the owner role. There’s about 6600 workspaces like this. My best guess is that these are pretty old workspaces that predate the current permissions model and never got updated for some reason… in any case, they won't be impacted by this change).
 
**How:**

1. Merge this change in Sam.
2. Change [Rawls code](https://github.com/broadinstitute/rawls/blob/9a7cc501a421895742c9df12bedd7fae9cb4e738/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L3277) to only grant `project-owner` role to the `project-owner` policy for new GCP workspaces.
3. Change[ WSM code](https://github.com/DataBiosphere/terra-workspace-manager/pull/1304) to add a `project-owner` policy to new Azure workspaces (with empty set of users). Rawls will add the billing project owner group email to this after an Azure workspaces is created (through the WSM policy API).

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
