### PR TITLE
ID-1095 null default route

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRequestContextDirectives.scala
@@ -180,9 +180,11 @@ object AkkaHttpServerAttributesGetter extends HttpServerAttributesGetter[HttpReq
 
   override def getUrlQuery(request: HttpRequest): String = request.uri.query().toString()
 
-  /** Defaults to the path of the request. Overridden by the `addTelemetry` directive.
+  /** Defaults to the null. Overridden by the `addTelemetry` directive. This defaults to null because the route is used in metrics and we need to prevent a
+    * cardinality explosion. If we defaulted to the uri path, then any request with path parameters would default to a unique route until overridden by
+    * `addTelemetry` which might not happen in the case of errors or bugs.
     */
-  override def getHttpRoute(request: HttpRequest): String = getUrlPath(request)
+  override def getHttpRoute(request: HttpRequest): String = null
 
   override def getHttpRequestMethod(request: HttpRequest): String = request.method.value
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1095

In my latest iteration of sam metrics on dev I found that when there is an error before we are able to figure out the route (e.g. unregistered user or user has not accepted TOS), the http path is used in the http route metrics tag leading to cardinality issues in dev. This might not be an acute problem in prod but it is a vulnerability. This PR makes the default `null` which also protects against cardinality problem if route does not update telemetry correctly.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
