### PR TITLE
[DR-3244] Add support for auth domains for snapshot readers

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1224,6 +1224,7 @@ resourceTypes = {
       }
       read_data = {
         description = "Read data from the datasnapshot"
+        authDomainConstrainable = true
       }
       discover_data = {
         description = "Discover data about the datasnapshot"
@@ -1257,6 +1258,7 @@ resourceTypes = {
       }
       export_snapshot = {
         description = "Export snapshot to a Terra workspace"
+        authDomainConstrainable = true
       }
       view_journal = {
         description = "View datasnapshot journal entries"
@@ -1281,6 +1283,7 @@ resourceTypes = {
       }
     }
     reuseIds = true
+    authDomainConstrainable = true
   }
   service-perimeter = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1282,7 +1282,7 @@ resourceTypes = {
         roleActions = ["read_policies", "share_policy::steward", "alter_policies"]
       }
     }
-    reuseIds = true
+    reuseIds = false
     authDomainConstrainable = true
   }
   service-perimeter = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-3244

What:

Note: I didn't include discover_data in the list since presumably, we want the data to be discoverable
by users that aren't in the auth domain
(even if they don't have access)

discover_data doesn't give access to read the file or tabular data in (e.g. data plane data)

Why:

This will allow TDR to set auth domain groups on snapshots

