### PR TITLE
ID-815 Add created_at to user tos primary key.

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231011_add_tos_audit_table_created_at_pk.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231011_add_tos_audit_table_created_at_pk.xml
@@ -8,5 +8,9 @@
   <changeSet logicalFilePath="dummy"  author="garwood" id="add_tos_audit_table_created_at_pk">
     <dropPrimaryKey  tableName= "SAM_USER_TERMS_OF_SERVICE" constraintName="sam_user_terms_of_service_pkey"/>
     <addPrimaryKey tableName="SAM_USER_TERMS_OF_SERVICE" columnNames="sam_user_id,version,action,created_at" constraintName="sam_user_terms_of_service_pkey"/>
+
+    <createIndex indexName="sam_user_id_tos_idx" tableName="SAM_USER_TERMS_OF_SERVICE">
+      <column name="sam_user_id"/>
+    </createIndex>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231011_add_tos_audit_table_created_at_pk.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231011_add_tos_audit_table_created_at_pk.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet logicalFilePath="dummy"  author="garwood" id="add_tos_audit_table_created_at_pk">
+    <dropPrimaryKey  tableName= "SAM_USER_TERMS_OF_SERVICE" constraintName="sam_user_terms_of_service_pkey"/>
+    <addPrimaryKey tableName="SAM_USER_TERMS_OF_SERVICE" columnNames="sam_user_id,version,action,created_at" constraintName="sam_user_terms_of_service_pkey"/>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-815

What:

The table currently doesnt allow you to add multiple rejections for the same tos version and user for example. We want this table to track all user interactions with tos so the created_at needs to be a part of the pk as well.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
