### PR TITLE
ID-931 Fix get user self attrs for inactive user.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -61,7 +61,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
             } ~
             // api/user/v2/self/attributes
             pathPrefix("attributes") {
-              withActiveUser(samRequestContextWithoutUser) { samUser: SamUser =>
+              withUserAllowInactive(samRequestContextWithoutUser) { samUser: SamUser =>
                 val samRequestContext = samRequestContextWithoutUser.copy(samUser = Some(samUser))
                 pathEndOrSingleSlash {
                   getSamUserAttributes(samUser, samRequestContext) ~


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-931

This endpoint should be allowed for inactive users so that they can see their own status in the system. In particular this is relevant for the TOS flow when a user needs to accept the new TOS.
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
