### PR TITLE
WOR-1442 Improvements on new List Resourcs endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4387,7 +4387,7 @@ components:
         policies:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/FilteredFlatResourcePolicy'
           description: policies the user is a part of on the resource
         roles:
           type: array
@@ -4399,12 +4399,6 @@ components:
           items:
             type: string
           description: actions the user has on the resource
-        isPublic:
-          type: string
-          description: isPublic is the resource public or not
-        inherited:
-          type: boolean
-          description: is this resource policy inherited from a parent resource
         authDomainGroups:
           type: array
           items:
@@ -4415,6 +4409,18 @@ components:
           items:
             type: string
           description: Auth Domain groups the user is not a member of
+    FilteredFlatResourcePolicy:
+      type: object
+      properties:
+        policy:
+          type: string
+          description: The policy name
+        isPublic:
+          type: boolean
+          description: Is this policy on the resource a public policy?
+        inherited:
+          type: boolean
+          description: Is this policy inherited from an parent resource?
     FilteredHierarchicalResource:
       type: object
       properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4408,12 +4408,12 @@ components:
         authDomainGroups:
           type: array
           items:
-            - type: string
+            type: string
           description: The auth domain groups of the policy
         missingAuthDomainGroups:
           type: array
           items:
-            - type: string
+            type: string
           description: Auth Domain groups the user is not a member of
     FilteredHierarchicalResource:
       type: object
@@ -4432,12 +4432,12 @@ components:
         authDomainGroups:
           type: array
           items:
-            - type: string
+            type: string
           description: The auth domain groups of the policy
         missingAuthDomainGroups:
           type: array
           items:
-            - type: string
+            type: string
           description: Auth Domain groups the user is not a member of
     FilteredHierarchicalResourcePolicy:
       type: object

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4385,17 +4385,32 @@ components:
           type: string
           description: resourceId of the resource
         policies:
-          type: string
+          type: array
+          items:
+            type: string
           description: policies the user is a part of on the resource
         roles:
-          type: string
+          type: array
+          items:
+            type: string
           description: roles the user has on the resource
         actions:
-          type: string
+          type: array
+          items:
+            type: string
           description: actions the user has on the resource
         isPublic:
           type: string
           description: isPublic is the resource public or not
+        inherited:
+          type: boolean
+          description: is this resource policy inherited from a parent resource
+        authDomain:
+          type: string
+          description: The auth domain of the policy
+        inAuthDomain:
+          type: boolean
+          description: Is the user in the auth domain of the policy
     FilteredHierarchicalResource:
       type: object
       properties:
@@ -4410,6 +4425,12 @@ components:
           description: Policies on the resource
           items:
             $ref: '#/components/schemas/FilteredHierarchicalResourcePolicy'
+        authDomain:
+          type: string
+          description: The auth domain of the policy
+        inAuthDomain:
+          type: boolean
+          description: Is the user in the auth domain of the policy
     FilteredHierarchicalResourcePolicy:
       type: object
       properties:
@@ -4429,6 +4450,9 @@ components:
         isPublic:
           type: boolean
           description: Is this policy on the resource a public policy?
+        inherited:
+          type: boolean
+          description: Is this policy inherited from an parent resource?
     FilteredHierarchicalResourceRole:
       type: object
       properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4405,12 +4405,16 @@ components:
         inherited:
           type: boolean
           description: is this resource policy inherited from a parent resource
-        authDomain:
-          type: string
-          description: The auth domain of the policy
-        inAuthDomain:
-          type: boolean
-          description: Is the user in the auth domain of the policy
+        authDomainGroups:
+          type: array
+          items:
+            - type: string
+          description: The auth domain groups of the policy
+        missingAuthDomainGroups:
+          type: array
+          items:
+            - type: string
+          description: Auth Domain groups the user is not a member of
     FilteredHierarchicalResource:
       type: object
       properties:
@@ -4425,12 +4429,16 @@ components:
           description: Policies on the resource
           items:
             $ref: '#/components/schemas/FilteredHierarchicalResourcePolicy'
-        authDomain:
-          type: string
-          description: The auth domain of the policy
-        inAuthDomain:
-          type: boolean
-          description: Is the user in the auth domain of the policy
+        authDomainGroups:
+          type: array
+          items:
+            - type: string
+          description: The auth domain groups of the policy
+        missingAuthDomainGroups:
+          type: array
+          items:
+            - type: string
+          description: Auth Domain groups the user is not a member of
     FilteredHierarchicalResourcePolicy:
       type: object
       properties:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
@@ -1,10 +1,15 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
+
 case class FilterResourcesResult(
     resourceId: ResourceId,
     resourceTypeName: ResourceTypeName,
     policy: Option[AccessPolicyName],
     role: Option[ResourceRoleName],
     action: Option[ResourceAction],
-    isPublic: Boolean
+    isPublic: Boolean,
+    authDomain: Option[WorkbenchGroupName],
+    inAuthDomain: Boolean,
+    inherited: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
@@ -17,17 +17,26 @@ case class FilteredResourcesFlat(resources: Set[FilteredResourceFlat]) extends F
 }
 
 object FilteredResourceFlat {
-  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat9(FilteredResourceFlat.apply)
+  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat7(FilteredResourceFlat.apply)
 
 }
 case class FilteredResourceFlat(
     resourceType: ResourceTypeName,
     resourceId: ResourceId,
-    policies: Set[AccessPolicyName],
+    policies: Set[FilteredResourceFlatPolicy],
     roles: Set[ResourceRoleName],
     actions: Set[ResourceAction],
-    isPublic: Boolean,
-    inherited: Boolean,
     authDomainGroups: Set[WorkbenchGroupName],
     missingAuthDomainGroups: Set[WorkbenchGroupName]
+)
+
+case object FilteredResourceFlatPolicy {
+  implicit val filteredResourceFlatPolicyFormat: RootJsonFormat[FilteredResourceFlatPolicy] = jsonFormat3(
+    FilteredResourceFlatPolicy.apply
+  )
+}
+case class FilteredResourceFlatPolicy(
+    policy: AccessPolicyName,
+    isPublic: Boolean,
+    inherited: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicyName, ResourceAc
 import spray.json.DefaultJsonProtocol.jsonFormat1
 import spray.json.RootJsonFormat
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import spray.json.DefaultJsonProtocol._
 
 object FilteredResourcesFlat {
@@ -16,7 +17,7 @@ case class FilteredResourcesFlat(resources: Set[FilteredResourceFlat]) extends F
 }
 
 object FilteredResourceFlat {
-  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat7(FilteredResourceFlat.apply)
+  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat9(FilteredResourceFlat.apply)
 
 }
 case class FilteredResourceFlat(
@@ -27,6 +28,6 @@ case class FilteredResourceFlat(
     actions: Set[ResourceAction],
     isPublic: Boolean,
     inherited: Boolean,
-    authDomain: Option[WorkbenchGroupName],
-    inAuthDomain: Boolean
+    authDomainGroups: Set[WorkbenchGroupName],
+    missingAuthDomainGroups: Set[WorkbenchGroupName]
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesFlat.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.model.api
 
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicyName, ResourceAction, ResourceId, ResourceRoleName, ResourceTypeName}
 import spray.json.DefaultJsonProtocol.jsonFormat1
 import spray.json.RootJsonFormat
@@ -15,7 +16,7 @@ case class FilteredResourcesFlat(resources: Set[FilteredResourceFlat]) extends F
 }
 
 object FilteredResourceFlat {
-  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat6(FilteredResourceFlat.apply)
+  implicit val FilteredResourceFlatFormat: RootJsonFormat[FilteredResourceFlat] = jsonFormat7(FilteredResourceFlat.apply)
 
 }
 case class FilteredResourceFlat(
@@ -24,5 +25,8 @@ case class FilteredResourceFlat(
     policies: Set[AccessPolicyName],
     roles: Set[ResourceRoleName],
     actions: Set[ResourceAction],
-    isPublic: Boolean
+    isPublic: Boolean,
+    inherited: Boolean,
+    authDomain: Option[WorkbenchGroupName],
+    inAuthDomain: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesHierarchical.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesHierarchical.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
 object FilteredResourcesHierarchical {
   implicit val FilteredResourcesHierarchicalFormat: RootJsonFormat[FilteredResourcesHierarchical] = jsonFormat1(FilteredResourcesHierarchical.apply)
@@ -40,6 +41,6 @@ case class FilteredResourceHierarchical(
     resourceType: ResourceTypeName,
     resourceId: ResourceId,
     policies: Set[FilteredResourceHierarchicalPolicy],
-    authDomain: Option[WorkbenchGroupName],
-    inAuthDomain: Boolean
+    authDomainGroups: Set[WorkbenchGroupName],
+    missingAuthDomainGroups: Set[WorkbenchGroupName]
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesHierarchical.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/FilteredResourcesHierarchical.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.model.api
 
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import spray.json.DefaultJsonProtocol._
@@ -13,7 +14,7 @@ case class FilteredResourcesHierarchical(resources: Set[FilteredResourceHierarch
   override def format: String = "hierarchical"
 }
 case object FilteredResourceHierarchicalPolicy {
-  implicit val filteredResourceHierarchicalPolicyFormat: RootJsonFormat[FilteredResourceHierarchicalPolicy] = jsonFormat4(
+  implicit val filteredResourceHierarchicalPolicyFormat: RootJsonFormat[FilteredResourceHierarchicalPolicy] = jsonFormat5(
     FilteredResourceHierarchicalPolicy.apply
   )
 }
@@ -21,7 +22,8 @@ case class FilteredResourceHierarchicalPolicy(
     policy: AccessPolicyName,
     roles: Set[FilteredResourceHierarchicalRole],
     actions: Set[ResourceAction],
-    isPublic: Boolean
+    isPublic: Boolean,
+    inherited: Boolean
 )
 
 case object FilteredResourceHierarchicalRole {
@@ -31,11 +33,13 @@ case object FilteredResourceHierarchicalRole {
 case class FilteredResourceHierarchicalRole(role: ResourceRoleName, actions: Set[ResourceAction])
 
 case object FilteredResourceHierarchical {
-  implicit val filteredResourceHierarchicalFormat: RootJsonFormat[FilteredResourceHierarchical] = jsonFormat3(FilteredResourceHierarchical.apply)
+  implicit val filteredResourceHierarchicalFormat: RootJsonFormat[FilteredResourceHierarchical] = jsonFormat5(FilteredResourceHierarchical.apply)
 
 }
 case class FilteredResourceHierarchical(
     resourceType: ResourceTypeName,
     resourceId: ResourceId,
-    policies: Set[FilteredResourceHierarchicalPolicy]
+    policies: Set[FilteredResourceHierarchicalPolicy],
+    authDomain: Option[WorkbenchGroupName],
+    inAuthDomain: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -904,7 +904,10 @@ class ResourceService(
           policies = v.flatMap(_.policy).toSet,
           roles = v.flatMap(_.role).toSet,
           actions = v.flatMap(_.action).toSet,
-          isPublic = v.map(_.isPublic).head
+          isPublic = v.map(_.isPublic).head,
+          inherited = v.map(_.inherited).head,
+          authDomain = v.map(_.authDomain).head,
+          inAuthDomain = v.map(_.inAuthDomain).head
         )
       }
       .toSet
@@ -935,7 +938,9 @@ class ResourceService(
         FilteredResourceHierarchical(
           resourceId = resourceId,
           resourceType = resourceRows.head.resourceTypeName,
-          policies = policies
+          policies = policies,
+          authDomain = resourceRows.head.authDomain,
+          inAuthDomain = resourceRows.head.inAuthDomain
         )
       }
       .toSet

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -956,7 +956,7 @@ class ResourceService(
           resourceType = resourceRows.head.resourceTypeName,
           policies = policies,
           authDomainGroups = authDomainGroupMemberships.keySet,
-          missingAuthDomainGroups = authDomainGroupMemberships.filter(!_._2).keySet
+          missingAuthDomainGroups = authDomainGroupMemberships.filter(!_._2).keySet // Get only the auth domains where the user is not a member.
         )
       }
       .toSet

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
@@ -49,7 +49,10 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
               Set.empty,
               Set.empty,
               Set.empty,
-              isPublic = false
+              isPublic = false,
+              inherited = false,
+              Set.empty,
+              Set.empty
             )
           )
         )
@@ -72,6 +75,8 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
             FilteredResourceHierarchical(
               ResourceTypeName(UUID.randomUUID().toString),
               ResourceId(UUID.randomUUID().toString),
+              Set.empty,
+              Set.empty,
               Set.empty
             )
           )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
@@ -49,8 +49,6 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
               Set.empty,
               Set.empty,
               Set.empty,
-              isPublic = false,
-              inherited = false,
               Set.empty,
               Set.empty
             )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -38,25 +38,51 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       Some(readerRoleName),
       Some(readAction),
-      true
+      true,
+      None,
+      false,
+      false
     ),
-    FilterResourcesResult(ResourceId(UUID.randomUUID().toString), resourceTypeName, Some(AccessPolicyName(UUID.randomUUID().toString)), None, None, true),
+    FilterResourcesResult(
+      ResourceId(UUID.randomUUID().toString),
+      resourceTypeName,
+      Some(AccessPolicyName(UUID.randomUUID().toString)),
+      None,
+      None,
+      true,
+      None,
+      false,
+      false
+    ),
     FilterResourcesResult(
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       Some(readerRoleName),
       Some(readAction),
+      false,
+      None,
+      false,
       false
     ),
-    FilterResourcesResult(ResourceId(UUID.randomUUID().toString), resourceTypeName, Some(AccessPolicyName(UUID.randomUUID().toString)), None, None, false),
+    FilterResourcesResult(
+      ResourceId(UUID.randomUUID().toString),
+      resourceTypeName,
+      Some(AccessPolicyName(UUID.randomUUID().toString)),
+      None,
+      None,
+      false,
+      None,
+      false,
+      false
+    ),
     // Testable DB Results
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy1), Some(readerRoleName), Some(readAction), false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy2), Some(nothingRoleName), None, true),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy3), None, None, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true)
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy1), Some(readerRoleName), Some(readAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy2), Some(nothingRoleName), None, true, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy3), None, None, false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true, None, false, false)
   )
 
   val mockAccessPolicyDAO = mock[AccessPolicyDAO]

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.service
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api._
@@ -27,9 +28,13 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
   private val writeAction = ResourceAction("write")
   private val ownerRoleName = ResourceRoleName("owner")
   private val nothingRoleName = ResourceRoleName("cantDoNuthin")
+  private val authDomainGroup1 = WorkbenchGroupName("authDomain1")
+  private val authDomainGroup2 = WorkbenchGroupName("authDomain2")
 
   val testResourceId = ResourceId(UUID.randomUUID().toString)
-  val testPolicy1 :: testPolicy2 :: testPolicy3 :: testPolicy4 :: testPolicy5 :: _ = (1 to 6).map(_ => AccessPolicyName(UUID.randomUUID().toString)).toList
+  val testResourceId2 = ResourceId(UUID.randomUUID().toString)
+  val testPolicy1 :: testPolicy2 :: testPolicy3 :: testPolicy4 :: testPolicy5 :: testPolicy6 :: _ =
+    (1 to 7).map(_ => AccessPolicyName(UUID.randomUUID().toString)).toList
   val dbResult = Seq(
     // Some things we don't care about
     FilterResourcesResult(
@@ -82,7 +87,30 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy3), None, None, false, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true, None, false, false)
+    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true, None, false, false),
+    // Auth Domain Results
+    FilterResourcesResult(
+      testResourceId2,
+      resourceTypeName,
+      Some(testPolicy6),
+      Some(readerRoleName),
+      Some(readAction),
+      false,
+      Some(authDomainGroup1),
+      true,
+      false
+    ),
+    FilterResourcesResult(
+      testResourceId2,
+      resourceTypeName,
+      Some(testPolicy6),
+      Some(readerRoleName),
+      Some(readAction),
+      false,
+      Some(authDomainGroup2),
+      false,
+      false
+    )
   )
 
   val mockAccessPolicyDAO = mock[AccessPolicyDAO]
@@ -117,6 +145,14 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     oneResource.policies should be(Set(testPolicy1, testPolicy2, testPolicy3, testPolicy4, testPolicy5))
     oneResource.roles should be(Set(readerRoleName, ownerRoleName, nothingRoleName))
     oneResource.actions should be(Set(readAction, writeAction))
+
+    val authDomainResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId2)).head
+    authDomainResource.resourceType should be(resourceTypeName)
+    authDomainResource.policies should be(Set(testPolicy6))
+    authDomainResource.roles should be(Set(readerRoleName))
+    authDomainResource.actions should be(Set(readAction))
+    authDomainResource.authDomainGroups should be(Set(authDomainGroup1, authDomainGroup2))
+    authDomainResource.missingAuthDomainGroups should be(Set(authDomainGroup2))
   }
 
   it should "group filtered resources from the database appropriately hierarchically" in {
@@ -137,5 +173,11 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     val role = policyWithRoles.roles.head
     role.role should be(ownerRoleName)
     role.actions should be(Set(readAction, writeAction))
+
+    val authDomainResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId2)).head
+    authDomainResource.resourceType should be(resourceTypeName)
+    authDomainResource.policies.map(_.policy) should be(Set(testPolicy6))
+    authDomainResource.authDomainGroups should be(Set(authDomainGroup1, authDomainGroup2))
+    authDomainResource.missingAuthDomainGroups should be(Set(authDomainGroup2))
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -142,13 +142,21 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
 
     val oneResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId)).head
     oneResource.resourceType should be(resourceTypeName)
-    oneResource.policies should be(Set(testPolicy1, testPolicy2, testPolicy3, testPolicy4, testPolicy5))
+    oneResource.policies should be(
+      Set(
+        FilteredResourceFlatPolicy(testPolicy1, false, false),
+        FilteredResourceFlatPolicy(testPolicy2, true, false),
+        FilteredResourceFlatPolicy(testPolicy3, false, false),
+        FilteredResourceFlatPolicy(testPolicy4, false, false),
+        FilteredResourceFlatPolicy(testPolicy5, true, false)
+      )
+    )
     oneResource.roles should be(Set(readerRoleName, ownerRoleName, nothingRoleName))
     oneResource.actions should be(Set(readAction, writeAction))
 
     val authDomainResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId2)).head
     authDomainResource.resourceType should be(resourceTypeName)
-    authDomainResource.policies should be(Set(testPolicy6))
+    authDomainResource.policies should be(Set(FilteredResourceFlatPolicy(testPolicy6, false, false)))
     authDomainResource.roles should be(Set(readerRoleName))
     authDomainResource.actions should be(Set(readAction))
     authDomainResource.authDomainGroups should be(Set(authDomainGroup1, authDomainGroup2))


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1442



What:

For Rawls to use the new listResources endpoint, Sam needs to return info about auth domains. 

Why:

Rawls passes this info onto the UI so that the workspaces list can be displayed correctly

How:

Make listResourcesV2 return the same type of info as the listResourcesAndPoliciesV2 endpoint, even if its in a different format.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
