### PR TITLE
ID-652 No Requester Pays Option for Signed URLs

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3009,6 +3009,11 @@ components:
         duration:
           type: number
           description: Optional validity duration of the link in minutes. Defaults to 1 hour.
+          default: 60
+        noRequesterPays:
+          type: boolean
+          description: Do not use the pet service account project as the user project in the request
+          default: false
     CreateResourceRequest:
       required:
         - policies

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -159,6 +159,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                               GcsBucketName(request.bucketName),
                               GcsBlobName(request.blobName),
                               request.duration,
+                              request.noRequesterPays.exists(identity),
                               samRequestContext
                             )
                             .map { signedUrl =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -75,7 +75,7 @@ object SamJsonSupport {
 
   implicit val CreateResourceResponseFormat = jsonFormat4(CreateResourceResponse.apply)
 
-  implicit val SignedUrlRequestFormat = jsonFormat3(SignedUrlRequest.apply)
+  implicit val SignedUrlRequestFormat = jsonFormat4(SignedUrlRequest.apply)
 }
 
 object RootPrimitiveJsonSupport {
@@ -305,7 +305,7 @@ object BasicWorkbenchGroup {
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 
-@Lenses final case class SignedUrlRequest(bucketName: String, blobName: String, duration: Option[Long] = None)
+@Lenses final case class SignedUrlRequest(bucketName: String, blobName: String, duration: Option[Long] = None, noRequesterPays: Option[Boolean] = Option(false))
 object SamUser {
   def apply(
       id: WorkbenchUserId,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -275,7 +275,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt", Some(1), noRequesterPays = Option(true))
 
     Post(s"/api/google/v1/user/petServiceAccount/$projectName/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
-      responseAs[String] should not include("userProject")
+      responseAs[String] should not include "userProject"
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -270,6 +270,15 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     }
   }
 
+  it should "skip requester pays" in {
+    val (_, samRoutes, projectName) = setupSignedUrlTest()
+    val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt", Some(1), noRequesterPays = Option(true))
+
+    Post(s"/api/google/v1/user/petServiceAccount/$projectName/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+      responseAs[String] should not include("userProject")
+    }
+  }
+
   it should "404 when the user doesn't have access to the project" in {
     val (_, samRoutes, projectName) = setupSignedUrlTest()
     val blob = SignedUrlRequest("my-bucket", "my-folder/my-object.txt")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-652

  \<Don't forget to include the ticket number in the PR title!\>

What:

When we sign a URL, we pass in the workspace project in as the user project param to sign the URL. This lets us support Requester Pays buckets.However, a reader on a workspace is not granted billing permission. So, when we include the workspace project to sign a url for a blob in the workspace bucket, Google checks to see if the user can spend the money based on the user project. Because a reader doesn’t have billing access, the request fails.

How:

Provide an option for the UI to tell Sam that it shouldn't inject the pet account project into the signed url request.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
