### PR TITLE
ID-896 Isolate Misbehaving Query

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -163,10 +163,10 @@ db {
     password = ${?POSTGRES_PASSWORD}
   }
 
-  sam_bad_query {
-    poolName = "sam_background"
-    poolInitialSize = 5
-    poolMaxSize = 5
+  sam_read_replica {
+    poolName = "sam_read_replica"
+    poolInitialSize = 8
+    poolMaxSize = 8
     poolConnectionTimeoutMillis = 5000
     driver = "org.postgresql.Driver"
     url = ${?POSTGRES_READ_URL}

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -130,7 +130,7 @@ db {
     poolMaxSize = 8
     poolConnectionTimeoutMillis = 5000
     driver = "org.postgresql.Driver"
-    url = ${?POSTGRES_READ_URL}
+    url = ${?POSTGRES_WRITE_URL}
     user = ${?POSTGRES_USERNAME}
     password = ${?POSTGRES_PASSWORD}
   }
@@ -159,6 +159,17 @@ db {
     poolConnectionTimeoutMillis = 5000
     driver = "org.postgresql.Driver"
     url = ${?POSTGRES_WRITE_URL}
+    user = ${?POSTGRES_USERNAME}
+    password = ${?POSTGRES_PASSWORD}
+  }
+
+  sam_bad_query {
+    poolName = "sam_background"
+    poolInitialSize = 5
+    poolMaxSize = 5
+    poolConnectionTimeoutMillis = 5000
+    driver = "org.postgresql.Driver"
+    url = ${?POSTGRES_READ_URL}
     user = ${?POSTGRES_USERNAME}
     password = ${?POSTGRES_PASSWORD}
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -109,13 +109,15 @@ object Boot extends IOApp with LazyLogging {
       (foregroundDirectoryDAO, foregroundAccessPolicyDAO, postgresDistributedLockDAO, azureManagedResourceGroupDAO, lastQuotaErrorDAO) <- createDAOs(
         appConfig,
         appConfig.samDatabaseConfig.samWrite,
-        appConfig.samDatabaseConfig.samRead
+        appConfig.samDatabaseConfig.samRead,
+        appConfig.samDatabaseConfig.samBadQuery
       )
 
       // This special set of objects are for operations that happen in the background, i.e. not in the immediate service
       // of an api call (foreground). They are meant to partition resources so that background processes can't crowd our api calls.
       (backgroundDirectoryDAO, backgroundAccessPolicyDAO, _, _, _) <- createDAOs(
         appConfig,
+        appConfig.samDatabaseConfig.samBackground,
         appConfig.samDatabaseConfig.samBackground,
         appConfig.samDatabaseConfig.samBackground
       )
@@ -201,14 +203,16 @@ object Boot extends IOApp with LazyLogging {
   private def createDAOs(
       appConfig: AppConfig,
       writeDbConfig: DatabaseConfig,
-      readDbConfig: DatabaseConfig
+      readDbConfig: DatabaseConfig,
+      badQueryDbConfig: DatabaseConfig
   ): cats.effect.Resource[IO, (PostgresDirectoryDAO, AccessPolicyDAO, PostgresDistributedLockDAO[IO], AzureManagedResourceGroupDAO, LastQuotaErrorDAO)] =
     for {
       writeDbRef <- DbReference.resource(appConfig.liquibaseConfig, writeDbConfig)
       readDbRef <- DbReference.resource(appConfig.liquibaseConfig.copy(initWithLiquibase = false), readDbConfig)
+      badQueryDbRef <- DbReference.resource(appConfig.liquibaseConfig.copy(initWithLiquibase = false), readDbConfig)
 
       directoryDAO = new PostgresDirectoryDAO(writeDbRef, readDbRef)
-      accessPolicyDAO = new PostgresAccessPolicyDAO(writeDbRef, readDbRef)
+      accessPolicyDAO = new PostgresAccessPolicyDAO(writeDbRef, readDbRef, Some(badQueryDbRef))
       postgresDistributedLockDAO = new PostgresDistributedLockDAO[IO](writeDbRef, readDbRef, appConfig.distributedLockConfig)
       azureManagedResourceGroupDAO = new PostgresAzureManagedResourceGroupDAO(writeDbRef, readDbRef)
       lastQuotaErrorDAO = new PostgresLastQuotaErrorDAO(writeDbRef, readDbRef)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -145,7 +145,12 @@ object AppConfig {
   }
 
   implicit val samDatabaseConfigReader: ValueReader[SamDatabaseConfig] = ValueReader.relative { config =>
-    SamDatabaseConfig(config.as[DatabaseConfig]("sam_read"), config.as[DatabaseConfig]("sam_write"), config.as[DatabaseConfig]("sam_background"))
+    SamDatabaseConfig(
+      config.as[DatabaseConfig]("sam_read"),
+      config.as[DatabaseConfig]("sam_write"),
+      config.as[DatabaseConfig]("sam_background"),
+      config.as[DatabaseConfig]("sam_bad_query")
+    )
   }
 
   final case class AdminConfig(superAdminsGroup: WorkbenchEmail, allowedEmailDomains: Set[String], serviceAccountAdmins: Set[WorkbenchEmail])

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -149,7 +149,7 @@ object AppConfig {
       config.as[DatabaseConfig]("sam_read"),
       config.as[DatabaseConfig]("sam_write"),
       config.as[DatabaseConfig]("sam_background"),
-      config.as[DatabaseConfig]("sam_bad_query")
+      config.as[DatabaseConfig]("sam_read_replica")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DatabaseConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DatabaseConfig.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-final case class SamDatabaseConfig(samRead: DatabaseConfig, samWrite: DatabaseConfig, samBackground: DatabaseConfig, samBadQuery: DatabaseConfig)
+final case class SamDatabaseConfig(samRead: DatabaseConfig, samWrite: DatabaseConfig, samBackground: DatabaseConfig, samReadReplica: DatabaseConfig)
 
 final case class DatabaseConfig(
     dbName: Symbol,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DatabaseConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/DatabaseConfig.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-final case class SamDatabaseConfig(samRead: DatabaseConfig, samWrite: DatabaseConfig, samBackground: DatabaseConfig)
+final case class SamDatabaseConfig(samRead: DatabaseConfig, samWrite: DatabaseConfig, samBackground: DatabaseConfig, samBadQuery: DatabaseConfig)
 
 final case class DatabaseConfig(
     dbName: Symbol,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -26,7 +26,7 @@ import cats.effect.Temporal
 class PostgresAccessPolicyDAO(
     protected val writeDbRef: DbReference,
     protected val readDbRef: DbReference,
-    protected override val badQueryDbRef: Option[DbReference] = None
+    protected override val readReplicaDbRef: Option[DbReference] = None
 )(implicit timer: Temporal[IO])
     extends AccessPolicyDAO
     with DatabaseSupport
@@ -1357,7 +1357,7 @@ class PostgresAccessPolicyDAO(
       userId: WorkbenchUserId,
       samRequestContext: SamRequestContext
   ): IO[Iterable[ResourceIdWithRolesAndActions]] =
-    readOnlyTransactionBadQuery("listUserResourcesWithRolesAndActions", samRequestContext) { implicit session =>
+    readOnlyTransactionReadReplica("listUserResourcesWithRolesAndActions", samRequestContext) { implicit session =>
       class ListUserResourcesQuery extends UserResourcesQuery(resourceTypeName, None, userId) {
         val policyRole = EffectivePolicyRoleTable.syntax("policyRole")
         val resourceRole = ResourceRoleTable.syntax("resourceRole")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -23,7 +23,11 @@ import scala.collection.concurrent.TrieMap
 import scala.util.{Failure, Try}
 import cats.effect.Temporal
 
-class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)(implicit timer: Temporal[IO])
+class PostgresAccessPolicyDAO(
+    protected val writeDbRef: DbReference,
+    protected val readDbRef: DbReference,
+    protected override val badQueryDbRef: Option[DbReference] = None
+)(implicit timer: Temporal[IO])
     extends AccessPolicyDAO
     with DatabaseSupport
     with PostgresGroupDAO
@@ -1353,7 +1357,7 @@ class PostgresAccessPolicyDAO(protected val writeDbRef: DbReference, protected v
       userId: WorkbenchUserId,
       samRequestContext: SamRequestContext
   ): IO[Iterable[ResourceIdWithRolesAndActions]] =
-    readOnlyTransaction("listUserResourcesWithRolesAndActions", samRequestContext) { implicit session =>
+    readOnlyTransactionBadQuery("listUserResourcesWithRolesAndActions", samRequestContext) { implicit session =>
       class ListUserResourcesQuery extends UserResourcesQuery(resourceTypeName, None, userId) {
         val policyRole = EffectivePolicyRoleTable.syntax("policyRole")
         val resourceRole = ResourceRoleTable.syntax("resourceRole")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -13,15 +13,15 @@ import cats.effect.Temporal
 trait DatabaseSupport {
   protected val writeDbRef: DbReference
   protected val readDbRef: DbReference
-  protected val badQueryDbRef: Option[DbReference] = None
+  protected val readReplicaDbRef: Option[DbReference] = None
 
   protected def readOnlyTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A): IO[A] = {
     val databaseIO = IO(readDbRef.readOnly(databaseFunction))
     readDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO)
   }
 
-  protected def readOnlyTransactionBadQuery[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A): IO[A] = {
-    val dbRef = badQueryDbRef.getOrElse(readDbRef)
+  protected def readOnlyTransactionReadReplica[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A): IO[A] = {
+    val dbRef = readReplicaDbRef.getOrElse(readDbRef)
     val databaseIO = IO(dbRef.readOnly(databaseFunction))
     readDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/util/DatabaseSupport.scala
@@ -13,9 +13,16 @@ import cats.effect.Temporal
 trait DatabaseSupport {
   protected val writeDbRef: DbReference
   protected val readDbRef: DbReference
+  protected val badQueryDbRef: Option[DbReference] = None
 
   protected def readOnlyTransaction[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A): IO[A] = {
     val databaseIO = IO(readDbRef.readOnly(databaseFunction))
+    readDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO)
+  }
+
+  protected def readOnlyTransactionBadQuery[A](dbQueryName: String, samRequestContext: SamRequestContext)(databaseFunction: DBSession => A): IO[A] = {
+    val dbRef = badQueryDbRef.getOrElse(readDbRef)
+    val databaseIO = IO(dbRef.readOnly(databaseFunction))
     readDbRef.runDatabaseIO(dbQueryName, samRequestContext, databaseIO)
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-896

  \<Don't forget to include the ticket number in the PR title!\>

What:

Isolate the misbehaving query to the read replica. All other read/writes go to the main db.

Why:

Read replicas have lag. 

How:

Introduce a new `DbReference` to isolate misbehaving queries.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
