### PR TITLE
ID-901 Add pact publish boolean

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -284,6 +284,7 @@ jobs:
                           -v "$PWD":/working/sam \
                           -v ${{ env.COURSIER_CACHE }}:/root/.cache \
                           -v ${{ env.SBT_CACHE }}:/root/.sbt \
+                          -e PACT_PUBLISH_RESULTS=true \
                           -e PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} \
                           -e PROVIDER_SHA=${{ env.PROVIDER_SHA }} \
                           -e CONSUMER_NAME=${{ env.CONSUMER_NAME }} \

--- a/pact4s/README.md
+++ b/pact4s/README.md
@@ -29,6 +29,9 @@ Or you can run the following command from the root of the project:
 sbt "set scalafmtOnCompile := false" "project pact4s" "testOnly *SamProviderSpec"
 ```
 
+## Publishing Pacts
+Publishing is disabled by default. To enable publishing, set the `PACT_PUBLISH_RESULTS` environment variable to `true`.
+
 ## References
 * https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2660368406/Getting+Started+with+Pact+Contract+Testing
 * https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2681143308/Pact+Broker+Infrastructure

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -308,11 +308,12 @@ class SamProviderSpec
     )
 
   it should "Verify pacts" in {
+    val publishResults = sys.env.getOrElse("PACT_PUBLISH_RESULTS", "false").toBoolean
     verifyPacts(
       providerBranch = if (branch.isEmpty) None else Some(Branch(branch)),
-      publishVerificationResults = Some(
+      publishVerificationResults = if (publishResults) Some(
         PublishVerificationResults(gitSha, ProviderTags(branch))
-      ),
+      ) else None,
       providerVerificationOptions = Seq(
         ProviderVerificationOption.SHOW_STACKTRACE
       ).toList,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-901

What:

  Disabling pact publishing by default and enabling it in CI.

Why:

Publishing shouldn't happen when running locally.

How:

Added an env variable PACT_PUBLISH_RESULTS that defaults to false.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
