### PR TITLE
ID-739 Invited user registration dates

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -8,7 +8,7 @@ import sbt.{Compile, Test, _}
 import sbtassembly.AssemblyPlugin.autoImport._
 
 object Settings {
-  lazy val artifactory = "https://artifactory.broadinstitute.org/artifactory/"
+  lazy val artifactory = "https://broadinstitute.jfrog.io/artifactory/"
 
   val proxyResolvers = List(
     "internal-maven-proxy" at artifactory + "maven-central"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -166,7 +166,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
 
   private def registerInvitedUser(invitedUser: SamUser, invitedUserId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[SamUser] =
     openTelemetry.time("api.v1.user.registerInvitedUser.time", API_TIMING_DURATION_BUCKET) {
-      val userToRegister = invitedUser.copy(id = invitedUserId)
+      val userToRegister = invitedUser.copy(id = invitedUserId, registeredAt = Option(Instant.now()))
       for {
         _ <- updateUser(userToRegister, samRequestContext)
         groups <- directoryDAO.listUserDirectMemberships(userToRegister.id, samRequestContext)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -356,6 +356,25 @@ class OldUserServiceSpec
     }
   }
 
+  it should "record the date that the user registered if they were previously invited" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    // Arrange
+    val user = genWorkbenchUserGoogle.sample.get
+    assume(databaseEnabled, databaseEnabledClue)
+
+    // Act
+    val createdAt = Instant.now()
+    service.inviteUser(user.email, samRequestContext).unsafeRunSync()
+
+    val userStatus = service.createUser(user, samRequestContext).unsafeRunSync()
+
+    // Assert
+    val maybeUser = dirDAO.loadUser(userStatus.userInfo.userSubjectId, samRequestContext).unsafeRunSync()
+    inside(maybeUser.value) { persistedUser =>
+      persistedUser.registeredAt.value should beAround(createdAt)
+    }
+  }
+
   /** GoogleSubjectId Email no no ---> We've never seen this user before, create a new user
     */
   "UserService registerUser" should "create new user when there's no existing subject for a given googleSubjectId and email" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-739

  \<Don't forget to include the ticket number in the PR title!\>

What:

Fixes an issue where invited users weren't having their registration dates written to the DB when they actually did register

Why:

We need the info!

How:
Just make it do the same thing as a new user when an invited user registers.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
