### PR TITLE
PF-2970: add new resource type vwb-app with owner, writer, reader role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1430,6 +1430,44 @@ resourceTypes = {
     }
     reuseIds = false
   }
+  vwb-app = {
+    actionPatterns = {
+      read_policies = {
+        description = "view all policies and policy details for this app"
+      }
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this app"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this app"
+      }
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this app"
+      }
+      "read" = {
+        description = "perform reader actions on the app"
+      }
+      "write" = {
+        description = "perform writer actions on the app"
+      }
+      delete = {
+        description = "delete this app"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["delete", "read_policies", "read", "write", "share_policy::owner", "share_policy::writer", "share_policy::reader"]
+      }
+      writer = {
+        roleActions = ["read", "write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+    }
+    reuseIds = false
+  }
 }
 
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/PF-2970

  \<Don't forget to include the ticket number in the PR title!\>

What:

Add a new sam resource type vwb-app and define owner, reader and writer permissions.

Why:

 verily workbench is introducing a new vwb-app resource type and needs access control.

How:

the new resource is added in reference.conf following the existing pattern.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
