### PR TITLE
ID-698-Sam-GET-user-endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3715,15 +3715,6 @@ components:
           type: string
           description: User's email address
           format: email
-        azureB2CId:
-          type: string
-          description: User's Azure B2C Id
-        enabled:
-          type: boolean
-          description: Whether or not the user is enabled
-        acceptedTosVersion:
-          type: string
-          description: The version of terms of service the user accepted
       description: specification of a UpdateUserRequest
   securitySchemes:
     googleoauth:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -56,7 +56,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: '#/components/schemas/UpdateUserRequest'
       responses:
         200:
           description: User was updated successfully
@@ -3621,8 +3621,13 @@ components:
           example: my-managed-resource-group
       description: specifies a request for a pet managed identity
     User:
-      required:
       type: object
+      required:
+        - id
+        - email
+        - enabled
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: string
@@ -3656,6 +3661,26 @@ components:
           format: date-time
           description: User's time of last update
       description: specification of a User
+    UpdateUserRequest:
+      type: object
+      properties:
+        googleSubjectId:
+          type: string
+          description: User's Google subject Id
+        email:
+          type: string
+          description: User's email address
+          format: email
+        azureB2CId:
+          type: string
+          description: User's Azure B2C Id
+        enabled:
+          type: boolean
+          description: Whether or not the user is enabled
+        acceptedTosVersion:
+          type: string
+          description: The version of terms of service the user accepted
+      description: specification of a UpdateUserRequest
   securitySchemes:
     googleoauth:
       type: oauth2

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -72,6 +72,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/admin/v2/user/{userId}:
+    get:
+      tags:
+        - Admin
+      summary: Retrieves a user record, by user id
+      operationId: adminGetUser
+      parameters:
+        - name: userId
+          in: path
+          description: User ID of the user to be retrieved
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: User was retrieved successfully
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/User'
+        403:
+          description: You do not have admin privileges
+          content: { }
+        404:
+          description: User not found
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/admin/v1/user/email/{email}:
     get:
       tags:
@@ -3555,12 +3587,39 @@ components:
       description: specifies a request for a pet managed identity
     User:
       required:
-        - email
       type: object
       properties:
+        id:
+          type: string
+          description: User's Id
+        googleSubjectId:
+          type: string
+          description: User's Google subject Id
         email:
           type: string
           description: User's email address
+          format: email
+        azureB2CId:
+          type: string
+          description: User's Azure B2C Id
+        enabled:
+          type: boolean
+          description: Whether or not the user is enabled
+        acceptedTosVersion:
+          type: string
+          description: The version of terms of service the user accepted
+        createdAt:
+          type: string
+          format: date-time
+          description: User's time of creation
+        registeredAt:
+          type: string
+          format: date-time
+          description: User's time of registration
+        updatedAt:
+          type: string
+          format: date-time
+          description: User's time of last update
       description: specification of a User
   securitySchemes:
     googleoauth:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3715,6 +3715,9 @@ components:
           type: string
           description: User's email address
           format: email
+        enabled:
+          type: boolean
+          description: Whether or not the user is enabled
       description: specification of a UpdateUserRequest
   securitySchemes:
     googleoauth:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -31,6 +31,10 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
         adminUserRoutes(user, requestContext) ~
           adminResourcesRoutes(user, requestContext) ~
           adminResourceTypesRoutes(user, requestContext)
+      } ~ pathPrefix("v2") {
+        asWorkbenchAdmin(user) {
+          adminUserRoutesV2(user, requestContext)
+        }
       }
     }
 
@@ -114,6 +118,21 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
                 }
               }
           }
+      }
+    }
+
+  private def adminUserRoutesV2(user: SamUser, samRequestContext: SamRequestContext): server.Route =
+    pathPrefix("user") {
+      pathPrefix(Segment) { userId =>
+        pathEnd {
+          get {
+            complete {
+              userService
+                .getUser(WorkbenchUserId(userId), samRequestContext = samRequestContext)
+                .map(user => (if (user.isDefined) OK else NotFound) -> user)
+            }
+          }
+        }
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.{adminAddMember, adminReadPolicies, adminRemoveMember}
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes.resourceTypeAdminName
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.AccessPolicyMembershipRequest
+import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AdminUpdateUserRequest}
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.DefaultJsonProtocol._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.model
 import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
-import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse, AdminUpdateUserRequest}
 import org.broadinstitute.dsde.workbench.sam.model.api.SamApiJsonProtocol.PolicyInfoResponseBodyJsonFormat
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
@@ -62,7 +62,7 @@ object SamJsonSupport {
 
   implicit val UserPolicyResponseFormat = jsonFormat5(UserPolicyResponse.apply)
 
-  implicit val UserUpdateRequestFormat = jsonFormat5(AdminUpdateUserRequest.apply)
+  implicit val UserUpdateRequestFormat = jsonFormat3(AdminUpdateUserRequest.apply)
 
   implicit val RolesAndActionsFormat = jsonFormat2(RolesAndActions.apply)
 
@@ -308,14 +308,6 @@ object BasicWorkbenchGroup {
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 
 @Lenses final case class SignedUrlRequest(bucketName: String, blobName: String, duration: Option[Long] = None, requesterPays: Option[Boolean] = Option(true))
-
-@Lenses final case class AdminUpdateUserRequest(
-    googleSubjectId: Option[GoogleSubjectId],
-    email: Option[WorkbenchEmail],
-    azureB2CId: Option[AzureB2CId],
-    enabled: Option[Boolean],
-    acceptedTosVersion: Option[String]
-)
 
 object SamUser {
   def apply(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamModelApi.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamModelApi.scala
@@ -4,6 +4,11 @@ import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model._
 import spray.json.{DefaultJsonProtocol, JsObject, JsString, JsValue, RootJsonFormat, deserializationError}
+@Lenses final case class AdminUpdateUserRequest(
+    googleSubjectId: Option[GoogleSubjectId],
+    email: Option[WorkbenchEmail],
+    enabled: Option[Boolean]
+)
 
 // AccessPolicyMembership.memberPolicies is logically read-only; at some point in the future it could be lazy-loaded
 // (via extra queries) based on the contents of memberEmails.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -115,6 +115,11 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
       case None => IO(user)
     }
 
+  def getUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
+    openTelemetry.time("api.v2.user.getUser.time", API_TIMING_DURATION_BUCKET) {
+      directoryDAO.loadUser(userId, samRequestContext)
+    }
+
   def updateUserCrud(userId: WorkbenchUserId, request: AdminUpdateUserRequest, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     openTelemetry.time("api.v1.user.updateUserCrud.time", API_TIMING_DURATION_BUCKET) {
       directoryDAO.loadUser(userId, samRequestContext).flatMap {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.broadinstitute.dsde.workbench.sam.azure.ManagedIdentityObjectId
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.AdminUpdateUserRequest
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genWorkbenchUserId
 import org.broadinstitute.dsde.workbench.sam.util.AsyncLogging.IOWithLogging
 import org.broadinstitute.dsde.workbench.sam.util.{API_TIMING_DURATION_BUCKET, SamRequestContext}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -19,32 +19,29 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
   val defaultUserId: WorkbenchUserId = defaultUser.id
   val defaultUserEmail: WorkbenchEmail = defaultUser.email
   val adminGroupEmail: WorkbenchEmail = Generator.genFirecloudEmail.sample.get
-  val adminUser: SamUser = Generator.genWorkbenchUserBoth.sample.get
   val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
   private val badUserId = WorkbenchUserId(s"-$defaultUserId")
   private val newUserEmail = WorkbenchEmail(s"XXX${defaultUserEmail}XXX")
 
   "GET /admin/v1/user/{userSubjectId}" should "get the user status of a user (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
 
     // Act and Assert
-    Get(s"/api/admin/v1/user/${enabledUser.id}") ~> samRoutes.route ~> check {
+    Get(s"/api/admin/v1/user/${defaultUserId}") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] should beForUser(enabledUser)
+      responseAs[UserStatus] should beForUser(defaultUser)
     }
   }
 
   it should "not allow a non-admin to get the status of another user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
 
     // Act
@@ -56,10 +53,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not find a user that does not exist" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act and Assert
     Get(s"/api/admin/v1/user/$badUserId") ~> samRoutes.route ~> check {
@@ -69,33 +65,31 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "PATCH /admin/v1/user/{userSubjectId}" should "update a user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
     // Act
-    Patch(s"/api/admin/v1/user/${enabledUser.id}", requestBody) ~> samRoutes.route ~> check {
+    Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
       // Assert
       withClue(s"Response Body: ${responseAs[String]}")(status shouldEqual StatusCodes.OK)
       // Enabled in particular since we cant directly extract the user from the builder
-      responseAs[SamUser] shouldEqual enabledUser.copy(email = newUserEmail)
+      responseAs[SamUser] shouldEqual defaultUser.copy(email = newUserEmail)
     }
   }
 
   it should "not update a user with an invalid email in the request" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .withBadEmail()
       .build
     val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
 
     // Act
-    Patch(s"/api/admin/v1/user/$enabledUser.id", requestBody) ~> samRoutes.route ~> check {
+    Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
       // Assert
       withClue(s"Response Body: ${responseAs[String]}")(status shouldEqual StatusCodes.BadRequest)
     }
@@ -103,10 +97,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not update a user for a user that does not exist" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
 
@@ -119,15 +112,14 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not allow a non-admin to update a user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
 
     // Act
-    Patch(s"/api/admin/v1/user/${enabledUser.id}", requestBody) ~> samRoutes.route ~> check {
+    Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
       // Assert
       withClue(s"Response Body: ${responseAs[String]}")(status shouldEqual StatusCodes.Forbidden)
     }
@@ -135,10 +127,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not allow a non-admin to update a user for a user that does not exist" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
 
@@ -151,26 +142,24 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "GET /admin/v1/user/email/{email}" should "get the user status of a user by email (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
 
     // Act
-    Get(s"/api/admin/v1/user/email/${enabledUser.email}") ~> samRoutes.route ~> check {
+    Get(s"/api/admin/v1/user/email/$defaultUserEmail") ~> samRoutes.route ~> check {
       // Assert
       status shouldEqual StatusCodes.OK
-      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(enabledUser.id, enabledUser.email), enabledMapNoTosAccepted)
+      responseAs[UserStatus] shouldEqual UserStatus(UserStatusDetails(defaultUserId, defaultUserEmail), enabledMapNoTosAccepted)
     }
   }
 
   it should "return 404 for an unknown user by email (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Get(s"/api/admin/v1/user/email/$newUserEmail") ~> samRoutes.route ~> check {
@@ -182,20 +171,20 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
   it should "return 404 for an group's email (as an admin)" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser)
       .build
     // Act
-    Get(s"/api/admin/v1/user/email/fc-admins@dev.test.firecloud.org") ~> samRoutes.route ~> check {
+    Get(s"/api/admin/v1/user/email/$adminGroupEmail") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NotFound
     }
   }
 
   it should "not allow a non-admin to get the status of another user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Get(s"/api/admin/v1/user/email/$defaultUserEmail") ~> samRoutes.route ~> check {
@@ -205,17 +194,16 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "PUT /admin/v1/user/{userSubjectId}/disable" should "disable a user (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
-    Put(s"/api/admin/v1/user/${enabledUser.id}/disable") ~> samRoutes.route ~> check {
+    Put(s"/api/admin/v1/user/$defaultUserId/disable") ~> samRoutes.route ~> check {
       // Assert
       status shouldEqual StatusCodes.OK
       responseAs[UserStatus] shouldEqual UserStatus(
-        UserStatusDetails(enabledUser.id, enabledUser.email),
+        UserStatusDetails(defaultUserId, defaultUserEmail),
         enabledMapNoTosAccepted + ("ldap" -> false) + ("adminEnabled" -> false)
       )
     }
@@ -223,10 +211,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not disable a user that does not exist" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Put(s"/api/admin/v1/user/$badUserId/disable") ~> samRoutes.route ~> check {
@@ -237,10 +224,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not allow a non-admin to disable a user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Put(s"/api/admin/v1/user/$defaultUserId/disable") ~> samRoutes.route ~> check {
@@ -251,17 +237,16 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "PUT /admin/v1/user/{userSubjectId}/enable" should "enable a user (as an admin)" in {
     // Arrange
-    val user = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withDisabledUser(user) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withDisabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
-    Put(s"/api/admin/v1/user/${user.id}/enable") ~> samRoutes.route ~> check {
+    Put(s"/api/admin/v1/user/$defaultUserId/enable") ~> samRoutes.route ~> check {
       // Assert
       status shouldEqual StatusCodes.OK
       responseAs[UserStatus] shouldEqual UserStatus(
-        UserStatusDetails(user.id, user.email),
+        UserStatusDetails(defaultUserId, defaultUserEmail),
         enabledMapNoTosAccepted
       )
     }
@@ -269,10 +254,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not enable a user that does not exist" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(enabledUser)
-      .withDisabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser()
+      .withDisabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Put(s"/api/admin/v1/user/$badUserId/enable") ~> samRoutes.route ~> check {
@@ -283,10 +267,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not allow a non-admin to enable a user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withDisabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withDisabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Put(s"/api/admin/v1/user/$defaultUserId/enable") ~> samRoutes.route ~> check {
@@ -297,13 +280,12 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "DELETE /admin/v1/user/{userSubjectId}" should "delete a user (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
-    Delete(s"/api/admin/v1/user/${enabledUser.id}") ~> samRoutes.route ~> check {
+    Delete(s"/api/admin/v1/user/$defaultUserId") ~> samRoutes.route ~> check {
       // Assert
       status shouldEqual StatusCodes.OK
     }
@@ -311,10 +293,9 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   it should "not allow a non-admin to delete a user" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Delete(s"/api/admin/v1/user/$defaultUserId") ~> samRoutes.route ~> check {
@@ -325,26 +306,51 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
 
   "DELETE /admin/v1/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withAdminUser(adminUser) // enabled "admin" user who is making the http request
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
-    Delete(s"/api/admin/v1/user/${enabledUser.id}/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+    Delete(s"/api/admin/v1/user/$defaultUserId/petServiceAccount/myproject") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.NoContent
     }
   }
 
   it should "not allow a non-admin to delete a pet" in {
     // Arrange
-    val enabledUser = Generator.genWorkbenchUserBoth.sample.get
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withNonAdminUser(enabledUser)
-      .withEnabledUser(enabledUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
     // Act
     Delete(s"/api/admin/v1/user/$defaultUserId/petServiceAccount/myproject") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  "GET /admin/v2/user/{userId}" should "get the corresponding user object (as an admin)" in {
+    // Arrange
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withAdminUser() // enabled "admin" user who is making the http request
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
+      .build
+
+    // Act and Assert
+    Get(s"/api/admin/v2/user/$defaultUserId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[SamUser] shouldEqual defaultUser
+    }
+  }
+
+  it should "not allow access to a user object (as an non admin)" in {
+    // Arrange
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .build
+
+    // Act and Assert
+    Get(s"/api/admin/v2/user/$defaultUserId") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport.enabledMapNoTosAccepted
 import org.broadinstitute.dsde.workbench.sam.matchers.BeForUserMatcher.beForUser
 import org.broadinstitute.dsde.workbench.sam.model.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.AdminUpdateUserRequest
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.scalatest.MockitoSugar
@@ -69,7 +70,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       .withAdminUser() // enabled "admin" user who is making the http request
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
-    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
+    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None)
     // Act
     Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
       // Assert
@@ -86,7 +87,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .withBadEmail()
       .build
-    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
+    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None)
 
     // Act
     Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
@@ -101,7 +102,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       .withAdminUser()
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
-    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
+    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None)
 
     // Act
     Patch(s"/api/admin/v1/user/$badUserId", requestBody) ~> samRoutes.route ~> check {
@@ -116,7 +117,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       .withNonAdminUser()
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
-    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
+    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None)
 
     // Act
     Patch(s"/api/admin/v1/user/$defaultUserId", requestBody) ~> samRoutes.route ~> check {
@@ -131,7 +132,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       .withNonAdminUser()
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
-    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None, None, None)
+    val requestBody = AdminUpdateUserRequest(None, Some(newUserEmail), None)
 
     // Act
     Patch(s"/api/admin/v1/user/$badUserId", requestBody) ~> samRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -95,7 +95,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user if the user does not exist and the requesting user is an admin" in {
+  it should "not find a user when trying to update a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -209,7 +209,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user if the user does not exist and the requesting user is an admin" in {
+  it should "not find a user when trying to disable a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -252,7 +252,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user if the user does not exist and the requesting user is an admin" in {
+  it should "not find a user when trying to enable a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -368,7 +368,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user if it does not exist and the requesting user is an admin" in {
+  it should "not find a user when trying to get a user if it does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -23,7 +23,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
   private val badUserId = WorkbenchUserId(s"-$defaultUserId")
   private val newUserEmail = WorkbenchEmail(s"XXX${defaultUserEmail}XXX")
 
-  "GET /admin/v1/user/{userSubjectId}" should "get the user status of a user (as an admin)" in {
+  "GET /admin/v1/user/{userSubjectId}" should "get the user status of a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -37,7 +37,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to get the status of another user" in {
+  it should "forbid getting a user status if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -51,7 +51,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user that does not exist" in {
+  it should "not find a user status if that user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -63,7 +63,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "PATCH /admin/v1/user/{userSubjectId}" should "update a user" in {
+  "PATCH /admin/v1/user/{userSubjectId}" should "update a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -79,7 +79,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not update a user with an invalid email in the request" in {
+  it should "report an error when updating a user if the request email is invalid and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -95,7 +95,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not update a user for a user that does not exist" in {
+  it should "not find a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -110,7 +110,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to update a user" in {
+  it should "forbid updating a user if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -125,7 +125,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to update a user for a user that does not exist" in {
+  it should "forbid updating a user for a user if the user does not exist and the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -140,7 +140,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "GET /admin/v1/user/email/{email}" should "get the user status of a user by email (as an admin)" in {
+  "GET /admin/v1/user/email/{email}" should "get the user status of a user by email if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -155,7 +155,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "return 404 for an unknown user by email (as an admin)" in {
+  it should "not find a user status by email if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -168,7 +168,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "return 404 for an group's email (as an admin)" in {
+  it should "not find a group by email if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -180,7 +180,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to get the status of another user" in {
+  it should "forbid getting a user status if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -192,7 +192,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "PUT /admin/v1/user/{userSubjectId}/disable" should "disable a user (as an admin)" in {
+  "PUT /admin/v1/user/{userSubjectId}/disable" should "disable a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -209,7 +209,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not disable a user that does not exist" in {
+  it should "not find a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -222,7 +222,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to disable a user" in {
+  it should "forbid the disabling of a user if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -235,7 +235,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "PUT /admin/v1/user/{userSubjectId}/enable" should "enable a user (as an admin)" in {
+  "PUT /admin/v1/user/{userSubjectId}/enable" should "enable a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -252,7 +252,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not enable a user that does not exist" in {
+  it should "not find a user if the user does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser()
@@ -265,7 +265,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to enable a user" in {
+  it should "forbid enabling a user if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -278,7 +278,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "DELETE /admin/v1/user/{userSubjectId}" should "delete a user (as an admin)" in {
+  "DELETE /admin/v1/user/{userSubjectId}" should "delete a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -291,7 +291,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to delete a user" in {
+  it should "forbid deleting a user if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -304,7 +304,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "DELETE /admin/v1/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet (as an admin)" in {
+  "DELETE /admin/v1/user/{userSubjectId}/petServiceAccount/{project}" should "delete a pet if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -316,7 +316,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow a non-admin to delete a pet" in {
+  it should "forbid deleting a pet if the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withNonAdminUser()
@@ -328,7 +328,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  "GET /admin/v2/user/{userId}" should "get the corresponding user object (as an admin)" in {
+  "GET /admin/v2/user/{userId}" should "get the corresponding user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withAdminUser() // enabled "admin" user who is making the http request
@@ -342,11 +342,11 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow access to a user object (as an non admin)" in {
+  it should "forbid getting a user if the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
-      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .withNonAdminUser()
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
       .build
 
     // Act and Assert
@@ -355,7 +355,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not allow access even if a user object does not exist (as an admin)" in {
+  it should "forbid getting a user even if a user does not exist and the requesting user is a non admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
@@ -368,7 +368,7 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
     }
   }
 
-  it should "not find a user user object if it does not exist (as an admin)" in {
+  it should "not find a user if it does not exist and the requesting user is an admin" in {
     // Arrange
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
       .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminUserRoutesSpec.scala
@@ -354,4 +354,30 @@ class AdminUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteT
       status shouldEqual StatusCodes.Forbidden
     }
   }
+
+  it should "not allow access even if a user object does not exist (as an admin)" in {
+    // Arrange
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
+      .withNonAdminUser()
+      .build
+
+    // Act and Assert
+    Get(s"/api/admin/v2/user/$badUserId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "not find a user user object if it does not exist (as an admin)" in {
+    // Arrange
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
+      .withAdminUser()
+      .build
+
+    // Act and Assert
+    Get(s"/api/admin/v2/user/$badUserId") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutesBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutesBuilder.scala
@@ -44,14 +44,13 @@ class MockSamRoutesBuilder(allUsersGroup: WorkbenchGroup)(implicit system: Actor
     this
   }
 
-  def withAdminUser(samUser: SamUser): MockSamRoutesBuilder = {
-    adminUser = Option(samUser)
-    cloudExtensionsBuilder.withAdminUser(samUser)
+  def withAdminUser(): MockSamRoutesBuilder = {
+    cloudExtensionsBuilder.withAdminUser()
     this
   }
 
-  def withNonAdminUser(samUser: SamUser): MockSamRoutesBuilder = {
-    cloudExtensionsBuilder.withNonAdminUser(samUser)
+  def withNonAdminUser(): MockSamRoutesBuilder = {
+    cloudExtensionsBuilder.withNonAdminUser()
     this
   }
 
@@ -63,8 +62,8 @@ class MockSamRoutesBuilder(allUsersGroup: WorkbenchGroup)(implicit system: Actor
   // Can only have 1 active user when making a request.  If the adminUser is set, that takes precedence, otherwise try
   // to get the enabledUser.
   private def getActiveUser: SamUser =
-    adminUser
-      .orElse(enabledUser.orElse(disabledUser))
+    enabledUser
+      .orElse(disabledUser)
       .getOrElse(throw new Exception("Try building MockSamRoutes .withAdminUser(), .withEnabledUser(), withDisabledUser() first"))
 
   // TODO: This is not great.  We need to do a little state management to set and look up users and admin users.  This

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.{SubsystemStatus, Subsystems}
-import org.mockito.ArgumentMatchersSugar.{any, argThat, eqTo}
+import org.mockito.ArgumentMatchersSugar.{any, argThat}
 import org.mockito.{IdiomaticMockito, Strictness}
 
 import scala.collection.mutable
@@ -40,20 +40,13 @@ case class MockCloudExtensionsBuilder(allUsersGroup: WorkbenchGroup) extends Idi
     this
   }
 
-  def withAdminUser(samUser: SamUser): MockCloudExtensionsBuilder = withAdminUser(samUser.email)
-  def withAdminUser(adminUserEmail: WorkbenchEmail): MockCloudExtensionsBuilder = {
-    mockedCloudExtensions.isWorkbenchAdmin(eqTo(adminUserEmail)) returns Future.successful(true)
+  def withAdminUser(): MockCloudExtensionsBuilder = {
+    mockedCloudExtensions.isWorkbenchAdmin(any[WorkbenchEmail]) returns Future.successful(true)
     this
   }
   // testing cases where nonAdmin is attempting to use admin routes
-  def withNonAdminUser(samUser: SamUser): MockCloudExtensionsBuilder = withNonAdminUser(samUser.email)
-  def withNonAdminUser(adminUserEmail: WorkbenchEmail): MockCloudExtensionsBuilder = {
-    mockedCloudExtensions.isWorkbenchAdmin(eqTo(adminUserEmail)) returns Future.successful(false)
-    this
-  }
-
-  def withAdminUsers(samUsers: Iterable[SamUser]): MockCloudExtensionsBuilder = {
-    samUsers.foreach(u => withAdminUser(u))
+  def withNonAdminUser(): MockCloudExtensionsBuilder = {
+    mockedCloudExtensions.isWorkbenchAdmin(any[WorkbenchEmail]) returns Future.successful(false)
     this
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -24,8 +24,12 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
   mockUserService.updateUserCrud(any[WorkbenchUserId], any[AdminUpdateUserRequest], any[SamRequestContext]) returns {
     IO(None)
   }
+  mockUserService.getUser(any[WorkbenchUserId], any[SamRequestContext]) returns {
+    IO(None)
+  }
 
   private def makeUser(samUser: SamUser): Unit = {
+    mockUserService.getUser(eqTo(samUser.id), any[SamRequestContext]) answers ((_: WorkbenchUserId) => IO(Option(samUser)))
     mockUserService.deleteUser(eqTo(samUser.id), any[SamRequestContext]) returns IO(())
     mockUserService.updateUserCrud(eqTo(samUser.id), any[AdminUpdateUserRequest], any[SamRequestContext]) answers (
       (_: WorkbenchUserId, r: AdminUpdateUserRequest) => IO(Option(samUser.copy(email = r.email.get)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -5,7 +5,8 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.errorReportSource //not ideal but need to use error report
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.enabledMapNoTosAccepted
-import org.broadinstitute.dsde.workbench.sam.model.{AdminUpdateUserRequest, SamUser, UserStatus, UserStatusDetails}
+import org.broadinstitute.dsde.workbench.sam.model.{SamUser, UserStatus, UserStatusDetails}
+import org.broadinstitute.dsde.workbench.sam.model.api.AdminUpdateUserRequest
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.{SubsystemStatus, Subsystems}
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUserSpec.scala
@@ -28,7 +28,7 @@ class GetUserSpec extends UserServiceTestTraits {
         assert(response.nonEmpty, "Getting a user who exists should return a user object object")
         assert(
           response.get equals userWithBothIds,
-          "Getting a user with who exists should return the corresponding user."
+          "Getting a user who exists should return the corresponding user."
         )
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUserSpec.scala
@@ -1,0 +1,52 @@
+package org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, TestUserServiceBuilder}
+
+import scala.concurrent.ExecutionContextExecutor
+
+class GetUserSpec extends UserServiceTestTraits {
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+  val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
+
+  describe("When getting") {
+    describe("an existing user") {
+      it("should be successful") {
+        // Arrange
+        val userWithBothIds = genWorkbenchUserBoth.sample.get.copy(enabled = true)
+        val userService = TestUserServiceBuilder()
+          .withAllUsersGroup(allUsersGroup)
+          .withEnabledUser(userWithBothIds)
+          .build
+        // Act
+        val response = runAndWait(userService.getUser(userWithBothIds.id, samRequestContext))
+
+        // Assert
+        assert(response.nonEmpty, "Getting a user who exists should return a user object object")
+        assert(
+          response.get equals userWithBothIds,
+          "Getting a user with who exists should return the corresponding user."
+        )
+      }
+    }
+
+  }
+  describe("a user that does not exist") {
+    it("should be unsuccessful") {
+      // Arrange
+      val userWithBothIds = genWorkbenchUserBoth.sample.get
+      val userService = TestUserServiceBuilder()
+        .withAllUsersGroup(allUsersGroup)
+        .build
+      // Act
+      val response = runAndWait(userService.getUser(userWithBothIds.id, samRequestContext))
+
+      // Assert
+      assert(response.isEmpty, "Getting a nonexistent user should not find a user")
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UpdateUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UpdateUserSpec.scala
@@ -3,7 +3,8 @@ package org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
-import org.broadinstitute.dsde.workbench.sam.model.{AdminUpdateUserRequest, BasicWorkbenchGroup}
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.model.api.AdminUpdateUserRequest
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, TestUserServiceBuilder}
 
 import scala.concurrent.ExecutionContextExecutor
@@ -24,7 +25,7 @@ class UpdateUserSpec extends UserServiceTestTraits {
             .withEnabledUser(userWithBothIds)
             .build
           val email = "goodemail@gmail.com"
-          val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail(email)), None, None, None)
+          val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail(email)), None)
           // Act
           val response = runAndWait(userService.updateUserCrud(userWithBothIds.id, request, samRequestContext))
 
@@ -45,7 +46,7 @@ class UpdateUserSpec extends UserServiceTestTraits {
             .withEnabledUser(userWithBothIds)
             .build
           val email = "bademail.com"
-          val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail(email)), None, None, None)
+          val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail(email)), None)
 
           // Act
           val error = intercept[WorkbenchExceptionWithErrorReport] {
@@ -69,7 +70,7 @@ class UpdateUserSpec extends UserServiceTestTraits {
         val userService = TestUserServiceBuilder()
           .withAllUsersGroup(allUsersGroup)
           .build
-        val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail("goodemail@gmail.com")), None, None, None)
+        val request = AdminUpdateUserRequest(None, Some(WorkbenchEmail("goodemail@gmail.com")), None)
         // Act
         val response = runAndWait(userService.updateUserCrud(userWithBothIds.id, request, samRequestContext))
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-698

What:

This PR adds a GET user admin endpoint so that it is possible to retrieve a user record from sam.

Why:

This will allow easier access to sam user data which previously was accessed though the database directly.

How:

This PR adds a v2 user admin route which returns a user record

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
