### PR TITLE
ID-660 Updated workbench-libs/util to 0.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val postgresDriverVersion = "42.5.0"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "d764a9b"
+  val workbenchLibV = "32f499b"
   val workbenchUtilV = s"0.9-$workbenchLibV"
   val workbenchUtil2V = s"0.4-$workbenchLibV"
   val workbenchModelV = s"0.18-$workbenchLibV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val sentryVersion = "6.15.0"
 
   val workbenchLibV = "d764a9b"
-  val workbenchUtilV = s"0.8-$workbenchLibV"
+  val workbenchUtilV = s"0.9-$workbenchLibV"
   val workbenchUtil2V = s"0.4-$workbenchLibV"
   val workbenchModelV = s"0.18-$workbenchLibV"
   val workbenchGoogleV = s"0.27-$workbenchLibV"

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/CoordinatedBackoffHttpGoogleDirectoryDAOSpec.scala
@@ -29,7 +29,7 @@ class CoordinatedBackoffHttpGoogleDirectoryDAOSpec extends AnyFreeSpec with Matc
         Await.result(test, Duration.Inf) match {
           case Right(_) => fail("expected error")
           case Left(errors) =>
-            errors.length shouldBe 7
+            errors.length shouldBe 8
             errors.forall(_ == googleDao.usageLimitedException)
         }
       }


### PR DESCRIPTION
Ticket: [ID-660](https://broadworkbench.atlassian.net/browse/ID-660)

What:

This PR updates the workbench-libs util version to 0.9 which corresponds to the changes made for this ticket in : [Workbench Libs PR](https://github.com/broadinstitute/workbench-libs/pull/1399)

Why:

This will enable the features added in workbench libs util 0.9 to increase backoff interval length for retry requests which should help reduce the amount of issues propagating in sentry when we have hit google request rate limit. 

How:

By updating the library to the latest version which supports the features mentioned above.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes


[ID-660]: https://broadworkbench.atlassian.net/browse/ID-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ