### PR TITLE
Fix system allowance for tos reject special case, add /api to tos history endpoint swagger docs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths-ignore: ['**.md']
   push:
+    branches:
+      - develop
     paths-ignore: ['**.md']
 
 jobs:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3370,7 +3370,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /termsOfService/v1/user/self/history:
+  /api/termsOfService/v1/user/self/history:
     get:
       tags:
         - TermsOfService
@@ -3396,7 +3396,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /termsOfService/v1/user/{sam_user_id}/history:
+  /api/termsOfService/v1/user/{sam_user_id}/history:
     get:
       tags:
         - TermsOfService


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-811

Fixes a special case for tos where the user has accepted the previous version and is in the acceptance window, but they have rejected the current tos.

I forgot to add /api to the swagger docs for these endpoints.

Also removing duplicate runs of the build ci job


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
