### PR TITLE
ID-741 Reduce logs emitted by Sam

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -63,7 +63,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
       optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId)))
       .as(OIDCHeaders)
       .map { oidcHeaders =>
-        logger.debug(s"Auth Headers: $oidcHeaders")
+        logger.info(s"Auth Headers: $oidcHeaders")
         oidcHeaders
       }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -29,7 +29,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
     onSuccess {
       getActiveSamUser(oidcHeaders, userService, tosService, samRequestContext).unsafeToFuture()
     }.tmap { samUser =>
-      logger.info(s"Handling request for active Sam User: $samUser")
+      logger.debug(s"Handling request for active Sam User: $samUser")
       samUser
     }
   }
@@ -38,7 +38,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
     onSuccess {
       getSamUser(oidcHeaders, userService, samRequestContext).unsafeToFuture()
     }.tmap { samUser =>
-      logger.info(s"Handling request for (in)active Sam User: $samUser")
+      logger.debug(s"Handling request for (in)active Sam User: $samUser")
       samUser
     }
   }
@@ -63,7 +63,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
       optionalHeaderValueByName(managedIdentityObjectIdHeader).map(_.map(ManagedIdentityObjectId)))
       .as(OIDCHeaders)
       .map { oidcHeaders =>
-        logger.info(s"Auth Headers: $oidcHeaders")
+        logger.debug(s"Auth Headers: $oidcHeaders")
         oidcHeaders
       }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
@@ -22,7 +22,7 @@ class GoogleGroupSyncMessageReceiver(groupSynchronizer: GoogleGroupSynchronizer)
   override def receiveMessage(message: PubsubMessage, consumer: AckReplyConsumer): Unit =
     traceIO("GoogleGroupSyncMessageReceiver-PubSubMessage", SamRequestContext()) { samRequestContext =>
       val groupId: WorkbenchGroupIdentity = parseMessage(message)
-      logger.info(s"received sync message: $groupId")
+      logger.debug(s"received sync message: $groupId")
       samRequestContext.parentSpan.foreach(
         _.putAttribute("groupId", AttributeValue.stringAttributeValue(groupId.toString))
       )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
@@ -58,7 +58,7 @@ class GoogleGroupSyncMessageReceiver(groupSynchronizer: GoogleGroupSynchronizer)
     */
   private def syncComplete(report: Map[WorkbenchEmail, Seq[SyncReportItem]], consumer: AckReplyConsumer): Unit = {
     val errorReports = report.values.flatten.collect {
-      case SyncReportItem(_, _, errorReports) if errorReports.nonEmpty => errorReports
+      case SyncReportItem(_, _, _, errorReports) if errorReports.nonEmpty => errorReports
     }.flatten
 
     import DefaultJsonProtocol._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -69,7 +69,12 @@ class GoogleGroupSynchronizer(
 
   private def removeMemberFromGoogleGroup(group: WorkbenchGroup, samRequestContext: SamRequestContext)(removeEmail: String) =
     traceIOWithContext("removeMemberFromGoogleGroup", samRequestContext) { _ =>
-      SyncReportItem.fromIO("removed", removeEmail, group.id.toString, IO.fromFuture(IO(googleDirectoryDAO.removeMemberFromGroup(group.email, WorkbenchEmail(removeEmail)))))
+      SyncReportItem.fromIO(
+        "removed",
+        removeEmail,
+        group.id.toString,
+        IO.fromFuture(IO(googleDirectoryDAO.removeMemberFromGroup(group.email, WorkbenchEmail(removeEmail))))
+      )
     }
 
   private def addMemberToGoogleGroup(group: WorkbenchGroup, samRequestContext: SamRequestContext)(addEmail: String) =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -69,12 +69,12 @@ class GoogleGroupSynchronizer(
 
   private def removeMemberFromGoogleGroup(group: WorkbenchGroup, samRequestContext: SamRequestContext)(removeEmail: String) =
     traceIOWithContext("removeMemberFromGoogleGroup", samRequestContext) { _ =>
-      SyncReportItem.fromIO("removed", removeEmail, IO.fromFuture(IO(googleDirectoryDAO.removeMemberFromGroup(group.email, WorkbenchEmail(removeEmail)))))
+      SyncReportItem.fromIO("removed", removeEmail, group.id.toString, IO.fromFuture(IO(googleDirectoryDAO.removeMemberFromGroup(group.email, WorkbenchEmail(removeEmail)))))
     }
 
   private def addMemberToGoogleGroup(group: WorkbenchGroup, samRequestContext: SamRequestContext)(addEmail: String) =
     traceIOWithContext("addMemberToGoogleGroup", samRequestContext) { _ =>
-      SyncReportItem.fromIO("added", addEmail, IO.fromFuture(IO(googleDirectoryDAO.addMemberToGroup(group.email, WorkbenchEmail(addEmail)))))
+      SyncReportItem.fromIO("added", addEmail, group.id.toString, IO.fromFuture(IO(googleDirectoryDAO.addMemberToGroup(group.email, WorkbenchEmail(addEmail)))))
     }
 
   /** convert each subject to an email address

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
@@ -8,7 +8,7 @@ object SamGoogleModelJsonSupport {
   import DefaultJsonProtocol._
   import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 
-  implicit val SyncReportItemFormat = jsonFormat3(SyncReportItem.apply)
+  implicit val SyncReportItemFormat = jsonFormat4(SyncReportItem.apply)
 }
 
 /** A SyncReportItem represents the results of synchronizing a single member of a google group. Synchronizing a google group will result in a collection of
@@ -20,9 +20,9 @@ object SamGoogleModelJsonSupport {
   * @param errorReport
   *   whether or not there was an error
   */
-final case class SyncReportItem(operation: String, email: String, errorReport: Option[ErrorReport])
+final case class SyncReportItem(operation: String, email: String, workbenchGroupIdentity: String, errorReport: Option[ErrorReport])
 
 object SyncReportItem {
-  def fromIO[T](operation: String, email: String, result: IO[T])(implicit errorReportSource: ErrorReportSource): IO[SyncReportItem] =
-    result.redeem(t => SyncReportItem(operation, email, Option(ErrorReport(t))), _ => SyncReportItem(operation, email, None))
+  def fromIO[T](operation: String, email: String, workbenchGroupIdentity: String,  result: IO[T])(implicit errorReportSource: ErrorReportSource): IO[SyncReportItem] =
+    result.redeem(t => SyncReportItem(operation, email, workbenchGroupIdentity, Option(ErrorReport(t))), _ => SyncReportItem(operation, email, workbenchGroupIdentity, None))
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
@@ -23,6 +23,11 @@ object SamGoogleModelJsonSupport {
 final case class SyncReportItem(operation: String, email: String, workbenchGroupIdentity: String, errorReport: Option[ErrorReport])
 
 object SyncReportItem {
-  def fromIO[T](operation: String, email: String, workbenchGroupIdentity: String,  result: IO[T])(implicit errorReportSource: ErrorReportSource): IO[SyncReportItem] =
-    result.redeem(t => SyncReportItem(operation, email, workbenchGroupIdentity, Option(ErrorReport(t))), _ => SyncReportItem(operation, email, workbenchGroupIdentity, None))
+  def fromIO[T](operation: String, email: String, workbenchGroupIdentity: String, result: IO[T])(implicit
+      errorReportSource: ErrorReportSource
+  ): IO[SyncReportItem] =
+    result.redeem(
+      t => SyncReportItem(operation, email, workbenchGroupIdentity, Option(ErrorReport(t))),
+      _ => SyncReportItem(operation, email, workbenchGroupIdentity, None)
+    )
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -237,7 +237,7 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     import SamGoogleModelJsonSupport._
     Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", TestSupport.proxyEmail(user.id).value.toLowerCase, None)))) {
+      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", TestSupport.proxyEmail(user.id).value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name}", None)))) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -237,7 +237,13 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     import SamGoogleModelJsonSupport._
     Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", TestSupport.proxyEmail(user.id).value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name}", None)))) {
+      assertResult(
+        Map(
+          createdPolicy.email -> Seq(
+            SyncReportItem("added", TestSupport.proxyEmail(user.id).value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name}", None)
+          )
+        )
+      ) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -117,7 +117,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val proxyEmail = WorkbenchEmail(s"PROXY_${user.id}@${googleServicesConfig.appsDomain}")
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", proxyEmail.value.toLowerCase, None)))) {
+      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", proxyEmail.value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name.value}", None)))) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -117,7 +117,13 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Post(s"/api/google/v1/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val proxyEmail = WorkbenchEmail(s"PROXY_${user.id}@${googleServicesConfig.appsDomain}")
-      assertResult(Map(createdPolicy.email -> Seq(SyncReportItem("added", proxyEmail.value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name.value}", None)))) {
+      assertResult(
+        Map(
+          createdPolicy.email -> Seq(
+            SyncReportItem("added", proxyEmail.value.toLowerCase, s"${createdPolicy.policyName.value}.foo.${resourceType.name.value}", None)
+          )
+        )
+      ) {
         responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -179,11 +179,11 @@ class GoogleExtensionSpec(_system: ActorSystem)
       val results = runAndWait(synchronizer.synchronizeGroupMembers(target.id, samRequestContext = samRequestContext))
 
       results.head._1 should equal(target.email)
-      results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
-        removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
+      results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, target.id.toString, None)) ++
+        removed.map(e => SyncReportItem("removed", e.value.toLowerCase, target.id.toString, None)) ++
         Seq(
-          SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
-          SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))
+          SyncReportItem("added", addErrorProxyEmail.toLowerCase, target.id.toString, Option(ErrorReport(addException))),
+          SyncReportItem("removed", removeError.toLowerCase, target.id.toString, Option(ErrorReport(removeException)))
         ))
 
       added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
@@ -318,11 +318,11 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val results = runAndWait(synchronizer.synchronizeGroupMembers(testPolicy.id, samRequestContext = samRequestContext))
 
     results.head._1 should equal(testPolicy.email)
-    results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, None)) ++
-      removed.map(e => SyncReportItem("removed", e.value.toLowerCase, None)) ++
+    results.head._2 should contain theSameElementsAs (added.map(e => SyncReportItem("added", e.value.toLowerCase, testPolicy.id.toString, None)) ++
+      removed.map(e => SyncReportItem("removed", e.value.toLowerCase, testPolicy.id.toString, None)) ++
       Seq(
-        SyncReportItem("added", addErrorProxyEmail.toLowerCase, Option(ErrorReport(addException))),
-        SyncReportItem("removed", removeError.toLowerCase, Option(ErrorReport(removeException)))
+        SyncReportItem("added", addErrorProxyEmail.toLowerCase, testPolicy.id.toString, Option(ErrorReport(addException))),
+        SyncReportItem("removed", removeError.toLowerCase, testPolicy.id.toString, Option(ErrorReport(removeException)))
       ))
 
     added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiverSpec.scala
@@ -50,7 +50,7 @@ class GoogleGroupSyncMessageReceiverSpec extends AnyFlatSpecLike with Matchers w
 
   it should "nack on completion with errors" in {
     when(synchronizer.synchronizeGroupMembers(ArgumentMatchers.eq(testGroup), ArgumentMatchers.eq(Set.empty), any[SamRequestContext]))
-      .thenReturn(IO.pure(Map(WorkbenchEmail(s"${testGroup.value}@foo.com") -> Seq(SyncReportItem("added", "member email", Option(ErrorReport("failure")))))))
+      .thenReturn(IO.pure(Map(WorkbenchEmail(s"${testGroup.value}@foo.com") -> Seq(SyncReportItem("added", "member email", testGroup.value, Option(ErrorReport("failure")))))))
     receiver.receiveMessage(PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8(testGroup.toJson.compactPrint)).build(), consumer)
     verify(consumer).nack()
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiverSpec.scala
@@ -50,7 +50,11 @@ class GoogleGroupSyncMessageReceiverSpec extends AnyFlatSpecLike with Matchers w
 
   it should "nack on completion with errors" in {
     when(synchronizer.synchronizeGroupMembers(ArgumentMatchers.eq(testGroup), ArgumentMatchers.eq(Set.empty), any[SamRequestContext]))
-      .thenReturn(IO.pure(Map(WorkbenchEmail(s"${testGroup.value}@foo.com") -> Seq(SyncReportItem("added", "member email", testGroup.value, Option(ErrorReport("failure")))))))
+      .thenReturn(
+        IO.pure(
+          Map(WorkbenchEmail(s"${testGroup.value}@foo.com") -> Seq(SyncReportItem("added", "member email", testGroup.value, Option(ErrorReport("failure")))))
+        )
+      )
     receiver.receiveMessage(PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8(testGroup.toJson.compactPrint)).build(), consumer)
     verify(consumer).nack()
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-741

  \<Don't forget to include the ticket number in the PR title!\>

What:

Sam logs a ton. It should log less.

Why:

Logs cost money

How:
Reduce the logging of duplicate information, and reduce verbosity.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
