### PR TITLE
ID-893 No Liquibase for Read Replicas

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -205,7 +205,7 @@ object Boot extends IOApp with LazyLogging {
   ): cats.effect.Resource[IO, (PostgresDirectoryDAO, AccessPolicyDAO, PostgresDistributedLockDAO[IO], AzureManagedResourceGroupDAO, LastQuotaErrorDAO)] =
     for {
       writeDbRef <- DbReference.resource(appConfig.liquibaseConfig, writeDbConfig)
-      readDbRef <- DbReference.resource(appConfig.liquibaseConfig, readDbConfig)
+      readDbRef <- DbReference.resource(appConfig.liquibaseConfig.copy(initWithLiquibase = false), readDbConfig)
 
       directoryDAO = new PostgresDirectoryDAO(writeDbRef, readDbRef)
       accessPolicyDAO = new PostgresAccessPolicyDAO(writeDbRef, readDbRef)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.db
 
-import cats.effect.{Async, IO, ParallelF, Resource}
+import cats.effect.{Async, IO, Resource}
 import com.google.common.base.Throwables
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.AttributeValue

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/DbReference.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.db
 
-import cats.effect.{Async, IO, Resource}
+import cats.effect.{Async, IO, ParallelF, Resource}
 import com.google.common.base.Throwables
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.AttributeValue
@@ -51,7 +51,10 @@ object DbReference extends LazyLogging {
     DBs.setup(dbName)
     DBs.loadGlobalSettings()
     if (liquibaseConfig.initWithLiquibase) {
+      logger.info(s"Initializing $dbName with liquibase")
       initWithLiquibase(liquibaseConfig, dbName)
+    } else {
+      logger.info(s"Initializing $dbName with without liquibase")
     }
 
     DbReference(dbName, dbExecutionContext)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-893

  \<Don't forget to include the ticket number in the PR title!\>

What:

Liquibase can't run on read replicas, so don't try to do it.

Why:

it breaks 

How:

just make it not run liquibase for read-only connections.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
