### PR TITLE
[PF-2972] Update dependencies with known vulnerabilities

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
   val scalaV = "2.13"
 
-  val jacksonV = "2.12.0"
+  val jacksonV = "2.12.6.1"
   val akkaV = "2.6.19"
-  val akkaHttpV = "10.2.2"
+  val akkaHttpV = "10.2.9"
 
   val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle2V = "0.24-447afa5"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaV = "2.13"
 
-  val jacksonV = "2.12.6.1"
+  val jacksonV = "2.15.2"
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.9"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,7 +105,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID =
     "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
-  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.23.2"
+  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.8.0"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.2"
   val snakeYAML: ModuleID = "org.yaml" % "snakeyaml" % "1.33"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.9"
-  val jacksonV = "2.9.5"
+  val jacksonV = "2.12.6.1"
   val scalaLoggingV = "3.9.2"
   val scalaTestV = "3.2.12"
   val scalaCheckV = "1.14.3"
@@ -62,7 +62,7 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test"
   val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
-  val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.85.Final"
+  val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.98.Final"
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.1"
@@ -105,7 +105,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID =
     "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
-  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
+  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.23.2"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.2"
   val snakeYAML: ModuleID = "org.yaml" % "snakeyaml" % "1.33"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.9"
-  val jacksonV = "2.12.6.1"
+  val jacksonV = "2.15.2"
   val scalaLoggingV = "3.9.2"
   val scalaTestV = "3.2.12"
   val scalaCheckV = "1.14.3"
@@ -105,7 +105,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID =
     "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
-  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.8.0"
+  val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.2.2"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.2"
   val snakeYAML: ModuleID = "org.yaml" % "snakeyaml" % "1.33"


### PR DESCRIPTION
Ticket: [PF-2972](https://broadworkbench.atlassian.net/browse/PF-2972)

What:
Update a number of dependencies with known vulnerabilities. This also changes a few of the integration test ones which were flagged, but I didn't want to modify those too much as I'm not sure how to run the Sam integration tests to validate.

Why:
Verily security has started using a different dependency analysis tool which flagged a handful of vulnerabilities. I'd like to update dependencies to fix issues raised by both Verily's tool and Sourceclear.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[PF-2972]: https://broadworkbench.atlassian.net/browse/PF-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ