### PR TITLE
[PF-2931] Fix TOS_ENABLED config value

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -37,7 +37,7 @@ opencensus-scala {
 }
 
 termsOfService {
-  enabled = ${?TOS_ENABLED}
+  isTosEnabled = ${?TOS_ENABLED}
   isGracePeriodEnabled = ${?TOS_GRACE_PERIOD_ENABLED}
   version = ${?TOS_VERSION}
   url = ${?TOS_URL}


### PR DESCRIPTION
Ticket: [PF-2931](https://broadworkbench.atlassian.net/browse/PF-2931)

What: This PR fixes the TOS_ENABLED config value. This value is currently ignored, meaning ToS enforcement is always on and cannot be disabled.

Why: This config value was introduced to make it possible to disable ToS for a Sam deployment. I'd like to do this for a Verily deployment of Sam.

How: The config value in `sam.conf` does not match the corresponding [TermsOfServiceConfig field](https://github.com/broadinstitute/sam/blob/develop/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/TermsOfServiceConfig.scala#L12), so the value is not used. Changing the value in `sam.conf` does not require changes elsewhere, as the rest of the codebase reads from TermsOfServiceConfig.

As noted [when this config value was introduced](https://github.com/broadinstitute/sam/pull/1014), the default value is `true` (i.e. ToS enforcement enabled) and all live Sam environments explicitly set this value to `true`.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[PF-2931]: https://broadworkbench.atlassian.net/browse/PF-2931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ