### PR TITLE
[ID-1205] Fix workbench-google2 version

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val workbenchLibV = "d16cba9"
   val workbenchGoogleV = s"0.30-$workbenchLibV"
-  val workbenchGoogle2V = s"0.34-$workbenchLibV"
+  val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "d16cba9"
+  val workbenchLibV = "1c0cf92"
   val workbenchGoogleV = s"0.30-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "1c0cf92"
+  val workbenchLibV = "d16cba9"
   val workbenchGoogleV = s"0.30-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1205

What:
Update workbench-google2 version 

Why:
After updating the workbench-libs version used by the tests, the swatomation tests failed because the workbench-google2 version also needed to be updated: https://github.com/broadinstitute/terra-github-workflows/actions/runs/8913946342/job/24480487015

How:
Change 0.34 -> 0.36 in automation/project/Dependencies.scala

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
