### PR TITLE
ID-954 Force 60 second timeout on Google Group Sync

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -9,7 +9,14 @@ import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.sam.api.{ExtensionRoutes, SamModelDirectives, SamRequestContextDirectives, SamUserDirectives, SecurityDirectives, ioMarshaller}
+import org.broadinstitute.dsde.workbench.sam.api.{
+  ExtensionRoutes,
+  SamModelDirectives,
+  SamRequestContextDirectives,
+  SamUserDirectives,
+  SecurityDirectives,
+  ioMarshaller
+}
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-954

What:

Manually set the request timeout for the group sync endpoint.

Why:

We set the akka server request timeout to 60 seconds, but this doesn't seem to be respected. As a result, we're seeing the group-sync endpoint fail after 20 seconds. 

How:

Wrap it in a directive.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
