### PR TITLE
AJ-1570 mock read permission

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -165,13 +165,13 @@ class SamProviderSpec
     case ProviderState(States.HasResourceWritePermission, _) =>
       mockResourceActionPermission(SamResourceActions.write, hasPermission = true).unsafeRunSync()
     case ProviderState(States.HasResourceReadPermission, _) =>
-      mockResourceActionPermission(SamResourceActions.read, hasPermission = true).unsafeRunSync()
+      mockResourceActionPermission(ResourceAction("read"), hasPermission = true).unsafeRunSync()
     case ProviderState(States.DoesNotHaveResourceDeletePermission, _) =>
       mockResourceActionPermission(SamResourceActions.delete, hasPermission = false).unsafeRunSync()
     case ProviderState(States.DoesNotHaveResourceWritePermission, _) =>
       mockResourceActionPermission(SamResourceActions.write, hasPermission = false).unsafeRunSync()
     case ProviderState(States.DoesNotHaveResourceReadPermission, _) =>
-      mockResourceActionPermission(SamResourceActions.read, hasPermission = false).unsafeRunSync()
+      mockResourceActionPermission(ResourceAction("read"), hasPermission = false).unsafeRunSync()
     case ProviderState(States.UserStatusInfoRequestWithAccessToken, _) =>
       logger.debug(s"you may stub provider behaviors here for the state: ${States.UserStatusInfoRequestWithAccessToken}")
     case ProviderState(States.UserStatusInfoRequestWithoutAccessToken, _) =>

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -41,8 +41,10 @@ object States {
   val UserExists = "user exists"
   val HasResourceDeletePermission = "user has delete permission"
   val HasResourceWritePermission = "user has write permission"
+  val HasResourceReadPermission = "user had read permission"
   val DoesNotHaveResourceDeletePermission = "user does not have delete permission"
   val DoesNotHaveResourceWritePermission = "user does not have write permission"
+  val DoesNotHaveResourceReadPermission = "user does not have read permission"
   val UserStatusInfoRequestWithAccessToken = "user status info request with access token"
   val UserStatusInfoRequestWithoutAccessToken = "user status info request without access token"
 }
@@ -162,10 +164,14 @@ class SamProviderSpec
       mockResourceActionPermission(SamResourceActions.delete, hasPermission = true).unsafeRunSync()
     case ProviderState(States.HasResourceWritePermission, _) =>
       mockResourceActionPermission(SamResourceActions.write, hasPermission = true).unsafeRunSync()
+    case ProviderState(States.HasResourceReadPermission, _) =>
+      mockResourceActionPermission(SamResourceActions.read, hasPermission = true).unsafeRunSync()
     case ProviderState(States.DoesNotHaveResourceDeletePermission, _) =>
       mockResourceActionPermission(SamResourceActions.delete, hasPermission = false).unsafeRunSync()
     case ProviderState(States.DoesNotHaveResourceWritePermission, _) =>
       mockResourceActionPermission(SamResourceActions.write, hasPermission = false).unsafeRunSync()
+    case ProviderState(States.DoesNotHaveResourceReadPermission, _) =>
+      mockResourceActionPermission(SamResourceActions.read, hasPermission = false).unsafeRunSync()
     case ProviderState(States.UserStatusInfoRequestWithAccessToken, _) =>
       logger.debug(s"you may stub provider behaviors here for the state: ${States.UserStatusInfoRequestWithAccessToken}")
     case ProviderState(States.UserStatusInfoRequestWithoutAccessToken, _) =>

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -41,7 +41,7 @@ object States {
   val UserExists = "user exists"
   val HasResourceDeletePermission = "user has delete permission"
   val HasResourceWritePermission = "user has write permission"
-  val HasResourceReadPermission = "user had read permission"
+  val HasResourceReadPermission = "user has read permission"
   val DoesNotHaveResourceDeletePermission = "user does not have delete permission"
   val DoesNotHaveResourceWritePermission = "user does not have write permission"
   val DoesNotHaveResourceReadPermission = "user does not have read permission"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1570
In setting up can-i-deploy for WDS, I discovered we had added [more](https://github.com/DataBiosphere/terra-workspace-data-service/blob/a0261291bbd47842c5ad0e31090a8b9a3a4ba204/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java#L100) [pacts](https://github.com/DataBiosphere/terra-workspace-data-service/blob/a0261291bbd47842c5ad0e31090a8b9a3a4ba204/service/src/test/java/org/databiosphere/workspacedataservice/pact/SamPactTest.java#L115) between wds and Sam without setting up Sam to verify them.  The additional pacts were for read permissions, whereas we already had write and delete permissions, so hopefully this will fix that and allow the pacts to pass.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
