### PR TITLE
ID-710 Add database check to liveness endpoint.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
@@ -1,21 +1,25 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
+import akka.http.scaladsl.model.StatusCodes.{OK, ServiceUnavailable}
 import akka.http.scaladsl.server
-import akka.http.scaladsl.model.StatusCodes
-import cats.effect.IO
 import akka.http.scaladsl.server.Directives._
+import cats.effect.{IO, Resource}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
 
-class LivenessRoutes {
-
+class LivenessRoutes(postgresDirectoryDAO: Resource[IO, PostgresDirectoryDAO]) extends SamRequestContextDirectives {
   val route: server.Route =
-    pathPrefix("liveness") {
-      pathEndOrSingleSlash {
-        get {
-          complete {
-            IO(StatusCodes.OK)
+    withSamRequestContext { samRequestContext =>
+      pathPrefix("liveness") {
+        pathEndOrSingleSlash {
+          get {
+            complete {
+              postgresDirectoryDAO.use(_.checkStatus(samRequestContext).map {
+                case true => OK
+                case false => ServiceUnavailable
+              })
+            }
           }
         }
       }
     }
-
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
@@ -3,20 +3,19 @@ package org.broadinstitute.dsde.workbench.sam.api
 import akka.http.scaladsl.model.StatusCodes.{OK, ServiceUnavailable}
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import cats.effect.{IO, Resource}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 
-class LivenessRoutes(postgresDirectoryDAO: Resource[IO, PostgresDirectoryDAO]) extends SamRequestContextDirectives {
+class LivenessRoutes(directoryDAO: DirectoryDAO) extends SamRequestContextDirectives {
   val route: server.Route =
     withSamRequestContext { samRequestContext =>
       pathPrefix("liveness") {
         pathEndOrSingleSlash {
           get {
             complete {
-              postgresDirectoryDAO.use(_.checkStatus(samRequestContext).map {
+              directoryDAO.checkStatus(samRequestContext).map {
                 case true => OK
                 case false => ServiceUnavailable
-              })
+              }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
@@ -10,7 +10,6 @@ import io.opencensus.scala.akka.http.trace.HttpExtractors._
 import io.opencensus.scala.akka.http.utils.ExecuteAfterResponse
 import io.opencensus.scala.http.{HttpAttributes, StatusTranslator}
 import io.opencensus.trace.{Span, Status}
-import org.broadinstitute.dsde.workbench.sam.service.UserService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import scala.util.control.NonFatal
@@ -18,7 +17,6 @@ import scala.util.control.NonFatal
 /** Created by ajang on 2020-05-28
   */
 trait SamRequestContextDirectives {
-  val userService: UserService
 
   /** Provides a new SamRequestContext with a root tracing span.
     */

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutesSpec.scala
@@ -1,19 +1,31 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.{IO, Resource}
 import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.lenient
+import org.mockito.MockitoSugar.mock
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class LivenessRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
-  val livenessRoutes = new LivenessRoutes
+  val mockPostgres = mock[PostgresDirectoryDAO]
+  val mockPostgresResource = Resource.make[IO, PostgresDirectoryDAO](IO.pure(mockPostgres))(_ => IO.unit)
+  val livenessRoutes = new LivenessRoutes(mockPostgresResource)
+
+  lenient()
+    .when(mockPostgres.checkStatus(any[SamRequestContext]))
+    .thenReturn(IO.pure(true))
 
   "GET /liveness" should "give 200" in {
     eventually {
       Get("/liveness") ~> livenessRoutes.route ~> check {
-        status shouldEqual StatusCodes.OK
+        status shouldEqual OK
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutesSpec.scala
@@ -2,21 +2,20 @@ package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.dataAccess.PostgresDirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.lenient
-import org.mockito.MockitoSugar.mock
+import org.mockito.MockitoSugar.{mock, verify}
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class LivenessRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with TestSupport {
   val mockPostgres = mock[PostgresDirectoryDAO]
-  val mockPostgresResource = Resource.make[IO, PostgresDirectoryDAO](IO.pure(mockPostgres))(_ => IO.unit)
-  val livenessRoutes = new LivenessRoutes(mockPostgresResource)
+  val livenessRoutes = new LivenessRoutes(mockPostgres)
 
   lenient()
     .when(mockPostgres.checkStatus(any[SamRequestContext]))
@@ -26,6 +25,7 @@ class LivenessRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTe
     eventually {
       Get("/liveness") ~> livenessRoutes.route ~> check {
         status shouldEqual OK
+        verify(mockPostgres).checkStatus(any[SamRequestContext])
       }
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-710


What:

The current liveness check should cause sam to restart if the db connection is bad.

Why:

On db maintenance windows sam gets stuck in a state where the status endpoint is failing (k8s readiness probe is failing so no connections sent to the pod), but the liveness endpoint is succeeding even though the db connection is bad so the pod doesnt get killed. From the cluster's point of view the pod is finishing startup.

How:

Added a select 1 to the liveness check endpoint.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
