### PR TITLE
ID-1064 Use UNION ALL in listResourcesV2 query

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1738,7 +1738,7 @@ class PostgresAccessPolicyDAO(
           $notNullConstraintPolicyAction
                 """
 
-    val includePublicPolicyActionQuery = samsqls"union $publicPolicyActionQuery"
+    val includePublicPolicyActionQuery = samsqls"union all $publicPolicyActionQuery"
     val publicResourcesQuery = samsql"$publicRoleActionQuery $includePublicPolicyActionQuery"
 
     readOnlyTransaction("filterResourcesPublic", samRequestContext) { implicit session =>
@@ -1836,7 +1836,7 @@ class PostgresAccessPolicyDAO(
             $notNullConstraintPolicyAction
             """
 
-    val includePolicyActionQuery = if (roles.isEmpty) samsqls"union $policyActionQuery" else samsqls""
+    val includePolicyActionQuery = if (roles.isEmpty) samsqls"union all $policyActionQuery" else samsqls""
     val query =
       samsqls"""$policyRoleActionQuery
                             $includePolicyActionQuery"""

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -83,11 +83,44 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     ),
     // Testable DB Results
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy1), Some(readerRoleName), Some(readAction), false, None, false, false),
+    FilterResourcesResult(
+      testResourceId,
+      resourceTypeName,
+      Some(testPolicy1),
+      Some(readerRoleName),
+      Some(readAction),
+      false,
+      None,
+      false,
+      false
+    ), // testing duplicate row results
+    FilterResourcesResult(
+      testResourceId,
+      resourceTypeName,
+      Some(testPolicy1),
+      Some(readerRoleName),
+      Some(readAction),
+      false,
+      None,
+      false,
+      false
+    ), // testing duplicate row results
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy2), Some(nothingRoleName), None, true, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy3), None, None, false, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false, None, false, false),
     FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true, None, false, false),
+    FilterResourcesResult(
+      testResourceId,
+      resourceTypeName,
+      Some(testPolicy5),
+      None,
+      Some(readAction),
+      true,
+      None,
+      false,
+      false
+    ), // testing duplicate row results
     // Auth Domain Results
     FilterResourcesResult(
       testResourceId2,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1064

Turns out, `UNION` carries the same performance penalty is `DISTINCT`. This blew up the runtime for an AoU test user that had access to 1.5 million Google Projects. Replacing `UNION` with `UNION ALL` brings runtimes down to be in-line with other users. Getting 1.5 million resources takes 3 seconds instead of 53!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
