### PR TITLE
TOAZ-351 openIdConnect in api-docs.yaml

### DIFF
--- a/pact4s/src/test/resources/reference.conf
+++ b/pact4s/src/test/resources/reference.conf
@@ -119,8 +119,6 @@ testStuff = {
 oidc {
   authorityEndpoint = "https://accounts.google.com"
   oidcClientId = "some-client"
-  oidcClientSecret = "some-secret"
-  legacyGoogleClientId = "another-client"
 }
 
 liquibase {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "5762674" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "d16cba9" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.19-$workbenchLibV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,14 +11,14 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "1c0cf92" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "5762674" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.19-$workbenchLibV"
   val workbenchGoogleV = s"0.30-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchNotificationsV = s"0.6-$workbenchLibV"
-  val workbenchOauth2V = s"0.5-$workbenchLibV"
+  val workbenchOauth2V = s"0.7-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.30-SNAPSHOT"
   val tclVersion = "1.0.5-SNAPSHOT"

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -37,8 +37,6 @@ termsOfService {
 oidc {
   authorityEndpoint = ${?OIDC_AUTHORITY_ENDPOINT}
   oidcClientId = ${?OIDC_CLIENT_ID}
-  oidcClientSecret = ${?OIDC_CLIENT_SECRET}
-  legacyGoogleClientId = ${?LEGACY_GOOGLE_CLIENT_ID}
 }
 
 schemaLock {

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -11,14 +11,8 @@ info:
 servers:
   - url: /
 security:
-  - googleoauth:
-      - openid
-      - email
-      - profile
   - oidc:
       - openid
-      - email
-      - profile
 paths:
   /api/admin/v1/user/{userId}:
     get:
@@ -4638,22 +4632,7 @@ components:
           items:
             type: string
   securitySchemes:
-    googleoauth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: https://accounts.google.com/o/oauth2/auth
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
     oidc:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: /oauth2/authorize
-          tokenUrl: /oauth2/token
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
+      type: openIdConnect
+      openIdConnectUrl: OPEN_ID_CONNECT_URL
+      x-tokenName: id_token

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -34,7 +34,7 @@ import org.broadinstitute.dsde.workbench.google.{
 }
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageInterpreter, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
+import org.broadinstitute.dsde.workbench.oauth2.{ClientId, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.sam.api.{LivenessRoutes, SamRoutes, StandardSamUserDirectives}
 import org.broadinstitute.dsde.workbench.sam.azure.{AzureService, CrlService}
 import org.broadinstitute.dsde.workbench.sam.config.AppConfig.AdminConfig
@@ -140,8 +140,6 @@ object Boot extends IOApp with LazyLogging {
         OpenIDConnectConfiguration[IO](
           appConfig.oidcConfig.authorityEndpoint,
           ClientId(appConfig.oidcConfig.clientId),
-          oidcClientSecret = appConfig.oidcConfig.clientSecret.map(ClientSecret),
-          extraGoogleClientId = appConfig.oidcConfig.legacyGoogleClientId.map(ClientId),
           extraAuthParams = Some("prompt=login")
         )
       )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfig.scala
@@ -37,9 +37,7 @@ object AppConfig {
   implicit val oidcReader: ValueReader[OidcConfig] = ValueReader.relative { config =>
     OidcConfig(
       config.getString("authorityEndpoint"),
-      config.getString("oidcClientId"),
-      config.as[Option[String]]("oidcClientSecret"),
-      config.as[Option[String]]("legacyGoogleClientId")
+      config.getString("oidcClientId")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/OidcConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/OidcConfig.scala
@@ -1,3 +1,3 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-case class OidcConfig(authorityEndpoint: String, clientId: String, clientSecret: Option[String], legacyGoogleClientId: Option[String])
+case class OidcConfig(authorityEndpoint: String, clientId: String)

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -111,8 +111,6 @@ testStuff = {
 oidc {
   authorityEndpoint = "https://accounts.google.com"
   oidcClientId = "some-client"
-  oidcClientSecret = "some-secret"
-  legacyGoogleClientId = "another-client"
 }
 
 liquibase {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-351

update to latest version of workbench-libs oauth2 and adopt open api securitySchemes:
```
    oidc:
      type: openIdConnect
      openIdConnectUrl: OPEN_ID_CONNECT_URL
      x-tokenName: id_token
```

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
