### PR TITLE
ID-1264 support role and managed group summary api

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchLibV = "d16cba9"
   val workbenchGoogleV = s"0.30-$workbenchLibV"
-  val workbenchGoogle2V = s"0.34-$workbenchLibV"
+  val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -33,6 +33,9 @@ resourceTypes = {
       admin_remove_member = {
         description = "remove membership from policies on resources associated with this resource"
       }
+      admin_read_summary_information = {
+        description = "view summary information on resources of this resource type"
+      }
     }
 
     ownerRoleName = "owner"
@@ -42,6 +45,9 @@ resourceTypes = {
       }
       admin = {
         roleActions = ["admin_read_policies", "admin_add_member", "admin_remove_member"]
+      }
+      support = {
+        roleActions = ["admin_read_summary_information", "admin_read_policies"]
       }
     }
     reuseIds = false

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -424,6 +424,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/admin/v1/resourceTypes/{resourceTypeName}/action/{action}:
+    get:
+      tags:
+        - Admin
+      summary: Query if requesting user may perform the action on the resource type
+      operationId: resourceTypeAdminPermission
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource to query
+          required: true
+          schema:
+            type: string
+        - name: action
+          in: path
+          description: Action to perform
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: true if the user may perform the action, false if they may
+            not or the resource type does not exist
+          content:
+            application/json:
+              schema:
+                type: boolean
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/admin/v1/resourceTypes/{resourceTypeName}/policies:
     get:
       tags:
@@ -531,6 +564,32 @@ paths:
         404:
           description: Policy does not exist or resource type does not exist
           content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/admin/v1/groups/{groupName}/supportSummary:
+    get:
+      tags:
+        - Admin
+      summary: Get information about a group useful for Terra support
+      operationId: getAdminGroupSummaryInfo
+      parameters:
+        - name: groupName
+          in: path
+          description: Name of group
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: group summary information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedGroupSupportSummary'
         500:
           description: Internal Server Error
           content:
@@ -3870,6 +3929,29 @@ components:
           description: The email address associated with the group
       description: specification of a managed group with an access policy and the
         email associated with the managed group
+    ManagedGroupSupportSummary:
+      required:
+        - groupName
+        - email
+        - authDomainFor
+        - parentGroups
+      type: object
+      properties:
+        groupName:
+          type: string
+          description: The name of the group
+        email:
+          type: string
+          description: The email address associated with the group
+        authDomainFor:
+          type: array
+          items:
+            $ref: '#/components/schemas/FullyQualifiedResourceId'
+        parentGroups:
+          type: array
+          items:
+            type: string
+          description: The parent groups of the group
     PolicyIdentifiers:
       required:
         - policyName

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -20,6 +20,7 @@ import org.broadinstitute.dsde.workbench.sam.service.{ManagedGroupService, Resou
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsBoolean
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupModelJsonSupport._
 
 import scala.concurrent.ExecutionContext
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutes.scala
@@ -10,12 +10,12 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceId, _}
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{ManagedGroupAccessInstructions, SamUser}
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.ManagedGroupPolicyName
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupModelJsonSupport._
 
 import scala.concurrent.ExecutionContext
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -59,7 +59,12 @@ trait AccessPolicyDAO {
 
   def listResourcesWithAuthdomains(resourceTypeName: ResourceTypeName, resourceId: Set[ResourceId], samRequestContext: SamRequestContext): IO[Set[Resource]]
 
-  def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[Resource]]
+  def listResourceWithAuthDomains(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[Resource]]
+
+  def listResourcesUsingAuthDomain(
+      authDomainGroupName: WorkbenchGroupName,
+      samRequestContext: SamRequestContext
+  ): IO[Set[FullyQualifiedResourceId]]
 
 //  @deprecated("listing policies for resource type removed", since = "ResourceRoutes v2")
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceIdAndPolicyName]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -22,10 +22,15 @@ import java.util.Date
   */
 trait DirectoryDAO {
   def checkStatus(samRequestContext: SamRequestContext): IO[Boolean]
+
   def createGroup(group: BasicWorkbenchGroup, accessInstructionsOpt: Option[String] = None, samRequestContext: SamRequestContext): IO[BasicWorkbenchGroup]
+
   def loadGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[BasicWorkbenchGroup]]
+
   def loadGroupEmail(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
+
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]]
+
   def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit]
 
   /** @return
@@ -37,17 +42,25 @@ trait DirectoryDAO {
     *   true if the subject was removed, false if it was already gone
     */
   def removeGroupMember(groupId: WorkbenchGroupIdentity, removeMember: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean]
+
   def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean]
+
   def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit]
+
   def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]]
+
   def getSynchronizedEmail(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
 
   def loadSubjectFromEmail(email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]]
+
   def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
+
   def loadSubjectFromGoogleSubjectId(googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[WorkbenchSubject]]
 
   def createUser(user: SamUser, samRequestContext: SamRequestContext): IO[SamUser]
+
   def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
   def loadUsersByQuery(
       userId: Option[WorkbenchUserId],
       googleSubjectId: Option[GoogleSubjectId],
@@ -55,45 +68,72 @@ trait DirectoryDAO {
       limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Set[SamUser]]
+
   def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
   def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
   def setUserAzureB2CId(userId: WorkbenchUserId, b2cId: AzureB2CId, samRequestContext: SamRequestContext): IO[Unit]
+
   def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit]
+
   def deleteUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit]
+
   def updateUser(samUser: SamUser, userUpdate: AdminUpdateUserRequest, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 
   def listUsersGroups(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]]
+
   def listUserDirectMemberships(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[LazyList[WorkbenchGroupIdentity]]
+
   def listIntersectionGroupUsers(groupId: Set[WorkbenchGroupIdentity], samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]]
+
   def listAncestorGroups(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupIdentity]]
+
   def listFlattenedGroupMembers(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]]
 
   def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
+
   def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
+
   def isEnabled(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean]
 
   def getUserFromPetServiceAccount(petSA: ServiceAccountSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
+
   def createPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount]
+
   def loadPetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Option[PetServiceAccount]]
+
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit]
+
   def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]]
+
   def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount]
+
   def getManagedGroupAccessInstructions(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Option[String]]
+
   def setManagedGroupAccessInstructions(groupName: WorkbenchGroupName, accessInstructions: String, samRequestContext: SamRequestContext): IO[Unit]
+
   def setGoogleSubjectId(userId: WorkbenchUserId, googleSubjectId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Unit]
 
   def acceptTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
+
   def rejectTermsOfService(userId: WorkbenchUserId, tosVersion: String, samRequestContext: SamRequestContext): IO[Boolean]
+
   def getUserTermsOfService(userId: WorkbenchUserId, samRequestContext: SamRequestContext, action: Option[String] = None): IO[Option[SamUserTos]]
+
   def getUserTermsOfServiceVersion(
       userId: WorkbenchUserId,
       tosVersion: Option[String],
       samRequestContext: SamRequestContext,
       action: Option[String] = None
   ): IO[Option[SamUserTos]]
+
   def getUserTermsOfServiceHistory(userId: WorkbenchUserId, samRequestContext: SamRequestContext, limit: Integer): IO[List[SamUserTos]]
+
   def createPetManagedIdentity(petManagedIdentity: PetManagedIdentity, samRequestContext: SamRequestContext): IO[PetManagedIdentity]
+
   def loadPetManagedIdentity(petManagedIdentityId: PetManagedIdentityId, samRequestContext: SamRequestContext): IO[Option[PetManagedIdentity]]
+
   def getUserFromPetManagedIdentity(petManagedIdentityObjectId: ManagedIdentityObjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 
   def createActionManagedIdentity(actionManagedIdentity: ActionManagedIdentity, samRequestContext: SamRequestContext): IO[ActionManagedIdentity]
@@ -121,10 +161,14 @@ trait DirectoryDAO {
       billingProfileId: BillingProfileId,
       samRequestContext: SamRequestContext
   ): IO[Seq[ActionManagedIdentity]]
+
   def deleteAllActionManagedIdentitiesForBillingProfile(billingProfileId: BillingProfileId, samRequestContext: SamRequestContext): IO[Unit]
 
   def setUserRegisteredAt(userId: WorkbenchUserId, registeredAt: Instant, samRequestContext: SamRequestContext): IO[Unit]
+
   def getUserAttributes(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUserAttributes]]
 
   def setUserAttributes(samUserAttributes: SamUserAttributes, samRequestContext: SamRequestContext): IO[Unit]
+
+  def listParentGroups(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupName]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -41,6 +41,7 @@ object SamResourceActions {
   val adminRemoveMember = ResourceAction("admin_remove_member")
   val link = ResourceAction("link")
   val setManagedResourceGroup = ResourceAction("set_managed_resource_group")
+  val adminReadSummaryInformation = ResourceAction("admin_read_summary_information")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")
@@ -238,6 +239,12 @@ object BasicWorkbenchGroup {
 @Lenses final case class ManagedGroupAndRole(groupName: WorkbenchGroupName, role: MangedGroupRoleName)
 @Lenses final case class ManagedGroupMembershipEntry(groupName: ResourceId, role: ResourceRoleName, groupEmail: WorkbenchEmail)
 @Lenses final case class ManagedGroupAccessInstructions(value: String) extends ValueObject
+@Lenses final case class ManagedGroupSupportSummary(
+    groupName: WorkbenchGroupName,
+    email: WorkbenchEmail,
+    authDomainFor: Set[FullyQualifiedResourceId],
+    parentGroups: Set[WorkbenchGroupName]
+)
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.sam.model
 import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse, SamUser}
-import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
 import java.time.Instant
@@ -235,16 +234,6 @@ object BasicWorkbenchGroup {
       case _ => throw new WorkbenchException(s"WorkbenchGroup ${workbenchGroup} cannot be converted to a BasicWorkbenchGroup")
     }
 }
-
-@Lenses final case class ManagedGroupAndRole(groupName: WorkbenchGroupName, role: MangedGroupRoleName)
-@Lenses final case class ManagedGroupMembershipEntry(groupName: ResourceId, role: ResourceRoleName, groupEmail: WorkbenchEmail)
-@Lenses final case class ManagedGroupAccessInstructions(value: String) extends ValueObject
-@Lenses final case class ManagedGroupSupportSummary(
-    groupName: WorkbenchGroupName,
-    email: WorkbenchEmail,
-    authDomainFor: Set[FullyQualifiedResourceId],
-    parentGroups: Set[WorkbenchGroupName]
-)
 
 @Lenses final case class GroupSyncResponse(lastSyncDate: String, email: WorkbenchEmail)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/ManagedGroupModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/ManagedGroupModel.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.workbench.sam.model.api
+
+import monocle.macros.Lenses
+import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat, WorkbenchEmail, WorkbenchGroupName}
+import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceId, ResourceRoleName}
+import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService.MangedGroupRoleName
+import spray.json.DefaultJsonProtocol
+
+@Lenses final case class ManagedGroupAndRole(groupName: WorkbenchGroupName, role: MangedGroupRoleName)
+@Lenses final case class ManagedGroupMembershipEntry(groupName: ResourceId, role: ResourceRoleName, groupEmail: WorkbenchEmail)
+@Lenses final case class ManagedGroupAccessInstructions(value: String) extends ValueObject
+@Lenses final case class ManagedGroupSupportSummary(
+    groupName: WorkbenchGroupName,
+    email: WorkbenchEmail,
+    authDomainFor: Set[FullyQualifiedResourceId],
+    parentGroups: Set[WorkbenchGroupName]
+)
+
+object ManagedGroupModelJsonSupport {
+  import DefaultJsonProtocol._
+  import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+  import SamJsonSupport.{FullyQualifiedResourceIdFormat, ResourceIdFormat, ResourceRoleNameFormat}
+
+  implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
+
+  implicit val ManagedGroupAccessInstructionsFormat = ValueObjectFormat(ManagedGroupAccessInstructions.apply)
+
+  implicit val ManagedGroupSupportSummaryFormat = jsonFormat4(ManagedGroupSupportSummary.apply)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamJsonSupport.scala
@@ -11,9 +11,6 @@ import org.broadinstitute.dsde.workbench.sam.model.{
   FullyQualifiedPolicyId,
   FullyQualifiedResourceId,
   GroupSyncResponse,
-  ManagedGroupAccessInstructions,
-  ManagedGroupMembershipEntry,
-  ManagedGroupSupportSummary,
   OldTermsOfServiceDetails,
   PolicyIdentifiers,
   RequesterPaysSignedUrlRequest,
@@ -107,12 +104,6 @@ object SamJsonSupport {
   implicit val UserResourcesResponseFormat = jsonFormat6(UserResourcesResponse.apply)
 
   implicit val FullyQualifiedPolicyIdFormat = jsonFormat2(FullyQualifiedPolicyId.apply)
-
-  implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
-
-  implicit val ManagedGroupAccessInstructionsFormat = ValueObjectFormat(ManagedGroupAccessInstructions.apply)
-
-  implicit val ManagedGroupSupportSummaryFormat = jsonFormat4(ManagedGroupSupportSummary.apply)
 
   implicit val GroupSyncResponseFormat = jsonFormat2(GroupSyncResponse.apply)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/SamJsonSupport.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.sam.model.{
   GroupSyncResponse,
   ManagedGroupAccessInstructions,
   ManagedGroupMembershipEntry,
+  ManagedGroupSupportSummary,
   OldTermsOfServiceDetails,
   PolicyIdentifiers,
   RequesterPaysSignedUrlRequest,
@@ -110,6 +111,8 @@ object SamJsonSupport {
   implicit val ManagedGroupMembershipEntryFormat = jsonFormat3(ManagedGroupMembershipEntry.apply)
 
   implicit val ManagedGroupAccessInstructionsFormat = ValueObjectFormat(ManagedGroupAccessInstructions.apply)
+
+  implicit val ManagedGroupSupportSummaryFormat = jsonFormat4(ManagedGroupSupportSummary.apply)
 
   implicit val GroupSyncResponseFormat = jsonFormat2(GroupSyncResponse.apply)
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -8,6 +8,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupAndRole
 import org.broadinstitute.dsde.workbench.sam.util.OpenTelemetryIOUtils._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminGroupsRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminGroupsRoutesSpec.scala
@@ -7,8 +7,8 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.resourceTypeAdmin
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.adminReadSummaryInformation
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupModelJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.api.{ManagedGroupSupportSummary, SamUser}
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.scalatest.MockitoSugar

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminGroupsRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminGroupsRoutesSpec.scala
@@ -1,0 +1,78 @@
+package org.broadinstitute.dsde.workbench.sam.api
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
+import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.resourceTypeAdmin
+import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.adminReadSummaryInformation
+import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
+import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{AppendedClues, Assertion}
+
+class AdminGroupsRoutesSpec extends AnyFlatSpec with Matchers with TestSupport with ScalatestRouteTest with AppendedClues with MockitoSugar {
+  private val adminUser = Generator.genFirecloudUser.sample.get
+  private val nonAdminUser = Generator.genWorkbenchUserGoogle.sample.get
+
+  private val managedGroupResourceType = ResourceType(
+    ManagedGroupService.managedGroupTypeName,
+    Set.empty,
+    Set(
+      ResourceRole(ResourceRoleName("admin"), Set.empty),
+      ResourceRole(ResourceRoleName("member"), Set.empty),
+      ResourceRole(ResourceRoleName("admin-notifier"), Set.empty)
+    ),
+    ResourceRoleName("admin")
+  )
+
+  private val adminPolicyName = AccessPolicyName("admin")
+  private val adminResourceId = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(managedGroupResourceType.name.value))
+  private val managedGroupId = ResourceId("testGroup")
+
+  def withSamRoutes(requester: SamUser)(testCode: SamRoutes => Assertion): Assertion =
+    runAndWait {
+      val routes = TestSamRoutes(Map(managedGroupResourceType.name -> managedGroupResourceType), user = requester)
+      for {
+        _ <- createAdminPolicy(routes)
+        _ <- routes.managedGroupService.createManagedGroup(managedGroupId, requester, samRequestContext = samRequestContext)
+      } yield testCode(routes)
+    }
+
+  private def createAdminPolicy(routes: TestSamRoutes) =
+    routes.resourceService.createPolicy(
+      FullyQualifiedPolicyId(adminResourceId, adminPolicyName),
+      Set(adminUser.id),
+      Set(ResourceRoleName("test")),
+      Set(adminReadSummaryInformation),
+      Set(),
+      samRequestContext
+    )
+
+  "GET /api/admin/v1/groups/{groupName}/groups" should "200 when user has `admin_read_summary_information`" in
+    withSamRoutes(requester = adminUser) { routes =>
+      Get(s"/api/admin/v1/groups/${managedGroupId.value}/supportSummary") ~> routes.route ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[ManagedGroupSupportSummary].groupName shouldEqual WorkbenchGroupName(managedGroupId.value)
+      }
+    }
+
+  it should "404 when a user is not an admin for that resource type" in
+    withSamRoutes(requester = nonAdminUser) { routes =>
+      Get(s"/api/admin/v1/groups/${managedGroupId.value}/supportSummary") ~> routes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+
+  it should "404 when the group does not exist" in
+    withSamRoutes(requester = adminUser) { routes =>
+      Get(s"/api/admin/v1/groups/doesnotexist/supportSummary") ~> routes.route ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourceTypesRoutesSpec.scala
@@ -253,7 +253,10 @@ class AdminResourceTypesRoutesSpec extends AnyFlatSpec with Matchers with TestSu
     val samRoutes = createSamRoutes(isSamSuperAdmin = false)
     val testAction = ResourceAction("testAction")
 
-    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(defaultAdminResourceId), mockitoEq(testAction), mockitoEq(firecloudAdmin.id), any[SamRequestContext]))
+    when(
+      samRoutes.policyEvaluatorService
+        .hasPermission(mockitoEq(defaultAdminResourceId), mockitoEq(testAction), mockitoEq(firecloudAdmin.id), any[SamRequestContext])
+    )
       .thenReturn(IO(true))
 
     Get(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/action/${testAction.value}") ~> samRoutes.route ~> check {
@@ -266,7 +269,10 @@ class AdminResourceTypesRoutesSpec extends AnyFlatSpec with Matchers with TestSu
     val samRoutes = createSamRoutes(isSamSuperAdmin = false)
     val testAction = ResourceAction("testAction")
 
-    when(samRoutes.policyEvaluatorService.hasPermission(mockitoEq(defaultAdminResourceId), mockitoEq(testAction), mockitoEq(firecloudAdmin.id), any[SamRequestContext]))
+    when(
+      samRoutes.policyEvaluatorService
+        .hasPermission(mockitoEq(defaultAdminResourceId), mockitoEq(testAction), mockitoEq(firecloudAdmin.id), any[SamRequestContext])
+    )
       .thenReturn(IO(false))
 
     Get(s"/api/admin/v1/resourceTypes/${defaultResourceType.name}/action/${testAction.value}") ~> samRoutes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesSpec.scala
@@ -12,9 +12,9 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.samRequestContext
 import org.broadinstitute.dsde.workbench.sam.api.ManagedGroupRoutesSpec._
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{MockAccessPolicyDAO, MockDirectoryDAO}
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{ManagedGroupAccessInstructions, SamUser}
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.service.UserService.genRandom
 import org.scalatest.BeforeAndAfter

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ManagedGroupRoutesV1Spec.scala
@@ -7,9 +7,9 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.api.ManagedGroupRoutesSpec._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{ManagedGroupAccessInstructions, SamUser}
 import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/RouteSecuritySpec.scala
@@ -63,7 +63,7 @@ class RouteSecuritySpec extends AnyFlatSpec with Matchers with ScalatestRouteTes
       }
     }
 
-  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/v1/resourceTypes"))
+  for (PathAndMethod(path, method) <- routesFromApiYml if path.startsWith("/api/admin/v1/resourceTypes") && !path.contains("/action/"))
     s"$method $path" should "call asSamSuperAdmin" in {
       val samRoutes = Mockito.spy(TestSamRoutes(Map.empty))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -224,7 +224,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       samRequestContext: SamRequestContext
   ): IO[Set[Resource]] = IO.pure(Set.empty)
 
-  override def listResourceWithAuthdomains(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[Resource]] = IO.pure(None)
+  override def listResourceWithAuthDomains(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[Resource]] = IO.pure(None)
 
   override def listPublicAccessPolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicyWithoutMembers]] =
     IO.pure(
@@ -414,4 +414,6 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       .toSeq
   }
 
+  override def listResourcesUsingAuthDomain(authDomainGroupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] =
+    IO.pure(Set.empty)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
@@ -6,6 +6,7 @@ import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, databaseEnabledClue}
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.ManagedGroupMembershipEntry
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.scalatest.flatspec.AnyFlatSpecLike

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -465,4 +465,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
       case Some(_) =>
         userAttributes.update(samUserAttributes.userId, samUserAttributes)
     }
+
+  override def listParentGroups(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupName]] = IO.pure(Set.empty)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -567,4 +567,25 @@ class ManagedGroupServiceSpec
     }
     error.errorReport.statusCode should be(Some(StatusCodes.BadRequest))
   }
+
+  "ManagedGroupService loadManagedGroupSupportSummary" should "return a ManagedGroupSupportRequestSummary" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    val groupName = "myGroup"
+    val managedGroupResource = makeGroup(groupName, managedGroupService)
+    val managedGroupEmail =
+      managedGroupService.loadManagedGroup(managedGroupResource.resourceId, samRequestContext).unsafeRunSync().getOrElse(fail("group not found"))
+    managedGroupService.loadManagedGroupSupportSummary(managedGroupResource.resourceId, samRequestContext).unsafeRunSync() shouldEqual Some(
+      ManagedGroupSupportSummary(
+        WorkbenchGroupName(groupName),
+        managedGroupEmail,
+        Set.empty,
+        Set.empty
+      )
+    )
+  }
+
+  it should "return None if the group does not exist" in {
+    assume(databaseEnabled, databaseEnabledClue)
+    managedGroupService.loadManagedGroupSupportSummary(ResourceId("nonexistentGroup"), samRequestContext).unsafeRunSync() shouldEqual None
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport.{databaseEnabled, datab
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresAccessPolicyDAO, PostgresDirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.model.api.{ManagedGroupMembershipEntry, ManagedGroupSupportSummary, SamUser}
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1264

What:

these are the sam changes outlined in [this doc](https://docs.google.com/document/d/1tA-Y1mlZlIMEf2Q_Hxao8MiWw2tXBUMYsHpHB8OmjG4/edit#heading=h.w002iup2os6t). Specifically

1. adding a new resource type admin action `admin_read_summary_information`
2. adding a new resource type admin role `support`
3. adding an admin api to check actions on resource type admin
4. adding an admin api to get support summary information for a group

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
