### PR TITLE
ID-1224 Azure Action Managed Identities

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -141,7 +141,7 @@ object MockTestSupport extends MockTestSupport {
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(googleExt, directoryDAO, tosConfig)
-    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
+    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO)
     MockSamDependencies(
       mockResourceService,
       policyEvaluatorService,

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -141,7 +141,7 @@ object MockTestSupport extends MockTestSupport {
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(googleExt, directoryDAO, tosConfig)
-    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO)
+    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
     MockSamDependencies(
       mockResourceService,
       policyEvaluatorService,

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -28,4 +28,5 @@
     <include file="changesets/20230929_add_tos_audit_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231011_add_tos_audit_table_created_at_pk.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240417_action_managed_identities.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240417_action_managed_identities.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240417_action_managed_identities.xml
@@ -14,14 +14,8 @@
             <column name="resource_action_id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" foreignKeyName="FK_SAMI_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id"/>
             </column>
-            <column name="tenant_id" type="VARCHAR(40)">
-                <constraints nullable="false" primaryKey="true"/>
-            </column>
-            <column name="subscription_id" type="VARCHAR(40)">
-                <constraints nullable="false" primaryKey="true"/>
-            </column>
-            <column name="managed_resource_group_name" type="VARCHAR">
-                <constraints nullable="false" primaryKey="true"/>
+            <column name="managed_resource_group_id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" foreignKeyName="FK_SAMI_MRG" referencedTableName="SAM_AZURE_MANAGED_RESOURCE_GROUP" referencedColumnNames="id" deleteCascade="true"/>
             </column>
             <column name="object_id" type="VARCHAR">
                 <constraints nullable="false"/>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240417_action_managed_identities.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240417_action_managed_identities.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="tlangs" id="action_managed_identities">
+        <createTable tableName="SAM_ACTION_MANAGED_IDENTITY">
+            <column name="resource_id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" foreignKeyName="FK_SAMI_RESOURCE" referencedTableName="SAM_RESOURCE" referencedColumnNames="id" deleteCascade="true"/>
+            </column>
+
+            <column name="resource_action_id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" foreignKeyName="FK_SAMI_ACTION" referencedTableName="SAM_RESOURCE_ACTION" referencedColumnNames="id"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR(40)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="subscription_id" type="VARCHAR(40)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="managed_resource_group_name" type="VARCHAR">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="object_id" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="display_name" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1559,11 +1559,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /api/azure/v1/actionManagedIdentity/{resourceTypeName}/{resourceId}/{action}:
+  /api/azure/v1/actionManagedIdentity/{billingProfileId}/{resourceTypeName}/{resourceId}/{action}:
     post:
       tags:
         - Azure
-      summary: gets or creates an action managed identity that the calling user has access to
+      summary: creates an action managed identity that the calling user has access to
+      operationId: createActionManagedIdentity
+      parameters:
+        - name: billingProfileId
+          in: path
+          description: Billing Profile if the Managed Resource Group to create the Action Managed Identity in
+          required: true
+          schema:
+            type: string
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+        - name: action
+          in: path
+          description: Action to create the managed identity for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Action managed identity already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionManagedIdentityResponse'
+        201:
+          description: Successfully created the action managed identity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionManagedIdentityResponse'
+        400:
+          description: Invalid or incomplete request body
+          content: { }
+        403:
+          description: Caller does not have the action on the resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Resource does not exist
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/actionManagedIdentity/{resourceTypeName}/{resourceId}/{action}:
+    get:
+      tags:
+        - Azure
+      summary: gets an action managed identity that the calling user has access to
       operationId: getActionManagedIdentity
       parameters:
         - name: resourceTypeName
@@ -1584,20 +1646,13 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        description: The details of the managed resource group in which to create the action managed identity
-        content:
-          'application/json':
-            schema:
-              $ref: '#/components/schemas/GetOrCreateManagedIdentityRequest'
-        required: true
       responses:
         200:
           description: Successfully retrieved the action managed identity without creating it
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/ActionManagedIdentityResponse'
         201:
           description: Successfully created the action managed identity
           content:
@@ -4294,6 +4349,30 @@ components:
           description: the name of the Azure managed resource group
           example: my-managed-resource-group
       description: specifies a request for a managed identity
+    ActionManagedIdentityId:
+      type: object
+      required:
+        - resourceId
+        - action
+        - billingProfileId
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/FullyQualifiedResourceId'
+        action:
+          type: string
+        billingProfileId:
+          type: string
+    ActionManagedIdentityResponse:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ActionManagedIdentityId'
+        objectId:
+          type: string
+        displayName:
+          type: string
+        managedResourceGroupCoordinates:
+          $ref: '#/components/schemas/ManagedResourceGroupCoordinates'
     User:
       type: object
       required:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1479,7 +1479,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/GetOrCreatePetManagedIdentityRequest'
+              $ref: '#/components/schemas/GetOrCreateManagedIdentityRequest'
         required: true
       responses:
         200:
@@ -1528,7 +1528,7 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/GetOrCreatePetManagedIdentityRequest'
+              $ref: '#/components/schemas/GetOrCreateManagedIdentityRequest'
         required: true
       responses:
         200:
@@ -1559,6 +1559,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/azure/v1/actionManagedIdentity/{resourceTypeName}/{resourceId}/{action}:
+    post:
+      tags:
+        - Azure
+      summary: gets or creates an action managed identity that the calling user has access to
+      operationId: getActionManagedIdentity
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+        - name: action
+          in: path
+          description: Action to get the managed identity for
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The details of the managed resource group in which to create the action managed identity
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/GetOrCreateManagedIdentityRequest'
+        required: true
+      responses:
+        200:
+          description: Successfully retrieved the action managed identity without creating it
+          content:
+            application/json:
+              schema:
+                type: string
+        201:
+          description: Successfully created the action managed identity
+          content:
+            application/json:
+              schema:
+                type: string
+        400:
+          description: Invalid or incomplete request body
+          content: { }
+        403:
+          description: Caller does not have the action on the resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Resource does not exist
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
   /api/resources/v2:
     get:
       tags:
@@ -4210,7 +4274,7 @@ components:
           type: string
           description: the name of the Azure managed resource group
           example: my-managed-resource-group
-    GetOrCreatePetManagedIdentityRequest:
+    GetOrCreateManagedIdentityRequest:
       required:
         - tenantId
         - subscriptionId
@@ -4229,7 +4293,7 @@ components:
           type: string
           description: the name of the Azure managed resource group
           example: my-managed-resource-group
-      description: specifies a request for a pet managed identity
+      description: specifies a request for a managed identity
     User:
       type: object
       required:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -434,7 +434,7 @@ object Boot extends IOApp with LazyLogging {
       )
     val samApplication = SamApplication(userService, resourceService, statusService, tosService)
     val azureService = config.azureServicesConfig.map { azureConfig =>
-      new AzureService(new CrlService(azureConfig, config.janitorConfig), directoryDAO, azureManagedResourceGroupDAO)
+      new AzureService(new CrlService(azureConfig, config.janitorConfig), directoryDAO, azureManagedResourceGroupDAO, policyEvaluatorService)
     }
     cloudExtensionsInitializer match {
       case GoogleExtensionsInitializer(googleExt, synchronizer) =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -409,7 +409,7 @@ object Boot extends IOApp with LazyLogging {
     val resourceTypeMap = config.resourceTypes.map(rt => rt.name -> rt).toMap
     val policyEvaluatorService = PolicyEvaluatorService(config.emailDomain, resourceTypeMap, accessPolicyDAO, directoryDAO)
     val azureService = config.azureServicesConfig.map { azureConfig =>
-      new AzureService(new CrlService(azureConfig, config.janitorConfig), directoryDAO, azureManagedResourceGroupDAO, policyEvaluatorService)
+      new AzureService(new CrlService(azureConfig, config.janitorConfig), directoryDAO, azureManagedResourceGroupDAO)
     }
     val resourceService = new ResourceService(
       resourceTypeMap,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceId}
 import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 
 object AzureJsonSupport {
   implicit val tenantIdFormat = ValueObjectFormat(TenantId.apply)
@@ -23,6 +24,12 @@ object AzureJsonSupport {
   implicit val petManagedIdentityFormat = jsonFormat3(PetManagedIdentity.apply)
 
   implicit val managedResourceGroupCoordinatesFormat = jsonFormat3(ManagedResourceGroupCoordinates.apply)
+
+  implicit val billingProfileIdFormat = ValueObjectFormat(BillingProfileId.apply)
+
+  implicit val actionManagedIdentityIdFormat = jsonFormat3(ActionManagedIdentityId.apply)
+
+  implicit val actionManagedIdentityFormat = jsonFormat4(ActionManagedIdentity.apply)
 }
 
 final case class TenantId(value: String) extends ValueObject

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -56,9 +56,14 @@ final case class PetManagedIdentityId(
 
 final case class PetManagedIdentity(id: PetManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
 
-final case class ActionManagedIdentityId(resourceId: FullyQualifiedResourceId, action: ResourceAction, mrgCoordinates: ManagedResourceGroupCoordinates)
+final case class ActionManagedIdentityId(resourceId: FullyQualifiedResourceId, action: ResourceAction, billingProfileId: BillingProfileId)
 
-final case class ActionManagedIdentity(id: ActionManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
+final case class ActionManagedIdentity(
+    id: ActionManagedIdentityId,
+    objectId: ManagedIdentityObjectId,
+    displayName: ManagedIdentityDisplayName,
+    managedResourceGroupCoordinates: ManagedResourceGroupCoordinates
+)
 object AzureExtensions {
   val resourceId = ResourceId("azure")
   val getPetManagedIdentityAction = ResourceAction("get_pet_managed_identity")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -56,6 +56,15 @@ final case class PetManagedIdentityId(
 
 final case class PetManagedIdentity(id: PetManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
 
+final case class ActionManagedIdentityId(
+    resourceId: ResourceId,
+    action: ResourceAction,
+    tenantId: TenantId,
+    subscriptionId: SubscriptionId,
+    managedResourceGroupName: ManagedResourceGroupName
+)
+
+final case class ActionManagedIdentity(id: ActionManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
 object AzureExtensions {
   val resourceId = ResourceId("azure")
   val getPetManagedIdentityAction = ResourceAction("get_pet_managed_identity")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureModel.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.model.{ResourceAction, ResourceId}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceId}
 import spray.json.DefaultJsonProtocol._
 
 object AzureJsonSupport {
@@ -56,13 +56,7 @@ final case class PetManagedIdentityId(
 
 final case class PetManagedIdentity(id: PetManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
 
-final case class ActionManagedIdentityId(
-    resourceId: ResourceId,
-    action: ResourceAction,
-    tenantId: TenantId,
-    subscriptionId: SubscriptionId,
-    managedResourceGroupName: ManagedResourceGroupName
-)
+final case class ActionManagedIdentityId(resourceId: FullyQualifiedResourceId, action: ResourceAction, mrgCoordinates: ManagedResourceGroupCoordinates)
 
 final case class ActionManagedIdentity(id: ActionManagedIdentityId, objectId: ManagedIdentityObjectId, displayName: ManagedIdentityDisplayName)
 object AzureExtensions {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
   PetManagedIdentityId
 }
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -99,6 +99,12 @@ trait DirectoryDAO {
   def createActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity]
 
   def loadActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[ActionManagedIdentity]]
+
+  def loadActionManagedIdentity(
+      resource: FullyQualifiedResourceId,
+      action: ResourceAction,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ActionManagedIdentity]]
 
   def updateActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam.azure.{
   ActionManagedIdentity,
   ActionManagedIdentityId,
+  BillingProfileId,
   ManagedIdentityObjectId,
   PetManagedIdentity,
   PetManagedIdentityId
@@ -109,6 +110,13 @@ trait DirectoryDAO {
   ): IO[Seq[ActionManagedIdentity]]
 
   def deleteAllActionManagedIdentitiesForResource(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
+
+  def getAllActionManagedIdentitiesForBillingProfile(
+      billingProfileId: BillingProfileId,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[ActionManagedIdentity]]
+  def deleteAllActionManagedIdentitiesForBillingProfile(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Unit]
+
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
   def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -3,9 +3,15 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
-import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  ActionManagedIdentity,
+  ActionManagedIdentityId,
+  ManagedIdentityObjectId,
+  PetManagedIdentity,
+  PetManagedIdentityId
+}
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, ResourceId, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -88,6 +94,21 @@ trait DirectoryDAO {
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]
   def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
+  def createActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity]
+
+  def loadActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[ActionManagedIdentity]]
+
+  def updateActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity]
+
+  def deleteActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Unit]
+
+  def getAllActionManagedIdentitiesForResource(
+      resourceId: ResourceId,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[ActionManagedIdentity]]
+
+  def deleteAllActionManagedIdentitiesForResource(resourceId: ResourceId, samRequestContext: SamRequestContext): IO[Unit]
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
   def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
   PetManagedIdentityId
 }
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, ResourceId, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -104,11 +104,11 @@ trait DirectoryDAO {
   def deleteActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Unit]
 
   def getAllActionManagedIdentitiesForResource(
-      resourceId: ResourceId,
+      resourceId: FullyQualifiedResourceId,
       samRequestContext: SamRequestContext
   ): IO[Seq[ActionManagedIdentity]]
 
-  def deleteAllActionManagedIdentitiesForResource(resourceId: ResourceId, samRequestContext: SamRequestContext): IO[Unit]
+  def deleteAllActionManagedIdentitiesForResource(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
   def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -1007,6 +1007,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val actionManagedIdentityColumn = ActionManagedIdentityTable.column
       val resourceTable = ResourceTable.syntax
       val resourceTypeTable = ResourceTypeTable.syntax
+      val resourceActionTable = ResourceActionTable.syntax
       val managedResourceGroupTable = AzureManagedResourceGroupTable.syntax
 
       samsql"""insert into ${ActionManagedIdentityTable.table}
@@ -1019,7 +1020,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                  )
              values (
                       (select ${resourceTable.result.id} from ${ResourceTable as resourceTable} left join ${ResourceTypeTable as resourceTypeTable} on ${resourceTable.resourceTypeId} = ${resourceTypeTable.id} where ${resourceTable.name} = ${actionManagedIdentity.id.resourceId.resourceId} and ${resourceTypeTable.name} = ${actionManagedIdentity.id.resourceId.resourceTypeName}),
-                      (select ${ResourceActionTable.column.id} from ${ResourceActionTable.table} where ${ResourceActionTable.column.action} = ${actionManagedIdentity.id.action}),
+                      (select ${resourceActionTable.result.id} from ${ResourceActionTable as resourceActionTable} left join ${ResourceTypeTable as resourceTypeTable} on ${resourceActionTable.resourceTypeId} = ${resourceTypeTable.id} where ${resourceActionTable.action} = ${actionManagedIdentity.id.action} and ${resourceTypeTable.name} = ${actionManagedIdentity.id.resourceId.resourceTypeName}),
                       (select ${managedResourceGroupTable.result.id}
                       from ${AzureManagedResourceGroupTable as managedResourceGroupTable}
                       where ${managedResourceGroupTable.billingProfileId} = ${actionManagedIdentity.id.billingProfileId}),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ActionManagedIdentityTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ActionManagedIdentityTable.scala
@@ -7,9 +7,7 @@ import scalikejdbc._
 final case class ActionManagedIdentityRecord(
     resourceId: ResourcePK,
     resourceActionId: ResourceActionPK,
-    tenantId: TenantId,
-    subscriptionId: SubscriptionId,
-    managedResourceGroupName: ManagedResourceGroupName,
+    managedResourceGroupId: ManagedResourceGroupPK,
     objectId: ManagedIdentityObjectId,
     displayName: ManagedIdentityDisplayName
 )
@@ -21,9 +19,7 @@ object ActionManagedIdentityTable extends SQLSyntaxSupportWithDefaultSamDB[Actio
   def apply(e: ResultName[ActionManagedIdentityRecord])(rs: WrappedResultSet): ActionManagedIdentityRecord = ActionManagedIdentityRecord(
     rs.get(e.resourceId),
     rs.get(e.resourceActionId),
-    rs.get(e.tenantId),
-    rs.get(e.subscriptionId),
-    rs.get(e.managedResourceGroupName),
+    rs.get(e.managedResourceGroupId),
     rs.get(e.objectId),
     rs.get(e.displayName)
   )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ActionManagedIdentityTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ActionManagedIdentityTable.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.sam.azure._
+import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders
+import scalikejdbc._
+
+final case class ActionManagedIdentityRecord(
+    resourceId: ResourcePK,
+    resourceActionId: ResourceActionPK,
+    tenantId: TenantId,
+    subscriptionId: SubscriptionId,
+    managedResourceGroupName: ManagedResourceGroupName,
+    objectId: ManagedIdentityObjectId,
+    displayName: ManagedIdentityDisplayName
+)
+
+object ActionManagedIdentityTable extends SQLSyntaxSupportWithDefaultSamDB[ActionManagedIdentityRecord] {
+  override def tableName: String = "SAM_ACTION_MANAGED_IDENTITY"
+
+  import SamTypeBinders._
+  def apply(e: ResultName[ActionManagedIdentityRecord])(rs: WrappedResultSet): ActionManagedIdentityRecord = ActionManagedIdentityRecord(
+    rs.get(e.resourceId),
+    rs.get(e.resourceActionId),
+    rs.get(e.tenantId),
+    rs.get(e.subscriptionId),
+    rs.get(e.managedResourceGroupName),
+    rs.get(e.objectId),
+    rs.get(e.displayName)
+  )
+
+  def apply(p: SyntaxProvider[ActionManagedIdentityRecord])(rs: WrappedResultSet): ActionManagedIdentityRecord = apply(p.resultName)(rs)
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -103,7 +103,7 @@ testStuff = {
   azure {
     tenantId = "fad90753-2022-4456-9b0a-c7e5b934e408"
     subscriptionId = "f557c728-871d-408c-a28b-eb6b2141a087"
-    managedResourceGroupName = "e2e-8n6xqg"
+    managedResourceGroupName = "e2e-n6bgy8"
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -149,7 +149,7 @@ object TestSupport extends TestSupport {
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(googleExt, directoryDAO, tosConfig)
-    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
+    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO)
     SamDependencies(
       mockResourceService,
       policyEvaluatorService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -149,7 +149,7 @@ object TestSupport extends TestSupport {
     val mockManagedGroupService =
       new ManagedGroupService(mockResourceService, policyEvaluatorService, resourceTypes, policyDAO, directoryDAO, googleExt, "example.com")
     val tosService = new TosService(googleExt, directoryDAO, tosConfig)
-    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO)
+    val azureService = new AzureService(MockCrlService(), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
     SamDependencies(
       mockResourceService,
       policyEvaluatorService,
@@ -225,6 +225,7 @@ object TestSupport extends TestSupport {
     if (databaseEnabled) {
       dbRef.inLocalTransaction { implicit session =>
         val tables = List(
+          ActionManagedIdentityTable,
           PolicyActionTable,
           PolicyRoleTable,
           PolicyTable,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -203,7 +203,8 @@ object TestSamRoutes {
     mockResourceService.initResourceTypes(samRequestContext).unsafeRunSync()
 
     val mockStatusService = new StatusService(directoryDAO, cloudXtns)
-    val azureService = new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO)
+    val azureService =
+      new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
     new TestSamRoutes(
       mockResourceService,
       policyEvaluatorService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/TestSamRoutes.scala
@@ -204,7 +204,7 @@ object TestSamRoutes {
 
     val mockStatusService = new StatusService(directoryDAO, cloudXtns)
     val azureService =
-      new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
+      new AzureService(crlService.getOrElse(MockCrlService(Option(user))), directoryDAO, new MockAzureManagedResourceGroupDAO)
     new TestSamRoutes(
       mockResourceService,
       policyEvaluatorService,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceSpec.scala
@@ -184,12 +184,13 @@ class AzureServiceSpec(_system: ActorSystem)
     val crlService = new CrlService(azureServicesConfig.get, janitorConfig)
     val tosService = new TosService(NoExtensions, directoryDAO, tosConfig)
     val userService = new UserService(directoryDAO, NoExtensions, Seq.empty, tosService)
+    val azureManagedResourceGroupDAO = new PostgresAzureManagedResourceGroupDAO(TestSupport.dbRef, TestSupport.dbRef)
     val azureTestConfig = config.getConfig("testStuff.azure")
     val (resourceService, policyEvaluatorService, defaultResourceType, viewAction) = setUpResources(directoryDAO)
-    val azureService = new AzureService(crlService, directoryDAO, new MockAzureManagedResourceGroupDAO, policyEvaluatorService)
+    val azureService = new AzureService(crlService, directoryDAO, azureManagedResourceGroupDAO, policyEvaluatorService)
 
     // create user
-    val defaultUser = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("rtitlefireclouddev@gmail.com"))).get
+    val defaultUser = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("hermione.owner@test.firecloud.org"))).get
     val userStatus = userService.createUser(defaultUser, samRequestContext).unsafeRunSync()
     userStatus shouldBe UserStatus(
       UserStatusDetails(defaultUser.id, defaultUser.email),
@@ -282,7 +283,7 @@ class AzureServiceSpec(_system: ActorSystem)
     val azureService = new AzureService(crlService, directoryDAO, azureManagedResourceGroupDAO, policyEvaluatorService)
 
     // create user
-    val defaultUser = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("rtitlefireclouddev@gmail.com"))).get
+    val defaultUser = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("hermione.owner@test.firecloud.org"))).get
     val userStatus = userService.createUser(defaultUser, samRequestContext).unsafeRunSync()
     userStatus shouldBe UserStatus(
       UserStatusDetails(defaultUser.id, defaultUser.email),
@@ -379,7 +380,7 @@ class AzureServiceSpec(_system: ActorSystem)
       BillingProfileId("de38969d-f41b-4b80-99ba-db481e6db1cf")
     )
 
-    val user = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("rtitlefireclouddev@gmail.com")))
+    val user = Generator.genWorkbenchUserAzure.sample.map(_.copy(email = WorkbenchEmail("hermione.owner@test.firecloud.org")))
 
     azureService.createManagedResourceGroup(managedResourceGroup, samRequestContext.copy(samUser = user)).unsafeRunSync()
     mockMrgDAO.mrgs should contain(managedResourceGroup)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
@@ -1,0 +1,173 @@
+package org.broadinstitute.dsde.workbench.sam.azure
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.azure.core.management.Region
+import com.azure.core.util.Context
+import com.azure.resourcemanager.msi.MsiManager
+import com.azure.resourcemanager.msi.models.Identity.DefinitionStages
+import com.azure.resourcemanager.msi.models.{Identities, Identity}
+import com.azure.resourcemanager.resources.ResourceManager
+import com.azure.resourcemanager.resources.models.{ResourceGroup, ResourceGroups}
+import org.broadinstitute.dsde.workbench.model.WorkbenchExceptionWithErrorReport
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{AzureManagedResourceGroupDAO, DirectoryDAO}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceId, ResourceTypeName}
+import org.broadinstitute.dsde.workbench.sam.service.PolicyEvaluatorService
+import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+
+class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures with TestSupport with MockitoSugar with PropertyBasedTesting {
+
+  private val dummyUser = Generator.genWorkbenchUserBoth.sample.get
+
+  "AzureService" - {
+    "Action Managed Identities" - {
+      "create an Action Managed Identity" in {
+        val mockCrlService = mock[CrlService]
+        val mockDirectoryDAO = mock[DirectoryDAO]
+        val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
+        val mockPolicyEvaluatorService = mock[PolicyEvaluatorService]
+        val mockMsiManager = mock[MsiManager]
+        val mockResourceManager = mock[ResourceManager]
+        val mockResourceGroups = mock[ResourceGroups]
+        val mockResourceGroup = mock[ResourceGroup]
+        val mockIdentities = mock[Identities]
+        val mockIdentitiesBlank = mock[DefinitionStages.Blank]
+        val mockIdentityWithGroup = mock[DefinitionStages.WithGroup]
+        val mockIdentityWithCreate = mock[DefinitionStages.WithCreate]
+        val mockIdentity = mock[Identity]
+
+        val azureService = new AzureService(mockCrlService, mockDirectoryDAO, mockAzureManagedResourceGroupDAO, mockPolicyEvaluatorService)
+
+        val testMrgCoordinates = ManagedResourceGroupCoordinates(
+          TenantId(UUID.randomUUID().toString),
+          SubscriptionId(UUID.randomUUID().toString),
+          ManagedResourceGroupName(UUID.randomUUID().toString)
+        )
+        val testAction = ResourceAction("testAction")
+        val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
+        val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+
+        when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(true))
+        when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(None))
+        when(mockCrlService.buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockMsiManager))
+        when(mockCrlService.buildResourceManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockResourceManager))
+        when(mockResourceManager.resourceGroups()).thenReturn(mockResourceGroups)
+        when(mockResourceGroups.getByName(testMrgCoordinates.managedResourceGroupName.value)).thenReturn(mockResourceGroup)
+        when(mockResourceGroup.region()).thenReturn(Region.US_EAST)
+        when(mockMsiManager.identities()).thenReturn(mockIdentities)
+        when(mockIdentities.define(testDisplayName.value)).thenReturn(mockIdentitiesBlank)
+        when(mockIdentitiesBlank.withRegion(Region.US_EAST)).thenReturn(mockIdentityWithGroup)
+        when(mockIdentityWithGroup.withExistingResourceGroup(testMrgCoordinates.managedResourceGroupName.value)).thenReturn(mockIdentityWithCreate)
+        when(mockIdentityWithCreate.withTags(any[java.util.Map[String, String]])).thenReturn(mockIdentityWithCreate)
+        when(mockIdentityWithCreate.create(any[Context])).thenReturn(mockIdentity)
+        when(mockIdentity.id()).thenReturn(testObjectId.value)
+        when(mockIdentity.name()).thenReturn(testDisplayName.value)
+        when(mockDirectoryDAO.createActionManagedIdentity(testActionManagedIdentity, samRequestContext)).thenReturn(IO.pure(testActionManagedIdentity))
+
+        val (ami, created) =
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+        ami should be(testActionManagedIdentity)
+        created should be(true)
+      }
+
+      "retrieve an existing Action Managed Identity" in {
+        val mockCrlService = mock[CrlService]
+        val mockDirectoryDAO = mock[DirectoryDAO]
+        val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
+        val mockPolicyEvaluatorService = mock[PolicyEvaluatorService]
+
+        val azureService = new AzureService(mockCrlService, mockDirectoryDAO, mockAzureManagedResourceGroupDAO, mockPolicyEvaluatorService)
+
+        val testMrgCoordinates = ManagedResourceGroupCoordinates(
+          TenantId(UUID.randomUUID().toString),
+          SubscriptionId(UUID.randomUUID().toString),
+          ManagedResourceGroupName(UUID.randomUUID().toString)
+        )
+        val testAction = ResourceAction("testAction")
+        val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
+        val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+
+        when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(true))
+        when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(Option(testActionManagedIdentity)))
+
+        val (ami, created) =
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+        ami should be(testActionManagedIdentity)
+        created should be(false)
+        verify(mockCrlService, never).buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)
+      }
+
+      "delete an existing Action Managed Identity" in {
+        val mockCrlService = mock[CrlService]
+        val mockDirectoryDAO = mock[DirectoryDAO]
+        val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
+        val mockPolicyEvaluatorService = mock[PolicyEvaluatorService]
+        val mockMsiManager = mock[MsiManager]
+        val mockIdentities = mock[Identities]
+
+        val azureService = new AzureService(mockCrlService, mockDirectoryDAO, mockAzureManagedResourceGroupDAO, mockPolicyEvaluatorService)
+
+        val testMrgCoordinates = ManagedResourceGroupCoordinates(
+          TenantId(UUID.randomUUID().toString),
+          SubscriptionId(UUID.randomUUID().toString),
+          ManagedResourceGroupName(UUID.randomUUID().toString)
+        )
+        val testAction = ResourceAction("testAction")
+        val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
+        val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+
+        when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(Option(testActionManagedIdentity)))
+        when(mockCrlService.buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockMsiManager))
+        when(mockMsiManager.identities()).thenReturn(mockIdentities)
+        doNothing.when(mockIdentities).deleteById(testObjectId.value)
+        when(mockDirectoryDAO.deleteActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(()))
+
+        azureService.deleteActionManagedIdentity(testActionManagedIdentityId, samRequestContext).unsafeRunSync()
+      }
+
+      "refuse to interact with a user without the action" in {
+        val mockCrlService = mock[CrlService]
+        val mockDirectoryDAO = mock[DirectoryDAO]
+        val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
+        val mockPolicyEvaluatorService = mock[PolicyEvaluatorService]
+
+        val azureService = new AzureService(mockCrlService, mockDirectoryDAO, mockAzureManagedResourceGroupDAO, mockPolicyEvaluatorService)
+
+        val testMrgCoordinates = ManagedResourceGroupCoordinates(
+          TenantId(UUID.randomUUID().toString),
+          SubscriptionId(UUID.randomUUID().toString),
+          ManagedResourceGroupName(UUID.randomUUID().toString)
+        )
+        val testAction = ResourceAction("testAction")
+        val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
+        val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+
+        when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(false))
+
+        val thrown = intercept[WorkbenchExceptionWithErrorReport] {
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+        }
+        thrown.errorReport.statusCode should be(Some(StatusCodes.Forbidden))
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
@@ -3,14 +3,18 @@ package org.broadinstitute.dsde.workbench.sam.azure
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import com.azure.core.http.rest.PagedIterable
 import com.azure.core.management.Region
 import com.azure.core.util.Context
+import com.azure.resourcemanager.managedapplications.ApplicationManager
+import com.azure.resourcemanager.managedapplications.models.{Application, Applications, Plan}
 import com.azure.resourcemanager.msi.MsiManager
 import com.azure.resourcemanager.msi.models.Identity.DefinitionStages
 import com.azure.resourcemanager.msi.models.{Identities, Identity}
 import com.azure.resourcemanager.resources.ResourceManager
 import com.azure.resourcemanager.resources.models.{ResourceGroup, ResourceGroups}
 import org.broadinstitute.dsde.workbench.model.WorkbenchExceptionWithErrorReport
+import org.broadinstitute.dsde.workbench.sam.config.ManagedAppPlan
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AzureManagedResourceGroupDAO, DirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceId, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.service.PolicyEvaluatorService
@@ -34,6 +38,11 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
         val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
         val mockPolicyEvaluatorService = mock[PolicyEvaluatorService]
         val mockMsiManager = mock[MsiManager]
+        val mockApplicationManager = mock[ApplicationManager]
+        val mockApplications = mock[Applications]
+        val mockPagedResponse = mock[PagedIterable[Application]]
+        val mockApplication = mock[Application]
+        val mockPlan = mock[Plan]
         val mockResourceManager = mock[ResourceManager]
         val mockResourceGroups = mock[ResourceGroups]
         val mockResourceGroup = mock[ResourceGroup]
@@ -50,20 +59,37 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
           SubscriptionId(UUID.randomUUID().toString),
           ManagedResourceGroupName(UUID.randomUUID().toString)
         )
+        val testBillingProfileId = BillingProfileId(UUID.randomUUID().toString)
         val testAction = ResourceAction("testAction")
         val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
-        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testBillingProfileId)
         val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
         val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
-        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName, testMrgCoordinates)
+        val testManagedAppPlan = ManagedAppPlan("testPlan", "testPublisher", UUID.randomUUID().toString)
+        val testSamRequestContext = samRequestContext.copy(samUser = Some(dummyUser))
+        val testMrgId = UUID.randomUUID().toString
 
-        when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(true))
-        when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(None))
+        when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, testSamRequestContext)).thenReturn(IO.pure(true))
+        when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, testSamRequestContext)).thenReturn(IO.pure(None))
+        when(mockAzureManagedResourceGroupDAO.getManagedResourceGroupByBillingProfileId(testBillingProfileId, testSamRequestContext))
+          .thenReturn(IO.pure(Some(ManagedResourceGroup(testMrgCoordinates, testBillingProfileId))))
         when(mockCrlService.buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockMsiManager))
+        when(mockCrlService.buildApplicationManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockApplicationManager))
+        when(mockCrlService.getManagedAppPlans).thenReturn(Seq(testManagedAppPlan))
+        when(mockApplicationManager.applications()).thenReturn(mockApplications)
+        when(mockApplications.list()).thenReturn(mockPagedResponse)
+        when(mockPagedResponse.iterator()).thenReturn(java.util.List.of(mockApplication).iterator())
+        when(mockApplication.plan()).thenReturn(mockPlan)
+        when(mockApplication.managedResourceGroupId()).thenReturn(testMrgId)
+        when(mockApplication.parameters()).thenReturn(java.util.Map.of(testManagedAppPlan.authorizedUserKey, java.util.Map.of("value", dummyUser.email.value)))
+        when(mockPlan.name()).thenReturn(testManagedAppPlan.name)
+        when(mockPlan.publisher()).thenReturn(testManagedAppPlan.publisher)
         when(mockCrlService.buildResourceManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockResourceManager))
         when(mockResourceManager.resourceGroups()).thenReturn(mockResourceGroups)
         when(mockResourceGroups.getByName(testMrgCoordinates.managedResourceGroupName.value)).thenReturn(mockResourceGroup)
         when(mockResourceGroup.region()).thenReturn(Region.US_EAST)
+        when(mockResourceGroup.id()).thenReturn(testMrgId)
         when(mockMsiManager.identities()).thenReturn(mockIdentities)
         when(mockIdentities.define(testDisplayName.value)).thenReturn(mockIdentitiesBlank)
         when(mockIdentitiesBlank.withRegion(Region.US_EAST)).thenReturn(mockIdentityWithGroup)
@@ -72,10 +98,10 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
         when(mockIdentityWithCreate.create(any[Context])).thenReturn(mockIdentity)
         when(mockIdentity.id()).thenReturn(testObjectId.value)
         when(mockIdentity.name()).thenReturn(testDisplayName.value)
-        when(mockDirectoryDAO.createActionManagedIdentity(testActionManagedIdentity, samRequestContext)).thenReturn(IO.pure(testActionManagedIdentity))
+        when(mockDirectoryDAO.createActionManagedIdentity(testActionManagedIdentity, testSamRequestContext)).thenReturn(IO.pure(testActionManagedIdentity))
 
         val (ami, created) =
-          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testBillingProfileId, dummyUser, testSamRequestContext).unsafeRunSync()
         ami should be(testActionManagedIdentity)
         created should be(true)
       }
@@ -93,18 +119,19 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
           SubscriptionId(UUID.randomUUID().toString),
           ManagedResourceGroupName(UUID.randomUUID().toString)
         )
+        val testBillingProfileId = BillingProfileId(UUID.randomUUID().toString)
         val testAction = ResourceAction("testAction")
         val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
-        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testBillingProfileId)
         val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
         val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
-        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName, testMrgCoordinates)
 
         when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(true))
         when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(Option(testActionManagedIdentity)))
 
         val (ami, created) =
-          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testBillingProfileId, dummyUser, samRequestContext).unsafeRunSync()
         ami should be(testActionManagedIdentity)
         created should be(false)
         verify(mockCrlService, never).buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)
@@ -125,12 +152,13 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
           SubscriptionId(UUID.randomUUID().toString),
           ManagedResourceGroupName(UUID.randomUUID().toString)
         )
+        val testBillingProfileId = BillingProfileId(UUID.randomUUID().toString)
         val testAction = ResourceAction("testAction")
         val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
-        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
+        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testBillingProfileId)
         val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
         val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
-        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
+        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName, testMrgCoordinates)
 
         when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, samRequestContext)).thenReturn(IO.pure(Option(testActionManagedIdentity)))
         when(mockCrlService.buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockMsiManager))
@@ -149,22 +177,14 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
 
         val azureService = new AzureService(mockCrlService, mockDirectoryDAO, mockAzureManagedResourceGroupDAO, mockPolicyEvaluatorService)
 
-        val testMrgCoordinates = ManagedResourceGroupCoordinates(
-          TenantId(UUID.randomUUID().toString),
-          SubscriptionId(UUID.randomUUID().toString),
-          ManagedResourceGroupName(UUID.randomUUID().toString)
-        )
+        val testBillingProfileId = BillingProfileId(UUID.randomUUID().toString)
         val testAction = ResourceAction("testAction")
         val testResource = FullyQualifiedResourceId(ResourceTypeName("testResourceType"), ResourceId("testResource"))
-        val testActionManagedIdentityId = ActionManagedIdentityId(testResource, testAction, testMrgCoordinates)
-        val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
-        val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
-        val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName)
 
         when(mockPolicyEvaluatorService.hasPermission(testResource, testAction, dummyUser.id, samRequestContext)).thenReturn(IO.pure(false))
 
         val thrown = intercept[WorkbenchExceptionWithErrorReport] {
-          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testMrgCoordinates, dummyUser, samRequestContext).unsafeRunSync()
+          azureService.getOrCreateActionManagedIdentity(testResource, testAction, testBillingProfileId, dummyUser, samRequestContext).unsafeRunSync()
         }
         thrown.errorReport.statusCode should be(Some(StatusCodes.Forbidden))
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
 }
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, ResourceId, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, FullyQualifiedResourceId, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -415,11 +415,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   override def deleteActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Unit] = ???
 
   override def getAllActionManagedIdentitiesForResource(
-      resourceId: ResourceId,
+      resourceId: FullyQualifiedResourceId,
       samRequestContext: SamRequestContext
   ): IO[Seq[ActionManagedIdentity]] = ???
 
-  override def deleteAllActionManagedIdentitiesForResource(resourceId: ResourceId, samRequestContext: SamRequestContext): IO[Unit] =
+  override def deleteAllActionManagedIdentitiesForResource(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
     ???
 
   override def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -6,10 +6,16 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 import org.broadinstitute.dsde.workbench.sam._
-import org.broadinstitute.dsde.workbench.sam.azure.{ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  ActionManagedIdentity,
+  ActionManagedIdentityId,
+  ManagedIdentityObjectId,
+  PetManagedIdentity,
+  PetManagedIdentityId
+}
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, ResourceId, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -396,6 +402,25 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(None)
+
+  override def createActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity] = ???
+
+  override def loadActionManagedIdentity(
+      actionManagedIdentityId: ActionManagedIdentityId,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ActionManagedIdentity]] = ???
+
+  override def updateActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity] = ???
+
+  override def deleteActionManagedIdentity(actionManagedIdentityId: ActionManagedIdentityId, samRequestContext: SamRequestContext): IO[Unit] = ???
+
+  override def getAllActionManagedIdentitiesForResource(
+      resourceId: ResourceId,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[ActionManagedIdentity]] = ???
+
+  override def deleteAllActionManagedIdentitiesForResource(resourceId: ResourceId, samRequestContext: SamRequestContext): IO[Unit] =
+    ???
 
   override def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit] =
     loadUser(userId, samRequestContext).map {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
 }
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, FullyQualifiedResourceId, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -408,6 +408,12 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def loadActionManagedIdentity(
       actionManagedIdentityId: ActionManagedIdentityId,
+      samRequestContext: SamRequestContext
+  ): IO[Option[ActionManagedIdentity]] = ???
+
+  override def loadActionManagedIdentity(
+      resource: FullyQualifiedResourceId,
+      action: ResourceAction,
       samRequestContext: SamRequestContext
   ): IO[Option[ActionManagedIdentity]] = ???
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.azure.{
   ActionManagedIdentity,
   ActionManagedIdentityId,
+  BillingProfileId,
   ManagedIdentityObjectId,
   PetManagedIdentity,
   PetManagedIdentityId
@@ -417,10 +418,17 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   override def getAllActionManagedIdentitiesForResource(
       resourceId: FullyQualifiedResourceId,
       samRequestContext: SamRequestContext
-  ): IO[Seq[ActionManagedIdentity]] = ???
+  ): IO[Seq[ActionManagedIdentity]] = IO.pure(Seq.empty)
 
   override def deleteAllActionManagedIdentitiesForResource(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit] =
     ???
+
+  override def getAllActionManagedIdentitiesForBillingProfile(
+      billingProfileId: BillingProfileId,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[ActionManagedIdentity]] = IO.pure(Seq.empty)
+
+  override def deleteAllActionManagedIdentitiesForBillingProfile(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Unit] = ???
 
   override def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit] =
     loadUser(userId, samRequestContext).map {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -72,7 +72,11 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
   val defaultActionManagedIdentities: Set[ActionManagedIdentity] = Set(readAction, writeAction).map(action =>
     ActionManagedIdentity(
-      ActionManagedIdentityId(defaultResource.resourceId, action, defaultTenantId, defaultSubscriptionId, defaultManagedResourceGroup),
+      ActionManagedIdentityId(
+        FullyQualifiedResourceId(defaultResource.resourceTypeName, defaultResource.resourceId),
+        action,
+        ManagedResourceGroupCoordinates(defaultTenantId, defaultSubscriptionId, defaultManagedResourceGroup)
+      ),
       ManagedIdentityObjectId(UUID.randomUUID().toString),
       ManagedIdentityDisplayName(s"whoCares-$action")
     )
@@ -1940,12 +1944,12 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         defaultActionManagedIdentities.map(dao.createActionManagedIdentity(_, samRequestContext).unsafeRunSync())
 
         val bothLoadedServiceAccounts =
-          dao.getAllActionManagedIdentitiesForResource(defaultResource.resourceId, samRequestContext).unsafeRunSync().toSet
+          dao.getAllActionManagedIdentitiesForResource(defaultResource.fullyQualifiedId, samRequestContext).unsafeRunSync().toSet
         bothLoadedServiceAccounts should be(defaultActionManagedIdentities)
 
-        dao.deleteAllActionManagedIdentitiesForResource(defaultResource.resourceId, samRequestContext).unsafeRunSync()
+        dao.deleteAllActionManagedIdentitiesForResource(defaultResource.fullyQualifiedId, samRequestContext).unsafeRunSync()
 
-        dao.getAllActionManagedIdentitiesForResource(defaultResource.resourceId, samRequestContext).unsafeRunSync() should be(Seq.empty)
+        dao.getAllActionManagedIdentitiesForResource(defaultResource.fullyQualifiedId, samRequestContext).unsafeRunSync() should be(Seq.empty)
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -1944,6 +1944,24 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.loadActionManagedIdentity(writeActionManagedIdentity.get.id, samRequestContext).unsafeRunSync() should be(None)
       }
 
+      "can be loaded for a resource and action" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
+        policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
+        policyDAO.createResource(defaultBillingProfileResource, samRequestContext).unsafeRunSync()
+        azureManagedResourceGroupDAO.insertManagedResourceGroup(defaultManagedResourceGroup, samRequestContext).unsafeRunSync()
+
+        defaultActionManagedIdentities.map(dao.createActionManagedIdentity(_, samRequestContext).unsafeRunSync())
+
+        val readActionManagedIdentity = defaultActionManagedIdentities.find(_.id.action == readAction)
+        val loadedReadActionManagedIdentity = dao.loadActionManagedIdentity(defaultResource.fullyQualifiedId, readAction, samRequestContext).unsafeRunSync()
+        loadedReadActionManagedIdentity should be(readActionManagedIdentity)
+
+        val writeActionManagedIdentity = defaultActionManagedIdentities.find(_.id.action == writeAction)
+        val loadedWriteActionManagedIdentity = dao.loadActionManagedIdentity(defaultResource.fullyQualifiedId, writeAction, samRequestContext).unsafeRunSync()
+        loadedWriteActionManagedIdentity should be(writeActionManagedIdentity)
+      }
+
       "can be read, and deleted en mass for a resource" in {
         assume(databaseEnabled, databaseEnabledClue)
         policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1224

What:

Introducing Action Managed Identities for Azure Resources! This will power Terra's access to data and other resources through Private Endpoints. The first use-case for this is pulling private docker images from Azure Container Registry.

Why:

For the ease of IT Admin of customers, Terra will represent itself with an Action Managed Identity when pulling things through a private endpoint. This means IT Admins can grant a single identity access to the private resource, and Terra will manage user access to that identity. 

An Action Managed Identity is tied to an Action on a Resource. This means that if a user has, for example, the `read` action on resource `A`, they will also have access to the `read-A` Action Managed Identity. 

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
