### PR TITLE
ID-739 Actually Fix Invited User Registration Dates

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, Pet
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUser}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
+import java.time.Instant
 import java.util.Date
 
 /** Created by dvoet on 5/26/17.
@@ -78,4 +79,6 @@ trait DirectoryDAO {
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]
   def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
+  def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -451,10 +451,9 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val u = UserTable.column
       val results =
         samsql"""update ${UserTable.table}
-                 set (${u.azureB2cId}, ${u.updatedAt}, ${u.registeredAt}) =
+                 set (${u.azureB2cId}, ${u.updatedAt}) =
                  ($b2cId,
-                   ${Instant.now()},
-                   ${coalesceUserRegisteredAt(userId)}
+                   ${Instant.now()}
                  )
                  where ${u.id} = $userId and (${u.azureB2cId} is null or ${u.azureB2cId} = $b2cId)"""
           .update()
@@ -468,16 +467,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         ()
       }
     }
-
-  // Finds the specified user and returns their registered_at date.
-  // If it is null, default to the result of the PostgresSQL `now()`
-  private def coalesceUserRegisteredAt(userId: WorkbenchUserId): SQLSyntax = {
-    val u = UserTable.column
-    samsqls"""(select coalesce(${u.registeredAt}, now())
-              from ${UserTable.table}
-              where ${u.id} = $userId
-             )""".stripMargin
-  }
 
   override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
@@ -827,10 +816,9 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val u = UserTable.column
       val updateGoogleSubjectIdQuery =
         samsql"""update ${UserTable.table}
-                 set (${u.googleSubjectId}, ${u.updatedAt}, ${u.registeredAt}) =
+                 set (${u.googleSubjectId}, ${u.updatedAt}) =
                  (${googleSubjectId},
-                   ${Instant.now()},
-                   ${coalesceUserRegisteredAt(userId)}
+                   ${Instant.now()}
                  )
                  where ${u.id} = ${userId} and ${u.googleSubjectId} is null"""
 
@@ -905,5 +893,28 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val userRecordOpt: Option[UserRecord] = loadUserQuery.map(UserTable(userTable)).single().apply()
       userRecordOpt.map(UserTable.unmarshalUserRecord)
+    }
+
+  override def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("setUserRegisteredAt", samRequestContext) { implicit session =>
+      val u = UserTable.column
+      val results =
+        samsql"""update ${UserTable.table}
+               set (${u.registeredAt}, ${u.updatedAt}) =
+               (
+                 $registeredAt,
+                 ${Instant.now()}
+               )
+               where ${u.id} = $userId and ${u.registeredAt} is null"""
+          .update()
+          .apply()
+
+      if (results != 1) {
+        throw new WorkbenchException(
+          s"Cannot update registeredAt for user ${userId} because user does not exist or the registeredAt date has already been set for this user"
+        )
+      } else {
+        ()
+      }
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -469,16 +469,13 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
     }
 
-  // Finds the specified user and if their googleSubjectId AND azureB2CId are both null, then it will select `now()`,
-  // the postgres function for getting the current datetime.  If either googleSubjectId or azureB2CId is set, it will
-  // return whatever the current value is for `registeredAt`
+  // Finds the specified user and returns their registered_at date.
+  // If it is null, default to the result of the PostgresSQL `now()`
   private def coalesceUserRegisteredAt(userId: WorkbenchUserId): SQLSyntax = {
     val u = UserTable.column
     samsqls"""(select coalesce(${u.registeredAt}, now())
               from ${UserTable.table}
               where ${u.id} = $userId
-                and ${u.googleSubjectId} is null
-                and ${u.azureB2cId} is null
              )""".stripMargin
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -181,7 +181,7 @@ class UserService(val directoryDAO: DirectoryDAO, val cloudExtensions: CloudExte
 
   private def registerInvitedUser(invitedUser: SamUser, invitedUserId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[SamUser] =
     openTelemetry.time("api.v1.user.registerInvitedUser.time", API_TIMING_DURATION_BUCKET) {
-      val userToRegister = invitedUser.copy(id = invitedUserId, registeredAt = Option(Instant.now()))
+      val userToRegister = invitedUser.copy(id = invitedUserId)
       for {
         _ <- updateUser(userToRegister, samRequestContext)
         groups <- directoryDAO.listUserDirectMemberships(userToRegister.id, samRequestContext)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
@@ -7,6 +7,8 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.{IdiomaticMockito, Strictness}
 
+import java.time.Instant
+
 object MockDirectoryDaoBuilder {
   def apply(allUsersGroup: WorkbenchGroup) =
     new MockDirectoryDaoBuilder().withAllUsersGroup(allUsersGroup)
@@ -34,6 +36,7 @@ case class MockDirectoryDaoBuilder() extends IdiomaticMockito {
   mockedDirectoryDAO.setUserAzureB2CId(any[WorkbenchUserId], any[AzureB2CId], any[SamRequestContext]) returns IO.unit
   mockedDirectoryDAO.removeGroupMember(any[WorkbenchGroupIdentity], any[WorkbenchSubject], any[SamRequestContext]) returns IO(true)
   mockedDirectoryDAO.deleteUser(any[WorkbenchUserId], any[SamRequestContext]) returns IO.unit
+  mockedDirectoryDAO.setUserRegisteredAt(any[WorkbenchUserId], any[Instant], any[SamRequestContext]) returns IO.unit
 
   def withHealthyDatabase: MockDirectoryDaoBuilder = {
     mockedDirectoryDAO.checkStatus(any[SamRequestContext]) returns IO(true)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -1585,7 +1585,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         // Assert
         val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        loadedUser.value.registeredAt.get shouldBe registeredAt
+        loadedUser.value.registeredAt.get should beAround(registeredAt)
       }
 
       "refuses to overwrite the user's registeredAt date" in {
@@ -1600,7 +1600,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         }
 
         val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        loadedUser.value.registeredAt.get shouldBe registeredAt
+        loadedUser.value.registeredAt.get should beAround(registeredAt)
       }
 
       "refuses to update the registeredAt date for a non-existent user" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -16,6 +16,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.Date
 import scala.concurrent.duration._
 
@@ -1264,41 +1265,6 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         loadedUser.value.updatedAt should beAround(Instant.now())
       }
 
-      "sets the registeredAt datetime if all cloud ids for this user are blank" in {
-        // Arrange
-        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(googleSubjectId = None)
-        dao.createUser(user, samRequestContext).unsafeRunSync()
-        val newGoogleSubjectId = GoogleSubjectId("newGoogleSubjectId")
-
-        // Act
-        dao.setGoogleSubjectId(user.id, newGoogleSubjectId, samRequestContext).unsafeRunSync()
-
-        // Assert
-        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        inside(loadedUser.value) { user =>
-          user.registeredAt.value should beAround(Instant.now())
-        }
-      }
-
-      // This scenario really should never exist.  If one of the cloud IDs is set, then the registeredAt date should
-      // also already be set.  If this initial state exists, something probably went wrong.  Useful test though for
-      // making sure the sql is working correctly.
-      "does not set the registeredAt datetime if it is null and the azureB2CId is already set" in {
-        // Arrange
-        val user = Generator.genWorkbenchUserAzure.sample.get.copy(registeredAt = None)
-        dao.createUser(user, samRequestContext).unsafeRunSync()
-        val newGoogleSubjectId = GoogleSubjectId("newGoogleSubjectId")
-
-        // Act
-        dao.setGoogleSubjectId(user.id, newGoogleSubjectId, samRequestContext).unsafeRunSync()
-
-        // Assert
-        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        inside(loadedUser.value) { user =>
-          user.registeredAt shouldBe empty
-        }
-      }
-
       // Making an assumption that this is the intended behavior/UX we want?  :shrug:  This is a weird scenario that I
       // cannot imagine we would be in unless something went wrong.  The test is handy though to make sure the sql is
       // working correctly.
@@ -1470,41 +1436,6 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         loadedUser.value.updatedAt should beAround(Instant.now())
       }
 
-      "sets the registeredAt datetime if all cloud ids for this user are blank" in {
-        // Arrange
-        val user = Generator.genWorkbenchUserAzure.sample.get.copy(azureB2CId = None)
-        dao.createUser(user, samRequestContext).unsafeRunSync()
-        val newAzureB2CId = AzureB2CId("newAzureB2cId")
-
-        // Act
-        dao.setUserAzureB2CId(user.id, newAzureB2CId, samRequestContext).unsafeRunSync()
-
-        // Assert
-        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        inside(loadedUser.value) { user =>
-          user.registeredAt.value should beAround(Instant.now())
-        }
-      }
-
-      // This scenario really should never exist.  If one of the cloud IDs is set, then the registeredAt date should
-      // also already be set.  If this initial state exists, something probably went wrong.  Useful test though for
-      // making sure the sql is working correctly.
-      "does not set the registeredAt datetime if it is null and the googleSubjectId is already set" in {
-        // Arrange
-        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(registeredAt = None)
-        dao.createUser(user, samRequestContext).unsafeRunSync()
-        val newAzureB2CId = AzureB2CId("newAzureB2cId")
-
-        // Act
-        dao.setUserAzureB2CId(user.id, newAzureB2CId, samRequestContext).unsafeRunSync()
-
-        // Assert
-        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
-        inside(loadedUser.value) { user =>
-          user.registeredAt shouldBe empty
-        }
-      }
-
       // Making an assumption that this is the intended behavior/UX we want?  :shrug:  This is a weird scenario that I
       // cannot imagine we would be in unless something went wrong.  The test is handy though to make sure the sql is
       // working correctly.
@@ -1639,6 +1570,37 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         // Assert
         samStatus shouldBe false
+      }
+    }
+
+    "setUserRegisteredAt" - {
+      "sets the user's registeredAt column if its not yet set" in {
+        // Arrange
+        val registeredAt = Instant.now().minus(10, ChronoUnit.MINUTES)
+        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(registeredAt = None)
+        dao.createUser(user, samRequestContext).unsafeRunSync()
+
+        // Act
+        dao.setUserRegisteredAt(user.id, registeredAt, samRequestContext).unsafeRunSync()
+
+        // Assert
+        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
+        loadedUser.value.registeredAt.get shouldBe registeredAt
+      }
+
+      "refuses to overwrite the user's registeredAt date" in {
+        // Arrange
+        val registeredAt = Instant.now()
+        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(registeredAt = Some(registeredAt))
+        dao.createUser(user, samRequestContext).unsafeRunSync()
+
+        // Act + Assert
+        assertThrows[WorkbenchException] {
+          dao.setUserRegisteredAt(user.id, Instant.now().minus(10, ChronoUnit.MINUTES), samRequestContext).unsafeRunSync()
+        }
+
+        val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
+        loadedUser.value.registeredAt.get shouldBe registeredAt
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -1602,6 +1602,17 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedUser = dao.loadUser(user.id, samRequestContext).unsafeRunSync()
         loadedUser.value.registeredAt.get shouldBe registeredAt
       }
+
+      "refuses to update the registeredAt date for a non-existent user" in {
+        // Arrange
+        val registeredAt = Instant.now()
+        val user = Generator.genWorkbenchUserGoogle.sample.get.copy(registeredAt = Some(registeredAt))
+
+        // Act + Assert
+        assertThrows[WorkbenchException] {
+          dao.setUserRegisteredAt(user.id, Instant.now().minus(10, ChronoUnit.MINUTES), samRequestContext).unsafeRunSync()
+        }
+      }
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/matchers/BeSameUserMatcher.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/matchers/BeSameUserMatcher.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.workbench.sam.matchers
+
+import org.broadinstitute.dsde.workbench.sam.model.SamUser
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.collection.mutable.ListBuffer
+
+/** Asserts that the passed UserStatus.userInfo matches the passed in SamUser Id and Email
+  *
+  * @param expectedUser:
+  *   user to expect
+  */
+class BeSameUserMatcher(expectedUser: SamUser) extends Matcher[SamUser] {
+  def apply(samUser: SamUser): MatchResult = {
+    val doEmailsMatch = samUser.email == expectedUser.email
+    val doIdsMatch = samUser.id == expectedUser.id
+    val doGoogleSubjectIdsMatch = samUser.googleSubjectId == expectedUser.googleSubjectId
+    val doAzureB2CIdsMatch = samUser.azureB2CId == expectedUser.azureB2CId
+
+    val failureMessageList: ListBuffer[String] = ListBuffer.empty
+    val failureMessageNegatedList: ListBuffer[String] = ListBuffer.empty
+
+    if (!doEmailsMatch) {
+      failureMessageList += s"""SamUser email ${samUser.email} did not equal ${expectedUser.email}"""
+      failureMessageNegatedList += s"""SamUSer email ${samUser.email} equals ${expectedUser.email}"""
+    }
+
+    if (!doIdsMatch) {
+      failureMessageList += s"""SamUser id ${samUser.id} did not equal ${expectedUser.id}"""
+      failureMessageNegatedList += s"""SamUSer id ${samUser.id} equals ${expectedUser.id}"""
+    }
+
+    if (!doAzureB2CIdsMatch) {
+      failureMessageList += s"""SamUser Azure B2C ID ${samUser.azureB2CId} did not equal ${expectedUser.azureB2CId}"""
+      failureMessageNegatedList += s"""SamUSer Azure B2C ID ${samUser.azureB2CId} equals ${expectedUser.azureB2CId}"""
+    }
+
+    MatchResult(
+      doEmailsMatch && doIdsMatch && doGoogleSubjectIdsMatch && doAzureB2CIdsMatch,
+      failureMessageList.mkString(" and "),
+      failureMessageNegatedList.mkString(" and ")
+    )
+  }
+}
+
+object BeSameUserMatcher {
+  def beSameUserAs(expectedUser: SamUser) = new BeSameUserMatcher(expectedUser)
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -363,15 +363,15 @@ class OldUserServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     // Act
-    val createdAt = Instant.now()
     service.inviteUser(user.email, samRequestContext).unsafeRunSync()
 
+    val registeredAt = Instant.now()
     val userStatus = service.createUser(user, samRequestContext).unsafeRunSync()
 
     // Assert
     val maybeUser = dirDAO.loadUser(userStatus.userInfo.userSubjectId, samRequestContext).unsafeRunSync()
     inside(maybeUser.value) { persistedUser =>
-      persistedUser.registeredAt.value should beAround(createdAt)
+      persistedUser.registeredAt.value should beAround(registeredAt)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.sam.Generator.{arbNonPetEmail => _, _}
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
+import org.broadinstitute.dsde.workbench.sam.matchers.BeSameUserMatcher.beSameUserAs
 import org.broadinstitute.dsde.workbench.sam.matchers.TimeMatchers
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs.{CreateUserSpec, GetUserStatusSpec, InviteUserSpec}
@@ -381,18 +382,18 @@ class OldUserServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     val user = genWorkbenchUserGoogle.sample.get
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     val res = dirDAO.loadUser(user.id, samRequestContext).unsafeRunSync()
-    res shouldBe Some(user)
+    res.get should beSameUserAs(user)
   }
 
   it should "create new user when there's no existing subject for a given azureB2CId and email" in {
     assume(databaseEnabled, databaseEnabledClue)
 
     val user = genWorkbenchUserAzure.sample.get
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     val res = dirDAO.loadUser(user.id, samRequestContext).unsafeRunSync()
-    res shouldBe Some(user)
+    res.get should beSameUserAs(user)
   }
 
   /** GoogleSubjectId Email no yes ---> Someone invited this user previous and we have a record for this user already. We just need to update GoogleSubjetId
@@ -403,10 +404,10 @@ class OldUserServiceSpec
 
     val user = genWorkbenchUserGoogle.sample.get
     service.inviteUser(user.email, samRequestContext).unsafeRunSync()
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     val userId = dirDAO.loadSubjectFromEmail(user.email, samRequestContext).unsafeRunSync().value.asInstanceOf[WorkbenchUserId]
     val res = dirDAO.loadUser(userId, samRequestContext).unsafeRunSync()
-    res shouldBe Some(user.copy(id = userId))
+    res.get should beSameUserAs(user.copy(id = userId))
   }
 
   it should "update azureB2CId when there's no existing subject for a given googleSubjectId and but there is one for email" in {
@@ -414,10 +415,10 @@ class OldUserServiceSpec
 
     val user = genWorkbenchUserAzure.sample.get
     service.inviteUser(user.email, samRequestContext).unsafeRunSync()
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     val userId = dirDAO.loadSubjectFromEmail(user.email, samRequestContext).unsafeRunSync().value.asInstanceOf[WorkbenchUserId]
     val res = dirDAO.loadUser(userId, samRequestContext).unsafeRunSync()
-    res shouldBe Some(user.copy(id = userId))
+    res.get should beSameUserAs(user.copy(id = userId))
   }
 
   /** GoogleSubjectId Email no yes ---> Someone invited this user previous and we have a record for this user already. We just need to update GoogleSubjetId
@@ -430,7 +431,7 @@ class OldUserServiceSpec
     val group = genBasicWorkbenchGroup.sample.get.copy(email = user.email, members = Set.empty)
     dirDAO.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
     val res = intercept[WorkbenchExceptionWithErrorReport] {
-      service.registerUser(user, samRequestContext).unsafeRunSync()
+      service.createUser(user, samRequestContext).unsafeRunSync()
     }
     res.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
   }
@@ -442,7 +443,7 @@ class OldUserServiceSpec
     val group = genBasicWorkbenchGroup.sample.get.copy(email = user.email, members = Set.empty)
     dirDAO.createGroup(group, samRequestContext = samRequestContext).unsafeRunSync()
     val res = intercept[WorkbenchExceptionWithErrorReport] {
-      service.registerUser(user, samRequestContext).unsafeRunSync()
+      service.createUser(user, samRequestContext).unsafeRunSync()
     }
     res.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
   }
@@ -454,9 +455,9 @@ class OldUserServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     val user = genWorkbenchUserGoogle.sample.get
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     assertThrows[WorkbenchException] {
-      service.registerUser(user.copy(googleSubjectId = Option(genGoogleSubjectId.sample.get)), samRequestContext).unsafeRunSync()
+      service.createUser(user.copy(googleSubjectId = Option(genGoogleSubjectId.sample.get)), samRequestContext).unsafeRunSync()
     }
   }
 
@@ -464,9 +465,9 @@ class OldUserServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     val user = genWorkbenchUserAzure.sample.get
-    service.registerUser(user, samRequestContext).unsafeRunSync()
+    service.createUser(user, samRequestContext).unsafeRunSync()
     assertThrows[WorkbenchException] {
-      service.registerUser(user.copy(azureB2CId = Option(genAzureB2CId.sample.get)), samRequestContext).unsafeRunSync()
+      service.createUser(user.copy(azureB2CId = Option(genAzureB2CId.sample.get)), samRequestContext).unsafeRunSync()
     }
   }
 
@@ -478,9 +479,9 @@ class OldUserServiceSpec
     val user = genWorkbenchUserGoogle.sample.get
     dirDAO.createUser(user, samRequestContext).unsafeRunSync()
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      service.registerUser(user, samRequestContext).unsafeRunSync()
+      service.createUser(user, samRequestContext).unsafeRunSync()
     }
-    exception.errorReport shouldEqual ErrorReport(StatusCodes.Conflict, s"user ${user.email} already exists")
+    exception.errorReport shouldEqual ErrorReport(StatusCodes.Conflict, s"user ${user.email} is already registered")
   }
 
   it should "return conflict when there's an existing subject for a given azureB2CId" in {
@@ -489,9 +490,9 @@ class OldUserServiceSpec
     val user = genWorkbenchUserAzure.sample.get
     dirDAO.createUser(user, samRequestContext).unsafeRunSync()
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
-      service.registerUser(user, samRequestContext).unsafeRunSync()
+      service.createUser(user, samRequestContext).unsafeRunSync()
     }
-    exception.errorReport shouldEqual ErrorReport(StatusCodes.Conflict, s"user ${user.email} already exists")
+    exception.errorReport shouldEqual ErrorReport(StatusCodes.Conflict, s"user ${user.email} is already registered")
   }
 
   // Test arose out of: https://broadworkbench.atlassian.net/browse/PROD-677
@@ -514,8 +515,8 @@ class OldUserServiceSpec
     val googleSubjectId = Option(GoogleSubjectId("123456789"))
     val newRegisteringUserId = WorkbenchUserId("11111111111111111")
     val registeringUser = SamUser(newRegisteringUserId, googleSubjectId, emailToInvite, None, false, None)
-    val registeredUser = service.registerUser(registeringUser, samRequestContext).unsafeRunSync()
-    registeredUser.id should {
+    val registeredUser = service.createUser(registeringUser, samRequestContext).unsafeRunSync()
+    registeredUser.userInfo.userSubjectId should {
       equal(invitedUser.id) and
         not equal newRegisteringUserId
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-739

  \<Don't forget to include the ticket number in the PR title!\>

What:

The query to set the `registered_at` for invited users didn't actually set the `registered_at` value for invited users

Why:

The subquery that sets the `registered_at` value relied on both the GoogleSubjectID and Azure B2C ID being null. However, when registering an invited user, separate calls were made to set the GoogleSubjectID and Azure B2C ID. The first call set the `registered_at` value, but because the user now had a Google Subject ID or Azure B2C ID, the subquery returned no results, so the second query overwrote the `registered_at` date set by the first query.

How:

To fix this, I tried to just simplify the query. However, I realized that the query that updates a login provider ID _should not be updating the `registered_at` column_. This is because there may be reasons to set the GoogleSubjectID/AzureB2CID post registration (its happened before), and having methods that updates the `registered_at` value along with those IDs is _very_ likely to have unintended side effects. So, I've broken out the updating of `registered_at` into its own method, and refactored the code around that.

I also deleted a bunch of old code.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
