### PR TITLE
ID-1030 Sam smoke tests should fail GHA job when they are failing.

### DIFF
--- a/smoke_test/smoke_test.py
+++ b/smoke_test/smoke_test.py
@@ -49,7 +49,11 @@ def main(main_args):
     test_suite = gather_tests(main_args.user_token)
 
     runner = unittest.TextTestRunner(verbosity=main_args.verbosity)
-    runner.run(test_suite)
+    result = runner.run(test_suite)
+
+    # system exit if any tests fail
+    if result.failures or result.errors:
+        sys.exit(1)
 
 
 def verify_user_token(user_token: str) -> bool:

--- a/smoke_test/tests/authenticated/sam_resource_types_tests.py
+++ b/smoke_test/tests/authenticated/sam_resource_types_tests.py
@@ -9,5 +9,4 @@ class SamResourceTypesTests(SamSmokeTestCase):
         return SamSmokeTestCase.build_sam_url("/api/config/v1/resourceTypes")
 
     def test_status_code_is_200(self):
-        response = SamSmokeTestCase.call_sam(self.resource_types_url(), SamSmokeTestCase.USER_TOKEN)
-        self.assertEqual(response.status_code, 200, f"Resource Types HTTP Status is not 200: {response.text}")
+       self.assertEqual(1, 2)

--- a/smoke_test/tests/authenticated/sam_resource_types_tests.py
+++ b/smoke_test/tests/authenticated/sam_resource_types_tests.py
@@ -9,4 +9,5 @@ class SamResourceTypesTests(SamSmokeTestCase):
         return SamSmokeTestCase.build_sam_url("/api/config/v1/resourceTypes")
 
     def test_status_code_is_200(self):
-       self.assertEqual(1, 2)
+        response = SamSmokeTestCase.call_sam(self.resource_types_url(), SamSmokeTestCase.USER_TOKEN)
+        self.assertEqual(response.status_code, 200, f"Resource Types HTTP Status is not 200: {response.text}")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1030

We noticed that the smoke test job wasnt failing when some of the tests were failing. I fixed the tests separately by registering the SA the tests use as a user in terra. This pr is just to make sure that the test job actually fails if a test fails. It works as expected locally, but I will also test by disabling the SA user in dev once this is merged, running the smoke test against dev, then re-enabling the user. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
