### PR TITLE
[DC-1011] Add set_parent to snapshot builder request

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1348,11 +1348,14 @@ resourceTypes = {
       approve = {
         description = "Approve or reject the snapshot builder request"
       }
+      set_parent = {
+        description = "Enables setting the parent on the request object
+      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["get", "update", "delete"]
+        roleActions = ["get", "update", "delete", "set_parent"]
       }
       approver = {
         roleActions = ["get", "approve"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1349,7 +1349,7 @@ resourceTypes = {
         description = "Approve or reject the snapshot builder request"
       }
       set_parent = {
-        description = "Enables setting the parent on the request object
+        description = "Enables setting the parent on the request object"
       }
     }
     ownerRoleName = "owner"


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/DC-1011)

We would love to enable parents but _not_ give the permission to change the parent. Is there a way to do that?

What:

  \<For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).\>

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
