### PR TITLE
[ID-812] Add TOS acceptance to register user request

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -44,7 +44,7 @@ trait TermsOfServiceRoutes extends SamUserDirectives {
       pathPrefix("v1") { // api/termsOfService/v1
         pathEndOrSingleSlash {
           get {
-            complete(tosService.getTosConfig())
+            complete(tosService.getTermsOfServiceConfig())
           }
         } ~
         pathPrefix("docs") { // api/termsOfService/v1/docs
@@ -85,14 +85,14 @@ trait TermsOfServiceRoutes extends SamUserDirectives {
             pathPrefix("accept") { // api/termsOfService/v1/user/accept
               pathEndOrSingleSlash {
                 put {
-                  complete(tosService.acceptTosStatus(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
+                  complete(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                 }
               }
             } ~
             pathPrefix("reject") { // api/termsOfService/v1/user/reject
               pathEndOrSingleSlash {
                 put {
-                  complete(tosService.rejectTosStatus(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
+                  complete(tosService.rejectCurrentTermsOfService(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                 }
               }
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAttributesRequest.scala
@@ -21,6 +21,6 @@ case class SamUserAttributesRequest(
 
   private def validateMarketingConsentExists: Option[ErrorReport] =
     if (marketingConsent.isEmpty) {
-      Option(ErrorReport("A new user MUST provide a acceptance or denial to marketing consent"))
+      Option(ErrorReport("A new user must provide a acceptance or denial to marketing consent"))
     } else None
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
@@ -1,19 +1,30 @@
-package org.broadinstitute.dsde.workbench.sam.model.api
+package org.broadinstitute.dsde.workbench.sam
+package model.api
 
 import org.broadinstitute.dsde.workbench.model.ErrorReport
-import spray.json.DefaultJsonProtocol.jsonFormat1
+import spray.json.DefaultJsonProtocol.jsonFormat2
+import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
 object SamUserRegistrationRequest {
-  implicit val SamUserRegistrationRequestFormat: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat1(SamUserRegistrationRequest.apply)
+  implicit val SamUserRegistrationRequestFormat: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat2(SamUserRegistrationRequest.apply)
 }
 case class SamUserRegistrationRequest(
-    userAttributes: SamUserAttributesRequest
+     acceptsTermsOfService: Boolean,
+     userAttributes: SamUserAttributesRequest
 ) {
-
   def validateForNewUser: Option[Seq[ErrorReport]] = Option(
     Seq(
+      validateAcceptsTermsOfService.getOrElse(Seq.empty),
       userAttributes.validateForNewUser.getOrElse(Seq.empty)
+    ).flatten
+  ).filter(_.nonEmpty)
+
+  private def validateAcceptsTermsOfService: Option[Seq[ErrorReport]] = Option(
+    Seq(
+      if (!acceptsTermsOfService) {
+        Option(ErrorReport("A new user must accept the Terms of Service while registering"))
+      } else None
     ).flatten
   ).filter(_.nonEmpty)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserRegistrationRequest.scala
@@ -10,8 +10,8 @@ object SamUserRegistrationRequest {
   implicit val SamUserRegistrationRequestFormat: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat2(SamUserRegistrationRequest.apply)
 }
 case class SamUserRegistrationRequest(
-     acceptsTermsOfService: Boolean,
-     userAttributes: SamUserAttributesRequest
+    acceptsTermsOfService: Boolean,
+    userAttributes: SamUserAttributesRequest
 ) {
   def validateForNewUser: Option[Seq[ErrorReport]] = Option(
     Seq(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/TosService.scala
@@ -43,17 +43,17 @@ class TosService(
   val termsOfServiceText: String = TermsOfServiceDocument(termsOfServiceUri)
   val privacyPolicyText: String = TermsOfServiceDocument(privacyPolicyUri)
 
-  def acceptTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
+  def acceptCurrentTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
     directoryDao
       .acceptTermsOfService(userId, tosConfig.version, samRequestContext)
       .withInfoLogMessage(s"$userId has accepted version ${tosConfig.version} of the Terms of Service")
 
-  def rejectTosStatus(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
+  def rejectCurrentTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Boolean] =
     directoryDao
       .rejectTermsOfService(userId, tosConfig.version, samRequestContext)
       .withInfoLogMessage(s"$userId has rejected version ${tosConfig.version} of the Terms of Service")
 
-  def getTosConfig(): IO[TermsOfServiceConfigResponse] =
+  def getTermsOfServiceConfig(): IO[TermsOfServiceConfigResponse] =
     IO.pure(
       TermsOfServiceConfigResponse(
         enforced = tosConfig.isTosEnabled,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -114,7 +114,11 @@ class UserService(
     setUserAttributesFromRequest(userId, attributes, samRequestContext).map(_ => ())
   }
 
-  private def maybeAcceptTermsOfService(userId: WorkbenchUserId, registrationRequest: Option[SamUserRegistrationRequest], samRequestContext: SamRequestContext): IO[Unit] =
+  private def maybeAcceptTermsOfService(
+      userId: WorkbenchUserId,
+      registrationRequest: Option[SamUserRegistrationRequest],
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
     if (registrationRequest.exists(_.acceptsTermsOfService)) {
       tosService.acceptCurrentTermsOfService(userId, samRequestContext).map(_ => ())
     } else {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -103,7 +103,6 @@ class UserService(
       _.allowManagedIdentityUserCreation
     )
 
-  // add function like registerNewUserAttributes which accepts ToS on behalf of user
   private def registerNewUserAttributes(
       userId: WorkbenchUserId,
       registrationRequest: Option[SamUserRegistrationRequest],

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -266,13 +266,13 @@ object TestSupport extends TestSupport {
 
   def newUserWithAcceptedTos(services: StandardSamUserDirectives, samUser: SamUser, samRequestContext: SamRequestContext): SamUser = {
     TestSupport.runAndWait(services.userService.directoryDAO.createUser(samUser, samRequestContext))
-    TestSupport.runAndWait(services.tosService.acceptTosStatus(samUser.id, samRequestContext))
+    TestSupport.runAndWait(services.tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext))
     TestSupport.runAndWait(services.userService.directoryDAO.loadUser(samUser.id, samRequestContext)).orNull
   }
 
   def newUserStatusWithAcceptedTos(userService: UserService, tosService: TosService, samUser: SamUser, samRequestContext: SamRequestContext): UserStatus = {
     TestSupport.runAndWait(userService.createUser(samUser, samRequestContext))
-    TestSupport.runAndWait(tosService.acceptTosStatus(samUser.id, samRequestContext))
+    TestSupport.runAndWait(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext))
     TestSupport.runAndWait(userService.getUserStatus(samUser.id, userDetailsOnly = false, samRequestContext)).orNull
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
@@ -76,7 +76,7 @@ class AdminResourceTypesRoutesSpec extends AnyFlatSpec with Matchers with TestSu
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, cloudExtensions, emailDomain)
 
     runAndWait(mockUserService.createUser(user, samRequestContext))
-    runAndWait(tosService.acceptTosStatus(user.id, samRequestContext))
+    runAndWait(tosService.acceptCurrentTermsOfService(user.id, samRequestContext))
 
     new TestSamRoutes(
       mockResourceService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
@@ -59,7 +59,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
     )
 
     // Act and Assert
-    Get(s"/api/resources/v2/filter", SamUserRegistrationRequest(userAttributesRequest)) ~> samRoutes.route ~> check {
+    Get(s"/api/resources/v2/filter", SamUserRegistrationRequest(true, userAttributesRequest)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }
     verify(samRoutes.resourceService).filterResources(
@@ -74,7 +74,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
 
     Get(
       s"/api/resources/v2/filter?resourceTypes=fooType,barType&policies=fooPolicy&roles=fooRole,barRole,bazRole&actions=fooAction,barAction&includePublic=true",
-      SamUserRegistrationRequest(userAttributesRequest)
+      SamUserRegistrationRequest(true, userAttributesRequest)
     ) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesSpec.scala
@@ -55,7 +55,7 @@ class ResourceRoutesSpec extends RetryableAnyFlatSpec with Matchers with Scalate
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
     TestSupport.runAndWait(mockUserService.createUser(defaultUserInfo, samRequestContext))
-    TestSupport.runAndWait(tosService.acceptTosStatus(defaultUserInfo.id, samRequestContext))
+    TestSupport.runAndWait(tosService.acceptCurrentTermsOfService(defaultUserInfo.id, samRequestContext))
 
     new TestSamRoutes(
       mockResourceService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutesV2Spec.scala
@@ -60,7 +60,7 @@ class ResourceRoutesV2Spec extends RetryableAnyFlatSpec with Matchers with TestS
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, accessPolicyDAO, directoryDAO, NoExtensions, emailDomain)
 
     TestSupport.runAndWait(mockUserService.createUser(samUser, samRequestContext))
-    TestSupport.runAndWait(tosService.acceptTosStatus(samUser.id, samRequestContext))
+    TestSupport.runAndWait(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext))
 
     new TestSamRoutes(
       mockResourceService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/StandardSamUserDirectivesSpec.scala
@@ -167,7 +167,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(Right(user.azureB2CId.get), user.email, token)
     val userService = services.userService.asInstanceOf[MockUserService]
     userService.createUserDAO(user.copy(enabled = true), samRequestContext).unsafeRunSync()
-    services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
+    services.tosService.rejectCurrentTermsOfService(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
         status shouldBe StatusCodes.Unauthorized
@@ -179,7 +179,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(Right(user.azureB2CId.get), user.email, token)
     val userService = services.userService.asInstanceOf[MockUserService]
     userService.createUserDAO(user.copy(enabled = true), samRequestContext).unsafeRunSync()
-    services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
+    services.tosService.rejectCurrentTermsOfService(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
         status shouldBe StatusCodes.Unauthorized
@@ -191,7 +191,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(Left(user.googleSubjectId.get), user.email, token)
     val userService = services.userService.asInstanceOf[MockUserService]
     userService.createUserDAO(user.copy(enabled = true), samRequestContext).unsafeRunSync()
-    services.tosService.rejectTosStatus(user.id, samRequestContext).unsafeRunSync()
+    services.tosService.rejectCurrentTermsOfService(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
         status shouldBe StatusCodes.OK
@@ -203,7 +203,7 @@ class StandardSamUserDirectivesSpec extends AnyFlatSpec with PropertyBasedTestin
     val headers = createRequiredHeaders(Right(user.azureB2CId.get), user.email, token)
     val userService = services.userService.asInstanceOf[MockUserService]
     userService.createUserDAO(user.copy(enabled = true), samRequestContext).unsafeRunSync()
-    services.tosService.acceptTosStatus(user.id, samRequestContext).unsafeRunSync()
+    services.tosService.acceptCurrentTermsOfService(user.id, samRequestContext).unsafeRunSync()
     Get("/").withHeaders(headers) ~>
       handleExceptions(myExceptionHandler)(services.withActiveUser(samRequestContext)(_ => complete(""))) ~> check {
         status shouldBe StatusCodes.OK

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -65,7 +65,7 @@ class TestSamRoutes(
   def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route = reject
   def createUserAndAcceptTos(samUser: SamUser, samRequestContext: SamRequestContext): Unit = {
     TestSupport.runAndWait(userService.createUser(samUser, samRequestContext))
-    TestSupport.runAndWait(tosService.acceptTosStatus(samUser.id, samRequestContext))
+    TestSupport.runAndWait(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext))
   }
 
   override def asAdminServiceUser: Directive0 = Directive.Empty
@@ -199,7 +199,7 @@ object TestSamRoutes {
     TestSupport.runAndWait(mockUserService.createUser(user, samRequestContext))
 
     if (acceptTermsOfService) {
-      TestSupport.runAndWait(mockTosService.acceptTosStatus(user.id, samRequestContext))
+      TestSupport.runAndWait(mockTosService.acceptCurrentTermsOfService(user.id, samRequestContext))
     }
 
     val allUsersGroup = TestSupport.runAndWait(cloudXtns.getOrCreateAllUsersGroup(directoryDAO, samRequestContext))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -38,7 +38,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
       .build
 
     // Act and Assert
-    Post(s"/api/users/v2/self/register", SamUserRegistrationRequest(userAttributesRequest)) ~> samRoutes.route ~> check {
+    Post(s"/api/users/v2/self/register", SamUserRegistrationRequest(true, userAttributesRequest)) ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.Created
       responseAs[SamUserResponse] should beForUser(defaultUser)
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -19,7 +19,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpret
 import org.broadinstitute.dsde.workbench.model.Notifications.NotificationFormat
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue, truncateAll}
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
 import org.broadinstitute.dsde.workbench.sam.model._
@@ -33,7 +33,7 @@ import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfterAll, PrivateMethodTester}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, PrivateMethodTester}
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.{Date, GregorianCalendar, UUID}
@@ -49,6 +49,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     with MockitoSugar
     with ScalaFutures
     with BeforeAndAfterAll
+      with BeforeAndAfterEach
     with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 
@@ -59,6 +60,9 @@ class GoogleExtensionSpec(_system: ActorSystem)
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
+
+  override def beforeEach(): Unit =
+    truncateAll
 
   lazy val petServiceAccountConfig = TestSupport.petServiceAccountConfig
   lazy val googleServicesConfig = TestSupport.googleServicesConfig

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -49,7 +49,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     with MockitoSugar
     with ScalaFutures
     with BeforeAndAfterAll
-      with BeforeAndAfterEach
+    with BeforeAndAfterEach
     with PrivateMethodTester {
   def this() = this(ActorSystem("GoogleGroupSyncMonitorSpec"))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -472,7 +472,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
   def newUserWithAcceptedTos(userService: UserService, tosService: TosService, samUser: SamUser, samRequestContext: SamRequestContext): UserStatus = {
     TestSupport.runAndWait(userService.createUser(samUser, samRequestContext))
-    TestSupport.runAndWait(tosService.acceptTosStatus(samUser.id, samRequestContext))
+    TestSupport.runAndWait(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext))
     TestSupport.runAndWait(userService.getUserStatus(samUser.id, samRequestContext = samRequestContext)).orNull
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
@@ -66,8 +66,8 @@ case class MockTosServiceBuilder() extends MockitoSugar {
   }
 
   private def initializeDefaults(mockTosService: TosService): Unit = {
-    when(mockTosService.acceptCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
-    when(mockTosService.rejectCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
+    lenient().when(mockTosService.acceptCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
+    lenient().when(mockTosService.rejectCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
   }
 
   def build: TosService = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockTosServiceBuilder.scala
@@ -65,5 +65,13 @@ case class MockTosServiceBuilder() extends MockitoSugar {
       .getTermsOfServiceDetailsForUser(ArgumentMatchers.eq(samUser.id), any[SamRequestContext])
   }
 
-  def build: TosService = tosService
+  private def initializeDefaults(mockTosService: TosService): Unit = {
+    when(mockTosService.acceptCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
+    when(mockTosService.rejectCurrentTermsOfService(any[WorkbenchUserId], any[SamRequestContext])).thenReturn(IO.pure(true))
+  }
+
+  def build: TosService = {
+    initializeDefaults(tosService)
+    tosService
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/TosServiceSpec.scala
@@ -71,7 +71,7 @@ class TosServiceSpec(_system: ActorSystem)
       val tosService = new TosService(NoExtensions, dirDAO, TestSupport.tosConfig)
 
       // accept and get ToS status
-      val tosConfigResponse = tosService.getTosConfig().unsafeRunSync()
+      val tosConfigResponse = tosService.getTermsOfServiceConfig().unsafeRunSync()
       tosConfigResponse shouldBe TermsOfServiceConfigResponse(
         enforced = true,
         currentVersion = "0",
@@ -115,8 +115,8 @@ class TosServiceSpec(_system: ActorSystem)
       val tosService = new TosService(NoExtensions, dirDAO, TestSupport.tosConfig)
 
       // accept and get ToS status
-      val acceptTosStatusResult = tosService.acceptTosStatus(defaultUser.id, samRequestContext).unsafeRunSync()
-      acceptTosStatusResult shouldBe true
+      val acceptTermsOfServiceResult = tosService.acceptCurrentTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
+      acceptTermsOfServiceResult shouldBe true
 
       verify(dirDAO).acceptTermsOfService(defaultUser.id, tosConfig.version, samRequestContext)
     }
@@ -127,9 +127,9 @@ class TosServiceSpec(_system: ActorSystem)
 
       // reject and get ToS status
       val tosService = new TosService(NoExtensions, dirDAO, TestSupport.tosConfig)
-      val rejectTosStatusResult = tosService.rejectTosStatus(defaultUser.id, samRequestContext).unsafeRunSync()
+      val rejectTermsOfServiceResult = tosService.rejectCurrentTermsOfService(defaultUser.id, samRequestContext).unsafeRunSync()
 
-      rejectTosStatusResult shouldBe true
+      rejectTermsOfServiceResult shouldBe true
       verify(dirDAO).rejectTermsOfService(defaultUser.id, tosConfig.version, samRequestContext)
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
@@ -24,13 +24,6 @@ class CreateUserSpec extends UserServiceTestTraits {
   val defaultTosService: TosService = MockTosServiceBuilder().build
 
   describe("A new User") {
-    describe("should be able to register with Terms of Service accepted") {
-
-    }
-    describe("should not be able to register with Terms of Service rejected") {
-
-    }
-
     describe("should be able to register with old registration method") {
 
       // Not sure if this test can happen in the real world anymore now that we always log users in through B2C.

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
@@ -251,7 +251,7 @@ class CreateUserSpec extends UserServiceTestTraits {
 
         val invalidRegistrationRequest = SamUserRegistrationRequest(
           acceptsTermsOfService = true,
-          SamUserAttributesRequest( marketingConsent = None)
+          SamUserAttributesRequest(marketingConsent = None)
         )
 
         // Act and Assert

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
@@ -92,7 +92,9 @@ class UserAttributesSpec extends UserServiceTestTraits {
       val userAttributes = SamUserAttributes(user.id, marketingConsent = true)
 
       // Act
-      runAndWait(userService.createUser(user, Some(SamUserRegistrationRequest(true, SamUserAttributesRequest(marketingConsent = Some(true)))), samRequestContext))
+      runAndWait(
+        userService.createUser(user, Some(SamUserRegistrationRequest(true, SamUserAttributesRequest(marketingConsent = Some(true)))), samRequestContext)
+      )
 
       // Assert
       verify(directoryDAO).setUserAttributes(eqTo(userAttributes), any[SamRequestContext])

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/UserAttributesSpec.scala
@@ -92,7 +92,7 @@ class UserAttributesSpec extends UserServiceTestTraits {
       val userAttributes = SamUserAttributes(user.id, marketingConsent = true)
 
       // Act
-      runAndWait(userService.createUser(user, Some(SamUserRegistrationRequest(SamUserAttributesRequest(marketingConsent = Some(true)))), samRequestContext))
+      runAndWait(userService.createUser(user, Some(SamUserRegistrationRequest(true, SamUserAttributesRequest(marketingConsent = Some(true)))), samRequestContext))
 
       // Assert
       verify(directoryDAO).setUserAttributes(eqTo(userAttributes), any[SamRequestContext])


### PR DESCRIPTION
Ticket: (https://broadworkbench.atlassian.net/browse/ID-812)

What:

Adds TOS acceptance to the body of the sam register user request. We want to make registration rely on acceptance of the TOS so we are combining them into one API request. 

How:

I also renamed a couple things, many of the files changed are just a straight rename to write out `termsOfService` rather than `Tos`

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
