### PR TITLE
DC-830 - Revert "[DC-830] Add snapshot builder permissions (#1396)"

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1256,9 +1256,6 @@ resourceTypes = {
       "share_policy::reader" = {
         description = "Can grant and revoke a users' read permission"
       }
-      "share_policy::aggregate_data_reader" = {
-        description = "Can grant and revoke a users' aggregate data read permission"
-      }
       "share_policy::discoverer" = {
         description = "Can grant and revoke a users' discover permission"
       }
@@ -1293,45 +1290,20 @@ resourceTypes = {
       "unlock_resource" = {
         description = "Can unlock a resource"
       }
-      "read_aggregate_data" = {
-        description = "Can read aggregate data about a snapshot"
-      }
-      "create_snapshot_request" = {
-        description = "Can create a snapshot request for this snapshot"
-      }
-      "get_snapshot_builder_settings" = {
-        description = "Can get the snapshot builder settings for this snapshot"
-      }
-      "update_snapshot_builder_settings" = {
-        description = "Can update the snapshot builder settings for this snapshot"
-      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal"]
-        includedRoles = ["custodian"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::steward", "share_policy::custodian", "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "update_passport_identifier", "export_snapshot", "view_journal", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
-        includedRoles = ["reader"]
-      }
-      reader = {
-        roleActions = ["read_data", "read_policy::custodian","export_snapshot"]
-        includedRoles = ["aggregate_data_reader"]
-      }
-      aggregate_data_reader = {
-        roleActions = ["read_aggregate_data", "create_snapshot_request"]
-        includedRoles = ["discoverer"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "read_data",  "discover_data",  "share_policy::reader",  "share_policy::discoverer", "read_policies", "set_public", "export_snapshot", "read_auth_domain", "update_auth_domain", "lock_resource", "unlock_resource"]
       }
       discoverer = {
-        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain", "get_snapshot_builder_settings"]
+        roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain"]
       }
-      snapshot_builder_manager = {
-        roleActions = ["update_snapshot_builder_settings"]
-        descendantRoles = {
-          snapshot-builder-request = ["approver"]
-        }
+      reader = {
+        roleActions = ["read_data", "discover_data", "read_policy::steward", "read_policy::custodian", "read_policy::discoverer", "export_snapshot", "read_auth_domain"]
       }
       admin = {
         roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource"]
@@ -1339,32 +1311,6 @@ resourceTypes = {
     }
     reuseIds = false
     authDomainConstrainable = true
-  }
-  snapshot-builder-request = {
-    actionPatterns = {
-      get = {
-        description = "Get or list the snapshot builder request"
-      }
-      update = {
-        description = "Update the snapshot builder request"
-      }
-      delete = {
-        description = "Delete the snapshot builder request"
-      }
-      approve = {
-        description = "Approve or reject the snapshot builder request"
-      }
-    }
-    ownerRoleName = "owner"
-    roles = {
-      owner = {
-        roleActions = ["get", "update", "delete"]
-      }
-      approver = {
-        roleActions = ["get", "approve"]
-      }
-    }
-    reuseIds = false
   }
   service-perimeter = {
     actionPatterns = {


### PR DESCRIPTION
This reverts commit 60a65fb0a00695ac12cb1bad0313c15b739b1fa7.

Ticket: https://broadworkbench.atlassian.net/browse/DC-830

What:

TDR is in a degraded state with the changes in the original commit. I went to test something on TDR dev and wasn't able to retrieve any snapshots. Looking at the logs, we're seeing a flood of NPEs starting at 5:06PM which is shortly after the PR was merged at 4:57PM. The NPE is occurring on [SnapshotService.getSnapshotIdsAndRoles() on L436](https://github.com/DataBiosphere/jade-data-repo/blob/be6a093a53129e26475cf5fc878d62013f2497fe/src/main/java/bio/terra/service/snapshot/SnapshotService.java#L436), so that seems potentially related to a SAM change.

Why:

Revert changes so that they are not promoted to staging/prod and get TDR dev back into a working state.

How:

Revert commit from this PR - https://github.com/broadinstitute/sam/pull/1396

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
