### PR TITLE
QA2187: Followup work to enhance semver tagging mechanism for contract tests

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -17,6 +17,8 @@ env:
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml
+    with:
+      release-branches: develop
     secrets: inherit
 
   sam-build-tag-publish-job:
@@ -214,12 +216,12 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{  
+          inputs: '{
             "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"\"}",
-            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", 
-            "ENV": "${{ matrix.testing-env }}", 
+            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}",
+            "ENV": "${{ matrix.testing-env }}",
             "test-group-name": "${{ matrix.test-group.group_name }}",
-            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", 
+            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}",
             "test-context": "${{ env.test-context }}"
           }'
 
@@ -233,7 +235,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    steps:        
+    steps:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         env:
@@ -244,9 +246,9 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ 
-            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}", 
-            "ENV": "${{ matrix.testing-env }}", 
+          inputs: '{
+            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}",
+            "ENV": "${{ matrix.testing-env }}",
             "test-context": "${{ env.test-context }}"
           }'
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,6 +3,16 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout"
+        default: ''
+        required: false
+        type: string
+      dry-run:
+        description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
+        default: false
+        required: false
+        type: string
       print-tag:
         description: "Echo generated tag to console"
         default: "true"
@@ -10,32 +20,42 @@ on:
         type: string
     outputs:
       tag:
-        description: "Generated tag"
+        description: "The value of the latest tag after running this action"
         value: ${{ jobs.tag-job.outputs.tag }}
+      new-tag:
+        description: "The value of the newly created tag"
+        value: ${{ jobs.tag-job.outputs.new-tag }}
     secrets:
       BROADBOT_TOKEN:
         required: true
 
 jobs:
+  # On tag vs. new-tag.
+  # The new-tag is always the tag resulting from a bump to the original tag.
+  # However, the tag is by definition the value of the latest tag after running the action,
+  # which might not change if dry run is used, and remains same as the original tag.
   tag-job:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      new-tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout current code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref }}
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
         id: tag
         env:
           DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          DRY_RUN: ${{ inputs.dry-run }}
           RELEASE_BRANCHES: develop
           WITH_V: true
       - name: Echo generated tag to console
         if: ${{ inputs.print-tag == 'true' }}
         run: |
-          echo "app version tag: '${{ steps.tag.outputs.tag }}'"
+          echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,11 @@ on:
         default: "true"
         required: false
         type: string
+      release-branches:
+        description: "Default branch (main, develop, etc)"
+        default: 'main'
+        required: false
+        type: string
     outputs:
       tag:
         description: "The value of the latest tag after running this action"
@@ -47,13 +52,13 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
         id: tag
         env:
           DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           DRY_RUN: ${{ inputs.dry-run }}
-          RELEASE_BRANCHES: develop
+          RELEASE_BRANCHES: ${{ inputs.release-branches }}
           WITH_V: true
       - name: Echo generated tag to console
         if: ${{ inputs.print-tag == 'true' }}

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -85,8 +85,8 @@ jobs:
       # facilitating cross-referencing of a pact between Pact Broker and GitHub.
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
-      # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+      dry-run: true
+      release-branches: develop
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -74,22 +74,28 @@ env:
   SBT_CACHE: $HOME/.sbt
 
 jobs:
-  # Create a new version tag only when this workflow is triggered by a PR or merge commit.
-  # If triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
-  # is already included in the payload, making a new version tag unnecessary.
-  tag:
-    if: ${{ inputs.pb-event-type == '' }}
+  # We only need a new version tag when this workflow is triggered by opening, updating a PR or PR merge.
+  # When triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
+  # is already included in the payload, then a new version tag wouldn't be needed.
+  #
+  regulated-tag-job:
     uses: ./.github/workflows/tag.yml
+    with:
+      # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
+      # facilitating cross-referencing of a pact between Pact Broker and GitHub.
+      ref: ${{ github.head_ref || '' }}
+      # The 'dry-run' parameter prevents the new tag from being dispatched.
+      # We only need to dispatch a tag once if this is a PR merge.
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     secrets: inherit
 
   verify-consumer-pact:
     runs-on: ubuntu-latest
-    needs: [ tag ]
+    needs: [ regulated-tag-job ]
     permissions:
       contents: 'read'
       id-token: 'write'
     outputs:
-      provider-sha: ${{ steps.verification-test.outputs.provider-sha }}
       provider-version: ${{ steps.verification-test.outputs.provider-version }}
 
     steps:
@@ -104,73 +110,70 @@ jobs:
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
-            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             GITHUB_REF=${{ github.ref }} # The Git Ref that this workflow runs on
-            GITHUB_SHA=${{ github.sha }} # The Git Sha that this workflow runs on
           else
             echo "Failed to extract branch information"
             exit 1
           fi
           echo "CURRENT_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
-          echo "CURRENT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
-      - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
+      - name: Capture webhook event payload as envvars
         if: ${{ inputs.pb-event-type != '' }}
         run: |
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
+
+          # The consumer-version-branch and consumer-version-number identify the most recent
+          # consumer branch and version associated with the pact content.
           echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
+
+          # The provider-version-number represents the provider version number in the webhook event payload.
+          # This corresponds to the GitHub release tag recorded by Sherlock for the corresponding
+          # deployment environment (dev, staging, and prod).
           echo "provider-version-branch/provider-version-number=${{ inputs.provider-version-branch }}/${{ inputs.provider-version-number }}"
-          # The consumer-version-branch/consumer-version-number is practically sufficient.
+
           # The pact-url is included here in case future pact4s client supports it.
           echo "pact-url=${{ inputs.pact-url }}"
-          if [[ ! -z "${{ inputs.provider-version-branch }}" ]]; then
-            echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
-            echo "CHECKOUT_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
-          fi
-          if [[ ! -z "${{ inputs.provider-version-number }}" ]]; then
-            echo "PROVIDER_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
-            echo "CHECKOUT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
-          fi
-          echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
+
+          # Save webhook event parameters as envvars
+          echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
+          echo "PROVIDER_TAG=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
           echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
-          echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
+          echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
+          echo "CONSUMER_VERSION=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
 
-      - name: Set provider version envvar
+      - name: Set PROVIDER_VERSION envvar
         run: |
-          if [[ -n "${{ needs.tag.outputs.tag }}" ]]; then
-            echo "PROVIDER_VERSION=${{ needs.tag.outputs.tag }}" >> $GITHUB_ENV
-          else
-            echo "PROVIDER_VERSION=${{ env.PROVIDER_SHA }}" >> $GITHUB_ENV
-          fi
-
-      - name: Switch to appropriate branch
-        run: |
-          if [[ -z "${{ env.PROVIDER_BRANCH }}" ]]; then
+          # The PROVIDER_VERSION envvar is used to identify the provider version
+          # for publishing the results of provider verification.
+          if [[ -z "${{ inputs.pb-event-type }}" ]]; then
             echo "PROVIDER_BRANCH=${{ env.CURRENT_BRANCH }}" >> $GITHUB_ENV
-          fi
-          if [[ -z "${{ env.PROVIDER_SHA }}" ]]; then
-            echo "PROVIDER_SHA=${{ env.CURRENT_SHA }}" >> $GITHUB_ENV
-          fi
-          git fetch
-          if [[ ! -z "${{ env.CHECKOUT_BRANCH }}" ]] && [[ ! -z "${{ env.CHECKOUT_SHA }}" ]]; then
-            echo "git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}"
-            git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }} || echo "already in ${{ env.CHECKOUT_BRANCH }}"
-            echo "git branch"
-            git branch
+            echo "PROVIDER_VERSION=${{ needs.regulated-tag-job.outputs.new-tag }}" >> $GITHUB_ENV
           else
-            if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              echo "git checkout ${{ env.CURRENT_BRANCH }}"
-              git checkout ${{ env.CURRENT_BRANCH }}
-            else
-              echo "git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}"
-              git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}
-            fi
+            echo "PROVIDER_VERSION=${{ env.PROVIDER_TAG }}" >> $GITHUB_ENV
           fi
+
+      - name: Switch to appropriate provider branch
+        run: |
+          echo "This workflow has been triggered by '${{ github.event_name }}' event."
+
+          # If the PROVIDER_TAG envvar exists, switch to the corresponding tag.
+          # This condition is true when the workflow is triggered by a Pact Broker webhook event.
+          if [[ -n "${{ env.PROVIDER_TAG }}" ]]; then
+            echo "git checkout tags/${{ env.PROVIDER_TAG }}"
+            git checkout tags/${{ env.PROVIDER_TAG }}
+
+          # Otherwise, switch to CURRENT_BRANCH if the workflow has been triggered by a
+          # PR commit or merge onto the main branch.
+          elif [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "git checkout ${{ env.CURRENT_BRANCH }}"
+            git checkout ${{ env.CURRENT_BRANCH }}
+          fi
+
+          # Echo the HEAD commit of the provider branch that has been switched to.
           echo "git rev-parse HEAD"
           git rev-parse HEAD
 
@@ -284,17 +287,12 @@ jobs:
       - name: Verify consumer pacts and publish verification status to Pact Broker
         id: verification-test
         run: |
-          echo "provider-sha=${{ env.PROVIDER_SHA }}" >> $GITHUB_OUTPUT
           echo "provider-version=${{ env.PROVIDER_VERSION }}" >> $GITHUB_OUTPUT
-          echo "env.CHECKOUT_BRANCH=${{ env.CHECKOUT_BRANCH }} # If not empty, this reflects the branch being checked out (generated by Pact Broker)"
-          echo "env.CHECKOUT_SHA=${{ env.CHECKOUT_SHA }}       # If not empty, this reflects the git commit hash of the branch being checked out (generated by Pact Broker)"
-          echo "env.CURRENT_BRANCH=${{ env.CURRENT_BRANCH }}   # This reflects the branch being checked out if CHECKOUT_BRANCH is empty"
-          echo "env.CURRENT_SHA=${{ env.CURRENT_SHA }}         # This reflects the git commit hash of the branch being checked out if CHECKOUT_BRANCH is empty"
-          echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This reflects the provider branch for pact verification"
-          echo "env.PROVIDER_SHA=${{ env.PROVIDER_SHA }}       # This reflects the provider version for pact verification"
-          echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} # This reflects the consumer branch for pact verification (generated by Pact Broker)"
-          echo "env.CONSUMER_SHA=${{ env.CONSUMER_SHA }}       # This reflects the consumer version for pact verification (generated by Pact Broker)"
-          echo "env.PROVIDER_VERSION=${{ env.PROVIDER_VERSION }}  # Deprecate env.PROVIDER_SHA. This new envvar is used for migrating GIT hash to app versioning"
+          echo "env.CONSUMER_NAME=${{ env.CONSUMER_NAME }}   # This reflects the consumer branch for pact verification (generated by Pact Broker)"
+          echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }}   # This reflects the consumer branch for pact verification (generated by Pact Broker)"
+          echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }}   # This reflects the provider branch to switch to for pact verification"
+          echo "env.CONSUMER_VERSION=${{ env.CONSUMER_VERSION }} # This reflects the consumer version for pact verification (generated by Pact Broker)"
+          echo "env.PROVIDER_VERSION=${{ env.PROVIDER_VERSION }} # Deprecate env.PACT_PROVIDER_COMMIT. This new envvar is used for migrating GIT hash to app versioning"
 
           # Refer to https://github.com/sbt/docker-sbt on this Docker image
           # Recent sbt versions use Coursier instead of Ivy for dependency management.
@@ -307,11 +305,10 @@ jobs:
                           -v ${{ env.SBT_CACHE }}:/root/.sbt \
                           -e PACT_PUBLISH_RESULTS=true \
                           -e PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} \
-                          -e PROVIDER_SHA=${{ env.PROVIDER_SHA }} \
                           -e PROVIDER_VERSION=${{ env.PROVIDER_VERSION }} \
-                          -e CONSUMER_NAME=${{ env.CONSUMER_NAME }} \
+                          -e CONSUMER_NAME=${{ env.CONSUMER_NAME}} \
                           -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
-                          -e CONSUMER_SHA=${{ env.CONSUMER_SHA }} \
+                          -e CONSUMER_VERSION=${{ env.CONSUMER_VERSION }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \
                           -e PACT_BROKER_USERNAME=${{ env.PACT_BROKER_USERNAME }} \
                           -e PACT_BROKER_PASSWORD=${{ env.PACT_BROKER_PASSWORD }} \

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -306,7 +306,7 @@ jobs:
                           -e PACT_PUBLISH_RESULTS=true \
                           -e PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} \
                           -e PROVIDER_VERSION=${{ env.PROVIDER_VERSION }} \
-                          -e CONSUMER_NAME=${{ env.CONSUMER_NAME}} \
+                          -e CONSUMER_NAME=${{ env.CONSUMER_NAME }} \
                           -e CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} \
                           -e CONSUMER_VERSION=${{ env.CONSUMER_VERSION }} \
                           -e PACT_BROKER_URL=${{ env.PACT_BROKER_URL }} \

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -209,16 +209,14 @@ class SamProviderSpec
   lazy val pactBrokerUrl: String = sys.env.getOrElse("PACT_BROKER_URL", "")
   lazy val pactBrokerUser: String = sys.env.getOrElse("PACT_BROKER_USERNAME", "")
   lazy val pactBrokerPass: String = sys.env.getOrElse("PACT_BROKER_PASSWORD", "")
-  // Provider branch, sha
-  lazy val branch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
-  lazy val gitSha: String = sys.env.getOrElse("PROVIDER_SHA", "")
-  // gitSha is deprecated, use providerVer instead
+  // Provider branch, semver
+  lazy val providerBranch: String = sys.env.getOrElse("PROVIDER_BRANCH", "")
   lazy val providerVer: String = sys.env.getOrElse("PROVIDER_VERSION", "")
-  // Consumer name, bran, sha (used for webhook events only)
+  // Consumer name, branch, semver (used for webhook events only)
   lazy val consumerName: Option[String] = sys.env.get("CONSUMER_NAME")
   lazy val consumerBranch: Option[String] = sys.env.get("CONSUMER_BRANCH")
   // This matches the latest commit of the consumer branch that triggered the webhook event
-  lazy val consumerSha: Option[String] = sys.env.get("CONSUMER_SHA")
+  lazy val consumerVer: Option[String] = sys.env.get("CONSUMER_VERSION")
 
   var consumerVersionSelectors: ConsumerVersionSelectors = ConsumerVersionSelectors()
   // consumerVersionSelectors = consumerVersionSelectors.mainBranch
@@ -312,11 +310,11 @@ class SamProviderSpec
   it should "Verify pacts" in {
     val publishResults = sys.env.getOrElse("PACT_PUBLISH_RESULTS", "false").toBoolean
     verifyPacts(
-      providerBranch = if (branch.isEmpty) None else Some(Branch(branch)),
+      providerBranch = if (providerBranch.isEmpty) None else Some(Branch(providerBranch)),
       publishVerificationResults =
         if (publishResults)
           Some(
-            PublishVerificationResults(providerVer, ProviderTags(branch))
+            PublishVerificationResults(providerVer, ProviderTags(providerBranch))
           )
         else None,
       providerVerificationOptions = Seq(


### PR DESCRIPTION
Ticket: [QA-2187](https://broadworkbench.atlassian.net/browse/QA-2187)

What:

Lift and shift to use `semver` tagging for contract tests.

Why:

Sherlock now relies on semvar (aka application version) to post deployment env to Pact Broker.

More details on why we're doing this shifting. Considering the creation of a ledger to trace contracts through PR and merge commits. It is also crucial for Sherlock to be able to interact with Pact Broker to record deployment environment for the appropriate release tag.

    Multiple Developers and Commits in a PR:

    Multiple developers can collaborate on the same pull request (PR).
    The PR can have multiple commits.

    Sherlock and Helm Charts for `datarepo`:

    Sherlock doesn't synchronize Helm charts for the datarepo on PR commits
    The synchronization is only called upon during merge commit to develop branch

    Continuous Publishing and Verification of Contracts:

    You still want contracts from the PR to be continually published or verified.
    The tagging mechanism is introduced to create a ledger of published and verified contracts in Pact Broker. For PRs, the tag is appended with the commit hash. When the live tag is pushed to GitHub during merge commit, the contracts will be published or verified using the live tag without hash.
    This ledger allows developers to trace issues on both the consumer or provider side.

This ticket is a follow up to similar work done in [#1531](https://github.com/DataBiosphere/terra-workspace-manager/pull/1531), [#345](https://github.com/DataBiosphere/terra-billing-profile-manager/pull/345), and [#1546](https://github.com/DataBiosphere/jade-data-repo/pull/1546).

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[QA-2187]: https://broadworkbench.atlassian.net/browse/QA-2187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ