### PR TITLE
DC-1059: Delete update and view settings on a dataset

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1199,12 +1199,6 @@ resourceTypes = {
       view_journal = {
         description = "View dataset journal entries"
       }
-      view_snapshot_builder_settings = {
-        description = "allows viewing the snapshot builder settings"
-      }
-      update_snapshot_builder_settings = {
-        description = "allows updating the snapshot builder settings"
-      }
       "lock_resource" = {
         description = "Can lock a resource"
       }
@@ -1227,7 +1221,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "view_snapshot_builder_settings", "update_snapshot_builder_settings", "unlock_resource"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DC-1059

What:

Removes actions related to snapshot builder settings on datasets. There are still actions to view and update settings on snapshots.

Why:

We no longer support snapshot builder settings on datasets. Instead, we support snapshot builder settings on snapshots.


---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
