### PR TITLE
ID-717 Removed logic in updateUserEmail

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -456,27 +456,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
              )""".stripMargin
   }
 
-  override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] =
-    serializableWriteTransaction("updateUserEmail", samRequestContext) { implicit session =>
-      val u = UserTable.column
-      val results =
-        samsql"""update ${UserTable.table}
-                   set (${u.email}, ${u.updatedAt}) =
-                   ($email,
-                     ${Instant.now()}
-                   )
-                   where ${u.id} = $userId"""
-          .update()
-          .apply()
-
-      if (results != 1) {
-        throw new WorkbenchException(
-          s"Cannot update email for user ${userId} because user does not exist"
-        )
-      } else {
-        ()
-      }
-    }
+  override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
   override def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] =
     serializableWriteTransaction("deleteUser", samRequestContext) { implicit session =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-717

What:

This PR takes out the database update of user emails in the updateUserRequest flow

Why:

Currently, we need to do more research into how to update a user's email. We need to also update the user's proxy email. So we are pulling back on the update email until that is also supported.

How:

The database call through the `directoryDao` is replaced with a `Unit`.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
