### PR TITLE
ID-1314 No MRG Validation for Action Managed Identity Creation

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/azure/AzureServiceUnitSpec.scala
@@ -2,17 +2,14 @@ package org.broadinstitute.dsde.workbench.sam.azure
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import com.azure.core.http.rest.PagedIterable
 import com.azure.core.management.Region
 import com.azure.core.util.Context
-import com.azure.resourcemanager.managedapplications.ApplicationManager
-import com.azure.resourcemanager.managedapplications.models.{Application, Applications, Plan}
 import com.azure.resourcemanager.msi.MsiManager
 import com.azure.resourcemanager.msi.models.Identity.DefinitionStages
 import com.azure.resourcemanager.msi.models.{Identities, Identity}
 import com.azure.resourcemanager.resources.ResourceManager
 import com.azure.resourcemanager.resources.models.{ResourceGroup, ResourceGroups}
-import org.broadinstitute.dsde.workbench.sam.config.{AzureMarketPlace, AzureServicesConfig, ManagedAppPlan}
+import org.broadinstitute.dsde.workbench.sam.config.AzureServicesConfig
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AzureManagedResourceGroupDAO, DirectoryDAO}
 import org.broadinstitute.dsde.workbench.sam.model.{FullyQualifiedResourceId, ResourceAction, ResourceId, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.{Generator, PropertyBasedTesting, TestSupport}
@@ -35,11 +32,6 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
         val mockDirectoryDAO = mock[DirectoryDAO]
         val mockAzureManagedResourceGroupDAO = mock[AzureManagedResourceGroupDAO]
         val mockMsiManager = mock[MsiManager]
-        val mockApplicationManager = mock[ApplicationManager]
-        val mockApplications = mock[Applications]
-        val mockPagedResponse = mock[PagedIterable[Application]]
-        val mockApplication = mock[Application]
-        val mockPlan = mock[Plan]
         val mockResourceManager = mock[ResourceManager]
         val mockResourceGroups = mock[ResourceGroups]
         val mockResourceGroup = mock[ResourceGroup]
@@ -64,28 +56,16 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
         val testDisplayName = azureService.toManagedIdentityNameFromAmiId(testActionManagedIdentityId)
         val testObjectId = ManagedIdentityObjectId(UUID.randomUUID().toString)
         val testActionManagedIdentity = ActionManagedIdentity(testActionManagedIdentityId, testObjectId, testDisplayName, testMrgCoordinates)
-        val testManagedAppPlan = ManagedAppPlan("testPlan", "testPublisher", UUID.randomUUID().toString)
         val testSamRequestContext = samRequestContext.copy(samUser = Some(dummyUser))
-        val testMrgId = UUID.randomUUID().toString
 
         when(mockDirectoryDAO.loadActionManagedIdentity(testActionManagedIdentityId, testSamRequestContext)).thenReturn(IO.pure(None))
         when(mockAzureManagedResourceGroupDAO.getManagedResourceGroupByBillingProfileId(testBillingProfileId, testSamRequestContext))
           .thenReturn(IO.pure(Some(ManagedResourceGroup(testMrgCoordinates, testBillingProfileId))))
         when(mockCrlService.buildMsiManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockMsiManager))
-        when(mockCrlService.buildApplicationManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockApplicationManager))
-        when(mockApplicationManager.applications()).thenReturn(mockApplications)
-        when(mockApplications.list()).thenReturn(mockPagedResponse)
-        when(mockPagedResponse.iterator()).thenReturn(java.util.List.of(mockApplication).iterator())
-        when(mockApplication.plan()).thenReturn(mockPlan)
-        when(mockApplication.managedResourceGroupId()).thenReturn(testMrgId)
-        when(mockApplication.parameters()).thenReturn(java.util.Map.of(testManagedAppPlan.authorizedUserKey, java.util.Map.of("value", dummyUser.email.value)))
-        when(mockPlan.name()).thenReturn(testManagedAppPlan.name)
-        when(mockPlan.publisher()).thenReturn(testManagedAppPlan.publisher)
         when(mockCrlService.buildResourceManager(testMrgCoordinates.tenantId, testMrgCoordinates.subscriptionId)).thenReturn(IO.pure(mockResourceManager))
         when(mockResourceManager.resourceGroups()).thenReturn(mockResourceGroups)
         when(mockResourceGroups.getByName(testMrgCoordinates.managedResourceGroupName.value)).thenReturn(mockResourceGroup)
         when(mockResourceGroup.region()).thenReturn(Region.US_EAST)
-        when(mockResourceGroup.id()).thenReturn(testMrgId)
         when(mockMsiManager.identities()).thenReturn(mockIdentities)
         when(mockIdentities.define(testDisplayName.value)).thenReturn(mockIdentitiesBlank)
         when(mockIdentitiesBlank.withRegion(Region.US_EAST)).thenReturn(mockIdentityWithGroup)
@@ -95,8 +75,6 @@ class AzureServiceUnitSpec extends AnyFreeSpec with Matchers with ScalaFutures w
         when(mockIdentity.id()).thenReturn(testObjectId.value)
         when(mockIdentity.name()).thenReturn(testDisplayName.value)
         when(mockDirectoryDAO.createActionManagedIdentity(testActionManagedIdentity, testSamRequestContext)).thenReturn(IO.pure(testActionManagedIdentity))
-        when(mockAzureServicesConfig.azureServiceCatalog).thenReturn(None)
-        when(mockAzureServicesConfig.azureMarketPlace).thenReturn(Option(AzureMarketPlace(Seq(testManagedAppPlan))))
 
         // Act
         val (ami, created) =


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1314



What:
We don't actually need to validate the MRG when creating an Action Managed Identity. Doing so is just an artificial barrier to identity creation.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
