### PR TITLE
ID-1286 Update workbenchLibs - add retries to group creation

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,8 +7,9 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "d16cba9"
-  val workbenchGoogleV = s"0.30-$workbenchLibV"
+  val workbenchLibV = "c2a271"
+
+  val workbenchGoogleV = s"0.31-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "c2a271"
+  val workbenchLibV = "89f86ba"
 
-  val workbenchGoogleV = s"0.31-$workbenchLibV"
+  val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = "2.0-5863cbd"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,11 +11,11 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "d16cba9" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "89f86ba" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.19-$workbenchLibV"
-  val workbenchGoogleV = s"0.30-$workbenchLibV"
+  val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchNotificationsV = s"0.6-$workbenchLibV"
   val workbenchOauth2V = s"0.7-$workbenchLibV"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -7,6 +7,7 @@ object Merging {
     case PathList("javax", "activation", _ @_*) => MergeStrategy.first
     case PathList("javax", "xml", _ @_*) => MergeStrategy.first
     case PathList("google", "protobuf", _ @_*) => MergeStrategy.first
+    case PathList("org", "bouncycastle", _ @_*) => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class") => MergeStrategy.first
     case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
@@ -14,6 +15,7 @@ object Merging {
     case PathList("META-INF", "kotlin-stdlib.kotlin_module") => MergeStrategy.first
     case PathList("META-INF", "kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
     case PathList("META-INF", "okio.kotlin_module") => MergeStrategy.first
+    case PathList("META-INF", "versions", "9", "OSGI-INF", "MANIFEST.MF") => MergeStrategy.first
     case PathList("mozilla", "public-suffix-list.txt") => MergeStrategy.first
     case "module-info.class" =>
       MergeStrategy.discard


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1286

Workbench libs pr: https://github.com/broadinstitute/workbench-libs/pull/1685


What:

We added retries for an error we are seeing during group creation at the update step. We also force sequential update after group creation, they were happening concurrently which could cause race conditions. 

Why:

There is an error in prod affecting users.

How:

 See workbench libs pr

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
