### PR TITLE
ID-930 Deprecate old Terms of Service routes in Swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3125,6 +3125,7 @@ paths:
     get:
       tags:
         - Terms of Service
+      deprecated: true
       summary: gets terms of service details, including user's accepted version
       operationId: getTermsOfServiceDetails
       responses:
@@ -3138,6 +3139,7 @@ paths:
     get:
       tags:
         - Terms of Service
+      deprecated: true
       summary: gets info on whether the user has accepted the latest terms of service and if they can use the system based on that
       operationId: getTermsOfServiceComplianceStatus
       responses:
@@ -3179,6 +3181,7 @@ paths:
     post:
       tags:
         - Terms of Service
+      deprecated: true
       summary: accepts terms of service
       operationId: acceptTermsOfService
       requestBody:
@@ -3204,6 +3207,7 @@ paths:
     delete:
       tags:
         - Terms of Service
+      deprecated: true
       summary: rejects terms of service
       operationId: rejectTermsOfService
       responses:
@@ -3223,6 +3227,7 @@ paths:
     get:
       tags:
         - Terms of Service
+      deprecated: true
       summary: returns whether or not the user has accepted the current terms of service.
       operationId: getUserTermsOfServiceStatus
       responses:
@@ -3244,6 +3249,7 @@ paths:
     get:
       tags:
         - Terms of Service
+      deprecated: true
       summary: gets terms of service text
       operationId: getTermsOfServiceText
       responses:
@@ -3257,6 +3263,7 @@ paths:
     get:
       tags:
         - Terms of Service
+      deprecated: true
       summary: gets privacy policy text
       operationId: getPrivacyPolicyText
       responses:


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-930

What:

Mark deprecated Terms of Service routes as such in Swagger

Why:

Its less confusing this way

How:

Just add some tags to the swagger definition.


![image](https://github.com/broadinstitute/sam/assets/3210510/8d3054bd-3776-46f7-b292-115a5d52adc4)

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
