### PR TITLE
ID-822 New endpoint to sign Requester Pays urls

### DIFF
--- a/render_config.sh
+++ b/render_config.sh
@@ -6,6 +6,8 @@ SAM_VAULT_PATH="secret/dsde/firecloud/$ENV/sam"
 SERVICE_OUTPUT_LOCATION="$(dirname "$0")/src/main/resources/rendered"
 SECRET_ENV_VARS_LOCATION="${SERVICE_OUTPUT_LOCATION}/secrets.env"
 
+USE_GKE_GCLOUD_AUTH_PLUGIN=True # https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+
 gcloud container clusters get-credentials --zone us-central1-a --project broad-dsde-dev terra-dev
 
 kubectl -n terra-dev get secret sam-sa-secret -o 'go-template={{index .data "sam-account.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/sam-account.json

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1029,6 +1029,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/google/v1/user/signedUrlForBlob:
+    post:
+      tags:
+        - Google
+      summary: Gets a signed URL for the given blob, signed by the arbitrary Pet Service account of the calling user.
+        The signed URL is active for 1 hour and scoped to the permissions of the signing Pet Service Account.
+        An optional requesterPaysProject can be provided to specify which Google Project is billed.
+        Sam will provide a signed URL for any object path, even if that object does not exist.
+      operationId: getRequesterPaysSignedUrlForBlob
+      requestBody:
+        description: bucketName and blobName of the object to get a signed URL for
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/RequesterPaysSignedUrlRequest'
+        required: true
+      responses:
+        200:
+          description: signed URL for the blob, signed by the user's arbitrary Pet Service Account key
+          content:
+            application/json:
+              schema:
+                type: string
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/user/petServiceAccount/{project}:
     get:
       tags:
@@ -3191,6 +3220,26 @@ components:
           type: boolean
           description: Use the pet service account project as the user project in the request.
           default: true
+    RequesterPaysSignedUrlRequest:
+      type: object
+      required:
+        - bucketName
+        - blobName
+      properties:
+        bucketName:
+          type: string
+          description: bucket of the blob
+        blobName:
+          type: string
+          description: path to the blob in the bucket
+        duration:
+          type: number
+          description: Optional validity duration of the link in minutes. Defaults to 1 hour.
+          default: 60
+        requesterPaysProject:
+          type: string
+          description: Optional Google Project to use for billing.
+          default: undefined
     CreateResourceRequest:
       required:
         - policies

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1033,13 +1033,13 @@ paths:
     post:
       tags:
         - Google
-      summary: Gets a signed URL for the given blob, signed by the arbitrary Pet Service account of the calling user.
-        The signed URL is active for 1 hour and scoped to the permissions of the signing Pet Service Account.
+      summary: Gets a signed URL for the given blob.
+        The signed URL is active for 1 hour and scoped to the permissions of the user.
         An optional requesterPaysProject can be provided to specify which Google Project is billed.
         Sam will provide a signed URL for any object path, even if that object does not exist.
       operationId: getRequesterPaysSignedUrlForBlob
       requestBody:
-        description: bucketName and blobName of the object to get a signed URL for
+        description: GsPath of to get a signed URL for
         content:
           'application/json':
             schema:
@@ -3223,8 +3223,7 @@ components:
     RequesterPaysSignedUrlRequest:
       type: object
       required:
-        - bucketName
-        - blobName
+        - gsPath
       properties:
         gsPath:
           type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3226,12 +3226,9 @@ components:
         - bucketName
         - blobName
       properties:
-        bucketName:
+        gsPath:
           type: string
-          description: bucket of the blob
-        blobName:
-          type: string
-          description: path to the blob in the bucket
+          description: GS Path to the blob
         duration:
           type: number
           description: Optional validity duration of the link in minutes. Defaults to 1 hour.

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3239,7 +3239,6 @@ components:
         requesterPaysProject:
           type: string
           description: Optional Google Project to use for billing.
-          default: undefined
     CreateResourceRequest:
       required:
         - policies

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -201,8 +201,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   googleExtensions
                     .getRequesterPaysSignedUrl(
                       samUser,
-                      GcsBucketName(request.bucketName),
-                      GcsBlobName(request.blobName),
+                      request.gsPath,
                       request.duration,
                       request.requesterPaysProject.map(GoogleProject),
                       samRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -85,6 +85,8 @@ object SamJsonSupport {
   implicit val CreateResourceResponseFormat = jsonFormat4(CreateResourceResponse.apply)
 
   implicit val SignedUrlRequestFormat = jsonFormat4(SignedUrlRequest.apply)
+
+  implicit val RequesterPaysSignedUrlRequestFormat = jsonFormat4(RequesterPaysSignedUrlRequest.apply)
 }
 
 object RootPrimitiveJsonSupport {
@@ -308,6 +310,12 @@ object BasicWorkbenchGroup {
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 
 @Lenses final case class SignedUrlRequest(bucketName: String, blobName: String, duration: Option[Long] = None, requesterPays: Option[Boolean] = Option(true))
+@Lenses final case class RequesterPaysSignedUrlRequest(
+    bucketName: String,
+    blobName: String,
+    duration: Option[Long] = None,
+    requesterPaysProject: Option[String] = None
+)
 
 object SamUser {
   def apply(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -86,7 +86,7 @@ object SamJsonSupport {
 
   implicit val SignedUrlRequestFormat = jsonFormat4(SignedUrlRequest.apply)
 
-  implicit val RequesterPaysSignedUrlRequestFormat = jsonFormat4(RequesterPaysSignedUrlRequest.apply)
+  implicit val RequesterPaysSignedUrlRequestFormat = jsonFormat3(RequesterPaysSignedUrlRequest.apply)
 }
 
 object RootPrimitiveJsonSupport {
@@ -311,8 +311,7 @@ object BasicWorkbenchGroup {
 
 @Lenses final case class SignedUrlRequest(bucketName: String, blobName: String, duration: Option[Long] = None, requesterPays: Option[Boolean] = Option(true))
 @Lenses final case class RequesterPaysSignedUrlRequest(
-    bucketName: String,
-    blobName: String,
+    gsPath: String,
     duration: Option[Long] = None,
     requesterPaysProject: Option[String] = None
 )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
 import org.broadinstitute.dsde.workbench.google.mock._
-import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
@@ -87,7 +87,8 @@ object TestSupport extends TestSupport {
       googleDirectoryDAO: Option[GoogleDirectoryDAO] = None,
       policyAccessDAO: Option[AccessPolicyDAO] = None,
       policyEvaluatorServiceOpt: Option[PolicyEvaluatorService] = None,
-      resourceServiceOpt: Option[ResourceService] = None
+      resourceServiceOpt: Option[ResourceService] = None,
+      googProjectDAO: Option[GoogleProjectDAO] = None
   )(implicit system: ActorSystem) = {
     val googleDirectoryDAO = new MockGoogleDirectoryDAO()
     val directoryDAO = new MockDirectoryDAO()
@@ -98,7 +99,7 @@ object TestSupport extends TestSupport {
     val googleDisableUsersPubSubDAO = new MockGooglePubSubDAO()
     val googleKeyCachePubSubDAO = new MockGooglePubSubDAO()
     val googleStorageDAO = new MockGoogleStorageDAO()
-    val googleProjectDAO = new MockGoogleProjectDAO()
+    val googleProjectDAO = googProjectDAO.getOrElse(new MockGoogleProjectDAO())
     val notificationDAO = new PubSubNotificationDAO(notificationPubSubDAO, "foo")
     val cloudKeyCache = new GoogleKeyCache(
       distributedLock,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -295,7 +295,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   }
   "POST /api/google/v1/user/signedUrlForBlob" should "200 with a signed url" in {
     val (user, samRoutes, projectName) = setupSignedUrlTest()
-    val blob = RequesterPaysSignedUrlRequest("my-bucket", "my-folder/my-object.txt", requesterPaysProject = Some(projectName))
+    val blob = RequesterPaysSignedUrlRequest("gs://my-bucket/my-folder/my-object.txt", requesterPaysProject = Some(projectName))
     val urlEncodedEmail = URLEncoder.encode(user.email.value, StandardCharsets.UTF_8)
 
     Post(s"/api/google/v1/user/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
@@ -307,16 +307,16 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
 
   it should "set a duration for a signed url" in {
     val (_, samRoutes, projectName) = setupSignedUrlTest()
-    val blob = RequesterPaysSignedUrlRequest("my-bucket", "my-folder/my-object.txt", Some(2))
+    val blob = RequesterPaysSignedUrlRequest("gs://my-bucket/my-folder/my-object.txt", Some(2))
 
-    Post(s"/api/google/v1/user/petServiceAccount/$projectName/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
+    Post(s"/api/google/v1/user/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
       responseAs[String] should include("X-Goog-Expires=120")
     }
   }
 
   it should "skip requester pays if no project provided" in {
     val (_, samRoutes, _) = setupSignedUrlTest()
-    val blob = RequesterPaysSignedUrlRequest("my-bucket", "my-folder/my-object.txt", requesterPaysProject = None)
+    val blob = RequesterPaysSignedUrlRequest("gs://my-bucket/my-folder/my-object.txt", requesterPaysProject = None)
 
     Post(s"/api/google/v1/user/signedUrlForBlob", blob) ~> samRoutes.route ~> check {
       responseAs[String] should not include "userProject"

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -56,6 +56,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
     val googleProject = genGoogleProject.sample.get
     val gcsBucket = genGcsBucketName.sample.get
     val gcsBlob = genGcsBlobName.sample.get
+    val gsPath = s"gs://${gcsBucket.value}/${gcsBlob.value}"
     val petServiceAccount = genPetServiceAccount.sample.get
     val petServiceAccountKey = RealKeyMockGoogleIamDAO.generateNewRealKey(petServiceAccount.serviceAccount.email)._2
     val expectedUrl = new URL("https", "localhost", 80, s"${gcsBucket.value}/${gcsBlob.value}")
@@ -173,8 +174,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         runAndWait(
           googleExtensions.getRequesterPaysSignedUrl(
             newGoogleUser,
-            gcsBucket,
-            gcsBlob,
+            gsPath,
             None,
             requesterPaysProject = Some(requesterPaysGoogleProject),
             samRequestContext
@@ -192,7 +192,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         )
       }
       "does not include a requester pays user project if none is provided" in {
-        runAndWait(googleExtensions.getRequesterPaysSignedUrl(newGoogleUser, gcsBucket, gcsBlob, None, requesterPaysProject = None, samRequestContext))
+        runAndWait(googleExtensions.getRequesterPaysSignedUrl(newGoogleUser, gsPath, None, requesterPaysProject = None, samRequestContext))
         verify(mockGoogleStorageService).getSignedBlobUrl(
           eqTo(gcsBucket),
           eqTo(gcsBlob),


### PR DESCRIPTION
Ticket :https://broadworkbench.atlassian.net/browse/ID-822

  \<Don't forget to include the ticket number in the PR title!\>

What:

Introduce a new endpoint that allows the caller to get a signed URL while also specifying the requester pays google project.

Why:

We need to be able to specify which project to bill when signing a url for an object in a requester-pays bucket.

How:

Introduced a new endpoint instead of changing the existing one as to not break clients.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
