### PR TITLE
ID-815 New terms of service tracking table.

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -25,4 +25,5 @@
     <include file="changesets/20221115_azure_managed_resource_group.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230203_last_quota_error.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230328_add_date_columns_to_user.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230929_add_tos_audit_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
@@ -16,5 +16,8 @@
             update sam_user set accepted_tos_version = '0' where id in
             (select gmf.member_user_id from sam_group_member_flat gmf join sam_group g on g.id = gmf.group_id where g.name = 'tos_accepted_0' and gmf.member_user_id is not null)
         </sql>
+        <dropColumn tableName="sam_user">
+            <column name="accepted_tos_version"/>
+        </dropColumn>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20220511_tos_version.xml
@@ -16,8 +16,5 @@
             update sam_user set accepted_tos_version = '0' where id in
             (select gmf.member_user_id from sam_group_member_flat gmf join sam_group g on g.id = gmf.group_id where g.name = 'tos_accepted_0' and gmf.member_user_id is not null)
         </sql>
-        <dropColumn tableName="sam_user">
-            <column name="accepted_tos_version"/>
-        </dropColumn>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230929_add_tos_audit_table.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230929_add_tos_audit_table.xml
@@ -10,25 +10,25 @@
       <column name="sam_user_id" type="VARCHAR">
         <constraints primaryKey="true" foreignKeyName="FK_TOS_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id" deleteCascade="true"/>
       </column>
-      <column name="terms_of_service_version" type="VARCHAR(40)">
+      <column name="version" type="VARCHAR(40)">
         <constraints primaryKey="true"/>
       </column>
       <column name="action" type="VARCHAR">
         <constraints primaryKey="true"/>
       </column>
-      <column name="updated_at" type="timestamptz"/>
+      <column name="created_at" type="timestamptz"/>
     </createTable>
 
     <sql stripComments="true">
       INSERT INTO sam_user_terms_of_service
       (sam_user_id,
-       terms_of_service_version,
+       version,
        action,
-       updated_at)
+       created_at)
       SELECT su.id                    as sam_user_id,
-             su.accepted_tos_version  as terms_of_service_version,
+             su.accepted_tos_version  as version,
              'ACCEPT'                 as action,
-       '1970-01-01 00:00:00-00' as updated_at
+       '1970-01-01 00:00:00-00' as created_at
       FROM sam_user su
       WHERE su.accepted_tos_version is not null;
     </sql>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230929_add_tos_audit_table.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20230929_add_tos_audit_table.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet logicalFilePath="dummy" author="tgarwood" id="add_tos_audit_table">
+    <createTable tableName="SAM_USER_TERMS_OF_SERVICE">
+      <column name="sam_user_id" type="VARCHAR">
+        <constraints primaryKey="true" foreignKeyName="FK_TOS_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id" deleteCascade="true"/>
+      </column>
+      <column name="terms_of_service_version" type="VARCHAR(40)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="action" type="VARCHAR">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="updated_at" type="timestamptz"/>
+    </createTable>
+
+    <sql stripComments="true">
+      INSERT INTO sam_user_terms_of_service
+      (sam_user_id,
+       terms_of_service_version,
+       action,
+       updated_at)
+      SELECT su.id                    as sam_user_id,
+             su.accepted_tos_version  as terms_of_service_version,
+             'ACCEPT'                 as action,
+       '1970-01-01 00:00:00-00' as updated_at
+      FROM sam_user su
+      WHERE su.accepted_tos_version is not null;
+    </sql>
+
+      <dropColumn tableName="sam_user">
+      <column name="accepted_tos_version"/>
+    </dropColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectives.scala
@@ -61,7 +61,7 @@ trait StandardSamUserDirectives extends SamUserDirectives with LazyLogging with 
     val googleSubjectId = (oidcHeaders.externalId.left.toOption ++ oidcHeaders.googleSubjectIdFromAzure).headOption
     val azureB2CId = oidcHeaders.externalId.toOption // .right is missing (compared to .left above) since Either is Right biased
 
-    SamUser(genWorkbenchUserId(System.currentTimeMillis()), googleSubjectId, oidcHeaders.email, azureB2CId, false, None)
+    SamUser(genWorkbenchUserId(System.currentTimeMillis()), googleSubjectId, oidcHeaders.email, azureB2CId, false)
   }
 
   /** Utility function that knows how to convert all the various headers into OIDCHeaders
@@ -122,7 +122,7 @@ object StandardSamUserDirectives {
   def getActiveSamUser(oidcHeaders: OIDCHeaders, userService: UserService, tosService: TosService, samRequestContext: SamRequestContext): IO[SamUser] =
     for {
       user <- getSamUser(oidcHeaders, userService, samRequestContext)
-      tosComplianceDetails <- tosService.getTosComplianceStatus(user)
+      tosComplianceDetails <- tosService.getTosComplianceStatus(user, samRequestContext)
     } yield {
       if (!tosComplianceDetails.permitsSystemUsage) {
         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.Unauthorized, "User must accept the latest terms of service."))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala
@@ -66,7 +66,7 @@ trait UserRoutes extends SamUserDirectives with SamRequestContextDirectives {
                 get {
                   withUserAllowInactive(samRequestContext) { samUser =>
                     complete {
-                      tosService.getTosComplianceStatus(samUser).map { tosAcceptanceStatus =>
+                      tosService.getTosComplianceStatus(samUser, samRequestContext).map { tosAcceptanceStatus =>
                         StatusCodes.OK -> Option(JsBoolean(tosAcceptanceStatus.permitsSystemUsage))
                       }
                     }
@@ -139,12 +139,12 @@ trait UserRoutes extends SamUserDirectives with SamRequestContextDirectives {
                 } ~
                 path("termsOfServiceDetails") {
                   get {
-                    complete(tosService.getTosDetails(user))
+                    complete(tosService.getTosDetails(user, samRequestContext))
                   }
                 } ~
                 path("termsOfServiceComplianceStatus") {
                   get {
-                    complete(tosService.getTosComplianceStatus(user))
+                    complete(tosService.getTosComplianceStatus(user, samRequestContext))
                   }
                 }
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -75,7 +75,7 @@ trait DirectoryDAO {
 
   def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
   def rejectTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
-  def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]]
+  def getUserTos(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserTos]]
 
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUser}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUser, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -74,7 +74,8 @@ trait DirectoryDAO {
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit]
 
   def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
-  def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean]
+  def rejectTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
+  def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]]
 
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -647,7 +647,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     }
   }
 
-  override def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
+  override def getUserTos(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
     readOnlyTransaction("getUserTos", samRequestContext) { implicit session =>
       val tosTable = TosTable.syntax
       val column = TosTable.column
@@ -655,7 +655,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val loadUserTosQuery =
         samsql"""select ${tosTable.resultAll}
               from ${TosTable as tosTable}
-              where ${column.samUserId} = ${userId} and ${column.version} = ${tosVersion}
+              where ${column.samUserId} = ${userId}
               order by ${column.createdAt} desc
               limit 1"""
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -353,7 +353,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                   ${userColumn.googleSubjectId},
                   ${userColumn.enabled},
                   ${userColumn.azureB2cId},
-                  ${userColumn.acceptedTosVersion},
                   ${userColumn.createdAt},
                   ${userColumn.registeredAt},
                   ${userColumn.updatedAt})
@@ -363,7 +362,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                   ${newUser.googleSubjectId},
                   ${newUser.enabled},
                   ${newUser.azureB2CId},
-                  ${newUser.acceptedTosVersion},
                   ${newUser.createdAt},
                   ${newUser.registeredAt},
                   ${newUser.updatedAt})"""
@@ -631,25 +629,38 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
     }
 
-  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
+  override def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] = {
+    val tosTable = TosTable.syntax
+    val tosColumns = TosTable.column
     serializableWriteTransaction("acceptTermsOfService", samRequestContext) { implicit session =>
-      val u = UserTable.column
-      samsql"""update ${UserTable.table}
-               set (${u.acceptedTosVersion}, ${u.updatedAt}) =
-               (${tosVersion}, ${Instant.now()})
-               where ${u.id} = ${userId}
-                and (${u.acceptedTosVersion} is null
-                or ${u.acceptedTosVersion} != ${tosVersion})""".update().apply() > 0
+      samsql"""insert into ${TosTable as tosTable} (${tosColumns.samUserId}, ${tosColumns.version}, ${tosColumns.action}, ${tosColumns.createdAt})
+               values ($userId, $tosVersion, ${TosTable.ACCEPT}, ${Instant.now()})""".update().apply() > 0
     }
+  }
 
-  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
+  override def rejectTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] = {
+    val tosTable = TosTable.syntax
+    val tosColumns = TosTable.column
     serializableWriteTransaction("rejectTermsOfService", samRequestContext) { implicit session =>
-      val u = UserTable.column
-      samsql"""update ${UserTable.table}
-               set (${u.acceptedTosVersion}, ${u.updatedAt}) =
-               (null, ${Instant.now()})
-               where ${u.id} = ${userId}
-                and ${u.acceptedTosVersion} is not null""".update().apply() > 0
+      samsql"""insert into ${TosTable as tosTable} (${tosColumns.samUserId}, ${tosColumns.version}, ${tosColumns.action}, ${tosColumns.createdAt})
+         values ($userId, $tosVersion, ${TosTable.REJECT}, ${Instant.now()})""".update().apply() > 0
+    }
+  }
+
+  override def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
+    readOnlyTransaction("getUserTos", samRequestContext) { implicit session =>
+      val tosTable = TosTable.syntax
+      val column = TosTable.column
+
+      val loadUserTosQuery =
+        samsql"""select ${tosTable.resultAll}
+              from ${TosTable as tosTable}
+              where ${column.samUserId} = ${userId} and ${column.version} = ${tosVersion}
+              order by ${column.createdAt} desc
+              limit 1"""
+
+      val userTosRecordOpt: Option[TosRecord] = loadUserTosQuery.map(TosTable(tosTable)).first().apply()
+      userTosRecordOpt.map(TosTable.unmarshalUserRecord)
     }
 
   override def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/TosTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/TosTable.scala
@@ -1,0 +1,39 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
+import org.broadinstitute.dsde.workbench.sam.model.SamUserTos
+import scalikejdbc._
+
+import java.time.Instant
+
+final case class TosRecord(
+    samUserId: WorkbenchUserId,
+    version: String,
+    action: String,
+    createdAt: Instant
+)
+
+object TosTable extends SQLSyntaxSupportWithDefaultSamDB[TosRecord] {
+  val ACCEPT = "ACCEPT"
+  val REJECT = "REJECT"
+  override def tableName: String = "SAM_USER_TERMS_OF_SERVICE"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[TosRecord])(rs: WrappedResultSet): TosRecord = TosRecord(
+    rs.get(e.samUserId),
+    rs.get(e.version),
+    rs.get(e.action),
+    rs.get(e.createdAt)
+  )
+
+  def apply(o: SyntaxProvider[TosRecord])(rs: WrappedResultSet): TosRecord = apply(o.resultName)(rs)
+
+  def unmarshalUserRecord(tosRecord: TosRecord): SamUserTos =
+    SamUserTos(
+      tosRecord.samUserId,
+      tosRecord.version,
+      tosRecord.action,
+      tosRecord.createdAt
+    )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserTable.scala
@@ -13,7 +13,6 @@ final case class UserRecord(
     googleSubjectId: Option[GoogleSubjectId],
     enabled: Boolean,
     azureB2cId: Option[AzureB2CId],
-    acceptedTosVersion: Option[String],
     createdAt: Instant,
     registeredAt: Option[Instant],
     updatedAt: Instant
@@ -29,7 +28,6 @@ object UserTable extends SQLSyntaxSupportWithDefaultSamDB[UserRecord] {
     rs.stringOpt(e.googleSubjectId).map(GoogleSubjectId),
     rs.get(e.enabled),
     rs.stringOpt(e.azureB2cId).map(AzureB2CId),
-    rs.stringOpt(e.acceptedTosVersion),
     rs.get(e.createdAt),
     rs.timestampOpt(e.registeredAt).map(_.toInstant),
     rs.get(e.updatedAt)
@@ -44,7 +42,6 @@ object UserTable extends SQLSyntaxSupportWithDefaultSamDB[UserRecord] {
       userRecord.email,
       userRecord.azureB2cId,
       userRecord.enabled,
-      userRecord.acceptedTosVersion,
       userRecord.createdAt,
       userRecord.registeredAt,
       userRecord.updatedAt

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -140,8 +140,7 @@ class GoogleExtensions(
                 Option(googleSubjectId),
                 googleServicesConfig.serviceAccountClientEmail,
                 None,
-                false,
-                None
+                false
               )
               samApplication.userService.createUser(newUser, samRequestContext).map(_ => newUser)
           }
@@ -424,7 +423,7 @@ class GoogleExtensions(
       subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
       key <- subject match {
         case Some(userId: WorkbenchUserId) =>
-          getPetServiceAccountKey(SamUser(userId, None, userEmail, None, false, None), project, samRequestContext).map(Option(_))
+          getPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), project, samRequestContext).map(Option(_))
         case _ => IO.pure(None)
       }
     } yield key
@@ -445,7 +444,7 @@ class GoogleExtensions(
       subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
       key <- subject match {
         case Some(userId: WorkbenchUserId) =>
-          IO.fromFuture(IO(getArbitraryPetServiceAccountKey(SamUser(userId, None, userEmail, None, false, None), samRequestContext))).map(Option(_))
+          IO.fromFuture(IO(getArbitraryPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), samRequestContext))).map(Option(_))
         case _ => IO.none
       }
     } yield key

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.workbench.sam.model
 import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
-import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse, AdminUpdateUserRequest}
 import org.broadinstitute.dsde.workbench.sam.model.api.SamApiJsonProtocol.PolicyInfoResponseBodyJsonFormat
+import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse, AdminUpdateUserRequest}
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
@@ -28,7 +28,7 @@ object SamJsonSupport {
 
   implicit val ResourceTypeFormat = jsonFormat6(ResourceType.apply)
 
-  implicit val SamUserFormat = jsonFormat9(SamUser.apply)
+  implicit val SamUserFormat = jsonFormat8(SamUser.apply)
 
   implicit val UserStatusDetailsFormat = jsonFormat2(UserStatusDetails.apply)
 
@@ -322,10 +322,9 @@ object SamUser {
       googleSubjectId: Option[GoogleSubjectId],
       email: WorkbenchEmail,
       azureB2CId: Option[AzureB2CId],
-      enabled: Boolean,
-      acceptedTosVersion: Option[String]
+      enabled: Boolean
   ): SamUser =
-    SamUser(id, googleSubjectId, email, azureB2CId, enabled, acceptedTosVersion, Instant.EPOCH, None, Instant.EPOCH)
+    SamUser(id, googleSubjectId, email, azureB2CId, enabled, Instant.EPOCH, None, Instant.EPOCH)
 }
 
 final case class SamUser(
@@ -334,7 +333,6 @@ final case class SamUser(
     email: WorkbenchEmail,
     azureB2CId: Option[AzureB2CId],
     enabled: Boolean,
-    acceptedTosVersion: Option[String],
     createdAt: Instant,
     registeredAt: Option[Instant],
     updatedAt: Instant
@@ -347,8 +345,17 @@ final case class SamUser(
       this.googleSubjectId == user.googleSubjectId &&
       this.email == user.email &&
       this.azureB2CId == user.azureB2CId &&
-      this.enabled == user.enabled &&
-      this.acceptedTosVersion == user.acceptedTosVersion
+      this.enabled == user.enabled
+    case _ => false
+  }
+}
+
+final case class SamUserTos(id: WorkbenchUserId, version: String, action: String, createdAt: Instant) {
+  override def equals(other: Any): Boolean = other match {
+    case userTos: SamUserTos =>
+      this.id == userTos.id &&
+      this.version == userTos.version &&
+      this.action == userTos.action
     case _ => false
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -33,12 +33,12 @@ class TosService(val directoryDao: DirectoryDAO, val tosConfig: TermsOfServiceCo
 
   @Deprecated
   def getTosDetails(samUser: SamUser, samRequestContext: SamRequestContext): IO[TermsOfServiceDetails] =
-    directoryDao.getUserTos(samUser.id, tosConfig.version, samRequestContext).map { tos =>
+    directoryDao.getUserTos(samUser.id, samRequestContext).map { tos =>
       TermsOfServiceDetails(isEnabled = true, tosConfig.isGracePeriodEnabled, tosConfig.version, tos.map(_.version))
     }
 
   def getTosComplianceStatus(samUser: SamUser, samRequestContext: SamRequestContext): IO[TermsOfServiceComplianceStatus] =
-    directoryDao.getUserTos(samUser.id, tosConfig.version, samRequestContext).map { tos =>
+    directoryDao.getUserTos(samUser.id, samRequestContext).map { tos =>
       val userHasAcceptedLatestVersion = userHasAcceptedLatestTosVersion(tos)
       val permitsSystemUsage = tosAcceptancePermitsSystemUsage(samUser, tos)
       TermsOfServiceComplianceStatus(samUser.id, userHasAcceptedLatestVersion, permitsSystemUsage)

--- a/src/test/scala/Generator.scala
+++ b/src/test/scala/Generator.scala
@@ -61,7 +61,7 @@ object Generator {
     email <- genNonPetEmail
     googleSubjectId <- genGoogleSubjectId
     userId <- genWorkbenchUserId
-  } yield SamUser(userId, Some(googleSubjectId), email, None, false, None)
+  } yield SamUser(userId, Some(googleSubjectId), email, None, false)
 
   val genFirecloudUser = for {
     email <- genFirecloudEmail
@@ -77,20 +77,20 @@ object Generator {
     email <- genServiceAccountEmail
     googleSubjectId <- genGoogleSubjectId
     userId <- genWorkbenchUserId
-  } yield SamUser(userId, Option(googleSubjectId), email, None, false, None)
+  } yield SamUser(userId, Option(googleSubjectId), email, None, false)
 
   val genWorkbenchUserAzure = for {
     email <- genNonPetEmail
     azureB2CId <- genAzureB2CId
     userId <- genWorkbenchUserId
-  } yield SamUser(userId, None, email, Option(azureB2CId), false, None)
+  } yield SamUser(userId, None, email, Option(azureB2CId), false)
 
   val genWorkbenchUserBoth = for {
     email <- genNonPetEmail
     googleSubjectId <- genGoogleSubjectId
     azureB2CId <- genAzureB2CId
     userId <- genWorkbenchUserId
-  } yield SamUser(userId, Option(googleSubjectId), email, Option(azureB2CId), false, None)
+  } yield SamUser(userId, Option(googleSubjectId), email, Option(azureB2CId), false)
 
   val genPetServiceAccountId = for {
     userId <- genWorkbenchUserId

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -447,7 +447,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true, None)
+    val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true)
     runAndWait(samRoutes.userService.createUser(secondUser, samRequestContext))
 
     val resourceId = ResourceId("foo")
@@ -560,7 +560,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
     // create a second owner so our test user can leave the owner policy without orphaning the resource
-    val secondOwner = SamUser(WorkbenchUserId("1111112"), Some(GoogleSubjectId("1111112")), WorkbenchEmail("seconduser@gmail.com"), None, true, None)
+    val secondOwner = SamUser(WorkbenchUserId("1111112"), Some(GoogleSubjectId("1111112")), WorkbenchEmail("seconduser@gmail.com"), None, true)
     runAndWait(samRoutes.userService.createUser(secondOwner, samRequestContext))
 
     val resourceId = ResourceId("foo")
@@ -668,7 +668,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
     )
     val samRoutes = TestSamRoutes(Map(resourceType.name -> resourceType))
 
-    val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true, None)
+    val secondUser = SamUser(WorkbenchUserId("11112"), Some(GoogleSubjectId("11112")), WorkbenchEmail("some-other-user@example.com"), None, true)
     runAndWait(samRoutes.userService.createUser(secondUser, samRequestContext))
 
     val resourceId = ResourceId("foo")

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
@@ -141,7 +141,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(externalId, email, accessToken)
     val user = TestSupport.newUserWithAcceptedTos(
       services,
-      SamUser(userId, externalId.left.toOption, email = email, azureB2CId = externalId.toOption, true, None),
+      SamUser(userId, externalId.left.toOption, email = email, azureB2CId = externalId.toOption, true),
       samRequestContext
     )
     Get("/").withHeaders(headers) ~>
@@ -255,7 +255,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
           services.withNewUser(samRequestContext)(user => complete(user.copy(id = WorkbenchUserId("")).toString))
         } ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption, false, None).toString
+          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), externalId.left.toOption, email, externalId.toOption, false).toString
         }
   }
 
@@ -268,7 +268,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
           services.withNewUser(samRequestContext)(x => complete(x.copy(id = WorkbenchUserId("")).toString))
         } ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId), false, None).toString
+          responseAs[String] shouldEqual SamUser(WorkbenchUserId(""), Option(googleSubjectId), email, Option(azureB2CId), false).toString
         }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.google.mock.MockGoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsde.workbench.sam.TestSupport.{samRequestContext, tosConfig}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService, MockCrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.AdminConfig
 import org.broadinstitute.dsde.workbench.sam.config.{LiquibaseConfig, TermsOfServiceConfig}
@@ -206,14 +206,13 @@ object TestSamRoutes {
 
     val mockStatusService = new StatusService(directoryDAO, cloudXtns)
     val azureService = new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO)
-    val userToTestWith = if (acceptTermsOfService) user.copy(acceptedTosVersion = Some(tosConfig.version)) else user
     new TestSamRoutes(
       mockResourceService,
       policyEvaluatorService,
       mockUserService,
       mockStatusService,
       mockManagedGroupService,
-      userToTestWith,
+      user,
       tosService = mockTosService,
       cloudExtensions = cloudXtns,
       azureService = Some(azureService)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -214,7 +214,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       policy.members
     }
     members.flatten.collect { case u: WorkbenchUserId =>
-      SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false, None)
+      SamUser(u, Some(GoogleSubjectId(u.value)), WorkbenchEmail("dummy"), None, false)
     }.toSet
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -8,7 +8,8 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
-import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, SamUser}
+import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, SamUser, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -20,6 +21,7 @@ import scala.collection.mutable
 class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, WorkbenchGroup] = new TrieMap(), passStatusCheck: Boolean = true) extends DirectoryDAO {
   private val groupSynchronizedDates: mutable.Map[WorkbenchGroupIdentity, Date] = new TrieMap()
   private val users: mutable.Map[WorkbenchUserId, SamUser] = new TrieMap()
+  private val userTos: mutable.Map[WorkbenchUserId, SamUserTos] = new TrieMap()
   private val userAttributes: mutable.Map[WorkbenchUserId, mutable.Map[String, Any]] = new TrieMap()
 
   private val usersWithEmails: mutable.Map[WorkbenchEmail, WorkbenchUserId] = new TrieMap()
@@ -324,24 +326,25 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     loadUser(userId, samRequestContext).map {
       case None => false
       case Some(user) =>
-        if (user.acceptedTosVersion.contains(tosVersion)) {
-          false
-        } else {
-          users.put(userId, user.copy(acceptedTosVersion = Option(tosVersion)))
-          true
-        }
+        users.put(userId, user)
+        userTos.put(userId, SamUserTos(userId, tosVersion, TosTable.ACCEPT, Instant.now()))
+        true
     }
 
-  override def rejectTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
+  override def rejectTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
     loadUser(userId, samRequestContext).map {
       case None => false
       case Some(user) =>
-        if (user.acceptedTosVersion.isEmpty) {
-          false
-        } else {
-          users.put(userId, user.copy(acceptedTosVersion = None))
-          true
-        }
+        users.put(userId, user)
+        userTos.put(userId, SamUserTos(userId, tosVersion, TosTable.REJECT, Instant.now()))
+        true
+    }
+
+  override def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
+    loadUser(userId, samRequestContext).map {
+      case None => None
+      case Some(user) =>
+        userTos.get(userId)
     }
 
   override def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -340,10 +340,10 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
         true
     }
 
-  override def getUserTos(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
+  override def getUserTos(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserTos]] =
     loadUser(userId, samRequestContext).map {
       case None => None
-      case Some(user) =>
+      case Some(_) =>
         userTos.get(userId)
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -1486,7 +1486,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.acceptTermsOfService(defaultUser.id, tosConfig.version, samRequestContext).unsafeRunSync() shouldBe true
 
         // Assert
-        val userTos = dao.getUserTos(defaultUser.id, tosConfig.version, samRequestContext).unsafeRunSync()
+        val userTos = dao.getUserTos(defaultUser.id, samRequestContext).unsafeRunSync()
         userTos should not be empty
         userTos.get.createdAt should beAround(Instant.now())
         userTos.get.action shouldBe TosTable.ACCEPT
@@ -1501,7 +1501,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.acceptTermsOfService(defaultUser.id, "2", samRequestContext).unsafeRunSync() shouldBe true
 
         // Assert
-        val userTos = dao.getUserTos(defaultUser.id, "2", samRequestContext).unsafeRunSync()
+        val userTos = dao.getUserTos(defaultUser.id, samRequestContext).unsafeRunSync()
         userTos should not be empty
         userTos.get.createdAt should beAround(Instant.now())
         userTos.get.action shouldBe TosTable.ACCEPT
@@ -1516,7 +1516,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.rejectTermsOfService(user.id, tosConfig.version, samRequestContext).unsafeRunSync() shouldBe true
 
         // Assert
-        val userTos = dao.getUserTos(user.id, tosConfig.version, samRequestContext).unsafeRunSync()
+        val userTos = dao.getUserTos(user.id, samRequestContext).unsafeRunSync()
         userTos should not be empty
         userTos.get.createdAt should beAround(Instant.now())
         userTos.get.action shouldBe TosTable.REJECT
@@ -1530,7 +1530,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.rejectTermsOfService(user.id, tosConfig.version, samRequestContext).unsafeRunSync() shouldBe true
 
         // Assert
-        val userTos = dao.getUserTos(user.id, tosConfig.version, samRequestContext).unsafeRunSync()
+        val userTos = dao.getUserTos(user.id, samRequestContext).unsafeRunSync()
         userTos should not be empty
         userTos.get.createdAt should beAround(Instant.now())
         userTos.get.action shouldBe TosTable.REJECT
@@ -1544,7 +1544,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.createUser(user, samRequestContext).unsafeRunSync()
 
         // Assert
-        val userTos = dao.getUserTos(user.id, tosConfig.version, samRequestContext).unsafeRunSync()
+        val userTos = dao.getUserTos(user.id, samRequestContext).unsafeRunSync()
         userTos should be(None)
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -423,7 +423,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     googleExtensions.deleteUserPetServiceAccount(newUser.userInfo.userSubjectId, googleProject, samRequestContext).unsafeRunSync() shouldBe true
 
     // the user should still exist in DB
-    dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(enabled = true, acceptedTosVersion = Some("0")))
+    dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(enabled = true))
 
     // the pet should not exist in DB
     dirDAO.loadPetServiceAccount(PetServiceAccountId(defaultUser.id, googleProject), samRequestContext).unsafeRunSync() shouldBe None

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.service
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.sam.model.{SamUser, TermsOfServiceComplianceStatus}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.Mockito.{RETURNS_SMART_NULLS, lenient}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.scalatest.MockitoSugar
@@ -32,7 +33,7 @@ case class MockTosServiceBuilder() extends MockitoSugar {
     lenient()
       .doAnswer((i: InvocationOnMock) => IO.pure(TermsOfServiceComplianceStatus(i.getArgument[SamUser](0).id, isAccepted, isAccepted)))
       .when(tosService)
-      .getTosComplianceStatus(any[SamUser])
+      .getTosComplianceStatus(any[SamUser], any[SamRequestContext])
 
   private def setAcceptedStateForUserTo(samUser: SamUser, isAccepted: Boolean) = {
     val matchesUser = new ArgumentMatcher[SamUser] {
@@ -42,7 +43,7 @@ case class MockTosServiceBuilder() extends MockitoSugar {
     lenient()
       .doReturn(IO.pure(TermsOfServiceComplianceStatus(samUser.id, isAccepted, isAccepted)))
       .when(tosService)
-      .getTosComplianceStatus(ArgumentMatchers.argThat(matchesUser))
+      .getTosComplianceStatus(ArgumentMatchers.argThat(matchesUser), any[SamRequestContext])
   }
 
   def build: TosService = tosService

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserService.scala
@@ -144,8 +144,8 @@ class MockUserService(
   def acceptTermsOfServiceDAO(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
     directoryDAO.acceptTermsOfService(userId, tosVersion, samRequestContext)
 
-  def rejectTermsOfServiceDAO(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
-    directoryDAO.rejectTermsOfService(userId, samRequestContext)
+  def rejectTermsOfServiceDAO(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean] =
+    directoryDAO.rejectTermsOfService(userId, tosVersion, samRequestContext)
 
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity] =
     directoryDAO.createPetManagedIdentity(petManagedIdentity, samRequestContext)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorServiceSpec.scala
@@ -127,8 +127,8 @@ class PolicyEvaluatorServiceSpec extends RetryableAnyFlatSpec with Matchers with
   private[service] def savePolicyMembers(policy: AccessPolicy) =
     policy.members.toList.traverse {
       case u: WorkbenchUserId =>
-        dirDAO.createUser(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false, None), samRequestContext).recoverWith {
-          case _: WorkbenchException => IO.pure(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false, None))
+        dirDAO.createUser(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false), samRequestContext).recoverWith { case _: WorkbenchException =>
+          IO.pure(SamUser(u, None, WorkbenchEmail(u.value + "@foo.bar"), None, false))
         }
       case g: WorkbenchGroupName =>
         managedGroupService.createManagedGroup(ResourceId(g.value), dummyUser, samRequestContext = samRequestContext).recoverWith {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -5,6 +5,8 @@ import cats.effect.unsafe.implicits.{global => globalEc}
 import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
 import org.broadinstitute.dsde.workbench.sam.TestSupport.tosConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
+import org.broadinstitute.dsde.workbench.sam.model.SamUserTos
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
 import org.mockito.Mockito.RETURNS_SMART_NULLS
@@ -12,6 +14,7 @@ import org.mockito.scalatest.MockitoSugar
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
+import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll with BeforeAndAfter with PropertyBasedTesting with MockitoSugar {
@@ -29,6 +32,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
   before {
     clearDatabase()
     TestSupport.truncateAll
+    reset(dirDAO)
   }
 
   protected def clearDatabase(): Unit =
@@ -53,7 +57,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
     }
 
     "rejects the ToS for a user" in {
-      when(dirDAO.rejectTermsOfService(any[WorkbenchUserId], any[SamRequestContext]))
+      when(dirDAO.rejectTermsOfService(any[WorkbenchUserId], any[String], any[SamRequestContext]))
         .thenReturn(IO.pure(true))
 
       // reject and get ToS status
@@ -61,23 +65,27 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       val rejectTosStatusResult = tosService.rejectTosStatus(defaultUser.id, samRequestContext).unsafeRunSync()
 
       rejectTosStatusResult shouldBe true
-      verify(dirDAO).rejectTermsOfService(defaultUser.id, samRequestContext)
+      verify(dirDAO).rejectTermsOfService(defaultUser.id, tosConfig.version, samRequestContext)
     }
 
     "always allows service account users to use the system" in {
+      val tosVersion = "2"
       val tosService =
-        new TosService(dirDAO, TestSupport.tosConfig.copy(version = "2"))
-      val complianceStatus = tosService.getTosComplianceStatus(serviceAccountUser).unsafeRunSync()
+        new TosService(dirDAO, TestSupport.tosConfig.copy(version = tosVersion))
+      when(dirDAO.getUserTos(serviceAccountUser.id, tosVersion, samRequestContext))
+        .thenReturn(IO.pure(Some(SamUserTos(serviceAccountUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
+      val complianceStatus = tosService.getTosComplianceStatus(serviceAccountUser, samRequestContext).unsafeRunSync()
       complianceStatus.permitsSystemUsage shouldBe true
     }
 
+    val tosVersion = "2"
     val withoutGracePeriod = "without the grace period enabled"
     val withGracePeriod = " with the grace period enabled"
     val cannotUseTheSystem = "says the user cannot use the system"
     val canUseTheSystem = "says the user can use the system"
-    val tosServiceV2 = new TosService(dirDAO, TestSupport.tosConfig.copy(version = "2"))
+    val tosServiceV2 = new TosService(dirDAO, TestSupport.tosConfig.copy(version = tosVersion))
     val tosServiceV2GracePeriodEnabled =
-      new TosService(dirDAO, TestSupport.tosConfig.copy(version = "2", isGracePeriodEnabled = true))
+      new TosService(dirDAO, TestSupport.tosConfig.copy(version = tosVersion, isGracePeriodEnabled = true))
 
     /** | Case | Grace Period Enabled | Accepted Version | Current Version | User accepted latest | Permits system usage |
       * |:-----|:---------------------|:-----------------|:----------------|:---------------------|:---------------------|
@@ -91,64 +99,115 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
 
     "when the user has not accepted any ToS version" - {
       "says the user has not accepted the latest version" in {
-        val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser).unsafeRunSync()
+        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          .thenReturn(IO.pure(None))
+        val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe false
       }
       withoutGracePeriod - {
         cannotUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(None))
           // CASE 1
-          val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser).unsafeRunSync()
+          val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe false
         }
       }
       withGracePeriod - {
         cannotUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(None))
           // CASE 4
-          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser).unsafeRunSync()
+          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe false
         }
       }
     }
     "when the user has accepted a non-current ToS version" - {
-      val userAcceptedV0 = defaultUser.copy(acceptedTosVersion = Option("0"))
       "says the user has not accepted the latest version" in {
-        val complianceStatus = tosServiceV2.getTosComplianceStatus(userAcceptedV0).unsafeRunSync()
+        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          .thenReturn(IO.pure(None))
+        val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe false
       }
       withoutGracePeriod - {
         cannotUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(None))
           // CASE 2
-          val complianceStatus = tosServiceV2.getTosComplianceStatus(userAcceptedV0).unsafeRunSync()
+          val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe false
         }
       }
       withGracePeriod - {
         canUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 5
-          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(userAcceptedV0).unsafeRunSync()
+          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe true
         }
       }
     }
     "when the user has accepted the current ToS version" - {
-      val userAcceptedCurrentVersion = defaultUser.copy(acceptedTosVersion = Option("2"))
       "says the user has accepted the latest version" in {
-        val complianceStatus = tosServiceV2.getTosComplianceStatus(userAcceptedCurrentVersion).unsafeRunSync()
+        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
+        val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe true
       }
       withoutGracePeriod - {
         canUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 3
-          val complianceStatus = tosServiceV2.getTosComplianceStatus(userAcceptedCurrentVersion).unsafeRunSync()
+          val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe true
         }
       }
       withGracePeriod - {
         canUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 6
-          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(userAcceptedCurrentVersion).unsafeRunSync()
+          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
           complianceStatus.permitsSystemUsage shouldBe true
         }
+      }
+    }
+
+    "when the user has rejected the latest ToS version" - {
+      "says the user has rejected the latest version" in {
+        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
+        val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
+        complianceStatus.userHasAcceptedLatestTos shouldBe false
+      }
+      withoutGracePeriod - {
+        cannotUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
+          // CASE 1
+          val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
+          complianceStatus.permitsSystemUsage shouldBe false
+        }
+      }
+      withGracePeriod - {
+        cannotUseTheSystem in {
+          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+            .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
+          // CASE 4
+          val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
+          complianceStatus.permitsSystemUsage shouldBe false
+        }
+      }
+    }
+    "when a service account is using the api" - {
+      "let it use the api regardless of tos status" in {
+        when(dirDAO.getUserTos(serviceAccountUser.id, tosVersion, samRequestContext))
+          .thenReturn(IO.pure(None))
+        val complianceStatus = tosServiceV2.getTosComplianceStatus(serviceAccountUser, samRequestContext).unsafeRunSync()
+        complianceStatus.permitsSystemUsage shouldBe true
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -72,7 +72,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       val tosVersion = "2"
       val tosService =
         new TosService(dirDAO, TestSupport.tosConfig.copy(version = tosVersion))
-      when(dirDAO.getUserTos(serviceAccountUser.id, tosVersion, samRequestContext))
+      when(dirDAO.getUserTos(serviceAccountUser.id, samRequestContext))
         .thenReturn(IO.pure(Some(SamUserTos(serviceAccountUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
       val complianceStatus = tosService.getTosComplianceStatus(serviceAccountUser, samRequestContext).unsafeRunSync()
       complianceStatus.permitsSystemUsage shouldBe true
@@ -99,14 +99,14 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
 
     "when the user has not accepted any ToS version" - {
       "says the user has not accepted the latest version" in {
-        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+        when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
           .thenReturn(IO.pure(None))
         val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe false
       }
       withoutGracePeriod - {
         cannotUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(None))
           // CASE 1
           val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -115,7 +115,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       }
       withGracePeriod - {
         cannotUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(None))
           // CASE 4
           val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -125,14 +125,14 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
     }
     "when the user has accepted a non-current ToS version" - {
       "says the user has not accepted the latest version" in {
-        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+        when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
           .thenReturn(IO.pure(None))
         val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe false
       }
       withoutGracePeriod - {
         cannotUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(None))
           // CASE 2
           val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -141,7 +141,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       }
       withGracePeriod - {
         canUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 5
           val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -151,14 +151,14 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
     }
     "when the user has accepted the current ToS version" - {
       "says the user has accepted the latest version" in {
-        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+        when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
           .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
         val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe true
       }
       withoutGracePeriod - {
         canUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 3
           val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -167,7 +167,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       }
       withGracePeriod - {
         canUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.ACCEPT, Instant.now()))))
           // CASE 6
           val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -178,14 +178,14 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
 
     "when the user has rejected the latest ToS version" - {
       "says the user has rejected the latest version" in {
-        when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+        when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
           .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
         val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
         complianceStatus.userHasAcceptedLatestTos shouldBe false
       }
       withoutGracePeriod - {
         cannotUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
           // CASE 1
           val complianceStatus = tosServiceV2.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -194,7 +194,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
       }
       withGracePeriod - {
         cannotUseTheSystem in {
-          when(dirDAO.getUserTos(defaultUser.id, tosVersion, samRequestContext))
+          when(dirDAO.getUserTos(defaultUser.id, samRequestContext))
             .thenReturn(IO.pure(Option(SamUserTos(defaultUser.id, tosVersion, TosTable.REJECT, Instant.now()))))
           // CASE 4
           val complianceStatus = tosServiceV2GracePeriodEnabled.getTosComplianceStatus(defaultUser, samRequestContext).unsafeRunSync()
@@ -204,7 +204,7 @@ class TosServiceSpec extends AnyFreeSpec with TestSupport with BeforeAndAfterAll
     }
     "when a service account is using the api" - {
       "let it use the api regardless of tos status" in {
-        when(dirDAO.getUserTos(serviceAccountUser.id, tosVersion, samRequestContext))
+        when(dirDAO.getUserTos(serviceAccountUser.id, samRequestContext))
           .thenReturn(IO.pure(None))
         val complianceStatus = tosServiceV2.getTosComplianceStatus(serviceAccountUser, samRequestContext).unsafeRunSync()
         complianceStatus.permitsSystemUsage shouldBe true

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -112,7 +112,7 @@ class OldUserServiceMockSpec
     when(googleExtensions.onGroupUpdate(any[Seq[WorkbenchGroupIdentity]], any[SamRequestContext])).thenReturn(IO.unit)
 
     mockTosService = mock[TosService](RETURNS_SMART_NULLS)
-    when(mockTosService.getTosComplianceStatus(any[SamUser]))
+    when(mockTosService.getTosComplianceStatus(any[SamUser], any[SamRequestContext]))
       .thenAnswer((i: InvocationOnMock) => IO.pure(TermsOfServiceComplianceStatus(i.getArgument[SamUser](0).id, true, true)))
 
     service = Mockito.spy(new UserService(dirDAO, googleExtensions, Seq(blockedDomain), mockTosService))
@@ -143,7 +143,8 @@ class OldUserServiceMockSpec
   }
 
   it should "return UserStatusDiagnostics.tosAccepted as false if user's TOS status is false" in {
-    when(mockTosService.getTosComplianceStatus(enabledUser)).thenReturn(IO.pure(TermsOfServiceComplianceStatus(enabledUser.id, false, false)))
+    when(mockTosService.getTosComplianceStatus(enabledUser, samRequestContext))
+      .thenReturn(IO.pure(TermsOfServiceComplianceStatus(enabledUser.id, false, false)))
     val status = service.getUserStatusDiagnostics(enabledUser.id, samRequestContext).unsafeRunSync()
     status.value.tosAccepted shouldBe false
   }
@@ -506,7 +507,7 @@ class OldUserServiceSpec
     // Lookup the invited user and their ID
     val invitedUserId = dirDAO.loadSubjectFromEmail(emailToInvite, samRequestContext).unsafeRunSync().value.asInstanceOf[WorkbenchUserId]
     val invitedUser = dirDAO.loadUser(invitedUserId, samRequestContext).unsafeRunSync().getOrElse(fail("Failed to load invited user after inviting them"))
-    invitedUser shouldBe SamUser(invitedUserId, None, emailToInvite, None, false, None)
+    invitedUser shouldBe SamUser(invitedUserId, None, emailToInvite, None, false)
 
     // Give them a fake GoogleSubjectId and a new WorkbenchUserId and use that to register them.
     // The real code in org/broadinstitute/dsde/workbench/sam/api/UserRoutes.scala calls
@@ -514,7 +515,7 @@ class OldUserServiceSpec
     // WorkbenchUserId for the SamUser on the request.
     val googleSubjectId = Option(GoogleSubjectId("123456789"))
     val newRegisteringUserId = WorkbenchUserId("11111111111111111")
-    val registeringUser = SamUser(newRegisteringUserId, googleSubjectId, emailToInvite, None, false, None)
+    val registeringUser = SamUser(newRegisteringUserId, googleSubjectId, emailToInvite, None, false)
     val registeredUser = service.createUser(registeringUser, samRequestContext).unsafeRunSync()
     registeredUser.userInfo.userSubjectId should {
       equal(invitedUser.id) and
@@ -548,14 +549,14 @@ class OldUserServiceSpec
 
     val userInPostgres = dirDAO.loadUser(invitedUserId, samRequestContext).unsafeRunSync()
     userInPostgres.value should {
-      equal(SamUser(invitedUserId, None, inviteeEmail, None, false, None))
+      equal(SamUser(invitedUserId, None, inviteeEmail, None, false))
     }
 
     val registeringUser = genWorkbenchUserGoogle.sample.get.copy(email = inviteeEmail)
     runAndWait(service.createUser(registeringUser, samRequestContext))
 
     val updatedUserInPostgres = dirDAO.loadUser(invitedUserId, samRequestContext).unsafeRunSync()
-    updatedUserInPostgres.value shouldBe SamUser(invitedUserId, registeringUser.googleSubjectId, inviteeEmail, None, true, None)
+    updatedUserInPostgres.value shouldBe SamUser(invitedUserId, registeringUser.googleSubjectId, inviteeEmail, None, true)
   }
 
   it should "update azureB2CId for this user" in {
@@ -566,13 +567,13 @@ class OldUserServiceSpec
     val invitedUserId = dirDAO.loadSubjectFromEmail(inviteeEmail, samRequestContext).unsafeRunSync().value.asInstanceOf[WorkbenchUserId]
 
     val userInPostgres = dirDAO.loadUser(invitedUserId, samRequestContext).unsafeRunSync()
-    userInPostgres.value should equal(SamUser(invitedUserId, None, inviteeEmail, None, false, None))
+    userInPostgres.value should equal(SamUser(invitedUserId, None, inviteeEmail, None, false))
 
     val registeringUser = genWorkbenchUserAzure.sample.get.copy(email = inviteeEmail)
     runAndWait(service.createUser(registeringUser, samRequestContext))
 
     val updatedUserInPostgres = dirDAO.loadUser(invitedUserId, samRequestContext).unsafeRunSync()
-    updatedUserInPostgres.value shouldBe SamUser(invitedUserId, None, inviteeEmail, registeringUser.azureB2CId, true, None)
+    updatedUserInPostgres.value shouldBe SamUser(invitedUserId, None, inviteeEmail, registeringUser.azureB2CId, true)
   }
 
   "UserService getUserIdInfoFromEmail" should "return the email along with the userSubjectId and googleSubjectId" in {


### PR DESCRIPTION
Ticket: [ID-815](https://broadworkbench.atlassian.net/browse/ID-815)

What:

This pr adds a new terms of service acceptance/rejection tracking table for users. It is an append only table that tracks userid, tos version, action (accept/reject), createdat.

Why:

For auditing purposes we need to be able to look back on when users accepted or rejected different versions of the tos.

How:

I added a new append-only table and moved tos information from the SamUser class to a new one. Included in the migration is a query that grabs all of the current tos acceptance data and puts it in the new table.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[ID-815]: https://broadworkbench.atlassian.net/browse/ID-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ