### PR TITLE
ID-1026 Vulnerability fix: update reactor-netty

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,8 +27,6 @@ object Dependencies {
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 = ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
-  val excludeCloudResourceLib = ExclusionRule(organization = "bio.terra", name = "terra-cloud-resource-lib_2.12")
-  val excludeCommonLib = ExclusionRule(organization = "bio.terra", name = "terra-common-lib_2.12")
   val excludeWorkbenchUtil = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
   val excludeWorkbenchUtil2 = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util2_2.12")
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
@@ -67,7 +65,7 @@ object Dependencies {
   val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
   val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.85.Final"
-  val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.0.39" excludeAll (excludeCloudResourceLib, excludeCommonLib)
+  val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.0.39"
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,8 @@ object Dependencies {
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaProtobufV3 = ExclusionRule(organization = "com.typesafe.akka", name = "akka-protobuf-v3_2.12")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
+  val excludeCloudResourceLib = ExclusionRule(organization = "bio.terra", name = "terra-cloud-resource-lib_2.12")
+  val excludeCommonLib = ExclusionRule(organization = "bio.terra", name = "terra-common-lib_2.12")
   val excludeWorkbenchUtil = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
   val excludeWorkbenchUtil2 = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util2_2.12")
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
@@ -65,6 +67,7 @@ object Dependencies {
   val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
   val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.85.Final"
+  val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.0.39" excludeAll (excludeCloudResourceLib, excludeCommonLib)
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.1"
@@ -214,6 +217,7 @@ object Dependencies {
     postgres,
     cloudResourceLib,
     nettyAll,
+    reactorNetty,
     azureManagedApplications,
     sentry,
     sentryLogback,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1026

HTTP Functionality for the Reactor Netty Library is vulnerable to Denial of Service https://nvd.nist.gov/vuln/detail/CVE-2023-34054. Please upgrade this dependency to a non-vulnerable version 1.0.39.

DefectDojo link: https://defectdojo.dsp-appsec.broadinstitute.org/finding/174630
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
