### PR TITLE
ID-1143 Update Workbench Libs to Update Jose4j

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "ad61f19" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "1c0cf92" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.19-$workbenchLibV"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1143

Remediates [CVE-2023-51775](https://nvd.nist.gov/vuln/detail/CVE-2023-51775). Just update workbench-libs, which pulls in this dependency.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
