### PR TITLE
ID-883 adjusted scalafmt rules to fix obnoxious indenting in Route files

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,3 +13,9 @@ rewrite.rules = [
   AsciiSortImports
   PreferCurlyFors
 ]
+
+fileOverride {
+  "glob:**/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/**Routes*.scala" {
+    indentOperator.excludeRegex = "^.*~.*$"
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -30,8 +30,8 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
     pathPrefix("admin") {
       adminUserRoutes(user, requestContext) ~ pathPrefix("v1") {
         adminUserRoutes(user, requestContext) ~
-          adminResourcesRoutes(user, requestContext) ~
-          adminResourceTypesRoutes(user, requestContext)
+        adminResourcesRoutes(user, requestContext) ~
+        adminResourceTypesRoutes(user, requestContext)
       } ~ pathPrefix("v2") {
         asWorkbenchAdmin(user) {
           adminUserRoutesV2(user, requestContext)
@@ -49,76 +49,76 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
               .map(status => (if (status.isDefined) OK else NotFound) -> status)
           }
         } ~
-          pathPrefix(Segment) { userId =>
-            pathEnd {
-              delete {
-                complete {
-                  userService.deleteUser(WorkbenchUserId(userId), samRequestContext).map(_ => OK)
-                }
-              } ~
-                get {
-                  complete {
-                    userService
-                      .getUserStatus(WorkbenchUserId(userId), samRequestContext = samRequestContext)
-                      .map(status => (if (status.isDefined) OK else NotFound) -> status)
-                  }
-                } ~
-                patch {
-                  entity(as[AdminUpdateUserRequest]) { request =>
-                    complete {
-                      userService
-                        .updateUserCrud(WorkbenchUserId(userId), request, samRequestContext)
-                        .map(user => (if (user.isDefined) OK else NotFound) -> user)
-                    }
-                  }
-                }
+        pathPrefix(Segment) { userId =>
+          pathEnd {
+            delete {
+              complete {
+                userService.deleteUser(WorkbenchUserId(userId), samRequestContext).map(_ => OK)
+              }
             } ~
-              pathPrefix("enable") {
-                pathEndOrSingleSlash {
-                  put {
-                    complete {
-                      userService
-                        .enableUser(WorkbenchUserId(userId), samRequestContext)
-                        .map(status => (if (status.isDefined) OK else NotFound) -> status)
-                    }
-                  }
-                }
-              } ~
-              pathPrefix("disable") {
-                pathEndOrSingleSlash {
-                  put {
-                    complete {
-                      userService
-                        .disableUser(WorkbenchUserId(userId), samRequestContext)
-                        .map(status => (if (status.isDefined) OK else NotFound) -> status)
-                    }
-                  }
-                }
-              } ~
-              // This will get removed once ID-87 is resolved
-              pathPrefix("repairAllUsersGroup") {
-                pathEndOrSingleSlash {
-                  put {
-                    complete {
-                      userService
-                        .addToAllUsersGroup(WorkbenchUserId(userId), samRequestContext)
-                        .map(_ => OK)
-                    }
-                  }
-                }
-              } ~
-              pathPrefix("petServiceAccount") {
-                path(Segment) { project =>
-                  delete {
-                    complete {
-                      cloudExtensions
-                        .deleteUserPetServiceAccount(WorkbenchUserId(userId), GoogleProject(project), samRequestContext)
-                        .map(_ => NoContent)
-                    }
-                  }
+            get {
+              complete {
+                userService
+                  .getUserStatus(WorkbenchUserId(userId), samRequestContext = samRequestContext)
+                  .map(status => (if (status.isDefined) OK else NotFound) -> status)
+              }
+            } ~
+            patch {
+              entity(as[AdminUpdateUserRequest]) { request =>
+                complete {
+                  userService
+                    .updateUserCrud(WorkbenchUserId(userId), request, samRequestContext)
+                    .map(user => (if (user.isDefined) OK else NotFound) -> user)
                 }
               }
+            }
+          } ~
+          pathPrefix("enable") {
+            pathEndOrSingleSlash {
+              put {
+                complete {
+                  userService
+                    .enableUser(WorkbenchUserId(userId), samRequestContext)
+                    .map(status => (if (status.isDefined) OK else NotFound) -> status)
+                }
+              }
+            }
+          } ~
+          pathPrefix("disable") {
+            pathEndOrSingleSlash {
+              put {
+                complete {
+                  userService
+                    .disableUser(WorkbenchUserId(userId), samRequestContext)
+                    .map(status => (if (status.isDefined) OK else NotFound) -> status)
+                }
+              }
+            }
+          } ~
+          // This will get removed once ID-87 is resolved
+          pathPrefix("repairAllUsersGroup") {
+            pathEndOrSingleSlash {
+              put {
+                complete {
+                  userService
+                    .addToAllUsersGroup(WorkbenchUserId(userId), samRequestContext)
+                    .map(_ => OK)
+                }
+              }
+            }
+          } ~
+          pathPrefix("petServiceAccount") {
+            path(Segment) { project =>
+              delete {
+                complete {
+                  cloudExtensions
+                    .deleteUserPetServiceAccount(WorkbenchUserId(userId), GoogleProject(project), samRequestContext)
+                    .map(_ => NoContent)
+                }
+              }
+            }
           }
+        }
       }
     }
 
@@ -152,31 +152,31 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
             }
           }
         } ~
-          pathPrefix(Segment / "memberEmails" / Segment) { case (policyName, userEmail) =>
-            val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
-            pathEndOrSingleSlash {
-              withSubject(WorkbenchEmail(userEmail), samRequestContext) { subject =>
-                put {
-                  requireAdminResourceAction(adminAddMember, resourceType, user, samRequestContext) {
-                    complete {
-                      resourceService
-                        .addSubjectToPolicy(policyId, subject, samRequestContext)
-                        .as(NoContent)
-                    }
+        pathPrefix(Segment / "memberEmails" / Segment) { case (policyName, userEmail) =>
+          val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
+          pathEndOrSingleSlash {
+            withSubject(WorkbenchEmail(userEmail), samRequestContext) { subject =>
+              put {
+                requireAdminResourceAction(adminAddMember, resourceType, user, samRequestContext) {
+                  complete {
+                    resourceService
+                      .addSubjectToPolicy(policyId, subject, samRequestContext)
+                      .as(NoContent)
                   }
-                } ~
-                  delete {
-                    requireAdminResourceAction(adminRemoveMember, resourceType, user, samRequestContext) {
-                      complete {
-                        resourceService
-                          .removeSubjectFromPolicy(policyId, subject, samRequestContext)
-                          .as(NoContent)
-                      }
-                    }
+                }
+              } ~
+              delete {
+                requireAdminResourceAction(adminRemoveMember, resourceType, user, samRequestContext) {
+                  complete {
+                    resourceService
+                      .removeSubjectFromPolicy(policyId, subject, samRequestContext)
+                      .as(NoContent)
                   }
+                }
               }
             }
           }
+        }
       }
     }
 
@@ -194,25 +194,25 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
               }
             }
           } ~
-            pathPrefix(Segment) { policyName =>
-              val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
-              pathEndOrSingleSlash {
-                put {
-                  entity(as[AccessPolicyMembershipRequest]) { membershipUpdate =>
-                    withResourceType(resourceTypeAdminName) { resourceTypeAdmin =>
-                      complete {
-                        resourceService
-                          .overwriteAdminPolicy(resourceTypeAdmin, policyId.accessPolicyName, policyId.resource, membershipUpdate, samRequestContext)
-                          .as(Created)
-                      }
+          pathPrefix(Segment) { policyName =>
+            val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
+            pathEndOrSingleSlash {
+              put {
+                entity(as[AccessPolicyMembershipRequest]) { membershipUpdate =>
+                  withResourceType(resourceTypeAdminName) { resourceTypeAdmin =>
+                    complete {
+                      resourceService
+                        .overwriteAdminPolicy(resourceTypeAdmin, policyId.accessPolicyName, policyId.resource, membershipUpdate, samRequestContext)
+                        .as(Created)
                     }
                   }
-                } ~
-                  delete {
-                    complete(resourceService.deletePolicy(policyId, samRequestContext).as(NoContent))
-                  }
+                }
+              } ~
+              delete {
+                complete(resourceService.deletePolicy(policyId, samRequestContext).as(NoContent))
               }
             }
+          }
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -41,13 +41,13 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
           withNonAdminResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
             pathEndOrSingleSlash {
               getUserPoliciesForResourceType(resourceType, samUser, samRequestContext) ~
-                postResource(resourceType, samUser, samRequestContext)
+              postResource(resourceType, samUser, samRequestContext)
             } ~ pathPrefix(Segment) { resourceId =>
               val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
 
               pathEndOrSingleSlash {
                 deleteResource(resource, samUser, samRequestContext) ~
-                  postDefaultResource(resourceType, resource, samUser, samRequestContext)
+                postDefaultResource(resourceType, resource, samUser, samRequestContext)
               } ~ pathPrefix("action") {
                 pathPrefix(Segment) { action =>
                   pathEndOrSingleSlash {
@@ -72,7 +72,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
 
                   pathEndOrSingleSlash {
                     getPolicy(policyId, samUser, samRequestContext) ~
-                      putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext)
+                    putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext)
                   } ~ pathPrefix("memberEmails") {
                     pathEndOrSingleSlash {
                       putPolicyMembershipOverwrite(policyId, samUser, samRequestContext)
@@ -86,7 +86,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                             samRequestContext
                           ) {
                             putUserInPolicy(policyId, subject, samRequestContext) ~
-                              deleteUserFromPolicy(policyId, subject, samRequestContext)
+                            deleteUserFromPolicy(policyId, subject, samRequestContext)
                           }
                         }
                       }
@@ -94,7 +94,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                   } ~ pathPrefix("public") {
                     pathEndOrSingleSlash {
                       getPublicFlag(policyId, samUser, samRequestContext) ~
-                        putPublicFlag(policyId, samUser, samRequestContext)
+                      putPublicFlag(policyId, samUser, samRequestContext)
                     }
                   }
                 }
@@ -119,116 +119,116 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
           withNonAdminResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
             pathEndOrSingleSlash {
               getUserResourcesOfType(resourceType, samUser, samRequestContext) ~
-                postResource(resourceType, samUser, samRequestContext)
+              postResource(resourceType, samUser, samRequestContext)
             } ~
-              pathPrefix(Segment) { resourceId =>
-                val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
+            pathPrefix(Segment) { resourceId =>
+              val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
 
-                pathEndOrSingleSlash {
-                  deleteResource(resource, samUser, samRequestContext) ~
-                    postDefaultResource(resourceType, resource, samUser, samRequestContext)
-                } ~
-                  pathPrefix("action") {
-                    pathPrefix(Segment) { action =>
+              pathEndOrSingleSlash {
+                deleteResource(resource, samUser, samRequestContext) ~
+                postDefaultResource(resourceType, resource, samUser, samRequestContext)
+              } ~
+              pathPrefix("action") {
+                pathPrefix(Segment) { action =>
+                  pathEndOrSingleSlash {
+                    getActionPermissionForUser(resource, samUser, action, samRequestContext)
+                  } ~
+                  pathPrefix("userEmail") {
+                    pathPrefix(Segment) { userEmail =>
                       pathEndOrSingleSlash {
-                        getActionPermissionForUser(resource, samUser, action, samRequestContext)
-                      } ~
-                        pathPrefix("userEmail") {
-                          pathPrefix(Segment) { userEmail =>
-                            pathEndOrSingleSlash {
-                              getActionPermissionForUserEmail(resource, samUser, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
-                            }
-                          }
-                        }
-                    }
-                  } ~
-                  pathPrefix("leave") {
-                    pathEndOrSingleSlash {
-                      leaveResource(resourceType, resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("authDomain") {
-                    pathEndOrSingleSlash {
-                      getResourceAuthDomain(resource, samUser, samRequestContext) ~
-                        patchResourceAuthDomain(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("roles") {
-                    pathEndOrSingleSlash {
-                      getUserResourceRoles(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("actions") {
-                    pathEndOrSingleSlash {
-                      listActionsForUser(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("allUsers") {
-                    pathEndOrSingleSlash {
-                      getAllResourceUsers(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("parent") {
-                    pathEndOrSingleSlash {
-                      getResourceParent(resource, samUser, samRequestContext) ~
-                        setResourceParent(resource, samUser, samRequestContext) ~
-                        deleteResourceParent(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("children") {
-                    pathEndOrSingleSlash {
-                      getResourceChildren(resource, samUser, samRequestContext)
-                    }
-                  } ~
-                  pathPrefix("policies") {
-                    pathEndOrSingleSlash {
-                      getResourcePolicies(resource, samUser, samRequestContext)
-                    } ~ pathPrefix(Segment) { policyName =>
-                      val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
-
-                      pathEndOrSingleSlash {
-                        getPolicy(policyId, samUser, samRequestContext) ~
-                          putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext) ~
-                          deletePolicy(policyId, samUser, samRequestContext)
-                      } ~
-                        pathPrefix("memberEmails") {
-                          requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
-                            pathEndOrSingleSlash {
-                              putPolicyMembershipOverwrite(policyId, samUser, samRequestContext)
-                            } ~
-                              pathPrefix(Segment) { email =>
-                                withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
-                                  pathEndOrSingleSlash {
-                                    putUserInPolicy(policyId, subject, samRequestContext) ~
-                                      deleteUserFromPolicy(policyId, subject, samRequestContext)
-                                  }
-                                }
-                              }
-                          }
-                        } ~
-                        pathPrefix("memberPolicies") {
-                          requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
-                            path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
-                              val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType), ResourceId(memberResourceId))
-                              val policySubject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
-                              withPolicy(policySubject, samRequestContext) { memberPolicy =>
-                                pathEndOrSingleSlash {
-                                  putUserInPolicy(policyId, memberPolicy.id, samRequestContext) ~
-                                    deleteUserFromPolicy(policyId, memberPolicy.id, samRequestContext)
-                                }
-                              }
-                            }
-                          }
-                        } ~
-                        pathPrefix("public") {
-                          pathEndOrSingleSlash {
-                            getPublicFlag(policyId, samUser, samRequestContext) ~
-                              putPublicFlag(policyId, samUser, samRequestContext)
-                          }
-                        }
+                        getActionPermissionForUserEmail(resource, samUser, ResourceAction(action), WorkbenchEmail(userEmail), samRequestContext)
+                      }
                     }
                   }
+                }
+              } ~
+              pathPrefix("leave") {
+                pathEndOrSingleSlash {
+                  leaveResource(resourceType, resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("authDomain") {
+                pathEndOrSingleSlash {
+                  getResourceAuthDomain(resource, samUser, samRequestContext) ~
+                  patchResourceAuthDomain(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("roles") {
+                pathEndOrSingleSlash {
+                  getUserResourceRoles(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("actions") {
+                pathEndOrSingleSlash {
+                  listActionsForUser(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("allUsers") {
+                pathEndOrSingleSlash {
+                  getAllResourceUsers(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("parent") {
+                pathEndOrSingleSlash {
+                  getResourceParent(resource, samUser, samRequestContext) ~
+                  setResourceParent(resource, samUser, samRequestContext) ~
+                  deleteResourceParent(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("children") {
+                pathEndOrSingleSlash {
+                  getResourceChildren(resource, samUser, samRequestContext)
+                }
+              } ~
+              pathPrefix("policies") {
+                pathEndOrSingleSlash {
+                  getResourcePolicies(resource, samUser, samRequestContext)
+                } ~ pathPrefix(Segment) { policyName =>
+                  val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
+
+                  pathEndOrSingleSlash {
+                    getPolicy(policyId, samUser, samRequestContext) ~
+                    putPolicyOverwrite(resourceType, policyId, samUser, samRequestContext) ~
+                    deletePolicy(policyId, samUser, samRequestContext)
+                  } ~
+                  pathPrefix("memberEmails") {
+                    requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
+                      pathEndOrSingleSlash {
+                        putPolicyMembershipOverwrite(policyId, samUser, samRequestContext)
+                      } ~
+                      pathPrefix(Segment) { email =>
+                        withSubject(WorkbenchEmail(email), samRequestContext) { subject =>
+                          pathEndOrSingleSlash {
+                            putUserInPolicy(policyId, subject, samRequestContext) ~
+                            deleteUserFromPolicy(policyId, subject, samRequestContext)
+                          }
+                        }
+                      }
+                    }
+                  } ~
+                  pathPrefix("memberPolicies") {
+                    requireActionsForSharePolicy(policyId, samUser, samRequestContext) {
+                      path(Segment / Segment / Segment) { (memberResourceType, memberResourceId, memberPolicyName) =>
+                        val memberResource = FullyQualifiedResourceId(ResourceTypeName(memberResourceType), ResourceId(memberResourceId))
+                        val policySubject = FullyQualifiedPolicyId(memberResource, AccessPolicyName(memberPolicyName))
+                        withPolicy(policySubject, samRequestContext) { memberPolicy =>
+                          pathEndOrSingleSlash {
+                            putUserInPolicy(policyId, memberPolicy.id, samRequestContext) ~
+                            deleteUserFromPolicy(policyId, memberPolicy.id, samRequestContext)
+                          }
+                        }
+                      }
+                    }
+                  } ~
+                  pathPrefix("public") {
+                    pathEndOrSingleSlash {
+                      getPublicFlag(policyId, samUser, samRequestContext) ~
+                      putPublicFlag(policyId, samUser, samRequestContext)
+                    }
+                  }
+                }
               }
+            }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -61,30 +61,30 @@ abstract class SamRoutes(
 
   def route: server.Route = (logRequestResult & handleExceptions(myExceptionHandler)) {
     oidcConfig.swaggerRoutes("swagger/api-docs.yaml") ~
-      oidcConfig.oauth2Routes ~
-      statusRoutes ~
-      oldTermsOfServiceRoutes ~
-      termsOfServiceRoutes ~
-      withExecutionContext(ExecutionContext.global) {
-        withSamRequestContext { samRequestContext =>
-          pathPrefix("register")(oldUserRoutes(samRequestContext)) ~
-            pathPrefix("api") {
-              // these routes are for machine to machine authorized requests
-              // the whitelisted service admin account email is in the header of the request
-              serviceAdminRoutes(samRequestContext) ~
-                userRoutesV2(samRequestContext) ~
-                withActiveUser(samRequestContext) { samUser =>
-                  val samRequestContextWithUser = samRequestContext.copy(samUser = Option(samUser))
-                  resourceRoutes(samUser, samRequestContextWithUser) ~
-                    adminRoutes(samUser, samRequestContextWithUser) ~
-                    extensionRoutes(samUser, samRequestContextWithUser) ~
-                    groupRoutes(samUser, samRequestContextWithUser) ~
-                    azureRoutes(samUser, samRequestContextWithUser) ~
-                    userRoutesV1(samUser, samRequestContextWithUser)
-                }
-            }
+    oidcConfig.oauth2Routes ~
+    statusRoutes ~
+    oldTermsOfServiceRoutes ~
+    termsOfServiceRoutes ~
+    withExecutionContext(ExecutionContext.global) {
+      withSamRequestContext { samRequestContext =>
+        pathPrefix("register")(oldUserRoutes(samRequestContext)) ~
+        pathPrefix("api") {
+          // these routes are for machine to machine authorized requests
+          // the whitelisted service admin account email is in the header of the request
+          serviceAdminRoutes(samRequestContext) ~
+          userRoutesV2(samRequestContext) ~
+          withActiveUser(samRequestContext) { samUser =>
+            val samRequestContextWithUser = samRequestContext.copy(samUser = Option(samUser))
+            resourceRoutes(samUser, samRequestContextWithUser) ~
+            adminRoutes(samUser, samRequestContextWithUser) ~
+            extensionRoutes(samUser, samRequestContextWithUser) ~
+            groupRoutes(samUser, samRequestContextWithUser) ~
+            azureRoutes(samUser, samRequestContextWithUser) ~
+            userRoutesV1(samUser, samRequestContextWithUser)
+          }
         }
       }
+    }
   }
 
   // basis for logRequestResult lifted from http://stackoverflow.com/questions/32475471/how-does-one-log-akka-http-client-requests

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -40,58 +40,58 @@ trait TermsOfServiceRoutes {
             complete(StatusCodes.NotImplemented)
           }
         } ~
-          pathPrefix("docs") { // api/termsOfService/v1/docs
+        pathPrefix("docs") { // api/termsOfService/v1/docs
+          pathEndOrSingleSlash {
+            get {
+              complete(StatusCodes.NotImplemented)
+            }
+          } ~
+          pathPrefix("redirect") { // api/termsOfService/v1/docs/redirect
+            pathEndOrSingleSlash {
+              get {
+                complete(StatusCodes.NotImplemented)
+              }
+            }
+          }
+        } ~
+        pathPrefix("user") { // api/termsOfService/v1/user
+          pathPrefix("self") { // api/termsOfService/v1/user/self
             pathEndOrSingleSlash {
               get {
                 complete(StatusCodes.NotImplemented)
               }
             } ~
-              pathPrefix("redirect") { // api/termsOfService/v1/docs/redirect
-                pathEndOrSingleSlash {
-                  get {
-                    complete(StatusCodes.NotImplemented)
-                  }
+            pathPrefix("accept") { // api/termsOfService/v1/user/accept
+              pathEndOrSingleSlash {
+                put {
+                  complete(StatusCodes.NotImplemented)
                 }
               }
+            } ~
+            pathPrefix("reject") { // api/termsOfService/v1/user/reject
+              pathEndOrSingleSlash {
+                put {
+                  complete(StatusCodes.NotImplemented)
+                }
+              }
+            }
           } ~
-          pathPrefix("user") { // api/termsOfService/v1/user
-            pathPrefix("self") { // api/termsOfService/v1/user/self
+          // The {user_id} route must be last otherwise it will try to parse the other routes incorrectly as user id's
+          pathPrefix(Segment) { userId => // api/termsOfService/v1/user/{userId}
+            pathEndOrSingleSlash {
+              get {
+                complete(StatusCodes.NotImplemented)
+              }
+            } ~
+            pathPrefix("history") { // api/termsOfService/v1/user/{userId}/history
               pathEndOrSingleSlash {
                 get {
                   complete(StatusCodes.NotImplemented)
                 }
-              } ~
-                pathPrefix("accept") { // api/termsOfService/v1/user/accept
-                  pathEndOrSingleSlash {
-                    put {
-                      complete(StatusCodes.NotImplemented)
-                    }
-                  }
-                } ~
-                pathPrefix("reject") { // api/termsOfService/v1/user/reject
-                  pathEndOrSingleSlash {
-                    put {
-                      complete(StatusCodes.NotImplemented)
-                    }
-                  }
-                }
-            } ~
-              // The {user_id} route must be last otherwise it will try to parse the other routes incorrectly as user id's
-              pathPrefix(Segment) { userId => // api/termsOfService/v1/user/{userId}
-                pathEndOrSingleSlash {
-                  get {
-                    complete(StatusCodes.NotImplemented)
-                  }
-                } ~
-                  pathPrefix("history") { // api/termsOfService/v1/user/{userId}/history
-                    pathEndOrSingleSlash {
-                      get {
-                        complete(StatusCodes.NotImplemented)
-                      }
-                    }
-                  }
               }
+            }
           }
+        }
       }
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV1.scala
@@ -28,17 +28,17 @@ trait UserRoutesV1 extends SamUserDirectives with SamRequestContextDirectives {
           }
         }
       } ~
-        pathPrefix("invite") {
-          post {
-            path(Segment) { inviteeEmail =>
-              complete {
-                userService
-                  .inviteUser(WorkbenchEmail(inviteeEmail.trim), samRequestContext)
-                  .map(userStatus => StatusCodes.Created -> userStatus)
-              }
+      pathPrefix("invite") {
+        post {
+          path(Segment) { inviteeEmail =>
+            complete {
+              userService
+                .inviteUser(WorkbenchEmail(inviteeEmail.trim), samRequestContext)
+                .map(userStatus => StatusCodes.Created -> userStatus)
             }
           }
         }
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -42,26 +42,26 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
             pathEndOrSingleSlash {
               getSamUserResponse(samUser, samRequestContext)
             } ~
-              // api/users/v2/self/allowed
-              pathPrefix("allowed") {
-                pathEndOrSingleSlash {
-                  getSamUserAllowances(samUser, samRequestContext)
-                }
-              }
-          } ~
-            pathPrefix(Segment) { samUserId =>
-              val workbenchUserId = WorkbenchUserId(samUserId)
-              // api/users/v2/{sam_user_id}
+            // api/users/v2/self/allowed
+            pathPrefix("allowed") {
               pathEndOrSingleSlash {
-                regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
-              } ~
-                // api/users/v2/{sam_user_id}/allowed
-                pathPrefix("allowed") {
-                  pathEndOrSingleSlash {
-                    regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
-                  }
-                }
+                getSamUserAllowances(samUser, samRequestContext)
+              }
             }
+          } ~
+          pathPrefix(Segment) { samUserId =>
+            val workbenchUserId = WorkbenchUserId(samUserId)
+            // api/users/v2/{sam_user_id}
+            pathEndOrSingleSlash {
+              regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
+            } ~
+            // api/users/v2/{sam_user_id}/allowed
+            pathPrefix("allowed") {
+              pathEndOrSingleSlash {
+                regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
+              }
+            }
+          }
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -52,33 +52,33 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
               pathEndOrSingleSlash {
                 getSamUserResponse(samUser, samRequestContext)
               } ~
-                // api/users/v2/self/allowed
-                pathPrefix("allowed") {
-                  pathEndOrSingleSlash {
-                    getSamUserAllowances(samUser, samRequestContext)
-                  }
-                } ~
-                // api/user/v2/self/attributes
-                pathPrefix("attributes") {
-                  pathEndOrSingleSlash {
-                    getSamUserAttributes(samUser, samRequestContext) ~
-                      patchSamUserAttributes(samUser, samRequestContext)
-                  }
-                }
-            } ~
-              pathPrefix(Segment) { samUserId =>
-                val workbenchUserId = WorkbenchUserId(samUserId)
-                // api/users/v2/{sam_user_id}
+              // api/users/v2/self/allowed
+              pathPrefix("allowed") {
                 pathEndOrSingleSlash {
-                  regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
-                } ~
-                  // api/users/v2/{sam_user_id}/allowed
-                  pathPrefix("allowed") {
-                    pathEndOrSingleSlash {
-                      regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
-                    }
-                  }
+                  getSamUserAllowances(samUser, samRequestContext)
+                }
+              } ~
+              // api/user/v2/self/attributes
+              pathPrefix("attributes") {
+                pathEndOrSingleSlash {
+                  getSamUserAttributes(samUser, samRequestContext) ~
+                  patchSamUserAttributes(samUser, samRequestContext)
+                }
               }
+            } ~
+            pathPrefix(Segment) { samUserId =>
+              val workbenchUserId = WorkbenchUserId(samUserId)
+              // api/users/v2/{sam_user_id}
+              pathEndOrSingleSlash {
+                regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserResponse)(getAdminSamUserResponse)
+              } ~
+              // api/users/v2/{sam_user_id}/allowed
+              pathPrefix("allowed") {
+                pathEndOrSingleSlash {
+                  regularUserOrAdmin(samUser, workbenchUserId, samRequestContext)(getSamUserAllowances)(getAdminSamUserAllowances)
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-883

What:

Fixes annoying scalafmt indentation in Akka Routes definitions

Why:

The routes are ugly and hard enough to read already

How:

look at `scalafmt.conf` first

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
