### PR TITLE
[ID-1178] add Resource Access Constraint DB tables

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -28,4 +28,6 @@
     <include file="changesets/20230929_add_tos_audit_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231011_add_tos_audit_table_created_at_pk.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240416_add_sam_rac_tables.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -30,7 +30,7 @@
         </createTable>
         <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT_LOCK">
             <column name="resource_access_constraint_id" type="BIGINT">
-                <constraints primaryKey="true" foreignKeyName="FK_SRACL_RESOURCE_ACCESS_CONSTRAINT_ID" referencedTableName="SAM_RESOURCE_ACCESS_CONSTRAINT" referencedColumnNames="id"/>
+                <constraints primaryKey="true" foreignKeyName="FK_SRACL_RESOURCE_ACCESS_CONSTRAINT_ID" referencedTableName="SAM_RESOURCE_ACCESS_CONSTRAINT" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="lock_id" type="BIGINT">
                 <constraints primaryKey="false" foreignKeyName="FK_SRACL_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
@@ -41,7 +41,7 @@
         </createTable>
         <createTable tableName="SAM_KEYCHAIN_GROUP">
             <column name="lock_id" type="BIGINT">
-                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id"/>
+                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="group_id" type="BIGINT">
                 <constraints primaryKey="false" foreignKeyName="FK_SKG_GROUP_ID" referencedTableName="SAM_GROUP" referencedColumnNames="id"/>
@@ -49,7 +49,7 @@
         </createTable>
         <createTable tableName="SAM_KEYCHAIN_USER">
             <column name="lock_id" type="BIGINT">
-                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id"/>
+                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="user_id" type="VARCHAR">
                 <constraints primaryKey="false" foreignKeyName="FK_SKG_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id"/>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -51,7 +51,7 @@
             <column name="lock_id" type="BIGINT">
                 <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id"/>
             </column>
-            <column name="user_id" type="BIGINT">
+            <column name="user_id" type="VARCHAR">
                 <constraints primaryKey="false" foreignKeyName="FK_SKG_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id"/>
             </column>
         </createTable>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -8,15 +8,15 @@
     <changeSet logicalFilePath="dummy" author="kfeldman" id="add_sam_rac_tables">
         <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT">
             <column name="id" type="BIGINT" autoIncrement="true">
-                <constraints primaryKey="true"/>
+                <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="resource_id" type="BIGINT">
-                <constraints primaryKey="false" foreignKeyName="FK_SRAC_RESOURCE_ID" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
+                <constraints primaryKey="false" foreignKeyName="FK_SRAC_RESOURCE_ID" referencedTableName="SAM_RESOURCE" referencedColumnNames="id" nullable="true"/>
             </column>
         </createTable>
         <createTable tableName="SAM_LOCK">
             <column name="id" type="BIGINT" autoIncrement="true">
-                <constraints primaryKey="true"/>
+                <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="lock_detail" type="JSONB">
                 <constraints primaryKey="false" nullable="false"/>
@@ -25,7 +25,7 @@
                 <constraints primaryKey="false" nullable="false"/>
             </column>
             <column name="description" type="VARCHAR">
-                <constraints primaryKey="false"/>
+                <constraints primaryKey="false" nullable="true"/>
             </column>
         </createTable>
         <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT_LOCK">

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -44,7 +44,7 @@
                 <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="group_id" type="BIGINT">
-                <constraints primaryKey="false" foreignKeyName="FK_SKG_GROUP_ID" referencedTableName="SAM_GROUP" referencedColumnNames="id"/>
+                <constraints primaryKey="false" foreignKeyName="FK_SKG_GROUP_ID" referencedTableName="SAM_GROUP" referencedColumnNames="id" nullable="false"/>
             </column>
         </createTable>
         <createTable tableName="SAM_KEYCHAIN_USER">
@@ -52,7 +52,7 @@
                 <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="user_id" type="VARCHAR">
-                <constraints primaryKey="false" foreignKeyName="FK_SKG_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id"/>
+                <constraints primaryKey="false" foreignKeyName="FK_SKG_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id" nullable="false"/>
             </column>
         </createTable>
     </changeSet>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -18,10 +18,13 @@
             <column name="id" type="BIGINT" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="lock_detail" type="JSONB">
+            <column name="name" type="VARCHAR">
                 <constraints primaryKey="false" nullable="false"/>
             </column>
-            <column name="name" type="VARCHAR">
+            <column name="lock_type" type="VARCHAR">
+                <constraints primaryKey="false" nullable="false"/>
+            </column>
+            <column name="lock_detail" type="JSONB">
                 <constraints primaryKey="false" nullable="false"/>
             </column>
             <column name="description" type="VARCHAR">

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -4,46 +4,35 @@
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-
-    <changeSet logicalFilePath="dummy" author="kfeldman" id="add_sam_rac_tables">
+    <changeSet logicalFilePath="dummy" author="kfeldman" id="add_sam_resource_access_constraint_table">
         <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT">
-            <column name="id" type="BIGINT" autoIncrement="true">
+            <column name="id" type="UUID" autoIncrement="false">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="resource_id" type="BIGINT">
                 <constraints primaryKey="false" foreignKeyName="FK_SRAC_RESOURCE_ID" referencedTableName="SAM_RESOURCE" referencedColumnNames="id" nullable="true"/>
             </column>
         </createTable>
-        <createTable tableName="SAM_LOCK">
-            <column name="id" type="BIGINT" autoIncrement="true">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="name" type="VARCHAR">
-                <constraints primaryKey="false" nullable="false"/>
-            </column>
-            <column name="lock_type" type="VARCHAR">
-                <constraints primaryKey="false" nullable="false"/>
-            </column>
-            <column name="lock_detail" type="JSONB">
-                <constraints primaryKey="false" nullable="false"/>
-            </column>
-            <column name="description" type="VARCHAR">
-                <constraints primaryKey="false" nullable="true"/>
-            </column>
-        </createTable>
-        <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT_LOCK">
-            <column name="resource_access_constraint_id" type="BIGINT">
-                <constraints primaryKey="true" foreignKeyName="FK_SRACL_RESOURCE_ACCESS_CONSTRAINT_ID" referencedTableName="SAM_RESOURCE_ACCESS_CONSTRAINT" referencedColumnNames="id" nullable="false"/>
-            </column>
-            <column name="lock_id" type="BIGINT">
-                <constraints primaryKey="false" foreignKeyName="FK_SRACL_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
-            </column>
-            <column name="relationship" type="VARCHAR">
-                <constraints primaryKey="false" nullable="false"/>
-            </column>
-        </createTable>
+    </changeSet>
+    <changeSet logicalFilePath="dummy" author="kfeldman" id="add_sam_rac_and_lock_tables">
+        <sql stripComments="true">
+            CREATE TYPE LOCK_TYPE AS ENUM ('GENERIC', 'DUOS');
+            CREATE TABLE SAM_LOCK (
+            id UUID PRIMARY KEY NOT NULL,
+            lock_type LOCK_TYPE NOT NULL,
+            lock_detail JSONB NOT NULL,
+            description VARCHAR NULL
+            );
+
+            CREATE TYPE LOCK_RELATIONSHIP AS ENUM ('ONE_OF', 'ALL_OF');
+            CREATE TABLE SAM_RESOURCE_ACCESS_CONSTRAINT_LOCK (
+            resource_access_constraint_id UUID NOT NULL,
+            lock_id UUID NOT NULL,
+            CONSTRAINT FK_SRACL_RESOURCE_ACCESS_CONSTRAINT_ID FOREIGN KEY (resource_access_constraint_id) REFERENCES SAM_RESOURCE_ACCESS_CONSTRAINT(id)
+            );
+        </sql>
         <createTable tableName="SAM_KEYCHAIN_GROUP">
-            <column name="lock_id" type="BIGINT">
+            <column name="lock_id" type="UUID">
                 <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="group_id" type="BIGINT">
@@ -51,7 +40,7 @@
             </column>
         </createTable>
         <createTable tableName="SAM_KEYCHAIN_USER">
-            <column name="lock_id" type="BIGINT">
+            <column name="lock_id" type="UUID">
                 <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
             </column>
             <column name="user_id" type="VARCHAR">

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240416_add_sam_rac_tables.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="kfeldman" id="add_sam_rac_tables">
+        <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="resource_id" type="BIGINT">
+                <constraints primaryKey="false" foreignKeyName="FK_SRAC_RESOURCE_ID" referencedTableName="SAM_RESOURCE" referencedColumnNames="id"/>
+            </column>
+        </createTable>
+        <createTable tableName="SAM_LOCK">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="lock_detail" type="JSONB">
+                <constraints primaryKey="false" nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR">
+                <constraints primaryKey="false" nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR">
+                <constraints primaryKey="false"/>
+            </column>
+        </createTable>
+        <createTable tableName="SAM_RESOURCE_ACCESS_CONSTRAINT_LOCK">
+            <column name="resource_access_constraint_id" type="BIGINT">
+                <constraints primaryKey="true" foreignKeyName="FK_SRACL_RESOURCE_ACCESS_CONSTRAINT_ID" referencedTableName="SAM_RESOURCE_ACCESS_CONSTRAINT" referencedColumnNames="id"/>
+            </column>
+            <column name="lock_id" type="BIGINT">
+                <constraints primaryKey="false" foreignKeyName="FK_SRACL_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id" nullable="false"/>
+            </column>
+            <column name="relationship" type="VARCHAR">
+                <constraints primaryKey="false" nullable="false"/>
+            </column>
+        </createTable>
+        <createTable tableName="SAM_KEYCHAIN_GROUP">
+            <column name="lock_id" type="BIGINT">
+                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id"/>
+            </column>
+            <column name="group_id" type="BIGINT">
+                <constraints primaryKey="false" foreignKeyName="FK_SKG_GROUP_ID" referencedTableName="SAM_GROUP" referencedColumnNames="id"/>
+            </column>
+        </createTable>
+        <createTable tableName="SAM_KEYCHAIN_USER">
+            <column name="lock_id" type="BIGINT">
+                <constraints primaryKey="true" foreignKeyName="FK_SKG_LOCK_ID" referencedTableName="SAM_LOCK" referencedColumnNames="id"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints primaryKey="false" foreignKeyName="FK_SKG_USER_ID" referencedTableName="SAM_USER" referencedColumnNames="id"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/ID-1178)

What:

Putting into place the architecture for implementing Resource Access Constraints. This is just to add new tables in the Sam DB, there won't be any data in them yet, we will wire it up in future tickets. 

The liquibase migration should add tables that match this ERD. I made the ID fields auto-incrementing BIGINT since that seems standard except for the other Sam tables, except for the user ID which is VARCHAR. I ran this locally and checked that all the new tables were there and the FKs look correct. 

The fields that are nullable are noted in the ERD, if you have any differing opinions on what should be nullable, now is the time to mention it! I looked over the table relationships pretty carefully, but would love at least one close review on that to make sure all the FKs look good.

<img width="820" alt="Screenshot 2024-04-19 at 12 28 42 PM" src="https://github.com/broadinstitute/sam/assets/19541449/6ff082e5-0376-46c0-8d4d-d9bc7693d671">


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
