### PR TITLE
ID-937 upgrade client lib and code gen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,3 +97,19 @@ jobs:
         id: publishJavaClientSnapshot
         if: ${{ github.ref_name != 'develop' }}
         run: sbt "+ publish" -Dproject.isSnapshot=true
+
+      - name: Generate old javax java client
+        id: generateOldJavaClient
+        run: bash scripts/gen_java_client_old.sh
+
+      - name: Publish old javax java client for merge to develop branch
+        working-directory: codegen_java_old
+        id: publishOldJavaClient
+        if: ${{ github.ref_name == 'develop' }}
+        run: sbt "+ publish" -Dproject.isSnapshot=false
+
+      - name: Publish old javax java client as snapshot for PRs
+        working-directory: codegen_java_old
+        id: publishOldJavaClientSnapshot
+        if: ${{ github.ref_name != 'develop' }}
+        run: sbt "+ publish" -Dproject.isSnapshot=true

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ automation/src/test/resources/
 codegen_java/*
 !codegen_java/project
 !codegen_java/templates
+codegen_java_old/*
+!codegen_java_old/project
+!codegen_java_old/templates
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json

--- a/codegen_java/project/build.properties
+++ b/codegen_java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.6.2

--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -1,4 +1,7 @@
 {{! based on https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache }}
+import Publishing._
+import Version._
+
 lazy val root = (project in file(".")).
   settings(
     Seq(organization := "org.broadinstitute.dsde.workbench",

--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -1,6 +1,4 @@
-import Publishing._
-import Version._
-
+{{! based on https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache }}
 lazy val root = (project in file(".")).
   settings(
     Seq(organization := "org.broadinstitute.dsde.workbench",
@@ -12,32 +10,32 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
-      "io.swagger" % "swagger-annotations" % "1.5.24",
+      "io.swagger" % "swagger-annotations" % "1.6.5",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
       "com.squareup.okhttp3" % "logging-interceptor" % "4.10.0",
-      "com.google.code.gson" % "gson" % "2.8.6",
-      "org.apache.commons" % "commons-lang3" % "3.10",
+      "com.google.code.gson" % "gson" % "2.9.1",
+      "org.apache.commons" % "commons-lang3" % "3.12.0",
+      "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.1.0",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.2",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.6",
       {{/openApiNullable}}
+      {{#withAWSV4Signature}}
+      "software.amazon.awssdk" % "auth" % "2.20.157",
+      {{/withAWSV4Signature}}
       {{#hasOAuthMethods}}
-      "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1",
+      "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.2",
       {{/hasOAuthMethods}}
       {{#joda}}
       "joda-time" % "joda-time" % "2.9.9" % "compile",
       {{/joda}}
-      {{#threetenbp}}
-      "org.threeten" % "threetenbp" % "1.4.3" % "compile",
-      {{/threetenbp}}
       {{#dynamicOperations}}
-      "io.swagger.parser.v3" % "swagger-parser-v3" "2.0.23" % "compile"
+      "io.swagger.parser.v3" % "swagger-parser-v3" "2.0.30" % "compile"
       {{/dynamicOperations}}
-      "io.gsonfire" % "gson-fire" % "1.8.3" % "compile",
-      "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
+      "io.gsonfire" % "gson-fire" % "1.9.0" % "compile",
+      "jakarta.annotation" % "jakarta.annotation-api" % "2.1.1" % "compile",
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",
-      "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.1" % "test",
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.9.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test",
-      "javax.annotation" % "javax.annotation-api" % "1.3.2"
+      "org.mockito" % "mockito-core" % "3.12.4" % "test"
     )) ++ publishSettings:_*
   )

--- a/codegen_java_old/project/Artifactory.scala
+++ b/codegen_java_old/project/Artifactory.scala
@@ -1,0 +1,4 @@
+object Artifactory {
+  val artifactoryHost = "broadinstitute.jfrog.io"
+  val artifactory = s"https://$artifactoryHost/broadinstitute/"
+}

--- a/codegen_java_old/project/Publishing.scala
+++ b/codegen_java_old/project/Publishing.scala
@@ -1,0 +1,40 @@
+import sbt.Keys._
+import sbt._
+import Artifactory._
+
+/** NOTE: This was lifted wholesale from Cromwell.
+  */
+
+object Publishing {
+  private val buildTimestamp = System.currentTimeMillis() / 1000
+
+  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
+    val repoType = if (isSnapshot) "snapshot" else "release"
+    val repoUrl =
+      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
+    val repoName = "artifactory-publish"
+    repoName at repoUrl
+  }
+
+  private val artifactoryCredentials: Credentials = {
+    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
+    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
+    Credentials("Artifactory Realm", artifactoryHost, username, password)
+  }
+
+  val publishSettings: Seq[Setting[_]] =
+    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
+    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
+    Seq(
+      publishTo := Option(artifactoryResolver(false)),
+      publishArtifact in Compile := true,
+      publishArtifact in Test := true,
+      credentials += artifactoryCredentials
+    )
+
+  val noPublishSettings: Seq[Setting[_]] =
+    Seq(
+      publish := {},
+      publishLocal := {}
+    )
+}

--- a/codegen_java_old/project/Version.scala
+++ b/codegen_java_old/project/Version.scala
@@ -1,0 +1,20 @@
+import scala.sys.process._
+
+object Version {
+
+  def createVersion(baseVersion: String) = {
+    def getLastCommitFromGit = s"""git rev-parse --short HEAD""" !!
+
+    // either specify git hash as an env var or derive it
+    // if building from the hseeberger/scala-sbt docker image use env var
+    // (scala-sbt doesn't have git in it)
+    val lastCommit = sys.env.getOrElse("GIT_HASH", getLastCommitFromGit).trim()
+    val version = baseVersion + "-" + lastCommit
+
+    // The project isSnapshot string passed in via command line settings, if desired.
+    val isSnapshot = sys.props.getOrElse("project.isSnapshot", "true").toBoolean
+
+    // For now, obfuscate SNAPSHOTs from sbt's developers: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
+    if (isSnapshot) s"$version-SNAP" else version
+  }
+}

--- a/codegen_java_old/project/build.properties
+++ b/codegen_java_old/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.7

--- a/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -1,0 +1,43 @@
+import Publishing._
+import Version._
+
+lazy val root = (project in file(".")).
+  settings(
+    Seq(organization := "org.broadinstitute.dsde.workbench",
+    name := "sam-client-javax",
+    version := createVersion("{{artifactVersion}}"),
+    scalaVersion := "2.13.10",
+    scalacOptions ++= Seq("-feature"),
+    javacOptions in compile ++= Seq("-Xlint:deprecation"),
+    publishArtifact in (Compile, packageDoc) := false,
+    resolvers += Resolver.mavenLocal,
+    libraryDependencies ++= Seq(
+      "io.swagger" % "swagger-annotations" % "1.5.24",
+      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+      "com.squareup.okhttp3" % "logging-interceptor" % "4.10.0",
+      "com.google.code.gson" % "gson" % "2.8.6",
+      "org.apache.commons" % "commons-lang3" % "3.10",
+      {{#openApiNullable}}
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.2",
+      {{/openApiNullable}}
+      {{#hasOAuthMethods}}
+      "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1",
+      {{/hasOAuthMethods}}
+      {{#joda}}
+      "joda-time" % "joda-time" % "2.9.9" % "compile",
+      {{/joda}}
+      {{#threetenbp}}
+      "org.threeten" % "threetenbp" % "1.4.3" % "compile",
+      {{/threetenbp}}
+      {{#dynamicOperations}}
+      "io.swagger.parser.v3" % "swagger-parser-v3" "2.0.23" % "compile"
+      {{/dynamicOperations}}
+      "io.gsonfire" % "gson-fire" % "1.8.3" % "compile",
+      "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
+      "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",
+      "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
+      "junit" % "junit" % "4.13.1" % "test",
+      "com.novocode" % "junit-interface" % "0.10" % "test",
+      "javax.annotation" % "javax.annotation-api" % "1.3.2"
+    )) ++ publishSettings:_*
+  )

--- a/scripts/gen_java_client.sh
+++ b/scripts/gen_java_client.sh
@@ -1,5 +1,5 @@
 set -e
 
-docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v5.4.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java/templates --library okhttp-gson
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v7.1.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java/templates --library okhttp-gson --additional-properties useJakartaEe=true
 cd codegen_java
 sbt test

--- a/scripts/gen_java_client_old.sh
+++ b/scripts/gen_java_client_old.sh
@@ -1,0 +1,5 @@
+set -e
+
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v5.4.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java_old --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java_old/templates --library okhttp-gson
+cd codegen_java_old
+sbt test


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-937

Copy old client lib generation to `codegen_java_old` and update existing client lib generation to new generator and jakarta. Eventually we can delete the old.

see the generateAndPublishClient job for results

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
