### PR TITLE
ID-1306 CBAS Submission, Filtering by Resource Parent, and Getting Resource Creator

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -30,4 +30,5 @@
     <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240417_action_managed_identities.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240416_add_sam_rac_tables.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240613_resource_created_by.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240613_resource_created_by.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240613_resource_created_by.xml
@@ -8,9 +8,10 @@
     <changeSet logicalFilePath="dummy" author="tlangs" id="resource_created_by">
         <addColumn tableName="sam_resource">
             <column name="created_by" type="VARCHAR">
-                <constraints nullable="true" foreignKeyName="FK_SR_CREATOR" referencedTableName="SAM_USER" referencedColumnNames="id"/>
+                <constraints nullable="true"/>
             </column>
         </addColumn>
+        <addForeignKeyConstraint baseTableName="sam_resource" baseColumnNames="created_by"  constraintName="FK_SR_CREATOR" referencedTableName="SAM_USER" referencedColumnNames="id" onDelete="SET NULL" />
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240613_resource_created_by.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240613_resource_created_by.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="tlangs" id="resource_created_by">
+        <addColumn tableName="sam_resource">
+            <column name="created_by" type="VARCHAR">
+                <constraints nullable="true" foreignKeyName="FK_SR_CREATOR" referencedTableName="SAM_USER" referencedColumnNames="id"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -172,6 +172,7 @@ resourceTypes = {
           wds-instance = ["owner"]
           kubernetes-app = ["manager"]
           kubernetes-app-shared = ["owner", "user"]
+          cbas-submission = ["reader"]
         }
       }
       application = {
@@ -188,6 +189,7 @@ resourceTypes = {
           google-project = ["pet-creator"]
           wds-instance = ["writer"]
           kubernetes-app-shared = ["user"]
+          cbas-submission = ["reader"]
         }
       }
       reader = {
@@ -198,6 +200,7 @@ resourceTypes = {
           google-project = ["pet-creator"]
           wds-instance = ["reader"]
           kubernetes-app-shared = ["user"]
+          cbas-submission = ["reader"]
         }
       }
       discoverer = {
@@ -1673,6 +1676,31 @@ resourceTypes = {
     }
     allowLeaving = false
     reuseIds = true
+  }
+
+  cbas-submission = {
+    actionPatterns = {
+      delete = {
+        description = "Delete this cbas-submission"
+      }
+      "read_policy::submitter" = {
+        description = "view the submitter policy and policy details for this cbas-submission"
+      }
+      read = {
+        description = "read from the private azure storage account"
+      }
+    }
+    ownerRoleName = "submitter"
+    roles = {
+      submitter = {
+        roleActions = ["delete", "read_policy::submitter", "read",]
+      }
+      reader = {
+        roleActions = ["read", "read_policy::submitter"]
+      }
+    }
+    allowLeaving = false
+    reuseIds = false
   }
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1680,8 +1680,8 @@ resourceTypes = {
 
   cbas-submission = {
     actionPatterns = {
-      delete = {
-        description = "Delete this cbas-submission"
+      abort = {
+        description = "Abort this cbas-submission"
       }
       "read_policy::submitter" = {
         description = "view the submitter policy and policy details for this cbas-submission"
@@ -1696,7 +1696,7 @@ resourceTypes = {
     ownerRoleName = "submitter"
     roles = {
       submitter = {
-        roleActions = ["delete", "read_policy::submitter", "read", "create_with_parent"]
+        roleActions = ["abort", "read_policy::submitter", "read", "create_with_parent"]
       }
       reader = {
         roleActions = ["read", "read_policy::submitter"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -172,7 +172,7 @@ resourceTypes = {
           wds-instance = ["owner"]
           kubernetes-app = ["manager"]
           kubernetes-app-shared = ["owner", "user"]
-          cbas-submission = ["owner"]
+          cbas-submission = ["reader"]
         }
       }
       application = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1689,11 +1689,14 @@ resourceTypes = {
       read = {
         description = "read from the private azure storage account"
       }
+      create_with_parent = {
+        description = "Enables creating the request object with a parent"
+      }
     }
     ownerRoleName = "submitter"
     roles = {
       submitter = {
-        roleActions = ["delete", "read_policy::submitter", "read",]
+        roleActions = ["delete", "read_policy::submitter", "read", "create_with_parent"]
       }
       reader = {
         roleActions = ["read", "read_policy::submitter"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -172,7 +172,7 @@ resourceTypes = {
           wds-instance = ["owner"]
           kubernetes-app = ["manager"]
           kubernetes-app-shared = ["owner", "user"]
-          cbas-submission = ["reader"]
+          cbas-submission = ["owner"]
         }
       }
       application = {
@@ -1683,23 +1683,21 @@ resourceTypes = {
       abort = {
         description = "Abort this cbas-submission"
       }
-      "read_policy::submitter" = {
-        description = "view the submitter policy and policy details for this cbas-submission"
-      }
       read = {
-        description = "read from the private azure storage account"
+        description = "read information about the submission"
       }
       create_with_parent = {
         description = "Enables creating the request object with a parent"
       }
     }
-    ownerRoleName = "submitter"
+    ownerRoleName = "owner"
     roles = {
-      submitter = {
-        roleActions = ["abort", "read_policy::submitter", "read", "create_with_parent"]
+      owner = {
+        roleActions = ["abort", "create_with_parent"]
+        includedRoles = ["reader"]
       }
       reader = {
-        roleActions = ["read", "read_policy::submitter"]
+        roleActions = ["read", "read_creator"]
       }
     }
     allowLeaving = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1689,6 +1689,9 @@ resourceTypes = {
       create_with_parent = {
         description = "Enables creating the request object with a parent"
       }
+      read_creator = {
+        description = "Enables reading the creator of the resource"
+      }
     }
     ownerRoleName = "owner"
     roles = {

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2985,6 +2985,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/resources/v2/{resourceTypeName}/{resourceId}/creator:
+    get:
+      tags:
+        - Resources
+      summary: Get the creator of a resource
+      operationId: getResourceCreator
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource to query
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource to query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: email address of the creator of this resource
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: You do not have permission get the creator of this resource
+          content: { }
+        404:
+          description: You do not have access to this resource or it does not exist
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/users/v1/{email}:
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1739,7 +1739,7 @@ paths:
         This endpoint is ONLY for determining the state of the user's permissions. 
         It does not take into account enabled status, or Terms of Service Compliance, nor does it take into account Auth Domains.
         To check if a user is allowed to execute an action on a resource, use /api/resources/v2/{resourceTypeName}/{resourceId}/action/{action}
-        By default, public resources are not included. Including public resources incurs a 3x cost of DB performance.
+        By default, public resources are not included. Including public resources might incur a 3x cost of DB performance.
       operationId: listResourcesV2
       parameters:
         - name: format
@@ -1783,6 +1783,15 @@ paths:
         - name: actions
           in: query
           description: Names of actions to filter on
+          required: false
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: parentResources
+          in: query
+          description: Fully Qualified Resource IDs of parent resources to filter on. Formatted as `resourceTypeName:resourceId`.
           required: false
           explode: false
           schema:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -252,6 +252,16 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
                     }
                   }
                 }
+              } ~
+              pathPrefix("creator") {
+                requireAction(resource, SamResourceActions.readCreator, samUser.id, samRequestContext) {
+                  pathEndOrSingleSlash {
+                    complete(resourceService.getResourceCreator(resource, samRequestContext).map {
+                      case Some(response) => StatusCodes.OK -> response.email
+                      case None => throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "resource creator not found"))
+                    })
+                  }
+                }
               }
             }
           }
@@ -605,7 +615,7 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
       "policies".as[String].?,
       "roles".as[String].?,
       "actions".as[String].?,
-      "parentResources".as[String] ?,
+      "parentResources".as[String].?,
       "includePublic" ? false,
       "format".as[String] ? "hierarchical"
     ) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ResourceRoutes.scala
@@ -605,38 +605,65 @@ trait ResourceRoutes extends SamUserDirectives with SecurityDirectives with SamM
       "policies".as[String].?,
       "roles".as[String].?,
       "actions".as[String].?,
+      "parentResources".as[String] ?,
       "includePublic" ? false,
       "format".as[String] ? "hierarchical"
-    ) { (resourceTypes: Option[String], policies: Option[String], roles: Option[String], actions: Option[String], includePublic: Boolean, format: String) =>
-      format match {
-        case "flat" =>
-          complete {
-            resourceService
-              .listResourcesFlat(
-                samUser.id,
-                resourceTypes.map(_.split(",").map(ResourceTypeName(_)).toSet).getOrElse(Set.empty),
-                policies.map(_.split(",").map(AccessPolicyName(_)).toSet).getOrElse(Set.empty),
-                roles.map(_.split(",").map(ResourceRoleName(_)).toSet).getOrElse(Set.empty),
-                actions.map(_.split(",").map(ResourceAction(_)).toSet).getOrElse(Set.empty),
-                includePublic,
-                samRequestContext
-              )
-              .map(StatusCodes.OK -> _)
-          }
-        case "hierarchical" =>
-          complete {
-            resourceService
-              .listResourcesHierarchical(
-                samUser.id,
-                resourceTypes.map(_.split(",").map(ResourceTypeName(_)).toSet).getOrElse(Set.empty),
-                policies.map(_.split(",").map(AccessPolicyName(_)).toSet).getOrElse(Set.empty),
-                roles.map(_.split(",").map(ResourceRoleName(_)).toSet).getOrElse(Set.empty),
-                actions.map(_.split(",").map(ResourceAction(_)).toSet).getOrElse(Set.empty),
-                includePublic,
-                samRequestContext
-              )
-              .map(StatusCodes.OK -> _)
-          }
-      }
+    ) {
+      (
+          resourceTypes: Option[String],
+          policies: Option[String],
+          roles: Option[String],
+          actions: Option[String],
+          parentResources: Option[String],
+          includePublic: Boolean,
+          format: String
+      ) =>
+        val parsedResourceTypes = resourceTypes.map(_.split(",").map(ResourceTypeName(_)).toSet).getOrElse(Set.empty)
+        val parsedPolicies = policies.map(_.split(",").map(AccessPolicyName(_)).toSet).getOrElse(Set.empty)
+        val parsedRoles = roles.map(_.split(",").map(ResourceRoleName(_)).toSet).getOrElse(Set.empty)
+        val parsedActions = actions.map(_.split(",").map(ResourceAction(_)).toSet).getOrElse(Set.empty)
+        val parsedParentResourceIds = parentResources
+          .map(
+            _.split(",")
+              .map { r =>
+                val splitted = r.split(":")
+                FullyQualifiedResourceId(ResourceTypeName(splitted(0)), ResourceId(splitted(1)))
+              }
+              .toSet
+          )
+          .getOrElse(Set.empty)
+        format match {
+          case "flat" =>
+            complete {
+              resourceService
+                .listResourcesFlat(
+                  samUser.id,
+                  parsedResourceTypes,
+                  parsedPolicies,
+                  parsedRoles,
+                  parsedActions,
+                  parsedParentResourceIds,
+                  includePublic,
+                  samRequestContext
+                )
+                .map(StatusCodes.OK -> _)
+            }
+          case "hierarchical" =>
+            complete {
+              resourceService
+                .listResourcesHierarchical(
+                  samUser.id,
+                  parsedResourceTypes,
+                  parsedPolicies,
+                  parsedRoles,
+                  parsedActions,
+                  parsedParentResourceIds,
+                  includePublic,
+                  samRequestContext
+                )
+                .map(StatusCodes.OK -> _)
+            }
+        }
+
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -197,6 +197,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives {
               Set.empty,
               Set(ResourceRoleName("user")),
               Set.empty,
+              Set.empty,
               includePublic = false,
               samRequestContext
             )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -123,6 +123,8 @@ trait AccessPolicyDAO {
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]]
 
+  def getResourceCreator(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUserId]]
+
 }
 
 sealed abstract class LoadResourceAuthDomainResult

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -118,6 +118,7 @@ trait AccessPolicyDAO {
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1775,7 +1775,9 @@ class PostgresAccessPolicyDAO(
               FilterResourcesResult(
                 rs.get[ResourceId](resource.resultName.name),
                 resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
-                rs.longOpt(resourceParent.resultName.resourceTypeId).map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid))).flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
+                rs.longOpt(resourceParent.resultName.resourceTypeId)
+                  .map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid)))
+                  .flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
                 rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
                 rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
                 rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),
@@ -1822,8 +1824,11 @@ class PostgresAccessPolicyDAO(
     val notNullConstraintRoleAction =
       samsqls"and not (${resourceRole.role} is null and ${resourceAction.action} is null)"
     val notNullConstraintPolicyAction = samsqls"and not (${resourceAction.action} is null)"
-    val resourceParentsConstraint = if (parentResourceIds.nonEmpty) samsqls"and ${parentResourceIds.map(parentResourceId => samsqls"(${resourceParent.resourceTypeId} = ${resourceTypePKsByName(parentResourceId.resourceTypeName)} and ${resourceParent.name} = ${parentResourceId.resourceId})")
-      .reduce((acc, clause) => samsqls"$acc or $clause")}" else samsqls""
+    val resourceParentsConstraint =
+      if (parentResourceIds.nonEmpty) samsqls"and ${parentResourceIds
+          .map(parentResourceId => samsqls"(${resourceParent.resourceTypeId} = ${resourceTypePKsByName(parentResourceId.resourceTypeName)} and ${resourceParent.name} = ${parentResourceId.resourceId})")
+          .reduce((acc, clause) => samsqls"$acc or $clause")}"
+      else samsqls""
 
     val policyRoleActionQuery =
       samsqls"""
@@ -1881,7 +1886,9 @@ class PostgresAccessPolicyDAO(
           FilterResourcesResult(
             rs.get[ResourceId](resource.resultName.name),
             resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
-            rs.longOpt(resourceParent.resultName.resourceTypeId).map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid))).flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
+            rs.longOpt(resourceParent.resultName.resourceTypeId)
+              .map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid)))
+              .flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
             rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
             rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
             rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1725,6 +1725,7 @@ class PostgresAccessPolicyDAO(
     val roleAction = RoleActionTable.syntax("roleAction")
     val resourceAction = ResourceActionTable.syntax("resourceAction")
     val resource = ResourceTable.syntax("resource")
+    val resourceParent = ResourceTable.syntax("resourceParent")
 
     val resourceTypeConstraint =
       samsqls"and ${resource.resourceTypeId} = ${resourceTypePKsByName.get(resourceTypeName)}"
@@ -1734,7 +1735,7 @@ class PostgresAccessPolicyDAO(
 
     val publicRoleActionQuery =
       samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourceParent.result.name}, ${resourceParent.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
           left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
           left join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
@@ -1742,6 +1743,7 @@ class PostgresAccessPolicyDAO(
           left join ${RoleActionTable as roleAction} on ${effectivePolicyRole.resourceRoleId} = ${roleAction.resourceRoleId}
           left join ${ResourceActionTable as resourceAction} on ${roleAction.resourceActionId} = ${resourceAction.id}
           left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
+          left join ${ResourceTable as resourceParent} on ${resource.resourceParentId} = ${resourceParent.id}
         where ${resourcePolicy.public}
           $resourceTypeConstraint
           $notNullConstraintRoleAction
@@ -1749,12 +1751,13 @@ class PostgresAccessPolicyDAO(
 
     val publicPolicyActionQuery =
       samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourceParent.result.name}, ${resourceParent.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
           left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
           left join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
           left join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
           left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
+          left join ${ResourceTable as resourceParent} on ${resource.resourceParentId} = ${resourceParent.id}
         where ${resourcePolicy.public}
           $resourceTypeConstraint
           $notNullConstraintPolicyAction
@@ -1772,6 +1775,7 @@ class PostgresAccessPolicyDAO(
               FilterResourcesResult(
                 rs.get[ResourceId](resource.resultName.name),
                 resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
+                rs.longOpt(resourceParent.resultName.resourceTypeId).map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid))).flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
                 rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
                 rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
                 rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),
@@ -1792,6 +1796,7 @@ class PostgresAccessPolicyDAO(
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] = {
     val groupMemberFlat = GroupMemberFlatTable.syntax("groupMemberFlat")
@@ -1803,6 +1808,7 @@ class PostgresAccessPolicyDAO(
     val roleAction = RoleActionTable.syntax("roleAction")
     val resourceAction = ResourceActionTable.syntax("resourceAction")
     val resource = ResourceTable.syntax("resource")
+    val resourceParent = ResourceTable.syntax("resourceParent")
     val authDomain = AuthDomainTable.syntax("authDomain")
     val authDomainGroup = GroupTable.syntax("authDomainGroup")
     val authDomainGroupMemberFlat = GroupMemberFlatTable.syntax("authDomainGroupMemberFlat")
@@ -1816,10 +1822,12 @@ class PostgresAccessPolicyDAO(
     val notNullConstraintRoleAction =
       samsqls"and not (${resourceRole.role} is null and ${resourceAction.action} is null)"
     val notNullConstraintPolicyAction = samsqls"and not (${resourceAction.action} is null)"
+    val resourceParentsConstraint = if (parentResourceIds.nonEmpty) samsqls"and ${parentResourceIds.map(parentResourceId => samsqls"(${resourceParent.resourceTypeId} = ${resourceTypePKsByName(parentResourceId.resourceTypeName)} and ${resourceParent.name} = ${parentResourceId.resourceId})")
+      .reduce((acc, clause) => samsqls"$acc or $clause")}" else samsqls""
 
     val policyRoleActionQuery =
       samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourceParent.result.name}, ${resourceParent.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
             left join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
@@ -1831,17 +1839,19 @@ class PostgresAccessPolicyDAO(
             left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
             left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
             left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
-          where ${groupMemberFlat.memberUserId} = ${samUserId}
+            left join ${ResourceTable as resourceParent} on ${resource.resourceParentId} = ${resourceParent.id}
+          where ${groupMemberFlat.memberUserId} = $samUserId
             $resourceTypeConstraint
             $policyConstraint
             $roleConstraint
             $actionConstraint
             $notNullConstraintRoleAction
+            $resourceParentsConstraint
             """
 
     val policyActionQuery =
       samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourceParent.result.name}, ${resourceParent.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
             left join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
@@ -1851,11 +1861,13 @@ class PostgresAccessPolicyDAO(
             left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
             left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
             left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
-          where ${groupMemberFlat.memberUserId} = ${samUserId}
+            left join ${ResourceTable as resourceParent} on ${resource.resourceParentId} = ${resourceParent.id}
+          where ${groupMemberFlat.memberUserId} = $samUserId
             $resourceTypeConstraint
             $policyConstraint
             $actionConstraint
             $notNullConstraintPolicyAction
+            $resourceParentsConstraint
             """
 
     val includePolicyActionQuery = if (roles.isEmpty) samsqls"union all $policyActionQuery" else samsqls""
@@ -1869,6 +1881,7 @@ class PostgresAccessPolicyDAO(
           FilterResourcesResult(
             rs.get[ResourceId](resource.resultName.name),
             resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
+            rs.longOpt(resourceParent.resultName.resourceTypeId).map(rtid => resourceTypeNamesByPK(ResourceTypePK(rtid))).flatMap(rtn => rs.stringOpt(resourceParent.resultName.name).map(rid => FullyQualifiedResourceId(rtn, ResourceId(rid)))),
             rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
             rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
             rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),
@@ -1889,6 +1902,7 @@ class PostgresAccessPolicyDAO(
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] =
@@ -1900,11 +1914,12 @@ class PostgresAccessPolicyDAO(
             .sequence
             .map(_.flatten)
         } else IO.pure(List.empty)
-      privateResources <- filterPrivateResources(samUserId, resourceTypeNames, policies, roles, actions, samRequestContext)
+      privateResources <- filterPrivateResources(samUserId, resourceTypeNames, policies, roles, actions, parentResourceIds, samRequestContext)
     } yield publicResources
       .filter(r => policies.isEmpty || r.policy.exists(p => policies.contains(p)))
       .filter(r => roles.isEmpty || r.role.exists(role => roles.contains(role)))
-      .filter(r => actions.isEmpty || r.action.exists(action => actions.contains(action))) ++ privateResources
+      .filter(r => actions.isEmpty || r.action.exists(action => actions.contains(action)))
+      .filter(r => parentResourceIds.isEmpty || r.parentResourceId.exists(parentResourceId => parentResourceIds.contains(parentResourceId))) ++ privateResources
 
   private def recreateEffectivePolicyRolesTableEntry(resourceTypeNames: Set[ResourceTypeName])(implicit session: DBSession): Int = {
     val resource = ResourceTable.syntax("resource")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/ResourceTable.scala
@@ -1,11 +1,18 @@
 package org.broadinstitute.dsde.workbench.sam.db.tables
 
+import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
 import org.broadinstitute.dsde.workbench.sam.db.{DatabaseKey, SamTypeBinders}
 import org.broadinstitute.dsde.workbench.sam.model.ResourceId
 import scalikejdbc._
 
 final case class ResourcePK(value: Long) extends DatabaseKey
-final case class ResourceRecord(id: ResourcePK, name: ResourceId, resourceTypeId: ResourceTypePK, resourceParentId: Option[ResourcePK])
+final case class ResourceRecord(
+    id: ResourcePK,
+    name: ResourceId,
+    resourceTypeId: ResourceTypePK,
+    resourceParentId: Option[ResourcePK],
+    createdBy: Option[WorkbenchUserId]
+)
 
 object ResourceTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRecord] {
   override def tableName: String = "SAM_RESOURCE"
@@ -15,6 +22,7 @@ object ResourceTable extends SQLSyntaxSupportWithDefaultSamDB[ResourceRecord] {
     rs.get(e.id),
     rs.get(e.name),
     rs.get(e.resourceTypeId),
-    rs.longOpt(e.resourceParentId).map(ResourcePK)
+    rs.longOpt(e.resourceParentId).map(ResourcePK),
+    rs.stringOpt(e.createdBy).map(WorkbenchUserId)
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 case class FilterResourcesResult(
     resourceId: ResourceId,
     resourceTypeName: ResourceTypeName,
+    parentResourceId: Option[FullyQualifiedResourceId],
     policy: Option[AccessPolicyName],
     role: Option[ResourceRoleName],
     action: Option[ResourceAction],

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -42,6 +42,7 @@ object SamResourceActions {
   val link = ResourceAction("link")
   val setManagedResourceGroup = ResourceAction("set_managed_resource_group")
   val adminReadSummaryInformation = ResourceAction("admin_read_summary_information")
+  val readCreator = ResourceAction("read_creator")
 
   def sharePolicy(policy: AccessPolicyName) = ResourceAction(s"share_policy::${policy.value}")
   def readPolicy(policy: AccessPolicyName) = ResourceAction(s"read_policy::${policy.value}")
@@ -111,7 +112,8 @@ object UserStatusDetails {
     resourceId: ResourceId,
     authDomain: Set[WorkbenchGroupName],
     accessPolicies: Set[AccessPolicy] = Set.empty,
-    parent: Option[FullyQualifiedResourceId] = None
+    parent: Option[FullyQualifiedResourceId] = None,
+    createdBy: Option[WorkbenchUserId] = None
 ) {
   val fullyQualifiedId = FullyQualifiedResourceId(resourceTypeName, resourceId)
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -1007,7 +1007,7 @@ class ResourceService(
       samRequestContext: SamRequestContext
   ): IO[Iterable[UserResourcesResponse]] =
     for {
-      resources <- listResourcesHierarchical(userId, Set(resourceTypeName), Set.empty, Set.empty, Set.empty, true, samRequestContext)
+      resources <- listResourcesHierarchical(userId, Set(resourceTypeName), Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext)
     } yield resources.resources.map(toUserResourcesResponse)
 
   def listResourcesFlat(
@@ -1016,10 +1016,11 @@ class ResourceService(
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesFlat] =
-    accessPolicyDAO.filterResources(samUserId, resourceTypeNames, policies, roles, actions, includePublic, samRequestContext).map(groupFlat)
+    accessPolicyDAO.filterResources(samUserId, resourceTypeNames, policies, roles, actions, parentResourceIds, includePublic, samRequestContext).map(groupFlat)
 
   def listResourcesHierarchical(
       samUserId: WorkbenchUserId,
@@ -1027,10 +1028,11 @@ class ResourceService(
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesHierarchical] =
     accessPolicyDAO
-      .filterResources(samUserId, resourceTypeNames, policies, roles, actions, includePublic, samRequestContext)
+      .filterResources(samUserId, resourceTypeNames, policies, roles, actions, parentResourceIds, includePublic, samRequestContext)
       .map(groupHierarchical)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
@@ -146,10 +146,12 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
       eqTo(Set(AccessPolicyName("fooPolicy"))),
       eqTo(Set(ResourceRoleName("fooRole"), ResourceRoleName("barRole"), ResourceRoleName("bazRole"))),
       eqTo(Set(ResourceAction("fooAction"), ResourceAction("barAction"))),
-      eqTo(Set(
-        FullyQualifiedResourceId(ResourceTypeName("barType"), ResourceId("barResource")),
-        FullyQualifiedResourceId(ResourceTypeName("bazType"), ResourceId("bazResource"))
-      )),
+      eqTo(
+        Set(
+          FullyQualifiedResourceId(ResourceTypeName("barType"), ResourceId("barResource")),
+          FullyQualifiedResourceId(ResourceTypeName("bazType"), ResourceId("bazResource"))
+        )
+      ),
       eqTo(true),
       any[SamRequestContext]
     )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/NewResourceRoutesV2Spec.scala
@@ -36,6 +36,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
         any[Set[AccessPolicyName]],
         any[Set[ResourceRoleName]],
         any[Set[ResourceAction]],
+        any[Set[FullyQualifiedResourceId]],
         any[Boolean],
         any[SamRequestContext]
       )
@@ -63,6 +64,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
         any[Set[AccessPolicyName]],
         any[Set[ResourceRoleName]],
         any[Set[ResourceAction]],
+        any[Set[FullyQualifiedResourceId]],
         any[Boolean],
         any[SamRequestContext]
       )
@@ -96,6 +98,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
       eqTo(Set.empty),
       eqTo(Set.empty),
       eqTo(Set.empty),
+      eqTo(Set.empty),
       eqTo(false),
       any[SamRequestContext]
     )
@@ -111,6 +114,7 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
       eqTo(Set(AccessPolicyName("fooPolicy"))),
       eqTo(Set(ResourceRoleName("fooRole"), ResourceRoleName("barRole"), ResourceRoleName("bazRole"))),
       eqTo(Set(ResourceAction("fooAction"), ResourceAction("barAction"))),
+      eqTo(Set.empty),
       eqTo(true),
       any[SamRequestContext]
     )
@@ -126,6 +130,26 @@ class NewResourceRoutesV2Spec extends AnyFlatSpec with Matchers with ScalatestRo
       eqTo(Set(AccessPolicyName("fooPolicy"))),
       eqTo(Set(ResourceRoleName("fooRole"), ResourceRoleName("barRole"), ResourceRoleName("bazRole"))),
       eqTo(Set(ResourceAction("fooAction"), ResourceAction("barAction"))),
+      eqTo(Set.empty),
+      eqTo(true),
+      any[SamRequestContext]
+    )
+
+    Get(
+      s"/api/resources/v2?format=hierarchical&resourceTypes=fooType,barType&policies=fooPolicy&roles=fooRole,barRole,bazRole&actions=fooAction,barAction&includePublic=true&parentResources=barType:barResource,bazType:bazResource"
+    ) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+    }
+    verify(samRoutes.resourceService).listResourcesHierarchical(
+      any[WorkbenchUserId],
+      eqTo(Set(ResourceTypeName("fooType"), ResourceTypeName("barType"))),
+      eqTo(Set(AccessPolicyName("fooPolicy"))),
+      eqTo(Set(ResourceRoleName("fooRole"), ResourceRoleName("barRole"), ResourceRoleName("bazRole"))),
+      eqTo(Set(ResourceAction("fooAction"), ResourceAction("barAction"))),
+      eqTo(Set(
+        FullyQualifiedResourceId(ResourceTypeName("barType"), ResourceId("barResource")),
+        FullyQualifiedResourceId(ResourceTypeName("bazType"), ResourceId("bazResource"))
+      )),
       eqTo(true),
       any[SamRequestContext]
     )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -294,6 +294,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with TimeMatchers with 
         any[Set[AccessPolicyName]],
         any[Set[ResourceRoleName]],
         any[Set[ResourceAction]],
+        any[Set[FullyQualifiedResourceId]],
         any[Boolean],
         any[SamRequestContext]
       )
@@ -348,6 +349,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with TimeMatchers with 
         any[Set[AccessPolicyName]],
         any[Set[ResourceRoleName]],
         any[Set[ResourceAction]],
+        any[Set[FullyQualifiedResourceId]],
         any[Boolean],
         any[SamRequestContext]
       )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -417,6 +417,9 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       .toSeq
   }
 
+  override def getResourceCreator(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Option[WorkbenchUserId]] =
+    IO.pure(resources.get(resource).flatMap(_.createdBy))
+
   override def listResourcesUsingAuthDomain(authDomainGroupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[FullyQualifiedResourceId]] =
     IO.pure(Set.empty)
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -368,6 +368,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
       actions: Set[ResourceAction],
+      parentResourceIds: Set[FullyQualifiedResourceId],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] = IO {
@@ -383,6 +384,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                   FilterResourcesResult(
                     fqPolicyId.resource.resourceId,
                     fqPolicyId.resource.resourceTypeName,
+                    None,
                     Some(fqPolicyId.accessPolicyName),
                     Some(role),
                     None,
@@ -397,6 +399,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                   FilterResourcesResult(
                     fqPolicyId.resource.resourceId,
                     fqPolicyId.resource.resourceTypeName,
+                    None,
                     Some(fqPolicyId.accessPolicyName),
                     Some(role),
                     Some(action),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAOSpec.scala
@@ -98,7 +98,7 @@ class MockAccessPolicyDAOSpec(_system: ActorSystem)
 
     val groupName = "fooGroup"
 
-    val intendedResource = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupName), Set.empty)
+    val intendedResource = Resource(ManagedGroupService.managedGroupTypeName, ResourceId(groupName), Set.empty, createdBy = Some(dummyUser.id))
 
     // just compare top level fields because createResource returns the policies, including the default one
     runAndWait(real.managedGroupService.createManagedGroup(ResourceId(groupName), dummyUser, samRequestContext = samRequestContext))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
@@ -93,6 +93,7 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         ArgumentMatchers.eq(Set.empty),
         ArgumentMatchers.eq(Set.empty),
         ArgumentMatchers.eq(Set.empty),
+        ArgumentMatchers.eq(Set.empty),
         ArgumentMatchers.eq(true),
         any[SamRequestContext]
       )
@@ -121,6 +122,7 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         FilterResourcesResult(
           accessPolicy.id.resource.resourceId,
           accessPolicy.id.resource.resourceTypeName,
+          None,
           Some(accessPolicy.id.accessPolicyName),
           None,
           None,
@@ -136,6 +138,7 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
           FilterResourcesResult(
             accessPolicy.id.resource.resourceId,
             accessPolicy.id.resource.resourceTypeName,
+            None,
             Some(accessPolicy.id.accessPolicyName),
             Some(role),
             None,
@@ -151,6 +154,7 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
              FilterResourcesResult(
                accessPolicy.id.resource.resourceId,
                accessPolicy.id.resource.resourceTypeName,
+               None,
                Some(accessPolicy.id.accessPolicyName),
                None,
                None,
@@ -165,6 +169,7 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
              FilterResourcesResult(
                accessPolicy.id.resource.resourceId,
                accessPolicy.id.resource.resourceTypeName,
+               None,
                Some(accessPolicy.id.accessPolicyName),
                None,
                Some(action),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -321,6 +321,23 @@ class ResourceServiceSpec
     err.errorReport.statusCode should equal(Some(StatusCodes.BadRequest))
   }
 
+  it should "get the resource creator, if one exists" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val resourceName = ResourceId("resource")
+    val resource = FullyQualifiedResourceId(defaultResourceType.name, resourceName)
+
+    service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
+
+    runAndWait(service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext))
+    val creator = service.getResourceCreator(resource, samRequestContext).unsafeRunSync()
+
+    creator shouldEqual Some(dummyUser)
+
+    // cleanup
+    runAndWait(service.deleteResource(resource, samRequestContext))
+  }
+
   "listUserResourceActions" should "list the user's actions for a resource" in {
     assume(databaseEnabled, databaseEnabledClue)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -40,6 +40,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
+      None,
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       Some(readerRoleName),
       Some(readAction),
@@ -51,6 +52,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
+      None,
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       None,
       None,
@@ -62,6 +64,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
+      None,
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       Some(readerRoleName),
       Some(readAction),
@@ -73,6 +76,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
+      None,
       Some(AccessPolicyName(UUID.randomUUID().toString)),
       None,
       None,
@@ -82,10 +86,11 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       false
     ),
     // Testable DB Results
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy1), Some(readerRoleName), Some(readAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy1), Some(readerRoleName), Some(readAction), false, None, false, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
+      None,
       Some(testPolicy1),
       Some(readerRoleName),
       Some(readAction),
@@ -97,6 +102,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
+      None,
       Some(testPolicy1),
       Some(readerRoleName),
       Some(readAction),
@@ -105,14 +111,15 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       false,
       false
     ), // testing duplicate row results
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy2), Some(nothingRoleName), None, true, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy3), None, None, false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, Some(testPolicy5), None, Some(readAction), true, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy2), Some(nothingRoleName), None, true, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy3), None, None, false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy4), Some(ownerRoleName), Some(readAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy4), Some(ownerRoleName), Some(writeAction), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, None, Some(testPolicy5), None, Some(readAction), true, None, false, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
+      None,
       Some(testPolicy5),
       None,
       Some(readAction),
@@ -125,6 +132,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       testResourceId2,
       resourceTypeName,
+      None,
       Some(testPolicy6),
       Some(readerRoleName),
       Some(readAction),
@@ -136,6 +144,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     FilterResourcesResult(
       testResourceId2,
       resourceTypeName,
+      None,
       Some(testPolicy6),
       Some(readerRoleName),
       Some(readAction),
@@ -154,6 +163,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       any[Set[AccessPolicyName]],
       any[Set[ResourceRoleName]],
       any[Set[ResourceAction]],
+      any[Set[FullyQualifiedResourceId]],
       any[Boolean],
       any[SamRequestContext]
     )
@@ -171,7 +181,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
   )
 
   "ResourceService" should "group filtered resources from the database appropriately flatly" in {
-    val filteredResources = resourceService.listResourcesFlat(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
+    val filteredResources = resourceService.listResourcesFlat(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
 
     val oneResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId)).head
     oneResource.resourceType should be(resourceTypeName)
@@ -199,7 +209,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
   it should "group filtered resources from the database appropriately hierarchically" in {
 
     val filteredResources =
-      resourceService.listResourcesHierarchical(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
+      resourceService.listResourcesHierarchical(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
 
     val oneResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId)).head
     oneResource.resourceType should be(resourceTypeName)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -181,7 +181,8 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
   )
 
   "ResourceService" should "group filtered resources from the database appropriately flatly" in {
-    val filteredResources = resourceService.listResourcesFlat(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
+    val filteredResources =
+      resourceService.listResourcesFlat(dummyUser.id, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
 
     val oneResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId)).head
     oneResource.resourceType should be(resourceTypeName)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1306

To help our Workflows friends, we need to add a `cbas-submissions` resource type, with `owner` and `reader` roles. This will allow CBAS to not need to store Sam User IDs, and instead let Sam do what Sam does best! 

We also need to augment the `listResourcesV2` endpoint so that it can take in a `parentResourceId` and constrain its results to resources with only that `parentResourceId`. 

I've added an optional query parameter to the `listResourcesV2` endpoint, which takes in a list of resource parents to filter on. The resource parents are formatted as `resourceTypeName:resourceId`, since we need both to be able to do a proper DB join. The `:` character is not allowed in resource names, so its an OK character to use as a separator. 

The response from `listResourcesV2` has not changed, as doing so might break any consumers of the endpoint. If there are no consumers that would break, it may be worth it to include this parent information in the response. 

I've added a new endpoint: `getResourceCreator`. If a user has the `read_creator` action, they'll be able to get the email address of the creator of the resource. Its odd that Sam wasn't storing this before!

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
