### PR TITLE
[WOR-1247] Add own action to billing project owner role

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -705,11 +705,14 @@ resourceTypes = {
       list_children = {
         description = "list children, e.g. google-project"
       }
+      own = {
+        description = "perform owner actions on this billing project"
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child"]
+        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child", "own"]
         descendantRoles = {
           google-project = ["owner"]
         }


### PR DESCRIPTION
Ticket: [WOR-1247](https://broadworkbench.atlassian.net/browse/WOR-1247)

What:
* Add `own` action to `owner` role on `billing-project` resource

Why:
* We need an action to check that a user owns a billing project to determine if they can migrate workspace buckets in the billing project. There is not currently an `own` action on the `billing-project` resource like there is for other resource types (e.g. workspace). Rather than add a specific `migrate_workspace_buckets` action to the `billing-project` resource type that will be obsolete after the migration is finished, I opted to add the more general `own` action.

How:
* Updates `reference.conf` to add new `own` action and includes that action in the `owner` role list of actions.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[WOR-1247]: https://broadworkbench.atlassian.net/browse/WOR-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ