### PR TITLE
[DC-830] Add snapshot builder permissions

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1340,16 +1340,16 @@ resourceTypes = {
   snapshot-builder-request = {
     actionPatterns = {
       get = {
-        description = "Get or list the snapshot builder request
+        description = "Get or list the snapshot builder request"
       }
       update = {
-        description = "Get or list the snapshot builder request
+        description = "Update the snapshot builder request"
       }
       delete = {
-        description = "Get or list the snapshot builder request
+        description = "Delete the snapshot builder request"
       }
       approve = {
-        description = "Approve or reject the snapshot builder request
+        description = "Approve or reject the snapshot builder request"
       }
     }
     ownerRoleName = "owner"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1300,7 +1300,7 @@ resourceTypes = {
         description = "Can get the snapshot builder settings for this snapshot"
       }
       "update_snapshot_builder_settings" = {
-        description = "Can get the snapshot builder settings for this snapshot"
+        description = "Can update the snapshot builder settings for this snapshot"
       }
     }
     ownerRoleName = "steward"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1337,7 +1337,7 @@ resourceTypes = {
     reuseIds = false
     authDomainConstrainable = true
   }
-  snapshot-builder-request = {
+  snapshotbuilderrequest = {
     actionPatterns = {
       get = {
         description = "Get or list the snapshot builder request"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1362,7 +1362,6 @@ resourceTypes = {
       }
     }
     reuseIds = false
-    authDomainConstrainable = false
   }
   service-perimeter = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1313,11 +1313,9 @@ resourceTypes = {
         roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
         includedRoles = ["reader"]
       }
-      snapshot_builder_manager = {
-        roleActions = ["update_snapshot_builder_settings"]
-        descendantRoles = {
-          snapshot_builder_request = ["approver"]
-        }
+      reader = {
+        roleActions = ["read_data", "read_policy::custodian","export_snapshot"]
+        includedRoles = ["aggregate_data_reader"]
       }
       aggregate_data_reader = {
         roleActions = ["read_aggregate_data", "create_snapshot_request"]
@@ -1326,9 +1324,11 @@ resourceTypes = {
       discoverer = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain", "get_snapshot_builder_settings"]
       }
-      reader = {
-        roleActions = ["read_data", "read_policy::custodian","export_snapshot"]
-        includedRoles = ["aggregate_data_reader"]
+      snapshot_builder_manager = {
+        roleActions = ["update_snapshot_builder_settings"]
+        descendantRoles = {
+          snapshot_builder_request = ["approver"]
+        }
       }
       admin = {
         roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1290,20 +1290,45 @@ resourceTypes = {
       "unlock_resource" = {
         description = "Can unlock a resource"
       }
+      "read_aggregate_data" = {
+        description = "Can read aggregate data about a snapshot"
+      }
+      "create_snapshot_request" = {
+        description = "Can create a snapshot request for this snapshot"
+      }
+      "get_snapshot_builder_settings" = {
+        description = "Can get the snapshot builder settings for this snapshot"
+      }
+      "update_snapshot_builder_settings" = {
+        description = "Can get the snapshot builder settings for this snapshot"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
+        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal"]
+        includedRoles = ["custodian"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
+        includedRoles = ["reader"]
+      }
+      snapshot_builder_manager = {
+        roleActions = ["update_snapshot_builder_settings"]
+        descendantRoles = {
+          snapshot_builder_request = ["approver"]
+        }
+      }
+      aggregate_data_reader = {
+        roleActions = ["read_aggregate_data", "create_snapshot_request"]
+        includedRoles = ["discoverer"]
       }
       discoverer = {
-        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
+        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain", "get_snapshot_builder_settings"]
       }
       reader = {
-        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
+        roleActions = ["read_data", "read_policy::custodian","export_snapshot"]
+        includedRoles = ["aggregate_data_reader"]
       }
       admin = {
         roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource"]
@@ -1311,6 +1336,31 @@ resourceTypes = {
     }
     reuseIds = false
     authDomainConstrainable = true
+  }
+  snapshot-builder-request = {
+    actionPatterns = {
+      get = {
+        description = "Get or list the snapshot builder request
+      }
+      update = {
+        description = "Get or list the snapshot builder request
+      }
+      delete = {
+        description = "Get or list the snapshot builder request
+      }
+      approve = {
+        description = "Approve or reject the snapshot builder request
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["get", "update", "delete"]
+      }
+      approver = {
+        roleActions = ["get", "approve"]
+      }
+    }
   }
   service-perimeter = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1361,6 +1361,8 @@ resourceTypes = {
         roleActions = ["get", "approve"]
       }
     }
+    reuseIds = false
+    authDomainConstrainable = false
   }
   service-perimeter = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1327,7 +1327,7 @@ resourceTypes = {
       snapshot_builder_manager = {
         roleActions = ["update_snapshot_builder_settings"]
         descendantRoles = {
-          snapshot_builder_request = ["approver"]
+          snapshot-builder-request = ["approver"]
         }
       }
       admin = {
@@ -1337,7 +1337,7 @@ resourceTypes = {
     reuseIds = false
     authDomainConstrainable = true
   }
-  snapshotbuilderrequest = {
+  snapshot-builder-request = {
     actionPatterns = {
       get = {
         description = "Get or list the snapshot builder request"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1256,6 +1256,9 @@ resourceTypes = {
       "share_policy::reader" = {
         description = "Can grant and revoke a users' read permission"
       }
+      "share_policy::aggregate_data_reader" = {
+        description = "Can grant and revoke a users' aggregate data read permission"
+      }
       "share_policy::discoverer" = {
         description = "Can grant and revoke a users' discover permission"
       }
@@ -1310,7 +1313,7 @@ resourceTypes = {
         includedRoles = ["custodian"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
         includedRoles = ["reader"]
       }
       reader = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DC-830

  \<Don't forget to include the ticket number in the PR title!\>

What:

This adds the permissions for the snapshot builder to the Sam config. While here, I also decided to use the new Sam _includedRoles_ feature that I noticed, which I think cleans up a lot of the role definitions. I only did it for snapshots because this PR doesn't touch datasets.

What this PR does not do:
1. This PR does not include descendant roles for the dataset<->snapshot relationship - that requires additional discussion
2. This PR does not remove the existing dataset permissions that we have given admins and are currently using to check permissions. I want to remove those later to avoid breaking our dev auth checks

Why:

The cleanup is useful to simplify our role definitions, and help document what is shared across roles. 
The addition of SnapshotBuilderRequests as separate objects allow us to more carefully manage the request objects.

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
