### PR TITLE
[TOAZ-337] Add Aster managed app offer to conf

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -205,6 +205,11 @@ azureServices {
         publisher = "thebroadinstituteinc1615909626976"
         authorizedUserKey = authorizedTerraUser
     }
+    {
+        name = "terra-aster-prod"
+        publisher = "thebroadinstituteinc1615909626976"
+        authorizedUserKey = "authorizedTerraUser"
+    }
   ]
 }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-337

Related BPM PR: https://github.com/broadinstitute/terra-helmfile/pull/4882

What:

Add a new (private) managed application offer to the Sam config. Note: it didn't look like these were in terra-helmfile (like BPM), so just added it to Sam application.conf.

Why:

Aster Insights is evaluating Terra on Azure, and doing a spike where we connect the Terra MRG to an external storage account. Because of Reasons they cannot use private endpoints; so instead we are just adding the Terra VNet to their storage account firewall rules. However this required a hole poked in the deny assignments to add Microsoft.Network/virtualNetworks/subnets/joinViaServiceEndpoint/action, which required a new managed app offer.

Separately I will evaluate whether this can be the default for our regular offer; but I'd like to get this in to unblock Aster in the short term.

How:

This allows Aster to deploy this private offer in app.terra.bio, and continue with their spike.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
