### PR TITLE
ID-807 stubbing out Routes for new ToS routes

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -37,7 +37,7 @@ object Settings {
     "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
     "-unchecked", // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    "-Wconf:cat=deprecation:ws,any:e", // Fail the compilation if there are any warnings, except for deprecation warnings.
     "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
     "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
     "-Xlint:delayedinit-select", // Selecting member of DelayedInit.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -61,6 +61,7 @@ abstract class SamRoutes(
     oidcConfig.swaggerRoutes("swagger/api-docs.yaml") ~
       oidcConfig.oauth2Routes ~
       statusRoutes ~
+      oldTermsOfServiceRoutes ~
       termsOfServiceRoutes ~
       withExecutionContext(ExecutionContext.global) {
         withSamRequestContext { samRequestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -83,7 +83,7 @@ trait TermsOfServiceRoutes {
                     complete(StatusCodes.NotImplemented)
                   }
                 } ~
-                  pathPrefix("history") {
+                  pathPrefix("history") { // api/termsOfService/v1/user/{userId}/history
                     pathEndOrSingleSlash {
                       get {
                         complete(StatusCodes.NotImplemented)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.sam.service.TosService
@@ -10,7 +11,8 @@ trait TermsOfServiceRoutes {
   val tosService: TosService
   implicit val executionContext: ExecutionContext
 
-  def termsOfServiceRoutes: server.Route =
+  @deprecated("Being replaced by REST-ful termsOfService routes")
+  def oldTermsOfServiceRoutes: server.Route =
     pathPrefix("tos") {
       path("text") {
         pathEndOrSingleSlash {
@@ -29,4 +31,67 @@ trait TermsOfServiceRoutes {
           }
         }
       }
+
+  def termsOfServiceRoutes: server.Route =
+    pathPrefix("termsOfService") {
+      pathPrefix("v1") { // api/termsOfService/v1
+        pathEndOrSingleSlash {
+          get {
+            complete(StatusCodes.NotImplemented)
+          }
+        } ~
+          pathPrefix("docs") { // api/termsOfService/v1/docs
+            pathEndOrSingleSlash {
+              get {
+                complete(StatusCodes.NotImplemented)
+              }
+            } ~
+              pathPrefix("redirect") { // api/termsOfService/v1/docs/redirect
+                pathEndOrSingleSlash {
+                  get {
+                    complete(StatusCodes.NotImplemented)
+                  }
+                }
+              }
+          } ~
+          pathPrefix("user") { // api/termsOfService/v1/user
+            pathPrefix("self") { // api/termsOfService/v1/user/self
+              pathEndOrSingleSlash {
+                get {
+                  complete(StatusCodes.NotImplemented)
+                }
+              } ~
+                pathPrefix("accept") { // api/termsOfService/v1/user/accept
+                  pathEndOrSingleSlash {
+                    put {
+                      complete(StatusCodes.NotImplemented)
+                    }
+                  }
+                } ~
+                pathPrefix("reject") { // api/termsOfService/v1/user/reject
+                  pathEndOrSingleSlash {
+                    put {
+                      complete(StatusCodes.NotImplemented)
+                    }
+                  }
+                }
+            } ~
+              // The {user_id} route must be last otherwise it will try to parse the other routes incorrectly as user id's
+              pathPrefix(Segment) { userId => // api/termsOfService/v1/user/{userId}
+                pathEndOrSingleSlash {
+                  get {
+                    complete(StatusCodes.NotImplemented)
+                  }
+                } ~
+                  pathPrefix("history") {
+                    pathEndOrSingleSlash {
+                      get {
+                        complete(StatusCodes.NotImplemented)
+                      }
+                    }
+                  }
+              }
+          }
+      }
+    }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutes.scala
@@ -59,6 +59,7 @@ abstract class MockSamRoutes(
     oidcConfig.swaggerRoutes("swagger/api-docs.yaml") ~
       oidcConfig.oauth2Routes ~
       statusRoutes ~
+      oldTermsOfServiceRoutes ~
       termsOfServiceRoutes ~
       withExecutionContext(ExecutionContext.global) {
         withSamRequestContext { samRequestContext =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-807 (and other tickets that need new ToS routes

What:

Stubbed Akka Routes all returning `501` just to get them in place so we don't end up stepping on each other as we implement the new routes.

Why:

Because akka routing is gross, and scalafmt makes it even worse, and I really really don't want to have to do manual code merges in a yucky file.  

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
