### PR TITLE
ID-1230 Ensure Audit Log Events Have Same Schema

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/audit/SamAuditModel.scala
@@ -21,8 +21,7 @@ case object ResourceParentUpdated extends ResourceEventType
 case object ResourceParentRemoved extends ResourceEventType
 case object ResourceDeleted extends ResourceEventType
 
-final case class ResourceEvent(eventType: ResourceEventType, resource: FullyQualifiedResourceId, changeDetails: Option[ResourceChange] = None)
-    extends AuditEvent
+final case class ResourceEvent(eventType: ResourceEventType, resource: FullyQualifiedResourceId, changeDetails: Set[ResourceChange] = Set()) extends AuditEvent
 
 case class AccessChange(
     member: WorkbenchSubject,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -143,7 +143,7 @@ class ResourceService(
 
             _ <- AuditLogger.logAuditEventIO(
               samRequestContext,
-              ResourceEvent(ResourceCreated, FullyQualifiedResourceId(resourceType.name, resourceId), parentOpt.map(ResourceChange))
+              ResourceEvent(ResourceCreated, FullyQualifiedResourceId(resourceType.name, resourceId), parentOpt.map(ResourceChange).toSet)
             )
 
             changeEvents = createAccessChangeEvents(FullyQualifiedResourceId(resourceType.name, resourceId), LazyList.empty, persisted.accessPolicies)
@@ -867,7 +867,7 @@ class ResourceService(
         case LoadResourceAuthDomainResult.NotConstrained =>
           for {
             _ <- accessPolicyDAO.setResourceParent(childResource, parentResource, samRequestContext)
-            _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentUpdated, childResource, Option(ResourceChange(parentResource))))
+            _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentUpdated, childResource, Set(ResourceChange(parentResource))))
           } yield ()
         case LoadResourceAuthDomainResult.Constrained(_) =>
           IO.raiseError(
@@ -890,7 +890,7 @@ class ResourceService(
       _ <- maybeOldParent.traverse { oldParent =>
         for {
           _ <- accessPolicyDAO.deleteResourceParent(resourceId, samRequestContext)
-          _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentRemoved, resourceId, Option(ResourceChange(oldParent))))
+          _ <- AuditLogger.logAuditEventIO(samRequestContext, ResourceEvent(ResourceParentRemoved, resourceId, Set(ResourceChange(oldParent))))
         } yield ()
       }
     } yield maybeOldParent.isDefined


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1230

It appears that if two log events have the same member names, but those members are different types, then BigQuery cannot handle both. This PR makes the `changeEvents` on Audit Log Events be `Set`s, instead of one being an `Option` and the other being a `Set`, so that BigQuery has a consistent schema for log entries.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
