### PR TITLE
AJ-1369 Remove -b from git checkout in verify_consumer_pacts.yml

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -139,8 +139,8 @@ jobs:
           fi
           git fetch
           if [[ ! -z "${{ env.CHECKOUT_BRANCH }}" ]] && [[ ! -z "${{ env.CHECKOUT_SHA }}" ]]; then
-            echo "git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}"
-            git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}
+            echo "git checkout ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}"
+            git checkout ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}
             echo "git branch"
             git branch
           else


### PR DESCRIPTION
As far as I can tell, when calling `git checkout` on line 142, this will always be an existing branch, and therefore the `-b` flag will always cause a failure.

Ticket: https://broadworkbench.atlassian.net/browse/AJ-1369
