### PR TITLE
ID-954 Fix Akka request timeouts, for good!

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -59,6 +59,7 @@ object Boot extends IOApp with LazyLogging {
   def run(args: List[String]): IO[ExitCode] = {
     // Init sentry always should be the first thing we do
     initSentry()
+//    val akkaConfig = ConfigFactory.parseResourcesAnySyntax("sam").withOnlyPath("akka").resolve()
     implicit val system = ActorSystem("sam")
 
     startup() *> ExitCode.Success.pure[IO]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -7,6 +7,7 @@ import cats.effect._
 import cats.implicits._
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.opentelemetry.trace.{TraceConfiguration, TraceExporter}
+import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
@@ -59,8 +60,8 @@ object Boot extends IOApp with LazyLogging {
   def run(args: List[String]): IO[ExitCode] = {
     // Init sentry always should be the first thing we do
     initSentry()
-//    val akkaConfig = ConfigFactory.parseResourcesAnySyntax("sam").withOnlyPath("akka").resolve()
-    implicit val system = ActorSystem("sam")
+    val akkaConfig = ConfigFactory.parseResourcesAnySyntax("sam").withOnlyPath("akka").resolve()
+    implicit val system = ActorSystem("sam", akkaConfig)
 
     startup() *> ExitCode.Success.pure[IO]
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -125,10 +125,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
   private def getSamUserAllowances(samUser: SamUser, samRequestContext: SamRequestContext): Route =
     get {
       complete {
-        userService.getUserAllowances(samUser, samRequestContext).map { r =>
-          Thread.sleep(30000)
-          StatusCodes.OK -> r
-        }
+        userService.getUserAllowances(samUser, samRequestContext).map(StatusCodes.OK -> _)
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -125,10 +125,10 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
   private def getSamUserAllowances(samUser: SamUser, samRequestContext: SamRequestContext): Route =
     get {
       complete {
-        userService.getUserAllowances(samUser, samRequestContext).map(r => {
+        userService.getUserAllowances(samUser, samRequestContext).map { r =>
           Thread.sleep(30000)
           StatusCodes.OK -> r
-        })
+        }
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -125,7 +125,10 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
   private def getSamUserAllowances(samUser: SamUser, samRequestContext: SamRequestContext): Route =
     get {
       complete {
-        userService.getUserAllowances(samUser, samRequestContext).map(StatusCodes.OK -> _)
+        userService.getUserAllowances(samUser, samRequestContext).map(r => {
+          Thread.sleep(30000)
+          StatusCodes.OK -> r
+        })
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -26,7 +26,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.JsString
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
 
 trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with SecurityDirectives with SamModelDirectives with SamRequestContextDirectives {
   implicit val executionContext: ExecutionContext
@@ -244,13 +243,10 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
               Seq("resourceTypeName" -> resource.resourceTypeName, "resourceId" -> resource.resourceId, "accessPolicyName" -> policyId.accessPolicyName)
             pathEndOrSingleSlash {
               postWithTelemetry(samRequestContext, params: _*) {
-                // This should not be necessary, but it appears that the akka config in sam.conf is not being respected.
-                withRequestTimeout(60.seconds) {
-                  complete {
-                    import SamGoogleModelJsonSupport._
-                    googleGroupSynchronizer.synchronizeGroupMembers(policyId, samRequestContext = samRequestContext).map { syncReport =>
-                      StatusCodes.OK -> syncReport
-                    }
+                complete {
+                  import SamGoogleModelJsonSupport._
+                  googleGroupSynchronizer.synchronizeGroupMembers(policyId, samRequestContext = samRequestContext).map { syncReport =>
+                    StatusCodes.OK -> syncReport
                   }
                 }
               } ~


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-954

What:

Akka wasn't respecting the `request-timeout` config in `sam.conf`. Turns out, you need to manually pass akka configs into the ActorSystem, or else, it reverts to defaults...

This was tested on a BEE. When adding a `Thread.sleep(30000)` to a call, Sam timed out until I added the configs manually to the ActorSystem

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
