### PR TITLE
ID-1086 Strongly Type User Allowances

### DIFF
--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -12,6 +12,7 @@ lazy val root = (project in file(".")).
     javacOptions in compile ++= Seq("-Xlint:deprecation"),
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
+    dependencyOverrides += "org.json" %% "json" % "20240205",
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",

--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -41,5 +41,5 @@ lazy val root = (project in file(".")).
       "com.novocode" % "junit-interface" % "0.10" % "test",
       "org.mockito" % "mockito-core" % "3.12.4" % "test"
     ),
-    dependencyOverrides += "org.json" %% "json" % "20240205") ++ publishSettings:_*
+    dependencyOverrides += "org.json" % "json" % "20240205") ++ publishSettings:_*
   )

--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -12,7 +12,6 @@ lazy val root = (project in file(".")).
     javacOptions in compile ++= Seq("-Xlint:deprecation"),
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
-    dependencyOverrides += "org.json" %% "json" % "20240205",
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
@@ -41,5 +40,6 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-api" % "5.9.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test",
       "org.mockito" % "mockito-core" % "3.12.4" % "test"
-    )) ++ publishSettings:_*
+    ),
+    dependencyOverrides += "org.json" %% "json" % "20240205") ++ publishSettings:_*
   )

--- a/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -40,6 +40,6 @@ lazy val root = (project in file(".")).
       "com.novocode" % "junit-interface" % "0.10" % "test",
       "javax.annotation" % "javax.annotation-api" % "1.3.2"
     ),
-    dependencyOverrides += "org.json" %% "json" % "20240205") ++ publishSettings:_*
+    dependencyOverrides += "org.json" % "json" % "20240205") ++ publishSettings:_*
   )
 

--- a/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -11,6 +11,7 @@ lazy val root = (project in file(".")).
     javacOptions in compile ++= Seq("-Xlint:deprecation"),
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
+    dependencyOverrides += "org.json" %% "json" % "20240205",
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.24",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
@@ -41,3 +42,4 @@ lazy val root = (project in file(".")).
       "javax.annotation" % "javax.annotation-api" % "1.3.2"
     )) ++ publishSettings:_*
   )
+

--- a/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java_old/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -11,7 +11,6 @@ lazy val root = (project in file(".")).
     javacOptions in compile ++= Seq("-Xlint:deprecation"),
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
-    dependencyOverrides += "org.json" %% "json" % "20240205",
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.24",
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
@@ -40,6 +39,7 @@ lazy val root = (project in file(".")).
       "org.junit.jupiter" % "junit-jupiter-api" % "5.9.1" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test",
       "javax.annotation" % "javax.annotation-api" % "1.3.2"
-    )) ++ publishSettings:_*
+    ),
+    dependencyOverrides += "org.json" %% "json" % "20240205") ++ publishSettings:_*
   )
 

--- a/scripts/gen_java_client.sh
+++ b/scripts/gen_java_client.sh
@@ -1,5 +1,5 @@
 set -e
 
-docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v7.2.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java/templates --library okhttp-gson --additional-properties useJakartaEe=true,disallowAdditionalPropertiesIfNotPresent=false
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v7.3.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java/templates --library okhttp-gson --additional-properties useJakartaEe=true,disallowAdditionalPropertiesIfNotPresent=false
 cd codegen_java
 sbt test

--- a/scripts/gen_java_client_old.sh
+++ b/scripts/gen_java_client_old.sh
@@ -1,5 +1,5 @@
 set -e
 
-docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v7.2.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java_old --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java_old/templates --library okhttp-gson --additional-properties disallowAdditionalPropertiesIfNotPresent=false
+docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v7.3.0 generate -i /local/src/main/resources/swagger/api-docs.yaml -g java -o /local/codegen_java_old --api-package org.broadinstitute.dsde.workbench.client.sam.api --model-package org.broadinstitute.dsde.workbench.client.sam.model --template-dir /local/codegen_java_old/templates --library okhttp-gson --additional-properties disallowAdditionalPropertiesIfNotPresent=false
 cd codegen_java_old
 sbt test

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4281,7 +4281,7 @@ components:
         - updatedAt
       properties:
         id:
-          type: number
+          type: string
           description: User's Id
         googleSubjectId:
           type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4281,7 +4281,7 @@ components:
         - updatedAt
       properties:
         id:
-          type: string
+          type: number
           description: User's Id
         googleSubjectId:
           type: string
@@ -4315,17 +4315,21 @@ components:
         allowed:
           type: boolean
           description: is the user allowed to use the system
+          nullable: false
         details:
           $ref: '#/components/schemas/SamUserAllowancesDetails'
     SamUserAllowancesDetails:
       type: object
+      nullable: false
       properties:
         enabled:
           type: boolean
           description: is the user enabled
+          nullable: false
         termsOfService:
           type: boolean
           description: has the user accepted the terms of service
+          nullable: false
     SamUserAttributes:
       type: object
       properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4316,8 +4316,16 @@ components:
           type: boolean
           description: is the user allowed to use the system
         details:
-          type: object
-          description: details of the user's allowances
+          $ref: '#/components/schemas/SamUserAllowancesDetails'
+    SamUserAllowancesDetails:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: is the user enabled
+        termsOfService:
+          type: boolean
+          description: has the user accepted the terms of service
     SamUserAttributes:
       type: object
       properties:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAllowances.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamUserAllowances.scala
@@ -2,19 +2,26 @@ package org.broadinstitute.dsde.workbench.sam.model.api
 
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
-
 object SamUserAllowances {
-  implicit val SamUserAllowedResponseFormat: RootJsonFormat[SamUserAllowances] = jsonFormat2(SamUserAllowances.apply)
+  implicit val SamUserAllowedResponseFormat: RootJsonFormat[SamUserAllowances] = jsonFormat2(SamUserAllowances.apply(_: Boolean, _: SamUserAllowancesDetails))
 
-  def apply(allowed: Boolean, enabled: Boolean, termsOfService: Boolean): SamUserAllowances =
-    SamUserAllowances(allowed, Map("enabled" -> enabled, "termsOfService" -> termsOfService))
+  def apply(enabled: Boolean, termsOfService: Boolean): SamUserAllowances =
+    SamUserAllowances(enabled && termsOfService, SamUserAllowancesDetails(enabled, termsOfService))
 }
 final case class SamUserAllowances(
     allowed: Boolean,
-    details: Map[String, Boolean]
+    details: SamUserAllowancesDetails
 ) {
 
-  def getEnabled: Boolean = details.get("enabled").exists(identity)
-  def getTermsOfServiceCompliance: Boolean = details.get("termsOfService").exists(identity)
+  def getEnabled: Boolean = details.enabled
+  def getTermsOfServiceCompliance: Boolean = details.termsOfService
 
 }
+
+object SamUserAllowancesDetails {
+  implicit val SamUserAllowancesDetailsResponseFormat: RootJsonFormat[SamUserAllowancesDetails] = jsonFormat2(SamUserAllowancesDetails.apply)
+}
+final case class SamUserAllowancesDetails(
+    enabled: Boolean,
+    termsOfService: Boolean
+)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -448,7 +448,6 @@ class UserService(
     for {
       tosStatus <- tosService.getTermsOfServiceComplianceStatus(samUser, samRequestContext)
     } yield SamUserAllowances(
-      allowed = samUser.enabled && tosStatus.permitsSystemUsage,
       enabled = samUser.enabled,
       termsOfService = tosStatus.permitsSystemUsage
     )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -123,7 +123,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
     // Act and Assert
     Get(s"/api/users/v2/self/allowed") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[SamUserAllowances] should be(SamUserAllowances(allowed = true, enabled = true, termsOfService = true))
+      responseAs[SamUserAllowances] should be(SamUserAllowances(enabled = true, termsOfService = true))
     }
   }
 
@@ -138,7 +138,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
     // Act and Assert
     Get(s"/api/users/v2/${defaultUser.id}/allowed") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[SamUserAllowances] should be(SamUserAllowances(allowed = true, enabled = true, termsOfService = true))
+      responseAs[SamUserAllowances] should be(SamUserAllowances(enabled = true, termsOfService = true))
     }
   }
 
@@ -169,12 +169,12 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRouteTest
     // Act and Assert
     Get(s"/api/users/v2/${otherUser.id}/allowed") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[SamUserAllowances] should be(SamUserAllowances(allowed = true, enabled = true, termsOfService = true))
+      responseAs[SamUserAllowances] should be(SamUserAllowances(enabled = true, termsOfService = true))
     }
 
     Get(s"/api/users/v2/${thirdUser.id}/allowed") ~> samRoutes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[SamUserAllowances] should be(SamUserAllowances(allowed = false, enabled = false, termsOfService = false))
+      responseAs[SamUserAllowances] should be(SamUserAllowances(enabled = false, termsOfService = false))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -89,7 +89,7 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
     }
 
     mockUserService.getUserAllowances(any[SamUser], any[SamRequestContext]) returns IO(
-      SamUserAllowances(allowed = false, enabled = false, termsOfService = false)
+      SamUserAllowances(enabled = false, termsOfService = false)
     )
     mockUserService.getUserAttributes(any[WorkbenchUserId], any[SamRequestContext]) returns IO(None)
   }
@@ -195,12 +195,12 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
 
   private def makeUserAppearAllowed(samUser: SamUser, mockUserService: UserService): Unit =
     mockUserService.getUserAllowances(eqTo(samUser), any[SamRequestContext]) returns IO(
-      SamUserAllowances(allowed = true, enabled = true, termsOfService = true)
+      SamUserAllowances(enabled = true, termsOfService = true)
     )
 
   private def makeUserAppearDisallowed(samUser: SamUser, mockUserService: UserService): Unit =
     mockUserService.getUserAllowances(any[SamUser], any[SamRequestContext]) returns IO(
-      SamUserAllowances(allowed = false, enabled = false, termsOfService = false)
+      SamUserAllowances(enabled = false, termsOfService = false)
     )
 
   private def makeUserAttributesAppear(userId: WorkbenchUserId, userAttributes: SamUserAttributes, mockUserService: UserService): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/AllowedUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/AllowedUserSpec.scala
@@ -28,7 +28,7 @@ class AllowedUserSpec extends UserServiceTestTraits {
         val response = runAndWait(userService.getUserAllowances(userWithBothIds, samRequestContext))
 
         // Assert
-        response should be(SamUserAllowances(allowed = true, enabled = true, termsOfService = true))
+        response should be(SamUserAllowances(enabled = true, termsOfService = true))
       }
     }
     describe("who has not accepted the Terms of Service") {
@@ -41,7 +41,7 @@ class AllowedUserSpec extends UserServiceTestTraits {
         val response = runAndWait(userService.getUserAllowances(userWithBothIds, samRequestContext))
 
         // Assert
-        response should be(SamUserAllowances(allowed = false, enabled = true, termsOfService = false))
+        response should be(SamUserAllowances(enabled = true, termsOfService = false))
       }
     }
   }
@@ -56,7 +56,7 @@ class AllowedUserSpec extends UserServiceTestTraits {
       val response = runAndWait(userService.getUserAllowances(userWithBothIds, samRequestContext))
 
       // Assert
-      response should be(SamUserAllowances(allowed = false, enabled = false, termsOfService = false))
+      response should be(SamUserAllowances(enabled = false, termsOfService = false))
     }
     it("should not be able to use the system even if the Terms of Service permits them to") {
       // Arrange
@@ -67,7 +67,7 @@ class AllowedUserSpec extends UserServiceTestTraits {
       val response = runAndWait(userService.getUserAllowances(userWithBothIds, samRequestContext))
 
       // Assert
-      response should be(SamUserAllowances(allowed = false, enabled = false, termsOfService = true))
+      response should be(SamUserAllowances(enabled = false, termsOfService = true))
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1086

What:

Strongly type the `getUserAllowances` response in the api client.

Also fixing a vulnerability in the transitive `json` dependency of the sam client.

Why:

Makes it easier for consumers of the API to use the response

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
