### PR TITLE
ID-880 Sam User Attributes

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -26,5 +26,5 @@
     <include file="changesets/20230203_last_quota_error.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230328_add_date_columns_to_user.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230929_add_tos_audit_table.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20231011_add_tos_audit_table_created_at_pk.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231019_sam_user_attributes_table.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231019_sam_user_attributes_table.xml
@@ -11,7 +11,7 @@
         <constraints primaryKey="true" foreignKeyName="FK_SUA_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id" deleteCascade="true"/>
       </column>
       <column name="marketing_consent" type="BOOLEAN">
-        <constraints primaryKey="false"/>
+        <constraints primaryKey="false" nullable="false"/>
       </column>
       <column name="updated_at" type="timestamptz"/>
     </createTable>
@@ -25,7 +25,6 @@
              true              as marketing_consent,
              current_timestamp as updated_at
       FROM sam_user su
-      WHERE su.enabled = true;
     </sql>
 
   </changeSet>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231019_sam_user_attributes_table.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20231019_sam_user_attributes_table.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet logicalFilePath="dummy" author="tlangs" id="add_sam_user_attributes_table">
+    <createTable tableName="SAM_USER_ATTRIBUTES">
+      <column name="sam_user_id" type="VARCHAR">
+        <constraints primaryKey="true" foreignKeyName="FK_SUA_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id" deleteCascade="true"/>
+      </column>
+      <column name="marketing_consent" type="BOOLEAN">
+        <constraints primaryKey="false"/>
+      </column>
+      <column name="updated_at" type="timestamptz"/>
+    </createTable>
+
+    <sql stripComments="true">
+      INSERT INTO sam_user_attributes
+      (sam_user_id,
+       marketing_consent,
+       updated_at)
+      SELECT su.id             as sam_user_id,
+             true              as marketing_consent,
+             current_timestamp as updated_at
+      FROM sam_user su
+      WHERE su.enabled = true;
+    </sql>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2812,6 +2812,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/users/v2/self/register:
+    post:
+      tags:
+        - Users
+      summary: create current user in the system using login credentials
+      operationId: registerUser
+      requestBody:
+        description: The details of the new parent resource
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SamUserRegistrationRequest'
+      responses:
+        201:
+          description: user successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SamUserResponse'
+        409:
+          description: user already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/users/v2/self/allowed:
     get:
       tags:
@@ -2827,6 +2852,25 @@ paths:
                 $ref: '#/components/schemas/SamUserAllowances'
         404:
           description: user not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/users/v2/self/attributes:
+    get:
+      tags:
+        - Users
+      summary: gets the user attributes
+      operationId: getSamUserAttributes
+      responses:
+        200:
+          description: attributes exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SamUserAttributes'
+        404:
+          description: attributes/user not found
           content:
             application/json:
               schema:
@@ -3942,6 +3986,17 @@ components:
         details:
           type: object
           description: details of the user's allowances
+    SamUserAttributes:
+      type: object
+      properties:
+        marketingConsent:
+          type: boolean
+          description: does the user consent to receiving marketing communications
+    SamUserRegistrationRequest:
+      type: object
+      properties:
+        userAttributes:
+          $ref: '#/components/schemas/SamUserAttributes'
     UpdateUserRequest:
       type: object
       properties:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.{NotFound, OK}
 import akka.http.scaladsl.server.Directives._
@@ -8,7 +9,7 @@ import akka.http.scaladsl.server.{Directive0, ExceptionHandler, Route}
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUserResponse._
-import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributesRequest, SamUserResponse}
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributesRequest, SamUserRegistrationRequest, SamUserResponse}
 import org.broadinstitute.dsde.workbench.sam.service.UserService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -29,49 +30,59 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
     })
   }
 
+  def userRegistrationRoutes(samRequestContextWithoutUser: SamRequestContext): Route =
+    pathPrefix("users" / "v2" / "self" / "register") {
+      withNewUser(samRequestContextWithoutUser) { createUser =>
+        pathEndOrSingleSlash {
+          postUserRegistration(createUser, samRequestContextWithoutUser)
+        }
+      }
+    }
+
   // These routes are wrapped in `withUserAllowInactive` because a user should be able to get info about themselves
   // Routes that need the user to be active should be wrapped in a directive, such as `withActiveUser`, to ensure
   // that the user is allowed to use the system.
   def userRoutesV2(samRequestContextWithoutUser: SamRequestContext): Route =
-    withUserAllowInactive(samRequestContextWithoutUser) { samUser: SamUser =>
-      val samRequestContext = samRequestContextWithoutUser.copy(samUser = Some(samUser))
-      pathPrefix("users") {
-        pathPrefix("v2") {
-          pathPrefix("self") {
-            // api/users/v2/self
-            pathEndOrSingleSlash {
-              getSamUserResponse(samUser, samRequestContext)
-            } ~
-              // api/users/v2/self/allowed
-              pathPrefix("allowed") {
-                pathEndOrSingleSlash {
-                  getSamUserAllowances(samUser, samRequestContext)
-                }
-              } ~
-              // api/user/v2/self/attributes
-              pathPrefix("attributes") {
-                pathEndOrSingleSlash {
-                  getSamUserAttributes(samUser, samRequestContext) ~
-                    patchSamUserAttributes(samUser, samRequestContext)
-                }
-              }
-          } ~
-            pathPrefix(Segment) { samUserId =>
-              val workbenchUserId = WorkbenchUserId(samUserId)
-              // api/users/v2/{sam_user_id}
+    userRegistrationRoutes(samRequestContextWithoutUser) ~
+      withUserAllowInactive(samRequestContextWithoutUser) { samUser: SamUser =>
+        val samRequestContext = samRequestContextWithoutUser.copy(samUser = Some(samUser))
+        pathPrefix("users") {
+          pathPrefix("v2") {
+            pathPrefix("self") {
+              // api/users/v2/self
               pathEndOrSingleSlash {
-                regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
+                getSamUserResponse(samUser, samRequestContext)
               } ~
-                // api/users/v2/{sam_user_id}/allowed
+                // api/users/v2/self/allowed
                 pathPrefix("allowed") {
                   pathEndOrSingleSlash {
-                    regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
+                    getSamUserAllowances(samUser, samRequestContext)
+                  }
+                } ~
+                // api/user/v2/self/attributes
+                pathPrefix("attributes") {
+                  pathEndOrSingleSlash {
+                    getSamUserAttributes(samUser, samRequestContext) ~
+                      patchSamUserAttributes(samUser, samRequestContext)
                   }
                 }
-            }
+            } ~
+              pathPrefix(Segment) { samUserId =>
+                val workbenchUserId = WorkbenchUserId(samUserId)
+                // api/users/v2/{sam_user_id}
+                pathEndOrSingleSlash {
+                  regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
+                } ~
+                  // api/users/v2/{sam_user_id}/allowed
+                  pathPrefix("allowed") {
+                    pathEndOrSingleSlash {
+                      regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
+                    }
+                  }
+              }
+          }
         }
       }
-    }
 
   private def regularUserOrAdmin(callingUser: SamUser, requestedUserId: WorkbenchUserId, samRequestContext: SamRequestContext)(
       asRegular: (SamUser, SamRequestContext) => Route
@@ -145,4 +156,14 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
         }
       }
     }
+
+  private def postUserRegistration(newUser: SamUser, samRequestContext: SamRequestContext): Route =
+    post {
+      entity(as[SamUserRegistrationRequest]) { userRegistrationRequest =>
+        complete {
+          userService.createUser(newUser, Some(userRegistrationRequest), samRequestContext).map(StatusCodes.Created -> _)
+        }
+      }
+    }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.StatusCodes.{NotFound, OK}
+import akka.http.scaladsl.model.StatusCodes.{Created, NotFound, OK}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, ExceptionHandler, Route}
 import cats.effect.IO
@@ -161,7 +160,12 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
     post {
       entity(as[SamUserRegistrationRequest]) { userRegistrationRequest =>
         complete {
-          userService.createUser(newUser, Some(userRegistrationRequest), samRequestContext).map(StatusCodes.Created -> _)
+          for {
+            userStatus <- userService.createUser(newUser, Some(userRegistrationRequest), samRequestContext)
+            samUserOpt <- userService.getUser(userStatus.userInfo.userSubjectId, samRequestContext)
+            samUser <- IO.fromOption(samUserOpt)(new WorkbenchException("Registered user not found"))
+            userResponse <- samUserResponse(samUser, samRequestContext)
+          } yield Created -> userResponse
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -83,4 +83,6 @@ trait DirectoryDAO {
   def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
   def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
+
+  def setUserAttributes(samUserAttributes: SamUserAttributes, samRequestContext: SamRequestContext): IO[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -81,6 +81,6 @@ trait DirectoryDAO {
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]
   def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
-
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
+  def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders._
 import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -947,5 +947,21 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       } else {
         ()
       }
+    }
+
+  override def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]] =
+    readOnlyTransaction("getUserAttributes", samRequestContext) { implicit session =>
+      val userAttributesTable = UserAttributesTable.syntax
+      val column = UserAttributesTable.column
+
+      val loadUserAttributesQuery =
+        samsql"""
+                 select ${userAttributesTable.result}
+                 from ${UserAttributesTable as userAttributesTable}
+                 where ${column.samUserId} = $userId
+        """
+
+      val userAttributesRecordOpt: Option[UserAttributesRecord] = loadUserAttributesQuery.map(UserAttributesTable(userAttributesTable)).first().apply()
+      userAttributesRecordOpt.map(UserAttributesTable.unmarshalUserAttributesRecord)
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -956,7 +956,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
       val loadUserAttributesQuery =
         samsql"""
-                 select ${userAttributesTable.result}
+                 select ${userAttributesTable.resultAll}
                  from ${UserAttributesTable as userAttributesTable}
                  where ${column.samUserId} = $userId
         """

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserAttributesTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserAttributesTable.scala
@@ -1,0 +1,34 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
+import org.broadinstitute.dsde.workbench.sam.model.SamUserTos
+import org.broadinstitute.dsde.workbench.sam.model.api.SamUserAttributes
+import scalikejdbc._
+
+import java.time.Instant
+
+final case class UserAttributesRecord(
+    samUserId: WorkbenchUserId,
+    marketingConsent: Boolean,
+    updatedAt: Instant
+)
+
+object UserAttributesTable extends SQLSyntaxSupportWithDefaultSamDB[UserAttributesRecord] {
+  override def tableName: String = "SAM_USER_ATTRIBUTES"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[UserAttributesRecord])(rs: WrappedResultSet): UserAttributesRecord = UserAttributesRecord(
+    rs.get(e.samUserId),
+    rs.get(e.marketingConsent),
+    rs.get(e.updatedAt)
+  )
+
+  def apply(o: SyntaxProvider[UserAttributesRecord])(rs: WrappedResultSet): UserAttributesRecord = apply(o.resultName)(rs)
+
+  def unmarshalUserAttributesRecord(userAttributesRecord: UserAttributesRecord): SamUserAttributes =
+    SamUserAttributes(
+      userAttributesRecord.samUserId,
+      userAttributesRecord.marketingConsent
+    )
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserAttributesTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/UserAttributesTable.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.sam.db.tables
 
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
-import org.broadinstitute.dsde.workbench.sam.model.SamUserTos
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUserAttributes
 import scalikejdbc._
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributes.scala
@@ -1,7 +1,10 @@
-package org.broadinstitute.dsde.workbench.sam.model.api
+package org.broadinstitute.dsde.workbench.sam
+package model.api
 
+import akka.http.scaladsl.model.StatusCodes
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchUserIdFormat
-import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchExceptionWithErrorReport, WorkbenchUserId}
 import spray.json.DefaultJsonProtocol.jsonFormat2
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
@@ -9,5 +12,18 @@ import spray.json.RootJsonFormat
 object SamUserAttributes {
   implicit val SamUserAttributesFormat: RootJsonFormat[SamUserAttributes] = jsonFormat2(SamUserAttributes.apply)
 
+  def newUserAttributesFromRequest(userId: WorkbenchUserId, userAttributesRequest: SamUserAttributesRequest): IO[SamUserAttributes] = {
+    val samUserAttributes = for {
+      marketingConsent <- userAttributesRequest.marketingConsent
+    } yield SamUserAttributes(userId, marketingConsent)
+    IO.fromOption(samUserAttributes)(
+      new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Missing values required for new user attributes."))
+    )
+
+  }
+
 }
-final case class SamUserAttributes(id: WorkbenchUserId, marketingConsent: Boolean)
+final case class SamUserAttributes(userId: WorkbenchUserId, marketingConsent: Boolean) {
+  def updateFromUserAttributesRequest(userAttributesRequest: SamUserAttributesRequest): IO[SamUserAttributes] =
+    IO(this.copy(marketingConsent = userAttributesRequest.marketingConsent.getOrElse(this.marketingConsent)))
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributes.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.workbench.sam.model.api
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchUserIdFormat
+import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import spray.json.DefaultJsonProtocol.jsonFormat2
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+object SamUserAttributes {
+  implicit val SamUserAttributesFormat: RootJsonFormat[SamUserAttributes] = jsonFormat2(SamUserAttributes.apply)
+
+}
+final case class SamUserAttributes(id: WorkbenchUserId, marketingConsent: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
@@ -1,5 +1,7 @@
-package org.broadinstitute.dsde.workbench.sam.model.api
+package org.broadinstitute.dsde.workbench.sam
+package model.api
 
+import org.broadinstitute.dsde.workbench.model.ErrorReport
 import spray.json.DefaultJsonProtocol.jsonFormat1
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
@@ -10,4 +12,15 @@ object SamUserAttributesRequest {
 }
 case class SamUserAttributesRequest(
     marketingConsent: Option[Boolean]
-)
+) {
+  def validateForNewUser: Option[Seq[ErrorReport]] = Option(
+    Seq(
+      validateMarketingConsentExists
+    ).flatten
+  ).filter(_.nonEmpty)
+
+  private def validateMarketingConsentExists: Option[ErrorReport] =
+    if (marketingConsent.isEmpty) {
+      Option(ErrorReport("A new user MUST provide a acceptance or denial to marketing consent"))
+    } else None
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.workbench.sam.model.api
+
+import spray.json.DefaultJsonProtocol.jsonFormat1
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+object SamUserAttributesRequest {
+  implicit val SamUserAttributesRequestFormat: RootJsonFormat[SamUserAttributesRequest] = jsonFormat1(SamUserAttributesRequest.apply)
+
+}
+case class SamUserAttributesRequest(
+    marketingConsent: Option[Boolean]
+)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.workbench.sam.model.api
+
+import org.broadinstitute.dsde.workbench.model.ErrorReport
+import spray.json.DefaultJsonProtocol.jsonFormat1
+import spray.json.RootJsonFormat
+
+object SamUserRegistrationRequest {
+  implicit val SamUserRegistrationRequestFormat: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat1(SamUserRegistrationRequest.apply)
+}
+case class SamUserRegistrationRequest(
+    userAttributes: SamUserAttributesRequest
+) {
+
+  def validateForNewUser: Option[Seq[ErrorReport]] = Option(
+    Seq(
+      userAttributes.validateForNewUser.getOrElse(Seq.empty)
+    ).flatten
+  ).filter(_.nonEmpty)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserResponse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserResponse.scala
@@ -11,7 +11,7 @@ import java.time.Instant
 
 object SamUserResponse {
 
-  implicit val SamUserFormat: RootJsonFormat[SamUserResponse] = jsonFormat8(SamUserResponse.apply)
+  implicit val SamUserResponseFormat: RootJsonFormat[SamUserResponse] = jsonFormat8(SamUserResponse.apply)
 
   def apply(samUser: SamUser, allowed: Boolean): SamUserResponse =
     SamUserResponse(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -247,7 +247,9 @@ object TestSupport extends TestSupport {
           UserTable,
           AccessInstructionsTable,
           GroupTable,
-          LastQuotaErrorTable
+          LastQuotaErrorTable,
+          TosTable,
+          UserAttributesTable
         )
 
         tables

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutesBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/MockSamRoutesBuilder.scala
@@ -7,7 +7,7 @@ import akka.stream.Materializer
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, WorkbenchGroup}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -61,6 +61,11 @@ class MockSamRoutesBuilder(allUsersGroup: WorkbenchGroup)(implicit system: Actor
   }
   def withAllowedUsers(samUsers: Iterable[SamUser]): MockSamRoutesBuilder = {
     userServiceBuilder.withAllowedUsers(samUsers)
+    this
+  }
+
+  def withUserAttributes(samUser: SamUser, userAttributes: SamUserAttributes): MockSamRoutesBuilder = {
+    userServiceBuilder.withUserAttributes(samUser, userAttributes)
     this
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -32,12 +32,15 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
     // Arrange
     val userAttributesRequest = SamUserAttributesRequest(marketingConsent = Some(false))
     val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withEnabledUser(defaultUser)
+      .withAllowedUser(defaultUser)
       .callAsNonAdminUser(Some(defaultUser))
       .build
 
     // Act and Assert
     Post(s"/api/users/v2/self/register", SamUserRegistrationRequest(userAttributesRequest)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
+      responseAs[SamUserResponse] should beForUser(defaultUser)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -7,7 +7,14 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail}
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.matchers.BeForSamUserResponseMatcher.beForUser
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAllowances, SamUserAttributes, SamUserAttributesRequest, SamUserResponse}
+import org.broadinstitute.dsde.workbench.sam.model.api.{
+  SamUser,
+  SamUserAllowances,
+  SamUserAttributes,
+  SamUserAttributesRequest,
+  SamUserRegistrationRequest,
+  SamUserResponse
+}
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.scalatest.MockitoSugar
@@ -20,6 +27,19 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
   val thirdUser: SamUser = Generator.genWorkbenchUserGoogle.sample.get
   val adminGroupEmail: WorkbenchEmail = Generator.genFirecloudEmail.sample.get
   val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
+
+  "POST /api/users/v2/self/register" should "register a user when the required attributes are provided" in {
+    // Arrange
+    val userAttributesRequest = SamUserAttributesRequest(marketingConsent = Some(false))
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .callAsNonAdminUser(Some(defaultUser))
+      .build
+
+    // Act and Assert
+    Post(s"/api/users/v2/self/register", SamUserRegistrationRequest(userAttributesRequest)) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.Created
+    }
+  }
 
   "GET /api/users/v2/self" should "get the user object of the requesting user" in {
     // Arrange

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -196,6 +196,20 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
     }
   }
 
+  it should "return Not Found if the user has no attributes" in {
+    // Arrange
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .withEnabledUser(defaultUser) // "persisted/enabled" user we will check the status of
+      .withAllowedUser(defaultUser) // "allowed" user we will check the status of
+      .callAsNonAdminUser()
+      .build
+
+    // Act and Assert
+    Get(s"/api/users/v2/self/attributes") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
   "PATCH /api/users/v2/self/attributes" should "update the user attributes of the calling user" in {
     // Arrange
     val userAttributesRequest = SamUserAttributesRequest(marketingConsent = Some(false))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -381,7 +381,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def setUserAttributes(samUserAttributes: SamUserAttributes, samRequestContext: SamRequestContext): IO[Unit] =
     loadUser(samUserAttributes.userId, samRequestContext).map {
-      case None => ()
+      case None => throw new WorkbenchException("No user found")
       case Some(_) =>
         userAttributes.update(samUserAttributes.userId, samUserAttributes)
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -23,7 +23,7 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   private val groupSynchronizedDates: mutable.Map[WorkbenchGroupIdentity, Date] = new TrieMap()
   private val users: mutable.Map[WorkbenchUserId, SamUser] = new TrieMap()
   private val userTos: mutable.Map[WorkbenchUserId, SamUserTos] = new TrieMap()
-  private val userAttributes: mutable.Map[WorkbenchUserId, mutable.Map[String, Any]] = new TrieMap()
+  private val userAttributes: mutable.Map[WorkbenchUserId, SamUserAttributes] = new TrieMap()
 
   private val usersWithEmails: mutable.Map[WorkbenchEmail, WorkbenchUserId] = new TrieMap()
   private val usersWithGoogleSubjectIds: mutable.Map[GoogleSubjectId, WorkbenchSubject] = new TrieMap()
@@ -273,22 +273,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     IO.pure(())
   }
 
-  private def addUserAttribute(userId: WorkbenchUserId, attrId: String, value: Any): IO[Unit] = {
-    userAttributes.get(userId) match {
-      case Some(attributes: Map[String, Any]) => attributes += attrId -> value
-      case _ => userAttributes += userId -> (new TrieMap() += attrId -> value)
-    }
-    IO.unit
-  }
-
-  private def readUserAttribute[T](userId: WorkbenchUserId, attrId: String): IO[Option[T]] = {
-    val value = for {
-      attributes <- userAttributes.get(userId)
-      value <- attributes.get(attrId)
-    } yield value.asInstanceOf[T]
-    IO.pure(value)
-  }
-
   override def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]] = {
     val res = for {
       uid <- usersWithGoogleSubjectIds.get(googleSubjectId)
@@ -386,5 +370,12 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
             s"Cannot update registeredAt for user ${userId} because user does not exist"
           )
         }
+    }
+
+  override def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]] =
+    loadUser(userId, samRequestContext).map {
+      case None => None
+      case Some(_) =>
+        userAttributes.get(userId)
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -378,4 +378,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
       case Some(_) =>
         userAttributes.get(userId)
     }
+
+  override def setUserAttributes(samUserAttributes: SamUserAttributes, samRequestContext: SamRequestContext): IO[Unit] =
+    loadUser(samUserAttributes.userId, samRequestContext).map {
+      case None => ()
+      case Some(_) =>
+        userAttributes.update(samUserAttributes.userId, samUserAttributes)
+    }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDaoBuilder.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.{IdiomaticMockito, Strictness}
@@ -38,6 +38,8 @@ case class MockDirectoryDaoBuilder() extends IdiomaticMockito {
   mockedDirectoryDAO.removeGroupMember(any[WorkbenchGroupIdentity], any[WorkbenchSubject], any[SamRequestContext]) returns IO(true)
   mockedDirectoryDAO.deleteUser(any[WorkbenchUserId], any[SamRequestContext]) returns IO.unit
   mockedDirectoryDAO.setUserRegisteredAt(any[WorkbenchUserId], any[Instant], any[SamRequestContext]) returns IO.unit
+  mockedDirectoryDAO.setUserAttributes(any[SamUserAttributes], any[SamRequestContext]) returns IO.unit
+  mockedDirectoryDAO.getUserAttributes(any[WorkbenchUserId], any[SamRequestContext]) returns IO(None)
 
   def withHealthyDatabase: MockDirectoryDaoBuilder = {
     mockedDirectoryDAO.checkStatus(any[SamRequestContext]) returns IO(true)
@@ -101,6 +103,11 @@ case class MockDirectoryDaoBuilder() extends IdiomaticMockito {
       Some(BasicWorkbenchGroup(allUsersGroup))
     )
     mockedDirectoryDAO.addGroupMember(eqTo(allUsersGroup.id), any[WorkbenchSubject], any[SamRequestContext]) returns IO(true)
+    this
+  }
+
+  def withUserAttributes(samUserAttributes: SamUserAttributes): MockDirectoryDaoBuilder = {
+    mockedDirectoryDAO.getUserAttributes(eqTo(samUserAttributes.userId), any[SamRequestContext]) returns IO(Some(samUserAttributes))
     this
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockDirectoryDaoBuilder.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchers
 import org.mockito.IdiomaticMockito.StubbingOps
@@ -128,6 +128,11 @@ case class StatefulMockDirectoryDaoBuilder() extends MockitoSugar {
     .doReturn(IO.unit)
     .when(mockedDirectoryDAO)
     .deleteUser(any[WorkbenchUserId], any[SamRequestContext])
+
+  lenient()
+    .doReturn(IO.unit)
+    .when(mockedDirectoryDAO)
+    .setUserAttributes(any[SamUserAttributes], any[SamRequestContext])
 
   def withExistingUser(samUser: SamUser): StatefulMockDirectoryDaoBuilder = withExistingUsers(Set(samUser))
   def withExistingUsers(samUsers: Iterable[SamUser]): StatefulMockDirectoryDaoBuilder = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -5,10 +5,18 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.errorReportSource
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.enabledMapNoTosAccepted
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAllowances, SamUserAttributes, SamUserAttributesRequest}
+import org.broadinstitute.dsde.workbench.sam.model.api.{
+  AdminUpdateUserRequest,
+  SamUser,
+  SamUserAllowances,
+  SamUserAttributes,
+  SamUserAttributesRequest,
+  SamUserRegistrationRequest
+}
 import org.broadinstitute.dsde.workbench.sam.model.{UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchersSugar.{any, argThat, eqTo}
+import org.mockito.Mockito.when
 import org.mockito.{IdiomaticMockito, Strictness}
 
 import scala.collection.mutable
@@ -57,6 +65,10 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
   }
 
   private def initializeDefaults(mockUserService: UserService): Unit = {
+    when(mockUserService.createUser(any[SamUser], any[Option[SamUserRegistrationRequest]], any[SamRequestContext])).thenAnswer { args =>
+      val user = args.getArgument[SamUser](0)
+      IO(UserStatus(UserStatusDetails(user), Map.empty))
+    }
     mockUserService.getUserStatusFromEmail(any[WorkbenchEmail], any[SamRequestContext]) returns IO(None)
     mockUserService.getUserStatus(any[WorkbenchUserId], false, any[SamRequestContext]) returns {
       IO(None)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -5,10 +5,10 @@ import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.errorReportSource
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.enabledMapNoTosAccepted
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAllowances}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAllowances, SamUserAttributes, SamUserAttributesRequest}
 import org.broadinstitute.dsde.workbench.sam.model.{UserStatus, UserStatusDetails}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.ArgumentMatchersSugar.{any, argThat, eqTo}
 import org.mockito.{IdiomaticMockito, Strictness}
 
 import scala.collection.mutable
@@ -18,6 +18,7 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
   private val enabledUsers: mutable.Set[SamUser] = mutable.Set.empty
   private val disabledUsers: mutable.Set[SamUser] = mutable.Set.empty
   private val allowedUsers: mutable.Set[SamUser] = mutable.Set.empty
+  private val userAttributesSet: mutable.Set[(WorkbenchUserId, SamUserAttributes)] = mutable.Set.empty
   private var isBadEmail = false
 
   private def existingUsers: mutable.Set[SamUser] =
@@ -41,6 +42,11 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
 
   def withAllowedUsers(samUsers: Iterable[SamUser]): MockUserServiceBuilder = {
     allowedUsers.addAll(samUsers)
+    this
+  }
+
+  def withUserAttributes(samUser: SamUser, userAttributes: SamUserAttributes): MockUserServiceBuilder = {
+    userAttributesSet.add(samUser.id -> userAttributes)
     this
   }
 
@@ -168,6 +174,16 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
       SamUserAllowances(allowed = true, enabled = true, termsOfService = true)
     )
 
+  private def makeUserAttributesAppear(userId: WorkbenchUserId, userAttributes: SamUserAttributes, mockUserService: UserService): Unit = {
+    mockUserService.getUserAttributes(eqTo(userId), any[SamRequestContext]) returns IO(Some(userAttributes))
+    mockUserService.setUserAttributes(argThat((attr: SamUserAttributes) => attr.userId.equals(userId)), any[SamRequestContext]) returns IO(userAttributes)
+    mockUserService.setUserAttributesFromRequest(
+      eqTo(userId),
+      SamUserAttributesRequest(Some(userAttributes.marketingConsent)),
+      any[SamRequestContext]
+    ) returns IO(userAttributes)
+  }
+
   private def handleMalformedEmail(mockUserService: UserService): Unit =
     if (isBadEmail) {
       mockUserService.updateUserCrud(any[WorkbenchUserId], any[AdminUpdateUserRequest], any[SamRequestContext]) returns {
@@ -185,6 +201,7 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
     enabledUsers.foreach(u => makeUserAppearEnabled(u, mockUserService))
     disabledUsers.foreach(u => makeUserAppearDisabled(u, mockUserService))
     allowedUsers.foreach(u => makeUserAppearAllowed(u, mockUserService))
+    userAttributesSet.foreach(tup => makeUserAttributesAppear(tup._1, tup._2, mockUserService))
     handleMalformedEmail(mockUserService)
     mockUserService
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -80,6 +80,7 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
     mockUserService.getUserAllowances(any[SamUser], any[SamRequestContext]) returns IO(
       SamUserAllowances(allowed = false, enabled = false, termsOfService = false)
     )
+    mockUserService.getUserAttributes(any[WorkbenchUserId], any[SamRequestContext]) returns IO(None)
   }
 
   private def makeUser(samUser: SamUser, mockUserService: UserService): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.matchers.BeSameUserMatcher.beSameUserAs
 import org.broadinstitute.dsde.workbench.sam.matchers.TimeMatchers
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs.{CreateUserSpec, GetUserStatusSpec, InviteUserSpec}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.Mockito
@@ -123,6 +123,7 @@ class OldUserServiceMockSpec(_system: ActorSystem)
     when(dirDAO.listUserDirectMemberships(defaultUser.id, samRequestContext)).thenReturn(IO(LazyList(allUsersGroup.id)))
     when(dirDAO.setGoogleSubjectId(defaultUser.id, defaultUser.googleSubjectId.get, samRequestContext)).thenReturn(IO(()))
     when(dirDAO.setUserAzureB2CId(defaultUser.id, defaultUser.azureB2CId.get, samRequestContext)).thenReturn(IO(()))
+    when(dirDAO.setUserAttributes(any[SamUserAttributes], any[SamRequestContext])).thenReturn(IO(()))
 
     googleExtensions = mock[GoogleExtensions](RETURNS_SMART_NULLS)
     when(googleExtensions.getOrCreateAllUsersGroup(any[DirectoryDAO], any[SamRequestContext])(any[ExecutionContext]))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
@@ -1,0 +1,75 @@
+package org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, MockDirectoryDaoBuilder}
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.model.api.{SamUserAttributes, SamUserAttributesRequest}
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, MockCloudExtensionsBuilder, MockTosServiceBuilder, TosService, UserService}
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.Mockito.verify
+
+import scala.concurrent.ExecutionContextExecutor
+
+class UserAttributesSpec extends UserServiceTestTraits {
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+  val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
+
+  val cloudExtensions: CloudExtensions = MockCloudExtensionsBuilder(allUsersGroup).build
+  val tosService: TosService = MockTosServiceBuilder().withAllAccepted().build
+
+  describe("user attributes") {
+    val user = genWorkbenchUserBoth.sample.get.copy(enabled = true)
+
+    it("should be retrieved for a user") {
+      // Arrange
+      val directoryDAO: DirectoryDAO = MockDirectoryDaoBuilder(allUsersGroup)
+        .withUserAttributes(SamUserAttributes(user.id, marketingConsent = true))
+        .build
+      val userService: UserService = new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService)
+      // Act
+      val response = runAndWait(userService.getUserAttributes(user.id, samRequestContext))
+
+      // Assert
+      response should be(Some(SamUserAttributes(user.id, marketingConsent = true)))
+      verify(directoryDAO).getUserAttributes(eqTo(user.id), any[SamRequestContext])
+    }
+
+    it("should set user attributes for a new user") {
+      // Arrange
+      val directoryDAO: DirectoryDAO = MockDirectoryDaoBuilder(allUsersGroup).build
+      val userService: UserService = new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService)
+      val userAttributesRequest = SamUserAttributesRequest(marketingConsent = Some(true))
+      // Act
+      val response = runAndWait(userService.setUserAttributes(user.id, userAttributesRequest, samRequestContext))
+
+      // Assert
+      val userAttributes = SamUserAttributes(user.id, marketingConsent = true)
+
+      response should be(userAttributes)
+      verify(directoryDAO).getUserAttributes(eqTo(user.id), any[SamRequestContext])
+      verify(directoryDAO).setUserAttributes(eqTo(userAttributes), any[SamRequestContext])
+    }
+
+    it("update existing user attributes") {
+      // Arrange
+      val userAttributes = SamUserAttributes(user.id, marketingConsent = true)
+      val directoryDAO: DirectoryDAO = MockDirectoryDaoBuilder(allUsersGroup)
+        .withUserAttributes(userAttributes)
+        .build
+      val userService: UserService = new UserService(directoryDAO, cloudExtensions, Seq.empty, tosService)
+      val userAttributesRequest = SamUserAttributesRequest(marketingConsent = Some(false))
+      // Act
+      val response = runAndWait(userService.setUserAttributes(user.id, userAttributesRequest, samRequestContext))
+
+      // Assert
+      val updatedUserAttributes = userAttributes.copy(marketingConsent = false)
+
+      response should be(updatedUserAttributes)
+      verify(directoryDAO).getUserAttributes(eqTo(user.id), any[SamRequestContext])
+      verify(directoryDAO).setUserAttributes(eqTo(updatedUserAttributes), any[SamRequestContext])
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-880

What:

Sam is the future of user information and preferences. The team has already decided that we want to migrate the data in Thurloe into Sam. 

This will be the start of that process. We’ll create a new table, sam_user_attributes, which will track the user’s marketing comms choice. It will be its own column with a true/false value, meaning there’s no ambiguity to if a user has consented or not. 

Why:

Thurloe has proven to be very difficult to work with. For something as important as GDPR compliance, we need to implement things in a straightforward and developer-friendly fashion as to minimize the risk of being out-of-compliance. 

How:

Implemented the storage of `marketingConsent` from API to DB. Tests included!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
