### PR TITLE
ID-1282 Finalize Azure Private Resource Types

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1655,9 +1655,6 @@ resourceTypes = {
       write = {
         description = "write to the private azure storage account"
       }
-      identify = {
-        description = "DEPRECATED - use the identity to access the storage account"
-      }
       "share_policy::owner" = {
         description = "change the membership of the owner policy for this private azure storage account"
       }
@@ -1671,16 +1668,13 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::owner", "share_policy::reader", "share_policy::writer", "read", "write"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::reader", "share_policy::writer", "read", "write"]
       }
       reader = {
         roleActions = ["read"]
       }
       writer = {
         roleActions = ["write"]
-      }
-      user = {
-        roleActions = ["identify"]
       }
     }
     allowLeaving = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1613,28 +1613,28 @@ resourceTypes = {
   private_azure_container_registry = {
     actionPatterns = {
       delete = {
-        description = "Delete this private acr"
+        description = "Delete this private azure container registry"
       }
       read_policies = {
-        description = "view all policies and policy details for this private acr"
+        description = "view all policies and policy details for this private azure container registry"
       }
-      identify = {
-        description = "use the identity that has access to this private acr"
+      pull_image = {
+        description = "pull an image from the private azure container registry"
       }
       "share_policy::admin" = {
-        description = "change the membership of the admin policy for this private acr"
+        description = "change the membership of the admin policy for this private azure container registry"
       }
-      "share_policy::user" = {
-        description = "change the membership of the user policy for this private acr"
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this private azure container registry"
       }
     }
     ownerRoleName = "admin"
     roles = {
       admin = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::user", "identify"]
+        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::reader", "pull_image"]
       }
-      user = {
-        roleActions = ["identify"]
+      reader = {
+        roleActions = ["pull_image"]
       }
     }
     allowLeaving = false
@@ -1649,51 +1649,35 @@ resourceTypes = {
       read_policies = {
         description = "view all policies and policy details for this private azure storage account"
       }
-      identify = {
-        description = "use the identity that has access to this private azure storage account"
+      read = {
+        description = "read from the private azure storage account"
       }
-      "share_policy::admin" = {
-        description = "change the membership of the admin policy for this private azure storage account"
-      }
-      "share_policy::user" = {
-        description = "change the membership of the user policy for this private azure storage account"
-      }
-    }
-    ownerRoleName = "admin"
-    roles = {
-      admin = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::user", "identify"]
-      }
-      user = {
-        roleActions = ["identify"]
-      }
-    }
-    allowLeaving = false
-    reuseIds = true
-  }
-
-  azure_managed_identity = {
-    actionPatterns = {
-      delete = {
-        description = "Delete this azure managed identity"
-      }
-      read_policies = {
-        description = "view all policies and policy details for this azure managed identity"
+      write = {
+        description = "write to the private azure storage account"
       }
       identify = {
-        description = "use the identity that has access to this azure managed identity"
+        description = "DEPRECATED - use the identity to access the storage account"
       }
-      "share_policy::admin" = {
-        description = "change the membership of the admin policy for this azure managed identity"
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this private azure storage account"
       }
-      "share_policy::user" = {
-        description = "change the membership of the user policy for this azure managed identity"
+      "share_policy::reader" = {
+        description = "change the membership of the reader policy for this private azure storage account"
+      }
+      "share_policy::writer" = {
+        description = "change the membership of the writer policy for this private azure storage account"
       }
     }
-    ownerRoleName = "admin"
+    ownerRoleName = "owner"
     roles = {
-      admin = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::user", "identify"]
+      owner = {
+        roleActions = ["delete", "read_policies", "use", "share_policy::owner", "share_policy::reader", "share_policy::writer", "read", "write"]
+      }
+      reader = {
+        roleActions = ["read"]
+      }
+      writer = {
+        roleActions = ["write"]
       }
       user = {
         roleActions = ["identify"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1621,17 +1621,17 @@ resourceTypes = {
       pull_image = {
         description = "pull an image from the private azure container registry"
       }
-      "share_policy::admin" = {
-        description = "change the membership of the admin policy for this private azure container registry"
+      "share_policy::owner" = {
+        description = "change the membership of the owner policy for this private azure container registry"
       }
       "share_policy::reader" = {
         description = "change the membership of the reader policy for this private azure container registry"
       }
     }
-    ownerRoleName = "admin"
+    ownerRoleName = "owner"
     roles = {
-      admin = {
-        roleActions = ["delete", "read_policies", "use", "share_policy::admin", "share_policy::reader", "pull_image"]
+      owner = {
+        roleActions = ["delete", "read_policies", "use", "share_policy::owner", "share_policy::reader", "pull_image"]
       }
       reader = {
         roleActions = ["pull_image"]


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/ID-1282)

  \<Don't forget to include the ticket number in the PR title!\>

What:

We've done a lot of technical feasibility work, and settled on what resource types need to exist for Private Azure Container Registries and Storage Accounts. This gets rid of previous resource types and actions, which will need to be manually removed from production.

Since resource types are upserted on boot, current resources should continue to work. We should migrate away from them and delete the resource types that are no longer in use.

Why:

Representing resources types as their logical Terra functional pieces gives us a lot of flexibility around access control and the evolution of features. A raw `azure_managed_identity` doesn't let Sam do what it does best: manage users' access to things. By representing an `azure_private_storage_account` as it's own resource, we can use Sam to manage which users can `read` and which user's can `write`. The Action Managed Identities are just an implementation detail of how the underlying cloud resource is accessed.

How:

Update `reference.conf`

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
