### PR TITLE
ID-1270 create_with_parent Action

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -74,7 +74,7 @@ trait SecurityDirectives {
     maybeParent match {
       case None => Directives.pass // no parent specified, proceed
       case Some(parent) =>
-        // parents are allowed for a resource type if the owner role contains the SamResourceActions.setParent action
+        // parents are allowed for a resource type if the owner role contains the SamResourceActions.setParent or SamResourceActions.createWithParent action
         val parentAllowed = resourceType.roles
           .find(_.roleName == resourceType.ownerRoleName)
           .exists(role => role.actions.contains(SamResourceActions.setParent) || role.actions.contains(SamResourceActions.createWithParent))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -75,7 +75,9 @@ trait SecurityDirectives {
       case None => Directives.pass // no parent specified, proceed
       case Some(parent) =>
         // parents are allowed for a resource type if the owner role contains the SamResourceActions.setParent action
-        val parentAllowed = resourceType.roles.find(_.roleName == resourceType.ownerRoleName).exists(_.actions.contains(SamResourceActions.setParent))
+        val parentAllowed = resourceType.roles
+          .find(_.roleName == resourceType.ownerRoleName)
+          .exists(role => role.actions.contains(SamResourceActions.setParent) || role.actions.contains(SamResourceActions.createWithParent))
         if (!parentAllowed) {
           Directives.failWith(
             new WorkbenchExceptionWithErrorReport(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -31,6 +31,7 @@ object SamResourceActions {
   val testAnyActionAccess = ResourceAction("test_any_action_access")
   val getParent = ResourceAction("get_parent")
   val setParent = ResourceAction("set_parent")
+  val createWithParent = ResourceAction("create_with_parent")
   val addChild = ResourceAction("add_child")
   val removeChild = ResourceAction("remove_child")
   val listChildren = ResourceAction("list_children")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1270

  \<Don't forget to include the ticket number in the PR title!\>

What:

Introduce a `create_with_parent` resource action, which will allow resource creation with a parent resource without letting users re-parent the resource later.

Why:

Needed for future functionality.

How:

Just add the resource action.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
