### PR TITLE
[ID-367] make registered_at non null and update null values to 1970

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ You only have to do this once.
 ```shell
 ./render_config.sh
 ```
+#### Get on the Broad VPN
+You need to be on the non-split VPN to perform the next steps
 
 #### Source Environment Variables
 ```shell
@@ -209,6 +211,8 @@ sh docker/run-proxy.sh start
 ```
 
 #### Run Sam!
+You can either use sbt, or if you are using intelliJ set up a run configuration to debug as described below instead
+
 ```shell
 sbt run
 ```

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -28,4 +28,6 @@
     <include file="changesets/20230929_add_tos_audit_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231011_add_tos_audit_table_created_at_pk.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240325_default_registered_at_to_1970.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240325_default_registered_at_to_1970.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240325_default_registered_at_to_1970.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="kfeldman" id="default_registered_at_to_1970">
+        <sql>
+            update sam_user set registered_at = '1970-01-01 00:00:00-00'::timestamptz where registered_at is null
+        </sql>
+    </changeSet>
+    <changeSet logicalFilePath="dummy" author="kfeldman" id="make_registered_at_non_nullable">
+        <dropNotNullConstraint tableName="sam_user" columnName="registered_at"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/ID-367)

What:

In using the registered_at date from Sam to send to appcues for the NPS survey timing, we discovered that some registered_at dates are null from when we migrated the dates from Rex to Sam. This PR will backfill all registered_at dates that are currently null and set them to a default value of 1970. This way we can still see which users we don't have accurate registration dates on, but don't have to handle null values. 


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
