### PR TITLE
ID-614 Ensure Email Uniqueness for Managed Groups

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1604,37 +1604,6 @@ resourceTypes = {
     reuseIds = true
   }
 
-  private_azure_container_registry = {
-    actionPatterns = {
-      delete = {
-        description = "Delete this private acr"
-      }
-      read_policies = {
-        description = "view all policies and policy details for this private acr"
-      }
-      use = {
-        description = "utilize this private acr"
-      }
-      "share_policy::admin" = {
-        description = "change the membership of the admin policy for this private acr"
-      }
-      "share_policy::user" = {
-        description = "change the membership of the user policy for this private acr"
-      }
-    }
-    ownerRoleName = "admin"
-    roles = {
-      admin = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::user"]
-      }
-      user = {
-        roleActions = ["use"]
-      }
-    }
-    allowLeaving = false
-    reuseIds = true
-  }
-
 }
 
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1604,6 +1604,37 @@ resourceTypes = {
     reuseIds = true
   }
 
+  private_azure_container_registry = {
+    actionPatterns = {
+      delete = {
+        description = "Delete this private acr"
+      }
+      read_policies = {
+        description = "view all policies and policy details for this private acr"
+      }
+      use = {
+        description = "utilize this private acr"
+      }
+      "share_policy::admin" = {
+        description = "change the membership of the admin policy for this private acr"
+      }
+      "share_policy::user" = {
+        description = "change the membership of the user policy for this private acr"
+      }
+    }
+    ownerRoleName = "admin"
+    roles = {
+      admin = {
+        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::user"]
+      }
+      user = {
+        roleActions = ["use"]
+      }
+    }
+    allowLeaving = false
+    reuseIds = true
+  }
+
 }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -423,7 +423,14 @@ object Boot extends IOApp with LazyLogging {
     )
     val tosService = new TosService(cloudExtensionsInitializer.cloudExtensions, directoryDAO, config.termsOfServiceConfig)
     val userService =
-      new UserService(directoryDAO, cloudExtensionsInitializer.cloudExtensions, config.blockedEmailDomains, tosService, config.azureServicesConfig)
+      new UserService(
+        directoryDAO,
+        cloudExtensionsInitializer.cloudExtensions,
+        config.blockedEmailDomains,
+        tosService,
+        config.azureServicesConfig,
+        Seq(config.emailDomain)
+      )
     val statusService =
       new StatusService(directoryDAO, cloudExtensionsInitializer.cloudExtensions, 10 seconds, 1 minute)
     val managedGroupService =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -29,7 +29,8 @@ class UserService(
     val cloudExtensions: CloudExtensions,
     blockedEmailDomains: Seq[String],
     tosService: TosService,
-    azureConfig: Option[AzureServicesConfig] = None
+    azureConfig: Option[AzureServicesConfig] = None,
+    nonInvitableDomains: Seq[String] = Seq.empty
 )(implicit
     val executionContext: ExecutionContext
 ) extends LazyLogging {
@@ -247,7 +248,7 @@ class UserService(
 
   def inviteUser(inviteeEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[UserStatusDetails] =
     for {
-      _ <- validateEmailAddress(inviteeEmail, blockedEmailDomains)
+      _ <- validateEmailAddress(inviteeEmail, blockedEmailDomains, nonInvitableDomains)
       existingSubject <- directoryDAO.loadSubjectFromEmail(inviteeEmail, samRequestContext)
       createdUser <- existingSubject match {
         case None => createUserInternal(SamUser(genWorkbenchUserId(System.currentTimeMillis()), None, inviteeEmail, None, false), samRequestContext)
@@ -436,13 +437,18 @@ class UserService(
 
   // moved this method from the UserService companion object into this class
   // because Mockito would not let us spy/mock the static method
-  def validateEmailAddress(email: WorkbenchEmail, blockedEmailDomains: Seq[String]): IO[Unit] =
+  def validateEmailAddress(email: WorkbenchEmail, blockedEmailDomains: Seq[String], nonInvitableDomain: Seq[String]): IO[Unit] =
     email.value match {
-      case emailString if blockedEmailDomains.exists(domain => emailString.endsWith("@" + domain) || emailString.endsWith("." + domain)) =>
+      case emailString if matchesBadDomain(emailString, blockedEmailDomains) =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain not permitted [${email.value}]")))
+      case emailString if matchesBadDomain(emailString, nonInvitableDomain) =>
+        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain cannot be invited [${email.value}]")))
       case UserService.emailRegex() => IO.unit
       case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"invalid email address [${email.value}]")))
     }
+
+  private def matchesBadDomain(emailString: String, badDomains: Seq[String]): Boolean =
+    badDomains.exists(domain => emailString.endsWith("@" + domain) || emailString.endsWith("." + domain))
 
   def getUserAllowances(samUser: SamUser, samRequestContext: SamRequestContext): IO[SamUserAllowances] =
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -442,7 +442,14 @@ class UserService(
       case emailString if matchesBadDomain(emailString, blockedEmailDomains) =>
         IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain not permitted [${email.value}]")))
       case emailString if matchesBadDomain(emailString, nonInvitableDomain) =>
-        IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"email domain cannot be invited [${email.value}]")))
+        IO.raiseError(
+          new WorkbenchExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"Email domain cannot be invited [${email.value}]. If you are trying to invite a group, please make sure that group exists before adding it to a resource policy."
+            )
+          )
+        )
       case UserService.emailRegex() => IO.unit
       case _ => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"invalid email address [${email.value}]")))
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -152,7 +152,7 @@ class ManagedGroupServiceSpec
     val exception = intercept[WorkbenchExceptionWithErrorReport] {
       runAndWait(managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext))
     }
-    exception.getMessage should include("A resource of this type and name already exists")
+    exception.getMessage should include(s"subject with email $groupName@$testDomain already exists")
     managedGroupService.loadManagedGroup(resourceId, samRequestContext).unsafeRunSync() shouldEqual None
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -8,7 +8,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.{global => globalEc}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.Generator.{arbNonPetEmail => _, _}
-import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
+import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue, truncateAll}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.matchers.BeSameUserMatcher.beSameUserAs
@@ -35,7 +35,7 @@ import scala.concurrent.duration._
 
 // TODO: continue breaking down old UserServiceSpec tests into nested suites
 // See: https://www.scalatest.org/scaladoc/3.2.3/org/scalatest/Suite.html
-class UserServiceSpec(_system: ActorSystem) extends TestKit(_system) with Suite with BeforeAndAfterAll {
+class UserServiceSpec(_system: ActorSystem) extends TestKit(_system) with Suite with BeforeAndAfterAll with BeforeAndAfterEach {
   override def nestedSuites: IndexedSeq[Suite] =
     IndexedSeq(
       new CreateUserSpec,
@@ -53,6 +53,11 @@ class UserServiceSpec(_system: ActorSystem) extends TestKit(_system) with Suite 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    truncateAll
+    super.beforeEach()
   }
 }
 
@@ -641,7 +646,7 @@ class OldUserServiceSpec(_system: ActorSystem)
     implicit val arbEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genEmail)
 
     forAll { email: WorkbenchEmail =>
-      assert(service.validateEmailAddress(email, Seq.empty).attempt.unsafeRunSync().isRight)
+      assert(service.validateEmailAddress(email, Seq.empty, Seq.empty).attempt.unsafeRunSync().isRight)
     }
   }
 
@@ -662,7 +667,7 @@ class OldUserServiceSpec(_system: ActorSystem)
     implicit val arbEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genEmail)
 
     forAll { email: WorkbenchEmail =>
-      assert(service.validateEmailAddress(email, Seq.empty).attempt.unsafeRunSync().isLeft)
+      assert(service.validateEmailAddress(email, Seq.empty, Seq.empty).attempt.unsafeRunSync().isLeft)
     }
   }
 
@@ -683,7 +688,7 @@ class OldUserServiceSpec(_system: ActorSystem)
     implicit val arbEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genEmail)
 
     forAll { email: WorkbenchEmail =>
-      assert(service.validateEmailAddress(email, Seq.empty).attempt.unsafeRunSync().isLeft)
+      assert(service.validateEmailAddress(email, Seq.empty, Seq.empty).attempt.unsafeRunSync().isLeft)
     }
   }
 
@@ -697,12 +702,17 @@ class OldUserServiceSpec(_system: ActorSystem)
     implicit val arbEmail: Arbitrary[WorkbenchEmail] = Arbitrary(genEmail)
 
     forAll { email: WorkbenchEmail =>
-      assert(service.validateEmailAddress(email, Seq.empty).attempt.unsafeRunSync().isLeft)
+      assert(service.validateEmailAddress(email, Seq.empty, Seq.empty).attempt.unsafeRunSync().isLeft)
     }
   }
 
   it should "reject blocked email domain" in {
-    assert(service.validateEmailAddress(WorkbenchEmail("foo@splat.bar.com"), Seq("bar.com")).attempt.unsafeRunSync().isLeft)
-    assert(service.validateEmailAddress(WorkbenchEmail("foo@bar.com"), Seq("bar.com")).attempt.unsafeRunSync().isLeft)
+    assert(service.validateEmailAddress(WorkbenchEmail("foo@splat.bar.com"), Seq("bar.com"), Seq.empty).attempt.unsafeRunSync().isLeft)
+    assert(service.validateEmailAddress(WorkbenchEmail("foo@bar.com"), Seq("bar.com"), Seq.empty).attempt.unsafeRunSync().isLeft)
+  }
+
+  it should "reject an un-invitable email domain" in {
+    assert(service.validateEmailAddress(WorkbenchEmail("foo@splat.bar.com"), Seq.empty, Seq("bar.com")).attempt.unsafeRunSync().isLeft)
+    assert(service.validateEmailAddress(WorkbenchEmail("foo@bar.com"), Seq.empty, Seq("bar.com")).attempt.unsafeRunSync().isLeft)
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
@@ -397,7 +397,7 @@ class CreateUserSpec extends UserServiceTestTraits {
       }
 
       // Assert
-      exception.errorReport.message should include("email domain cannot be invited")
+      exception.errorReport.message should include("Email domain cannot be invited")
     }
 
     it("should be able to be invited with no marketing consent") {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/CreateUserSpec.scala
@@ -383,6 +383,23 @@ class CreateUserSpec extends UserServiceTestTraits {
 
   describe("An invited User") {
 
+    it("should not be able to be invited with a non-invitable domain") {
+      // Arrange
+      val nonInvitableDomain = "non-invitable-domain.com"
+      val invitedGoogleUser = genWorkbenchUserGoogle.sample.get.copy(email = WorkbenchEmail(s"user@$nonInvitableDomain"))
+      val directoryDAO = MockDirectoryDaoBuilder(allUsersGroup).build
+      val cloudExtensions = MockCloudExtensionsBuilder(allUsersGroup).build
+      val userService = new UserService(directoryDAO, cloudExtensions, Seq.empty, defaultTosService, None, Seq(nonInvitableDomain))
+
+      // Act
+      val exception = intercept[WorkbenchExceptionWithErrorReport] {
+        runAndWait(userService.inviteUser(invitedGoogleUser.email, samRequestContext))
+      }
+
+      // Assert
+      exception.errorReport.message should include("email domain cannot be invited")
+    }
+
     it("should be able to be invited with no marketing consent") {
       // Arrange
       val invitedGoogleUser = genWorkbenchUserGoogle.sample.get


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-614

Sam wasn't checking for email uniqueness across all subject types when creating a managed group. This meant that someone could register a managed group that was already a registered user, and that would cause problems down the line. This change makes group creation check across all subject types, preventing this situation.

This change also adds an additional check to user invitation. Recently, a user invited a group to a workspace before the group was created in Sam. This meant Sam created a new user with the email address of the group. This should not be possible. So, I've made it so that Sam disallows inviting users with the same domain that it uses for groups.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
