### PR TITLE
[DR-3245] Include auth domain actions in TDR snapshot roles

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1263,23 +1263,29 @@ resourceTypes = {
       view_journal = {
         description = "View datasnapshot journal entries"
       }
+      read_auth_domain = {
+        description = "view the auth domain of the snapshot"
+      }
+      update_auth_domain = {
+        description = "update the groups in the auth domain of the snapshot"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain"]
       }
       discoverer = {
-        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer"]
+        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
       }
       reader = {
-        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot"]
+        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
       }
       admin = {
-        roleActions = ["read_policies", "share_policy::steward", "alter_policies"]
+        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1267,7 +1267,7 @@ resourceTypes = {
         description = "view the auth domain of the snapshot"
       }
       update_auth_domain = {
-        description = "update the groups in the auth domain of the snapshot"
+        description = "update the auth domain of the snapshot"
       }
     }
     ownerRoleName = "steward"


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/DR-3245

**What:** Enable TDR users to read and/or update the auth domain of a snapshot depending on their role.

**Why:** TDR is adding the ability for users to add an auth domain to their snapshot (which will get registered with a `group-constraint` policy in the Terra Policy Service) in order to enforce who is allowed to access the data when it gets exported to a Terra workspace.

**How**: Updated reference.conf `datasnapshot` config


---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
