### PR TITLE
Ddo 2930 add bq upload

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -176,7 +176,7 @@ jobs:
         with:
           workflow: .github/workflows/sam-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/DDO-2930-sam-report-test-results
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "log-results": "${{ needs.prepare-configs.outputs.log-results }}", "test-context": "${{ needs.prepare-configs.outputs.test-context }}", "caller_run_id": "${{ github.run_id }}" }'

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -174,7 +174,7 @@ jobs:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: .github/workflows/sam-swat-tests.yaml
+          workflow: .github/workflows/sam-swat-tests.yaml@DDO-2930-sam-report-test-results
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -174,9 +174,9 @@ jobs:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
-          workflow: .github/workflows/sam-swat-tests.yaml@DDO-2930-sam-report-test-results
+          workflow: .github/workflows/sam-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/DDO-2930-sam-report-test-results
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "log-results": "${{ needs.prepare-configs.outputs.log-results }}", "test-context": "${{ needs.prepare-configs.outputs.test-context }}", "caller_run_id": "${{ github.run_id }}" }'

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -74,6 +74,21 @@ jobs:
           echo "$GITHUB_CONTEXT"
           echo 'custom-version-json={\"sam\":{\"appVersion\":\"${{ steps.tag.outputs.tag }}\"}}' >> $GITHUB_OUTPUT
 
+  prepare-configs:
+    runs-on: ubuntu-latest
+    outputs:
+      log-results: ${{ steps.prepare-outputs.outputs.log-results }}
+      test-context: ${{ steps.prepare-outputs.outputs.test-context }}
+    steps:
+      - id: prepare-outputs
+        run: |-
+          echo 'log-results=true' >> $GITHUB_OUTPUT
+          if ${{ github.ref_name == 'develop' }}
+            echo 'test-context=dev-merge' >> $GITHUB_OUTPUT
+          else
+            echo 'test-context=pr-test' >> $GITHUB_OUTPUT
+          fi
+
   report-to-sherlock:
     # Report new Sam version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
@@ -151,7 +166,7 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
-    needs: [sam-smoke-test-job]
+    needs: [sam-smoke-test-job, prepare-configs]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -164,7 +179,7 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "log-results": "${{ needs.prepare-configs.outputs.log-results }}", "test-context": "${{ needs.prepare-configs.outputs.test-context }}", "caller_run_id": "${{ github.run_id }}" }'
 
   rawls-swat-test-job:
     strategy:

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - id: prepare-outputs
         run: |-
           echo 'log-results=true' >> $GITHUB_OUTPUT
-          if ${{ github.ref_name == 'develop' }}
+          if ${{ github.ref_name == 'develop' }}; then
             echo 'test-context=dev-merge' >> $GITHUB_OUTPUT
           else
             echo 'test-context=pr-test' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2930

Leverages updated GHAs in terra-github-workflows to enable reporting in sam prs as well as dev-merge tests.

What:

  \<For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).\>

Why:

So we have metrics once we stop testing on jenkins + developer enablement of which tests to log.

How:

Adds optional inputs to the sam swat test call.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
