### PR TITLE
update TCL to get fewer metrics buckets

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchOauth2V = s"0.5-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.30-SNAPSHOT"
-  val tclVersion = "0.1.11-SNAPSHOT"
+  val tclVersion = "0.1.19-SNAPSHOT"
   val slf4jVersion = "2.0.6"
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1095

The latest version of TCL reduced metrics buckets by a factor of 3. This will have a net effect of reducing metrics by a factor of 12 to 24 (3 is multiplied by the number of sam instances [4] and possibly by 2 when there are errors)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
