### PR TITLE
DR-3120 - Allow admins to delete spend profiles in TDR

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1100,7 +1100,7 @@ resourceTypes = {
         roleActions = ["link", "share_policy::user", "share_policy::pet-creator", "read_policy::pet-creator", "add_child", "create-pet"]
       }
       admin = {
-        roleActions = ["share_policy::owner", "read_policies", "alter_policies"]
+        roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete"]
       }
       pet-creator = {
         roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator"]


### PR DESCRIPTION
Ticket: [DR-3239](https://broadworkbench.atlassian.net/browse/DR-3239)

What:

Allow admins to TDR to delete billing profiles (AKA spend profile). 

Why:

DR-3239 in TDR add an admin-only option on billing profile delete that deletes the underlying azure cloud resources. Therefore, we need to allow admins to have access to delete billing profiles.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[DR-3239]: https://broadworkbench.atlassian.net/browse/DR-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ