### PR TITLE
ID-1313 resource type admin policy inheritance

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -18,7 +18,10 @@ trait AccessPolicyDAO {
 
   def createResource(resource: Resource, samRequestContext: SamRequestContext): IO[Resource]
 
-  def deleteResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
+  /** Deletes a resource. If leaveTombStone is true, a record of the resource will be kept in the database to prevent the resource name from being reused. If
+    * leaveTombStone is false, the resource will be completely removed from the database.
+    */
+  def deleteResource(resource: FullyQualifiedResourceId, leaveTombStone: Boolean, samRequestContext: SamRequestContext): IO[Unit]
 
   def loadResourceAuthDomain(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LoadResourceAuthDomainResult]
 
@@ -33,13 +36,9 @@ trait AccessPolicyDAO {
       samRequestContext: SamRequestContext
   ): IO[Set[FullyQualifiedPolicyId]]
 
-  def removeAuthDomainFromResource(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
-
   def createPolicy(policy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy]
 
   def deletePolicy(policy: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Unit]
-
-  def deleteAllResourcePolicies(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[Unit]
 
   def loadPolicy(resourceAndPolicyName: FullyQualifiedPolicyId, samRequestContext: SamRequestContext): IO[Option[AccessPolicy]]
 
@@ -66,7 +65,7 @@ trait AccessPolicyDAO {
       samRequestContext: SamRequestContext
   ): IO[Set[FullyQualifiedResourceId]]
 
-//  @deprecated("listing policies for resource type removed", since = "ResourceRoutes v2")
+  //  @deprecated("listing policies for resource type removed", since = "ResourceRoutes v2")
   def listAccessPolicies(resourceTypeName: ResourceTypeName, userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[ResourceIdAndPolicyName]]
 
   def listAccessPolicies(resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[LazyList[AccessPolicy]]
@@ -112,6 +111,7 @@ trait AccessPolicyDAO {
         ResourceIdWithRolesAndActions(resourceId, left.direct ++ right.direct, left.inherited ++ right.inherited, left.public ++ right.public)
       }
     }
+
   def filterResources(
       samUserId: WorkbenchUserId,
       resourceTypeNames: Set[ResourceTypeName],
@@ -122,6 +122,7 @@ trait AccessPolicyDAO {
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]]
 
+  def checkPolicyGroupsInUse(resourceId: FullyQualifiedResourceId, samRequestContext: SamRequestContext): IO[List[Map[String, String]]]
 }
 
 sealed abstract class LoadResourceAuthDomainResult

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
@@ -45,10 +45,10 @@ trait EffectivePolicyMutationStatements {
     */
   protected def deleteDescendantInheritedEffectivePolicies(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
     val ancestorResourceTable = AncestorResourceTable("ancestor_resource")
-    val ancestorResource = ancestorResourceTable.syntax("ancestorResource")
+    val ancestorResource = ancestorResourceTable.syntax("ancestor_resource")
 
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
-    val descendantResource = descendantResourceTable.syntax("descendantResource")
+    val descendantResource = descendantResourceTable.syntax("descendant_resource")
 
     val ep = EffectiveResourcePolicyTable.syntax("ep")
     val p = PolicyTable.syntax("p")
@@ -97,7 +97,7 @@ trait EffectivePolicyMutationStatements {
     */
   private def insertEffectivePolicyRolesForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
-    val descendantResource = descendantResourceTable.syntax("descendantResource")
+    val descendantResource = descendantResourceTable.syntax("descendant_resource")
 
     val erCol = EffectivePolicyRoleTable.column
     val pr = PolicyRoleTable.syntax("pr")
@@ -133,8 +133,8 @@ trait EffectivePolicyMutationStatements {
     val rr = ResourceRoleTable.syntax("rr")
     val ep = EffectiveResourcePolicyTable.syntax("ep")
     val sourcePolicy = PolicyTable.syntax("source_policy")
-    val newResource = ResourceTable.syntax("newResource")
-    val adminResource = ResourceTable.syntax("adminResource")
+    val newResource = ResourceTable.syntax("new_resource")
+    val adminResource = ResourceTable.syntax("admin_resource")
 
     samsql"""insert into ${EffectivePolicyRoleTable.table} (${erCol.effectiveResourcePolicyId}, ${erCol.resourceRoleId})
               select ${ep.id}, ${rr.id}
@@ -157,8 +157,8 @@ trait EffectivePolicyMutationStatements {
   private def insertEffectivePolicyActionsFromResourceTypeAdmin(newResourcePK: ResourcePK, adminTypePK: ResourceTypePK)(implicit session: DBSession): Int = {
     val eaCol = EffectivePolicyActionTable.column
     val pa = PolicyActionTable.syntax("pa")
-    val newResource = ResourceTable.syntax("newResource")
-    val adminResource = ResourceTable.syntax("adminResource")
+    val newResource = ResourceTable.syntax("new_resource")
+    val adminResource = ResourceTable.syntax("admin_resource")
     val ra = ResourceActionTable.syntax("ra")
     val ep = EffectiveResourcePolicyTable.syntax("ep")
     val sourcePolicy = PolicyTable.syntax("source_policy")
@@ -187,7 +187,7 @@ trait EffectivePolicyMutationStatements {
     */
   private def insertEffectivePolicyActionsForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
-    val descendantResource = descendantResourceTable.syntax("descendantResource")
+    val descendantResource = descendantResourceTable.syntax("descendant_resource")
 
     val eaCol = EffectivePolicyActionTable.column
     val pa = PolicyActionTable.syntax("pa")
@@ -220,10 +220,10 @@ trait EffectivePolicyMutationStatements {
     */
   private def insertEffectivePoliciesForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
     val ancestorResourceTable = AncestorResourceTable("ancestor_resource")
-    val ancestorResource = ancestorResourceTable.syntax("ancestorResource")
+    val ancestorResource = ancestorResourceTable.syntax("ancestor_resource")
 
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
-    val descendantResource = descendantResourceTable.syntax("descendantResource")
+    val descendantResource = descendantResourceTable.syntax("descendant_resource")
 
     val p = PolicyTable.syntax("p")
     val epCol = EffectiveResourcePolicyTable.column
@@ -246,8 +246,8 @@ trait EffectivePolicyMutationStatements {
   ): Int = {
     val p = PolicyTable.syntax("p")
     val epCol = EffectiveResourcePolicyTable.column
-    val adminResource = ResourceTable.syntax("adminResource")
-    val newResource = ResourceTable.syntax("newResource")
+    val adminResource = ResourceTable.syntax("admin_resource")
+    val newResource = ResourceTable.syntax("new_resource")
 
     samsql"""insert into ${EffectiveResourcePolicyTable.table} (${epCol.resourceId}, ${epCol.sourcePolicyId})
         select ${newResource.id}, ${p.id}
@@ -267,9 +267,9 @@ trait EffectivePolicyMutationStatements {
     */
   private def ancestorsRecursiveQuery(childResourcePK: ResourcePK, ancestorResourceTable: AncestorResourceTable) = {
     val resource = ResourceTable.syntax("resource")
-    val parentResource = ResourceTable.syntax("parentResource")
+    val parentResource = ResourceTable.syntax("parent_resource")
     val arColumn = ancestorResourceTable.column
-    val ancestorResource = ancestorResourceTable.syntax("ancestorResource")
+    val ancestorResource = ancestorResourceTable.syntax("ancestor_resource")
     samsqls"""
         ${ancestorResourceTable.table}(${arColumn.resourceId}) as (
           select ${resource.resourceParentId}
@@ -291,7 +291,7 @@ trait EffectivePolicyMutationStatements {
   private def descendantsRecursiveQuery(resourcePK: ResourcePK, descendantResourceTable: AncestorResourceTable) = {
     val resource = ResourceTable.syntax("resource")
     val drColumn = descendantResourceTable.column
-    val descendantResource = descendantResourceTable.syntax("descendantResource")
+    val descendantResource = descendantResourceTable.syntax("descendant_resource")
     samsqls"""
         ${descendantResourceTable.table}(${drColumn.resourceId}) as (
             select ${resourcePK}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
@@ -68,7 +68,8 @@ trait EffectivePolicyMutationStatements {
         and ${p.id} = ${ep.sourcePolicyId}""".update().apply()
   }
 
-  /** Calculate and store all effective policies for resource for given resource and its descendants.
+  /** Calculate and store all effective policies for resource for given resource and its descendants. Called when setting a resource's parent. This function
+    * does not handle resource type admin because resource type admins may not have parents.
     * @param childResourcePK
     * @param session
     * @return
@@ -86,9 +87,6 @@ trait EffectivePolicyMutationStatements {
     * @return
     */
   private def insertEffectivePolicyRolesForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
-    // Note that there is no special logic for resource type admin because resource type admin may not have parents
-    // and must exist before any resources of that type are created. This function is called only when a resource
-    // is created or when a resource's parent is changed.
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
     val descendantResource = descendantResourceTable.syntax("descendantResource")
 
@@ -125,9 +123,6 @@ trait EffectivePolicyMutationStatements {
     * @return
     */
   private def insertEffectivePolicyActionsForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
-    // Note that there is no special logic for resource type admin because resource type admin may not have parents
-    // and must exist before any resources of that type are created. This function is called only when a resource
-    // is created or when a resource's parent is changed.
     val descendantResourceTable = AncestorResourceTable("descendant_resource")
     val descendantResource = descendantResourceTable.syntax("descendantResource")
 
@@ -161,9 +156,6 @@ trait EffectivePolicyMutationStatements {
     * @return
     */
   private def insertEffectivePoliciesForChildAndDescendants(childResourcePK: ResourcePK)(implicit session: DBSession): Int = {
-    // Note that there is no special logic for resource type admin because resource type admin may not have parents
-    // and must exist before any resources of that type are created. This function is called only when a resource
-    // is created or when a resource's parent is changed.
     val ancestorResourceTable = AncestorResourceTable("ancestor_resource")
     val ancestorResource = ancestorResourceTable.syntax("ancestorResource")
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/EffectivePolicyMutationStatements.scala
@@ -271,6 +271,7 @@ trait EffectivePolicyMutationStatements {
 
     val policy = PolicyTable.syntax("policy")
 
+    // insert for resource type admin resource itself
     samsql"""insert into ${EffectivePolicyRoleTable.table} (${erCol.effectiveResourcePolicyId}, ${erCol.resourceRoleId})
               select ${ep.id}, ${rr.id}
               from ${PolicyTable as policy}
@@ -283,6 +284,7 @@ trait EffectivePolicyMutationStatements {
               and ${roleAppliesToResource(pr, fr, ep, policy)}
               on conflict do nothing""".update().apply()
 
+    // insert for all resources of the type
     samsql"""insert into ${EffectivePolicyRoleTable.table} (${erCol.effectiveResourcePolicyId}, ${erCol.resourceRoleId})
               select ${ep.id}, ${rr.id}
               from ${ResourceTable as r}
@@ -337,6 +339,7 @@ trait EffectivePolicyMutationStatements {
     val ra = ResourceActionTable.syntax("ra")
     val policy = PolicyTable.syntax("policy")
 
+    // insert for resource type admin resource itself
     samsql"""insert into ${EffectivePolicyActionTable.table} (${eaCol.effectiveResourcePolicyId}, ${eaCol.resourceActionId})
               select ${ep.id}, ${ra.id}
               from ${PolicyTable as policy}
@@ -349,6 +352,7 @@ trait EffectivePolicyMutationStatements {
               and ${r.resourceTypeId} = ${ra.resourceTypeId}
               on conflict do nothing""".update().apply()
 
+    // insert for all resources of the type
     samsql"""insert into ${EffectivePolicyActionTable.table} (${eaCol.effectiveResourcePolicyId}, ${eaCol.resourceActionId})
               select ${ep.id}, ${ra.id}
               from ${ResourceTable as r}
@@ -394,14 +398,14 @@ trait EffectivePolicyMutationStatements {
           select ${r.id}, ${policyPK}
           from ${ResourceTable as r}
           where ${r.resourceTypeId} = ${resourceTypePKsByName(SamResourceTypes.resourceTypeAdminName)}
-          and ${r.name} = ${policy.id.resource.resourceTypeName}
+          and ${r.name} = ${policy.id.resource.resourceId}
           """.update().apply()
 
     // insert for all resources of the type
     samsql"""insert into ${EffectiveResourcePolicyTable.table} (${epCol.resourceId}, ${epCol.sourcePolicyId})
           select ${r.id}, ${policyPK}
           from ${ResourceTable as r}
-          where ${r.resourceTypeId} = ${resourceTypePKsByName(policy.id.resource.resourceTypeName)}
+          where ${r.resourceTypeId} = ${resourceTypePKsByName(ResourceTypeName(policy.id.resource.resourceId.value))}
           """.update().apply()
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -480,6 +480,19 @@ class PostgresAccessPolicyDAO(
           populateInheritedEffectivePolicies(resourcePK)
         }
 
+        if (
+          !resource.fullyQualifiedId.resourceTypeName.isResourceTypeAdmin
+          // check that the resource type admin resource type exists
+          // many tests don't create it but it should be there irl, but if it isn't there, can't be any policies to inherit
+          && resourceTypePKsByName.contains(SamResourceTypes.resourceTypeAdminName)
+        ) {
+          populateResourceTypeAdminEffectivePolicies(
+            resourcePK,
+            resourceTypePKsByName(SamResourceTypes.resourceTypeAdminName),
+            ResourceId(resource.resourceTypeName.value)
+          )
+        }
+
         resource.accessPolicies.foreach { policy =>
           val groupPK = insertPolicyGroup(policy)
           val policyPK = insertPolicy(resourcePK, policy, groupPK)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -102,7 +102,7 @@ object UserStatusDetails {
 )
 
 @Lenses final case class ResourceTypeName(value: String) extends ValueObject {
-  val isResourceTypeAdmin: Boolean = value == SamResourceTypes.resourceTypeAdminName.value
+  def isResourceTypeAdmin: Boolean = value == SamResourceTypes.resourceTypeAdminName.value
 }
 
 @Lenses final case class FullyQualifiedResourceId(resourceTypeName: ResourceTypeName, resourceId: ResourceId) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -101,7 +101,9 @@ object UserStatusDetails {
     descendantRoles: Map[ResourceTypeName, Set[ResourceRoleName]] = Map.empty
 )
 
-@Lenses final case class ResourceTypeName(value: String) extends ValueObject
+@Lenses final case class ResourceTypeName(value: String) extends ValueObject {
+  val isResourceTypeAdmin: Boolean = value == SamResourceTypes.resourceTypeAdminName.value
+}
 
 @Lenses final case class FullyQualifiedResourceId(resourceTypeName: ResourceTypeName, resourceId: ResourceId) {
   override def toString: String = s"$resourceTypeName/$resourceId"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/PolicyEvaluatorService.scala
@@ -49,19 +49,8 @@ class PolicyEvaluatorService(
       userId: WorkbenchUserId,
       samRequestContext: SamRequestContext
   ): IO[Boolean] = traceIOWithContext("hasPermissionOneOf", samRequestContext) { samRequestContext =>
-    listUserResourceActions(resource, userId, samRequestContext).flatMap { userActions =>
-      if (actions.toSet.intersect(userActions).nonEmpty) {
-        IO.pure(true)
-      } else if (resource.resourceTypeName == SamResourceTypes.resourceTypeAdminName) {
-        IO.pure(false)
-      } else {
-        val resourceType = resource.resourceTypeName.value
-        hasPermissionOneOf(
-          FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId(resourceType)),
-          actions.map(a => ResourceAction(s"$resourceType::${a.value}")),
-          userId,
-          samRequestContext)
-      }
+    listUserResourceActions(resource, userId, samRequestContext).map { userActions =>
+      actions.toSet.intersect(userActions).nonEmpty
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -609,12 +609,13 @@ class ResourceService(
       resourceType: ResourceType,
       resourceId: ResourceId,
       descendantPermissions: Set[AccessPolicyDescendantPermissions]
-  ): Set[ErrorReport] = {
-      descendantPermissions.collect {
-        case descendantPermissions if resourceType.name.isResourceTypeAdmin && !descendantPermissions.resourceType.value.equalsIgnoreCase(resourceId.value) =>
-          ErrorReport(s"Resource type admin policies can only have descendant permissions for their matching resource type, ${descendantPermissions.resourceType} is a different type")
-      }
-  }
+  ): Set[ErrorReport] =
+    descendantPermissions.collect {
+      case descendantPermissions if resourceType.name.isResourceTypeAdmin && !descendantPermissions.resourceType.value.equalsIgnoreCase(resourceId.value) =>
+        ErrorReport(
+          s"Resource type admin policies can only have descendant permissions for their matching resource type, ${descendantPermissions.resourceType} is a different type"
+        )
+    }
 
   /** A valid email is one that matches the email address for a previously persisted WorkbenchSubject.
     *

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -658,7 +658,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         dao.listResourceWithAuthDomains(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() shouldEqual Option(resource)
 
-        dao.deleteResource(resource.fullyQualifiedId, samRequestContext).unsafeRunSync()
+        dao.deleteResource(resource.fullyQualifiedId, false, samRequestContext).unsafeRunSync()
 
         dao.listResourceWithAuthDomains(resource.fullyQualifiedId, samRequestContext).unsafeRunSync() shouldEqual None
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1950,22 +1950,36 @@ class ResourceServiceSpec
   }
 
   "validateResourceTypeAdminDescendantPermissions" should "succeed if resource type admin matches resource" in {
-    service.validateResourceTypeAdminDescendantPermissions(resourceTypeAdmin, ResourceId(defaultResourceType.name.value), Set(
-      AccessPolicyDescendantPermissions(defaultResourceType.name, defaultResourceTypeActions, Set.empty)
-    )) shouldBe empty
+    service.validateResourceTypeAdminDescendantPermissions(
+      resourceTypeAdmin,
+      ResourceId(defaultResourceType.name.value),
+      Set(
+        AccessPolicyDescendantPermissions(defaultResourceType.name, defaultResourceTypeActions, Set.empty)
+      )
+    ) shouldBe empty
   }
 
   it should "succeed if resource type is not admin" in {
-    service.validateResourceTypeAdminDescendantPermissions(defaultResourceType, ResourceId(defaultResourceType.name.value), Set(
-      AccessPolicyDescendantPermissions(defaultResourceType.name, defaultResourceTypeActions, Set.empty)
-    )) shouldBe empty
+    service.validateResourceTypeAdminDescendantPermissions(
+      defaultResourceType,
+      ResourceId(defaultResourceType.name.value),
+      Set(
+        AccessPolicyDescendantPermissions(defaultResourceType.name, defaultResourceTypeActions, Set.empty)
+      )
+    ) shouldBe empty
   }
 
   it should "fail if resource type admin does not match resource" in {
-    service.validateResourceTypeAdminDescendantPermissions(resourceTypeAdmin, ResourceId(defaultResourceType.name.value), Set(
-      AccessPolicyDescendantPermissions(otherResourceType.name, defaultResourceTypeActions, Set.empty)
-    )) should contain theSameElementsAs Set(
-      ErrorReport(s"Resource type admin policies can only have descendant permissions for their matching resource type, ${otherResourceType.name} is a different type")
+    service.validateResourceTypeAdminDescendantPermissions(
+      resourceTypeAdmin,
+      ResourceId(defaultResourceType.name.value),
+      Set(
+        AccessPolicyDescendantPermissions(otherResourceType.name, defaultResourceTypeActions, Set.empty)
+      )
+    ) should contain theSameElementsAs Set(
+      ErrorReport(
+        s"Resource type admin policies can only have descendant permissions for their matching resource type, ${otherResourceType.name} is a different type"
+      )
     )
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -1317,10 +1317,12 @@ class ResourceServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypeAdmin = defaultResourceType.copy(name = ResourceTypeName("resource_type_admin"))
-    val resource = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId("my-resource"))
+    val resourceType = defaultResourceType.copy(name = ResourceTypeName("my-resource"))
+    val resource = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value))
     val newAdminUser = Generator.genFirecloudUser.sample.get
 
     service.createResourceType(resourceTypeAdmin, samRequestContext).unsafeRunSync()
+    service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
     runAndWait(service.createResource(resourceTypeAdmin, resource.resourceId, dummyUser, samRequestContext))
     dirDAO.createUser(newAdminUser, samRequestContext).unsafeRunSync()
 
@@ -1355,9 +1357,11 @@ class ResourceServiceSpec
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypeAdmin = defaultResourceType.copy(name = ResourceTypeName("resource_type_admin"))
-    val resource = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId("my-resource"))
+    val resourceType = defaultResourceType.copy(name = ResourceTypeName("my-resource"))
+    val resource = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(resourceType.name.value))
 
     service.createResourceType(resourceTypeAdmin, samRequestContext).unsafeRunSync()
+    service.createResourceType(resourceType, samRequestContext).unsafeRunSync()
     runAndWait(service.createResource(resourceTypeAdmin, resource.resourceId, dummyUser, samRequestContext))
 
     val group = BasicWorkbenchGroup(WorkbenchGroupName("foo"), Set(), toEmail(resource.resourceTypeName.value, resource.resourceId.value, "foo"))


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1313

[Design doc](https://docs.google.com/document/d/13Mhiuym1zh7lOQ4VOeEbenS1WqmHL5v1cn_fUZwpR9o/edit#heading=h.6mdcf0m901wb)

Also, deleting a resource was refactored to put all database operations in a single transaction and to do a foreign key violation check before anything destructive happens. Had to touch this code anyway to remove effective policies from deleted resources where we want to leave a tomb stone record.

What:

implement resource policies that are inherited from resource type admin of the associated type

Why:

we intend to use this to grant Terra services blanket access to certain actions for all resources of a type

How:

Populate effective policy table from policies on resource type admin. There are 2 paths:
1. when a resource type admin policy is created or updated, effective policies for all associated resources need to be updated with those changes
2. when a resource is created, effective policies must be add from its resource type admin

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
