### PR TITLE
ID-808, ID-809 Implement PUT /api/termsOfService/v1/user/self/accept and reject

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3320,7 +3320,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-
+  /termsOfService/v1/user/self/accept:
+    get:
+      tags:
+        - TermsOfService
+      summary: Accepts the current terms of service for the requesting user.
+      operationId: userTermsOfServiceAcceptSelf
+      responses:
+        200:
+          description: OK
   /termsOfService/v1/user/{sam_user_id}:
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3327,7 +3327,16 @@ paths:
       summary: Accepts the current terms of service for the requesting user.
       operationId: userTermsOfServiceAcceptSelf
       responses:
-        200:
+        204:
+          description: OK
+  /termsOfService/v1/user/self/reject:
+    get:
+      tags:
+        - TermsOfService
+      summary: Rejects the current terms of service for the requesting user.
+      operationId: userTermsOfServiceRejectSelf
+      responses:
+        204:
           description: OK
   /termsOfService/v1/user/{sam_user_id}:
     get:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -85,7 +85,7 @@ trait TermsOfServiceRoutes extends SamUserDirectives {
             pathPrefix("accept") { // api/termsOfService/v1/user/accept
               pathEndOrSingleSlash {
                 put {
-                  complete(StatusCodes.NotImplemented)
+                  complete(tosService.acceptTosStatus(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                 }
               }
             } ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -92,7 +92,7 @@ trait TermsOfServiceRoutes extends SamUserDirectives {
             pathPrefix("reject") { // api/termsOfService/v1/user/reject
               pathEndOrSingleSlash {
                 put {
-                  complete(StatusCodes.NotImplemented)
+                  complete(tosService.rejectTosStatus(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                 }
               }
             }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
@@ -152,4 +152,13 @@ class TermsOfServiceRouteSpec extends AnyFunSpec with Matchers with ScalatestRou
     }
   }
 
+  it("should return 204 when tos accepted") {
+    val samRoutes = TestSamRoutes(Map.empty)
+    eventually {
+      Put("/api/termsOfService/v1/user/self/accept") ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+        responseAs[String] shouldBe ""
+      }
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRouteSpec.scala
@@ -161,4 +161,14 @@ class TermsOfServiceRouteSpec extends AnyFunSpec with Matchers with ScalatestRou
       }
     }
   }
+
+  it("should return 204 when tos rejected") {
+    val samRoutes = TestSamRoutes(Map.empty)
+    eventually {
+      Put("/api/termsOfService/v1/user/self/reject") ~> samRoutes.route ~> check {
+        status shouldEqual StatusCodes.NoContent
+        responseAs[String] shouldBe ""
+      }
+    }
+  }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-808
https://broadworkbench.atlassian.net/browse/ID-809


What:

When the user sends an empty PUT request to /api/termsOfService/v1/user/self/accept or reject they will accept/reject the tos and receive a successful 204 No Content response (empty body)

Why:

More streamlined api/endpoint

How:

Other aspects of the tos acceptance code are already covered by tests so this is a really simple pr.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
