### PR TITLE
AJ-268: update to latest workbench-libs, which removes trial billing references

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,11 +7,11 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "89f86ba"
+  val workbenchLibV = "9138393"
 
   val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
-  val workbenchServiceTestV = "2.0-5863cbd"
+  val workbenchServiceTestV = s"5.0-$workbenchLibV"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,10 +11,10 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "9138393" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "a6ad7dc" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
-  val workbenchModelV = s"0.20-$workbenchLibV"
+  val workbenchModelV = s"0.19-$workbenchLibV"
   val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchNotificationsV = s"0.6-$workbenchLibV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,10 +11,10 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "a6ad7dc" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "9138393" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
-  val workbenchModelV = s"0.19-$workbenchLibV"
+  val workbenchModelV = s"0.20-$workbenchLibV"
   val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchNotificationsV = s"0.6-$workbenchLibV"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-268

What:

This updates Sam's automation subdirectory (swat tests) to the latest versions of workbench-libs libraries. The latest version of service-test removes knowledge of the trial-billing SA. 

This pulls in https://github.com/broadinstitute/workbench-libs/pull/1692

I am making this change across Sam, Leo, Rawls, and Orch:
* https://github.com/DataBiosphere/leonardo/pull/4685
* https://github.com/broadinstitute/sam/pull/1471
* https://github.com/broadinstitute/rawls/pull/2940
* https://github.com/broadinstitute/firecloud-orchestration/pull/1385


Why:

This is a prerequisite for removing knowledge of trial-billing from the github workflows that run the swat tests, which in turn unblocks removing that unused SA entirely.

How:

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
