### PR TITLE
WOR-1510 add tcl and better http metrics buckets

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
   val workbenchOauth2V = s"0.5-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.30-SNAPSHOT"
+  val tclVersion = "0.1.11-SNAPSHOT"
   val slf4jVersion = "2.0.6"
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
@@ -124,36 +125,6 @@ object Dependencies {
   val pact4sCirce = "io.github.jbwheatley" %% "pact4s-circe" % pact4sV
   val circeCore = "io.circe" %% "circe-core" % "0.14.4"
 
-  // OpenTelemetry
-  val openTelemetryVersion = "1.31.0"
-  val otelApi: ModuleID = "io.opentelemetry" % "opentelemetry-api" % openTelemetryVersion
-  val otelSdk: ModuleID = "io.opentelemetry" % "opentelemetry-sdk" % openTelemetryVersion
-  val otelSdkMetrics: ModuleID = "io.opentelemetry" % "opentelemetry-sdk-metrics" % openTelemetryVersion
-  val otelExporterLogging: ModuleID = "io.opentelemetry" % "opentelemetry-exporter-logging" % openTelemetryVersion
-  val otelSemconv: ModuleID = "io.opentelemetry.semconv" % "opentelemetry-semconv" % "1.21.0-alpha"
-  val otelAnnotation: ModuleID = "io.opentelemetry.instrumentation" % "opentelemetry-instrumentation-annotations" % openTelemetryVersion
-  val otelInstrumentationApi: ModuleID = "io.opentelemetry.instrumentation" % "opentelemetry-instrumentation-api" % openTelemetryVersion
-  val otelInstrumentationApiSemconv: ModuleID =
-    "io.opentelemetry.instrumentation" % "opentelemetry-instrumentation-api-semconv" % (openTelemetryVersion + "-alpha")
-  val otelPrometheusExporter: ModuleID = "io.opentelemetry" % "opentelemetry-exporter-prometheus" % (openTelemetryVersion + "-alpha")
-
-  // Google cloud open telemetry exporters
-  var gcpOpenTelemetryExporterVersion = "0.25.2"
-  var googleTraceExporter: ModuleID = "com.google.cloud.opentelemetry" % "exporter-trace" % gcpOpenTelemetryExporterVersion
-
-  val openTelemetryDependencies = Seq(
-    otelApi,
-    otelSdk,
-    otelSdkMetrics,
-    otelExporterLogging,
-    otelSemconv,
-    otelAnnotation,
-    otelInstrumentationApi,
-    otelInstrumentationApiSemconv,
-    otelPrometheusExporter,
-    googleTraceExporter
-  )
-
   val pact4sDependencies = Seq(
     pact4sScalaTest,
     pact4sCirce,
@@ -166,6 +137,33 @@ object Dependencies {
     "bio.terra" % "terra-cloud-resource-lib" % crlVersion excludeAll (excludeGoogleServiceUsage, excludeGoogleCloudResourceManager, excludeJerseyCore, excludeJerseyMedia, excludeSLF4J, excludeAwsSdk)
   val azureManagedApplications: ModuleID =
     "com.azure.resourcemanager" % "azure-resourcemanager-managedapplications" % "1.0.0-beta.1"
+
+  def excludeSpringBoot = ExclusionRule("org.springframework.boot")
+  def excludeSpringAop = ExclusionRule("org.springframework.spring-aop")
+  def excludeSpringData = ExclusionRule("org.springframework.data")
+  def excludeSpringFramework = ExclusionRule("org.springframework")
+  def excludeOpenCensus = ExclusionRule("io.opencensus")
+  def excludeGoogleFindBugs = ExclusionRule("com.google.code.findbugs")
+  def excludeBroadWorkbench = ExclusionRule("org.broadinstitute.dsde.workbench")
+  def excludeSlf4j = ExclusionRule("org.slf4j")
+  def excludePostgresql = ExclusionRule("org.postgresql", "postgresql")
+  def excludeSnakeyaml = ExclusionRule("org.yaml", "snakeyaml")
+  def excludeLiquibase = ExclusionRule("org.liquibase")
+  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(
+    excludeSpringBoot,
+    excludeSpringAop,
+    excludeSpringData,
+    excludeSpringFramework,
+    excludeOpenCensus,
+    excludeGoogleFindBugs,
+    excludeBroadWorkbench,
+    excludePostgresql,
+    excludeSnakeyaml,
+    excludeSlf4j,
+    excludeLiquibase
+  )
+
+  val terraCommonLib = tclExclusions("bio.terra" % "terra-common-lib" % tclVersion classifier "plain")
 
   // was included transitively before, now explicit
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.15"
@@ -219,6 +217,7 @@ object Dependencies {
     azureManagedApplications,
     sentry,
     sentryLogback,
-    okio
-  ) ++ openTelemetryDependencies
+    okio,
+    terraCommonLib
+  )
 }

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -18,6 +18,8 @@ object Merging {
     case "module-info.class" =>
       MergeStrategy.discard
     case x if x.endsWith("arrow-git.properties") => MergeStrategy.concat
+    case "logback.xml" => MergeStrategy.first
+    case PathList("META-INF", "spring-configuration-metadata.json") => MergeStrategy.discard // don't need no stinkin' spring
     case x => oldStrategy(x)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
@@ -3,19 +3,19 @@ package org.broadinstitute.dsde.workbench.sam.api
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directive1, ExceptionHandler}
+import bio.terra.common.opentelemetry.HttpServerMetrics
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.TextMapGetter
-import io.opentelemetry.instrumentation.api.instrumenter.http.{
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import io.opentelemetry.instrumentation.api.semconv.http.{
   HttpServerAttributesExtractor,
   HttpServerAttributesGetter,
-  HttpServerMetrics,
   HttpServerRoute,
   HttpServerRouteSource,
   HttpSpanStatusExtractor
 }
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchEmail, WorkbenchUserId}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1510

* Adds dependency on terra common lib (which includes open telemetry dependencies)
* Remove explicit open telemetry dependencies
* Use `bio.terra.common.opentelemetry.HttpServerMetrics` instead of the same class in open telemetry to set our own http metrics buckets

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
