### PR TITLE
DR-3274: Add lock resource action

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1196,14 +1196,17 @@ resourceTypes = {
       update_snapshot_builder_settings = {
         description = "allows updating the snapshot builder settings"
       }
+      "lock_resource" = {
+        description = "Can lock or unlock a resource"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal", "lock_resource"]
       }
       custodian = {
-        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots"]
+        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_resource"]
       }
       ingester = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
@@ -1212,7 +1215,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "lock_resource"]
       }
     }
     reuseIds = true
@@ -1275,14 +1278,17 @@ resourceTypes = {
       update_auth_domain = {
         description = "update the auth domain of the snapshot"
       }
+      "lock_resource" = {
+        description = "Can lock or unlock a resource"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_resource"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_resource"]
       }
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
@@ -1291,7 +1297,7 @@ resourceTypes = {
         roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
       }
       admin = {
-        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain"]
+        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "lock_resource"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1200,7 +1200,7 @@ resourceTypes = {
         description = "Can lock a resource"
       }
       "unlock_resource" = {
-        description = "Can lock a resource"
+        description = "Can unlock a resource"
       }
     }
     ownerRoleName = "steward"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1196,17 +1196,17 @@ resourceTypes = {
       update_snapshot_builder_settings = {
         description = "allows updating the snapshot builder settings"
       }
-      "lock_resource" = {
+      "lock_unlock_resource" = {
         description = "Can lock or unlock a resource"
       }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal", "lock_resource"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal", "lock_unlock_resource"]
       }
       custodian = {
-        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_resource"]
+        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_unlock_resource"]
       }
       ingester = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
@@ -1215,7 +1215,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "lock_resource"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "lock_unlock_resource"]
       }
     }
     reuseIds = true
@@ -1278,17 +1278,17 @@ resourceTypes = {
       update_auth_domain = {
         description = "update the auth domain of the snapshot"
       }
-      "lock_resource" = {
+      "lock_unlock_resource" = {
         description = "Can lock or unlock a resource"
       }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
       }
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
@@ -1297,7 +1297,7 @@ resourceTypes = {
         roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
       }
       admin = {
-        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "lock_resource"]
+        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1196,17 +1196,20 @@ resourceTypes = {
       update_snapshot_builder_settings = {
         description = "allows updating the snapshot builder settings"
       }
-      "lock_unlock_resource" = {
-        description = "Can lock or unlock a resource"
+      "lock_resource" = {
+        description = "Can lock a resource"
+      }
+      "unlock_resource" = {
+        description = "Can lock a resource"
       }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal", "lock_unlock_resource"]
+        roleActions = ["delete", "read_dataset", "read_data", "edit_dataset", "manage_schema", "ingest_data",  "update_data", "soft_delete", "hard_delete", "create_datasnapshot",  "share_policy::steward", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "update_passport_identifier", "view_journal", "lock_resource", "unlock_resource"]
       }
       custodian = {
-        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_unlock_resource"]
+        roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource"]
       }
       ingester = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
@@ -1215,7 +1218,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "lock_unlock_resource"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "unlock_resource"]
       }
     }
     reuseIds = true
@@ -1278,17 +1281,20 @@ resourceTypes = {
       update_auth_domain = {
         description = "update the auth domain of the snapshot"
       }
-      "lock_unlock_resource" = {
-        description = "Can lock or unlock a resource"
+      "lock_resource" = {
+        description = "Can lock a resource"
+      }
+      "unlock_resource" = {
+        description = "Can unlock a resource"
       }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
       }
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
@@ -1297,7 +1303,7 @@ resourceTypes = {
         roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
       }
       admin = {
-        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "lock_unlock_resource"]
+        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: [DR-3274](https://broadworkbench.atlassian.net/browse/DR-3274)

What:

A dataset or snapshot's steward or custodian should be able to lock/unlock a resource. An admin should be able to unlock a resource.

Why:

Support new TDR lock/unlock endpoints for datasets and snapshots.

How:
Add TDR actions for locking and unlocking resources. 

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[DR-3274]: https://broadworkbench.atlassian.net/browse/DR-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ