### PR TITLE
ID-1026 Vulnerability fix: update netty-all

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test"
   val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
-  val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.85.Final"
+  val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.1.100.Final"
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
   val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.34.1"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1025

 Netty/Codec/Http2 dependency is vulnerable to Denial of Service. Please upgrade this dependency to a non-vulnerable version 4.1.100.Final

DefectDojo link: https://defectdojo.dsp-appsec.broadinstitute.org/finding/174632

I looked at the dependency tree and made sure that there weren't any instances of the old version being pulled in after upgrading. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
