### PR TITLE
Work around issue with empty body for addMemberPolicyV2 endpoint (ID-650).

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2097,6 +2097,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
       responses:
         204:
           description: Successfully added a member policy to the parent policy


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-650

Working around issue in the same way as https://github.com/broadinstitute/sam/pull/737/files#r914074911

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
