### PR TITLE
ID-1263 Correct Error Deleting Action Managed Identities

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/Lock.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/Lock.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.workbench.sam.model
+
+case class Lock(name: String, lockType: String, lockDetails: Map[String, String])

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/Lock.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/Lock.scala
@@ -1,3 +1,0 @@
-package org.broadinstitute.dsde.workbench.sam.model
-
-case class Lock(name: String, lockType: String, lockDetails: Map[String, String])


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1263

When deleting action managed identities, the query didn't use the composite `sam_resource_action.action` `sam_resource_action.resourceTypeId` key when getting Action Managed Identities to delete. This meant that the subquery returned resource action id's for any action name, even if two different actions on different resource types had the same name. This caused a sql error where a subquery returned more than one result. No bueno! 

Corrected the bug. This is brand new functionality, so bugs like this are bound to happen!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
