### PR TITLE
AJ-1234: Use helmchart name for pact identifier.

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -310,4 +310,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "sam-provider", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'
+          inputs: '{ "pacticipant": "sam", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -286,7 +286,7 @@ class SamProviderSpec
       .getOrElse(NoOpFilter)
 
   val provider: ProviderInfoBuilder = ProviderInfoBuilder(
-    name = "sam-provider",
+    name = "sam",
     pactSource = PactSource
       .PactBrokerWithSelectors(
         brokerUrl = pactBrokerUrl


### PR DESCRIPTION
This is prefactoring work for [AJ-1234](https://broadworkbench.atlassian.net/browse/AJ-1234)

This pairs with https://github.com/DataBiosphere/terra-workspace-data-service/pull/384, where `wds` also renames its reference from `sam-provider` to just `sam`.

* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698068076950019) discussing the `-consumer` and `-provider` suffix anti-pattern.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698241095600099) discussing the recommendation to use the helm chart name.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698262189799389) discussing doing this for `sam`.

[AJ-1234]: https://broadworkbench.atlassian.net/browse/AJ-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ