### PR TITLE
need to use WithTelemetry everywhere since default route is null

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/LivenessRoutes.scala
@@ -10,7 +10,7 @@ class LivenessRoutes(directoryDAO: DirectoryDAO) extends SamRequestContextDirect
     withSamRequestContext { samRequestContext =>
       pathPrefix("liveness") {
         pathEndOrSingleSlash {
-          get {
+          getWithTelemetry(samRequestContext) {
             complete {
               directoryDAO.checkStatus(samRequestContext).map {
                 case true => OK

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -72,7 +72,7 @@ trait ManagedGroupRoutes extends SamUserDirectives with SecurityDirectives with 
       }
     } ~ (pathPrefix("groups" / "v1") | pathPrefix("groups")) {
       pathEndOrSingleSlash {
-        get {
+        getWithTelemetry(samRequestContext) {
           handleListGroups(samUser, samRequestContext)
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/OldUserRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/OldUserRoutes.scala
@@ -37,7 +37,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
     pathPrefix("user") {
       (pathPrefix("v1") | pathEndOrSingleSlash) {
         pathEndOrSingleSlash {
-          post {
+          postWithTelemetry(samRequestContext) {
             withNewUser(samRequestContext) { createUser =>
               complete {
                 userService.createUser(createUser, samRequestContext).map(userStatus => StatusCodes.Created -> userStatus)
@@ -45,7 +45,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
             }
           } ~
           (changeForbiddenToNotFound & withUserAllowInactive(samRequestContext)) { user =>
-            get {
+            getWithTelemetry(samRequestContext) {
               parameter("userDetailsOnly".?) { userDetailsOnly =>
                 complete {
                   userService.getUserStatus(user.id, userDetailsOnly.exists(_.equalsIgnoreCase("true")), samRequestContext).map { statusOption =>
@@ -63,7 +63,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
         pathPrefix("termsofservice") {
           pathPrefix("status") {
             pathEndOrSingleSlash {
-              get {
+              getWithTelemetry(samRequestContext) {
                 withUserAllowInactive(samRequestContext) { samUser =>
                   complete {
                     tosService.getTermsOfServiceComplianceStatus(samUser, samRequestContext).map { tosAcceptanceStatus =>
@@ -75,7 +75,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
             }
           } ~
           pathEndOrSingleSlash {
-            post {
+            postWithTelemetry(samRequestContext) {
               withUserAllowInactive(samRequestContext) { samUser =>
                 withTermsOfServiceAcceptance {
                   complete {
@@ -90,7 +90,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
                 }
               }
             } ~
-            delete {
+            deleteWithTelemetry(samRequestContext) {
               withUserAllowInactive(samRequestContext) { samUser =>
                 complete {
                   userService.rejectTermsOfService(samUser.id, samRequestContext).map { userStatusOption =>
@@ -108,7 +108,7 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
       } ~ pathPrefix("v2") {
         pathPrefix("self") {
           pathEndOrSingleSlash {
-            post {
+            postWithTelemetry(samRequestContext) {
               withNewUser(samRequestContext) { createUser =>
                 complete {
                   userService.createUser(createUser, samRequestContext).map(userStatus => StatusCodes.Created -> userStatus)
@@ -118,14 +118,14 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
           } ~
           (changeForbiddenToNotFound & withUserAllowInactive(samRequestContext)) { user =>
             path("info") {
-              get {
+              getWithTelemetry(samRequestContext) {
                 complete {
                   userService.getUserStatusInfo(user, samRequestContext)
                 }
               }
             } ~
             path("diagnostics") {
-              get {
+              getWithTelemetry(samRequestContext) {
                 complete {
                   userService.getUserStatusDiagnostics(user.id, samRequestContext).map { statusOption =>
                     statusOption
@@ -138,12 +138,12 @@ trait OldUserRoutes extends SamUserDirectives with SamRequestContextDirectives {
               }
             } ~
             path("termsOfServiceDetails") {
-              get {
+              getWithTelemetry(samRequestContext) {
                 complete(tosService.getTosDetails(user, samRequestContext))
               }
             } ~
             path("termsOfServiceComplianceStatus") {
-              get {
+              getWithTelemetry(samRequestContext) {
                 complete(tosService.getTermsOfServiceComplianceStatus(user, samRequestContext))
               }
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -34,7 +34,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
   def resourceRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     (pathPrefix("config" / "v1" / "resourceTypes") | pathPrefix("resourceTypes")) {
       pathEndOrSingleSlash {
-        get {
+        getWithTelemetry(samRequestContext) {
           complete(resourceService.getResourceTypes().map(typeMap => StatusCodes.OK -> typeMap.values.toSet))
         }
       }
@@ -127,7 +127,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
       } ~
       pathPrefix("resources" / "v2") {
         pathEnd {
-          get {
+          getWithTelemetry(samRequestContext) {
             listUserResources(samUser, samRequestContext)
           }
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutes.scala
@@ -39,7 +39,7 @@ trait ServiceAdminRoutes extends SecurityDirectives with SamRequestContextDirect
 
   private def serviceAdminUserRoutes(samRequestContext: SamRequestContext): server.Route =
     pathPrefix("users") {
-      get {
+      getWithTelemetry(samRequestContext) {
         parameters("id".optional, "googleSubjectId".optional, "azureB2CId".optional, "limit".as[Int].optional) { (id, googleSubjectId, azureB2CId, limit) =>
           complete {
             userService

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/TermsOfServiceRoutes.scala
@@ -78,7 +78,7 @@ trait TermsOfServiceRoutes extends SamUserDirectives with SamRequestContextDirec
             withUserAllowInactive(samRequestContextWithoutUser) { samUser: SamUser =>
               val samRequestContext = samRequestContextWithoutUser.copy(samUser = Some(samUser))
               pathEndOrSingleSlash {
-                get {
+                getWithTelemetry(samRequestContext) {
                   complete {
                     tosService.getTermsOfServiceDetailsForUser(samUser.id, samRequestContext)
                   }
@@ -86,21 +86,21 @@ trait TermsOfServiceRoutes extends SamUserDirectives with SamRequestContextDirec
               } ~
               pathPrefix("accept") { // api/termsOfService/v1/user/self/accept
                 pathEndOrSingleSlash {
-                  put {
+                  putWithTelemetry(samRequestContext) {
                     complete(tosService.acceptCurrentTermsOfService(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                   }
                 }
               } ~
               pathPrefix("reject") { // api/termsOfService/v1/user/self/reject
                 pathEndOrSingleSlash {
-                  put {
+                  putWithTelemetry(samRequestContext) {
                     complete(tosService.rejectCurrentTermsOfService(samUser.id, samRequestContext).map(_ => StatusCodes.NoContent))
                   }
                 }
               } ~
               pathPrefix("history") { // api/termsOfService/v1/user/self/history
                 pathEndOrSingleSlash {
-                  get {
+                  getWithTelemetry(samRequestContext) {
                     parameters("limit".as[Integer].withDefault(100)) { (limit: Int) =>
                       complete {
                         tosService.getTermsOfServiceHistoryForUser(samUser.id, samRequestContext, limit)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -104,7 +104,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
 
   // Get Sam User
   private def getAdminSamUserResponse(samUserId: WorkbenchUserId, samRequestContext: SamRequestContext): Route =
-    get {
+    getWithTelemetry(samRequestContext) {
       complete {
         for {
           user <- userService.getUser(samUserId, samRequestContext)
@@ -117,7 +117,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
     }
 
   private def getSamUserResponse(samUser: SamUser, samRequestContext: SamRequestContext): Route =
-    get {
+    getWithTelemetry(samRequestContext) {
       complete {
         samUserResponse(samUser, samRequestContext).map(response => StatusCodes.OK -> response)
       }
@@ -129,14 +129,14 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
 
   // Get Sam User Allowed
   private def getSamUserAllowances(samUser: SamUser, samRequestContext: SamRequestContext): Route =
-    get {
+    getWithTelemetry(samRequestContext) {
       complete {
         userService.getUserAllowances(samUser, samRequestContext).map(StatusCodes.OK -> _)
       }
     }
 
   private def getAdminSamUserAllowances(samUserId: WorkbenchUserId, samRequestContext: SamRequestContext): Route =
-    get {
+    getWithTelemetry(samRequestContext) {
       complete {
         for {
           user <- userService.getUser(samUserId, samRequestContext)
@@ -149,14 +149,14 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
     }
 
   private def getSamUserAttributes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
-    get {
+    getWithTelemetry(samRequestContext) {
       complete {
         userService.getUserAttributes(samUser.id, samRequestContext).map(response => (if (response.isDefined) OK else NotFound) -> response)
       }
     }
 
   private def patchSamUserAttributes(samUser: SamUser, samRequestContext: SamRequestContext): Route =
-    patch {
+    patchWithTelemetry(samRequestContext) {
       entity(as[SamUserAttributesRequest]) { userAttributesRequest =>
         complete {
           userService.setUserAttributesFromRequest(samUser.id, userAttributesRequest, samRequestContext).map(OK -> _)
@@ -165,7 +165,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
     }
 
   private def postUserRegistration(newUser: SamUser, samRequestContext: SamRequestContext): Route =
-    post {
+    postWithTelemetry(samRequestContext) {
       entity(as[SamUserRegistrationRequest]) { userRegistrationRequest =>
         complete {
           for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureRoutes.scala
@@ -25,7 +25,7 @@ trait AzureRoutes extends SecurityDirectives with LazyLogging with SamRequestCon
       .map { service =>
         pathPrefix("azure" / "v1") {
           path("user" / "petManagedIdentity") {
-            post {
+            postWithTelemetry(samRequestContext) {
               entity(as[GetOrCreatePetManagedIdentityRequest]) { request =>
                 requireUserCreatePetAction(request, samUser, samRequestContext) {
                   complete {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -77,7 +77,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
         pathPrefix("user" / "petServiceAccount") {
           pathPrefix("key") {
             pathEndOrSingleSlash {
-              get {
+              getWithTelemetry(samRequestContext) {
                 complete {
                   import spray.json._
                   googleExtensions
@@ -89,7 +89,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
           } ~
             pathPrefix("token") {
               pathEndOrSingleSlash {
-                post {
+                postWithTelemetry(samRequestContext) {
                   entity(as[Set[String]]) { scopes =>
                     complete {
                       googleExtensions.getArbitraryPetServiceAccountToken(samUser, scopes, samRequestContext).map { token =>
@@ -205,7 +205,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
         } ~
         pathPrefix("user") {
           pathPrefix("signedUrlForBlob") {
-            post {
+            postWithTelemetry(samRequestContext) {
               entity(as[RequesterPaysSignedUrlRequest]) { request =>
                 complete {
                   googleExtensions


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1095

The default route was changed to be null to stop flooding metrics in cases that routes could not be set appropriately. Unfortunately there were api calls not setting any route explicitly since they had no path parameters. This should fix that by using *WithTelemetry directives everywhere.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
