### PR TITLE
PROD-972 ID-1324 Deduplicate group synchronization calls to google.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,10 +11,10 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "a6ad7dc" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "f7d5217" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
-  val workbenchModelV = s"0.19-$workbenchLibV"
+  val workbenchModelV = s"0.20-$workbenchLibV"
   val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchNotificationsV = s"0.6-$workbenchLibV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "f7d5217" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "8d55689" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.20-$workbenchLibV"

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -30,4 +30,5 @@
     <include file="changesets/20231019_sam_user_attributes_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240417_action_managed_identities.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240416_add_sam_rac_tables.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240701_add_group_version_and_last_synchronized_version.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240701_add_group_version_and_last_synchronized_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240701_add_group_version_and_last_synchronized_version.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="tgarwood" id="add_group_version_and_last_synchronized_version">
+
+        <addColumn tableName="sam_group">
+            <!-- Default value initially set to 1 for all existing records -->
+            <column name="version" type="BIGINT" defaultValue="1">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <!-- Default value initially set to null for all existing records -->
+        <addColumn tableName="sam_group">
+            <column name="last_synchronized_version" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -45,7 +45,9 @@ trait DirectoryDAO {
 
   def isGroupMember(groupId: WorkbenchGroupIdentity, member: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Boolean]
 
-  def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit]
+  def updateSynchronizedDateAndVersion(group: WorkbenchGroup, samRequestContext: SamRequestContext): IO[Unit]
+
+  def updateGroupUpdatedDateAndVersionWithSession(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit]
 
   def getSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Option[Date]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -995,6 +995,7 @@ class PostgresAccessPolicyDAO(
     }
     removeAllGroupMembers(groupId)
     insertGroupMembers(groupId, memberList)
+    updateGroupUpdatedDateAndVersion(id)
   }
 
   override def overwritePolicy(newPolicy: AccessPolicy, samRequestContext: SamRequestContext): IO[AccessPolicy] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1108,8 +1108,8 @@ class PostgresAccessPolicyDAO(
               rs.get[ResourceTypeName](rt.resultName.name),
               rs.get[WorkbenchEmail](g.resultName.email),
               rs.boolean(p.resultName.public),
-              rs.get[Integer](g.resultName.version),
-              rs.get[Option[Integer]](g.resultName.lastSynchronizedVersion)
+              rs.get[Int](g.resultName.version),
+              rs.get[Option[Int]](g.resultName.lastSynchronizedVersion)
             ),
             (rs.stringOpt(rr.resultName.role).map(ResourceRoleName(_)), rs.stringOpt(ra.resultName.action).map(ResourceAction(_)))
           )
@@ -1240,8 +1240,8 @@ class PostgresAccessPolicyDAO(
           resource.resourceTypeName,
           rs.get[WorkbenchEmail](g.resultName.email),
           rs.boolean(p.resultName.public),
-          rs.get[Integer](g.resultName.version),
-          rs.get[Option[Integer]](g.resultName.lastSynchronizedVersion)
+          rs.get[Int](g.resultName.version),
+          rs.get[Option[Int]](g.resultName.lastSynchronizedVersion)
         ),
         (
           RoleResult(
@@ -1498,8 +1498,8 @@ class PostgresAccessPolicyDAO(
               rs.get[ResourceTypeName](rt.resultName.name),
               rs.get[WorkbenchEmail](g.resultName.email),
               rs.boolean(p.resultName.public),
-              rs.get[Integer](g.resultName.version),
-              rs.get[Option[Integer]](g.resultName.lastSynchronizedVersion)
+              rs.get[Int](g.resultName.version),
+              rs.get[Option[Int]](g.resultName.lastSynchronizedVersion)
             ),
             (rs.stringOpt(rr.resultName.role).map(ResourceRoleName(_)), rs.stringOpt(ra.resultName.action).map(ResourceAction(_)))
           )
@@ -2072,8 +2072,8 @@ private final case class PolicyInfo(
     resourceTypeName: ResourceTypeName,
     email: WorkbenchEmail,
     public: Boolean,
-    version: Integer,
-    lastSynchronizedVersion: Option[Integer]
+    version: Int,
+    lastSynchronizedVersion: Option[Int]
 )
 private final case class RoleResult(resourceTypeName: Option[ResourceTypeName], role: Option[ResourceRoleName], descendantsOnly: Option[Boolean])
 private final case class ActionResult(resourceTypeName: Option[ResourceTypeName], action: Option[ResourceAction], descendantsOnly: Option[Boolean])

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -101,8 +101,8 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
               rs.stringOpt(p.resultName.name).map(AccessPolicyName(_)),
               rs.stringOpt(r.resultName.name).map(ResourceId(_)),
               rs.stringOpt(rt.resultName.name).map(ResourceTypeName(_)),
-              rs.get[Integer](g.resultName.version),
-              rs.get[Option[Integer]](g.resultName.lastSynchronizedVersion)
+              rs.get[Int](g.resultName.version),
+              rs.get[Option[Int]](g.resultName.lastSynchronizedVersion)
             )
           }
           .list()
@@ -201,7 +201,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       samsql"""update ${GroupTable.table}
               set ${g.synchronizedDate} = ${Instant.now()},
                   ${g.lastSynchronizedVersion} = ${group.version}
-              where ${g.id} = (${workbenchGroupIdentityToGroupPK(group.id)}) and (COALESCE(${g.lastSynchronizedVersion}, 0) < ${group.version}"""
+              where ${g.id} = (${workbenchGroupIdentityToGroupPK(group.id)}) and COALESCE(${g.lastSynchronizedVersion}, 0) < ${group.version}"""
         .update()
         .apply()
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresGroupDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresGroupDAO.scala
@@ -250,9 +250,12 @@ trait PostgresGroupDAO {
     query.map(rs => rs.int(1)).single().apply().getOrElse(0) > 0
   }
 
-  def updateGroupUpdatedDate(groupId: WorkbenchGroupIdentity)(implicit session: DBSession): Int = {
+  def updateGroupUpdatedDateAndVersion(groupId: WorkbenchGroupIdentity)(implicit session: DBSession): Int = {
     val g = GroupTable.column
-    samsql"update ${GroupTable.table} set ${g.updatedDate} = ${Instant.now()} where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})".update().apply()
+    samsql"""update ${GroupTable.table}
+            set ${g.updatedDate} = ${Instant.now()},
+                ${g.version} = ${g.version} + 1
+            where ${g.id} = (${workbenchGroupIdentityToGroupPK(groupId)})""".update().apply()
   }
 
   def deleteGroup(groupName: WorkbenchGroupName)(implicit session: DBSession): Int = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
@@ -7,7 +7,15 @@ import scalikejdbc._
 import java.time.Instant
 
 final case class GroupPK(value: Long) extends DatabaseKey
-final case class GroupRecord(id: GroupPK, name: WorkbenchGroupName, email: WorkbenchEmail, updatedDate: Option[Instant], synchronizedDate: Option[Instant])
+final case class GroupRecord(
+    id: GroupPK,
+    name: WorkbenchGroupName,
+    email: WorkbenchEmail,
+    version: Integer,
+    lastSynchronizedVersion: Option[Integer],
+    updatedDate: Option[Instant],
+    synchronizedDate: Option[Instant]
+)
 
 object GroupTable extends SQLSyntaxSupportWithDefaultSamDB[GroupRecord] {
   override def tableName: String = "SAM_GROUP"
@@ -17,6 +25,8 @@ object GroupTable extends SQLSyntaxSupportWithDefaultSamDB[GroupRecord] {
     rs.get(e.id),
     rs.get(e.name),
     rs.get(e.email),
+    rs.get(e.version),
+    rs.get(e.lastSynchronizedVersion),
     rs.timestampOpt(e.updatedDate).map(_.toInstant),
     rs.timestampOpt(e.synchronizedDate).map(_.toInstant)
   )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/GroupTable.scala
@@ -11,8 +11,8 @@ final case class GroupRecord(
     id: GroupPK,
     name: WorkbenchGroupName,
     email: WorkbenchEmail,
-    version: Integer,
-    lastSynchronizedVersion: Option[Integer],
+    version: Int,
+    lastSynchronizedVersion: Option[Int],
     updatedDate: Option[Instant],
     synchronizedDate: Option[Instant]
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSyncMessageReceiver.scala
@@ -49,6 +49,12 @@ class GoogleGroupSyncMessageReceiver(groupSynchronizer: GoogleGroupSynchronizer)
         logger.info(s"group to synchronize not found: ${groupNotFound.errorReport}")
         consumer.ack()
 
+      case groupAlreadySynchronized: GroupAlreadySynchronized =>
+        // this can happen if a group is synchronized multiple times in quick succession
+        // acknowledge it so we don't have to handle it again
+        logger.info(s"group already previously synchronized: ${groupAlreadySynchronized.getMessage}")
+        consumer.ack()
+
       case regrets: Throwable =>
         logger.error("failure synchronizing google group", regrets)
         consumer.nack() // redeliver message to hopefully rectify the failure

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -216,8 +216,8 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
     actions: Set[ResourceAction],
     descendantPermissions: Set[AccessPolicyDescendantPermissions],
     public: Boolean,
-    version: Integer = 1,
-    lastSynchronizedVersion: Option[Integer] = None
+    version: Int = 1,
+    lastSynchronizedVersion: Option[Int] = None
 ) extends WorkbenchGroup
 
 @Lenses final case class AccessPolicyDescendantPermissions(resourceType: ResourceTypeName, actions: Set[ResourceAction], roles: Set[ResourceRoleName])
@@ -234,16 +234,16 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
     roles: Set[ResourceRoleName],
     actions: Set[ResourceAction],
     public: Boolean,
-    version: Integer = 1,
-    lastSynchronizedVersion: Option[Integer] = None
+    version: Int = 1,
+    lastSynchronizedVersion: Option[Int] = None
 )
 
 @Lenses final case class BasicWorkbenchGroup(
     id: WorkbenchGroupName,
     members: Set[WorkbenchSubject],
     email: WorkbenchEmail,
-    version: Integer = 1,
-    lastSynchronizedVersion: Option[Integer] = None
+    version: Int = 1,
+    lastSynchronizedVersion: Option[Int] = None
 ) extends WorkbenchGroup
 object BasicWorkbenchGroup {
   def apply(workbenchGroup: WorkbenchGroup): BasicWorkbenchGroup =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -215,7 +215,9 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
     roles: Set[ResourceRoleName],
     actions: Set[ResourceAction],
     descendantPermissions: Set[AccessPolicyDescendantPermissions],
-    public: Boolean
+    public: Boolean,
+    version: Integer = 1,
+    lastSynchronizedVersion: Option[Integer] = None
 ) extends WorkbenchGroup
 
 @Lenses final case class AccessPolicyDescendantPermissions(resourceType: ResourceTypeName, actions: Set[ResourceAction], roles: Set[ResourceRoleName])
@@ -231,10 +233,18 @@ consistent "has a" relationship is tracked by this ticket: https://broadworkbenc
     email: WorkbenchEmail,
     roles: Set[ResourceRoleName],
     actions: Set[ResourceAction],
-    public: Boolean
+    public: Boolean,
+    version: Integer = 1,
+    lastSynchronizedVersion: Option[Integer] = None
 )
 
-@Lenses final case class BasicWorkbenchGroup(id: WorkbenchGroupName, members: Set[WorkbenchSubject], email: WorkbenchEmail) extends WorkbenchGroup
+@Lenses final case class BasicWorkbenchGroup(
+    id: WorkbenchGroupName,
+    members: Set[WorkbenchSubject],
+    email: WorkbenchEmail,
+    version: Integer = 1,
+    lastSynchronizedVersion: Option[Integer] = None
+) extends WorkbenchGroup
 object BasicWorkbenchGroup {
   def apply(workbenchGroup: WorkbenchGroup): BasicWorkbenchGroup =
     workbenchGroup.id match {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -83,7 +83,8 @@ class ManagedGroupService(
     val workbenchGroupName = WorkbenchGroupName(resource.resourceId.value)
     val groupMembers: Set[WorkbenchSubject] = componentPolicies.collect {
       // collect only member and admin policies
-      case AccessPolicy(id @ FullyQualifiedPolicyId(_, ManagedGroupService.memberPolicyName | ManagedGroupService.adminPolicyName), _, _, _, _, _, _) => id
+      case AccessPolicy(id @ FullyQualifiedPolicyId(_, ManagedGroupService.memberPolicyName | ManagedGroupService.adminPolicyName), _, _, _, _, _, _, _, _) =>
+        id
     }
     directoryDAO.createGroup(BasicWorkbenchGroup(workbenchGroupName, groupMembers, email), accessInstructionsOpt, samRequestContext = samRequestContext)
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -861,6 +861,10 @@ class ResourceService(
           for {
             originalPolicies <- accessPolicyDAO.listAccessPolicies(policyId.resource, samRequestContext)
             policyChanged <- accessPolicyDAO.setPolicyIsPublic(policyId, public, samRequestContext)
+            _ <- directoryDAO.updateGroupUpdatedDateAndVersionWithSession(
+              FullyQualifiedPolicyId(policyId.resource, policyId.accessPolicyName),
+              samRequestContext
+            )
             _ <- onPolicyUpdateIfChanged(policyId, originalPolicies, samRequestContext)(policyChanged)
           } yield ()
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -287,7 +287,7 @@ class ResourceService(
         } else IO.unit
       policies <- listResourcePolicies(resource, samRequestContext)
       _ <- accessPolicyDAO.addResourceAuthDomain(resource, authDomains, samRequestContext)
-      _ = policies.foreach(p => directoryDAO.updateGroupUpdatedDateAndVersionWithSession(FullyQualifiedPolicyId(resource, p.policyName), samRequestContext))
+      _ <- policies.traverse(p => directoryDAO.updateGroupUpdatedDateAndVersionWithSession(FullyQualifiedPolicyId(resource, p.policyName), samRequestContext))
       _ <- cloudExtensions.onGroupUpdate(policies.map(p => FullyQualifiedPolicyId(resource, p.policyName)), samRequestContext)
       authDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield authDomains

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -15,18 +15,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.AzureService
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
 import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.{
-  AccessPolicyMembershipRequest,
-  AccessPolicyMembershipResponse,
-  FilteredResourceFlat,
-  FilteredResourceFlatPolicy,
-  FilteredResourceHierarchical,
-  FilteredResourceHierarchicalPolicy,
-  FilteredResourceHierarchicalRole,
-  FilteredResourcesFlat,
-  FilteredResourcesHierarchical,
-  SamUser
-}
+import org.broadinstitute.dsde.workbench.sam.model.api._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.util.UUID
@@ -298,6 +287,7 @@ class ResourceService(
         } else IO.unit
       policies <- listResourcePolicies(resource, samRequestContext)
       _ <- accessPolicyDAO.addResourceAuthDomain(resource, authDomains, samRequestContext)
+      _ = policies.foreach(p => directoryDAO.updateGroupUpdatedDateAndVersionWithSession(FullyQualifiedPolicyId(resource, p.policyName), samRequestContext))
       _ <- cloudExtensions.onGroupUpdate(policies.map(p => FullyQualifiedPolicyId(resource, p.policyName)), samRequestContext)
       authDomains <- loadResourceAuthDomain(resource, samRequestContext)
     } yield authDomains

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -183,7 +183,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
         val newPolicy = policy.copy(public = isPublic)
         IO {
           policies.put(resourceAndPolicyName, newPolicy) match {
-            case Some(AccessPolicy(_, _, _, _, _, _, public)) => public != isPublic
+            case Some(AccessPolicy(_, _, _, _, _, _, public, _, _)) => public != isPublic
             case _ => false
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -257,10 +257,13 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     }.toSeq
   }
 
-  override def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] = {
-    groupSynchronizedDates += groupId -> new Date()
+  override def updateSynchronizedDateAndVersion(group: WorkbenchGroup, samRequestContext: SamRequestContext): IO[Unit] = {
+    groupSynchronizedDates += group.id -> new Date()
     IO.unit
   }
+
+  override def updateGroupUpdatedDateAndVersionWithSession(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] =
+    IO.unit
 
   override def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] = IO {
     subject match {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -713,8 +713,8 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createResource(resource1, samRequestContext).unsafeRunSync()
         dao.createResource(resource2, samRequestContext).unsafeRunSync()
 
-        dirDao.updateSynchronizedDate(policy1.id, samRequestContext).unsafeRunSync()
-        dirDao.updateSynchronizedDate(policy3.id, samRequestContext).unsafeRunSync()
+        dirDao.updateSynchronizedDateAndVersion(policy1, samRequestContext).unsafeRunSync()
+        dirDao.updateSynchronizedDateAndVersion(policy3, samRequestContext).unsafeRunSync()
 
         dao.listSyncedAccessPolicyIdsOnResourcesConstrainedByGroup(sharedAuthDomain.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(
           policy1.id,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -2896,7 +2896,7 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         dao.createPolicy(policy, samRequestContext).unsafeRunSync()
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(policy)
 
-        val newPolicy = policy.copy(members = Set(defaultUser.id, secondUser.id), actions = Set(readAction), roles = Set.empty, public = true)
+        val newPolicy = policy.copy(members = Set(defaultUser.id, secondUser.id), actions = Set(readAction), roles = Set.empty, public = true, version = 2)
         dao.overwritePolicy(newPolicy, samRequestContext).unsafeRunSync()
 
         dao.loadPolicy(policy.id, samRequestContext).unsafeRunSync() shouldEqual Option(newPolicy)
@@ -2969,7 +2969,8 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           actions = Set(readAction),
           roles = Set.empty,
           descendantPermissions = updatedDescendantPermissions,
-          public = true
+          public = true,
+          version = 2
         )
 
         val testResult = for {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -248,6 +248,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         val loadedGroup = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         loadedGroup.members should contain theSameElementsAs Set(subGroup.id)
+
+        loadedGroup.version shouldEqual 2
       }
 
       "add users to groups" in {
@@ -259,6 +261,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         val loadedGroup = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         loadedGroup.members should contain theSameElementsAs Set(defaultUser.id)
+
+        loadedGroup.version shouldEqual 2
       }
 
       "add policies to groups" in {
@@ -272,6 +276,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         val loadedGroup = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         loadedGroup.members should contain theSameElementsAs Set(defaultPolicy.id)
+
+        loadedGroup.version shouldEqual 2
       }
 
       "add groups to policies" in {
@@ -286,6 +292,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedPolicy =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(defaultGroup.id)
+
+        loadedPolicy.version shouldEqual 2
       }
 
       "add users to policies" in {
@@ -300,6 +308,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedPolicy =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(defaultUser.id)
+
+        loadedPolicy.version shouldEqual 2
       }
 
       "add policies to other policies" in {
@@ -316,6 +326,8 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedPolicy =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members should contain theSameElementsAs Set(memberPolicy.id)
+
+        loadedPolicy.version shouldEqual 2
       }
 
       "trying to add a group that does not exist will fail" in {
@@ -373,10 +385,13 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.addGroupMember(defaultGroup.id, subGroup.id, samRequestContext).unsafeRunSync() shouldBe true
         val afterAdd = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterAdd.members should contain theSameElementsAs Set(subGroup.id)
+        afterAdd.version shouldEqual 2
+
         dao.removeGroupMember(defaultGroup.id, subGroup.id, samRequestContext).unsafeRunSync() shouldBe true
 
         val afterRemove = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterRemove.members shouldBe empty
+        afterRemove.version shouldEqual 3
       }
 
       "remove users from groups" in {
@@ -387,10 +402,13 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.addGroupMember(defaultGroup.id, defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
         val afterAdd = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterAdd.members should contain theSameElementsAs Set(defaultUser.id)
+        afterAdd.version shouldEqual 2
+
         dao.removeGroupMember(defaultGroup.id, defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
 
         val afterRemove = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterRemove.members shouldBe empty
+        afterRemove.version shouldEqual 3
       }
 
       "remove policies from groups" in {
@@ -403,10 +421,13 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.addGroupMember(defaultGroup.id, defaultPolicy.id, samRequestContext).unsafeRunSync() shouldBe true
         val afterAdd = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterAdd.members should contain theSameElementsAs Set(defaultPolicy.id)
+        afterAdd.version shouldEqual 2
+
         dao.removeGroupMember(defaultGroup.id, defaultPolicy.id, samRequestContext).unsafeRunSync() shouldBe true
 
         val afterRemove = dao.loadGroup(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"failed to load group ${defaultGroup.id}"))
         afterRemove.members shouldBe empty
+        afterRemove.version shouldEqual 3
       }
 
       "remove groups from policies" in {
@@ -420,12 +441,16 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         dao.addGroupMember(defaultPolicy.id, defaultGroup.id, samRequestContext).unsafeRunSync()
         val afterAdd = policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         afterAdd.members should contain theSameElementsAs Set(defaultGroup.id)
+        afterAdd.version shouldEqual 2
+
         policyDAO.listFlattenedPolicyMembers(defaultPolicy.id, samRequestContext).unsafeRunSync() should contain theSameElementsAs Set(defaultUser)
         dao.removeGroupMember(defaultPolicy.id, defaultGroup.id, samRequestContext).unsafeRunSync()
 
         val afterRemove =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         afterRemove.members shouldBe empty
+        afterRemove.version shouldEqual 3
+
         policyDAO.listFlattenedPolicyMembers(defaultPolicy.id, samRequestContext).unsafeRunSync() shouldBe empty
       }
 
@@ -442,6 +467,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedPolicy =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members shouldBe empty
+        loadedPolicy.version shouldBe 3
       }
 
       "remove policies from other policies" in {
@@ -459,6 +485,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         val loadedPolicy =
           policyDAO.loadPolicy(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail(s"s'failed to load policy ${defaultPolicy.id}"))
         loadedPolicy.members shouldBe empty
+        loadedPolicy.version shouldBe 3
       }
     }
 
@@ -1320,7 +1347,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         assume(databaseEnabled, databaseEnabledClue)
         dao.createGroup(defaultGroup, samRequestContext = samRequestContext).unsafeRunSync()
 
-        dao.updateSynchronizedDate(defaultGroup.id, samRequestContext).unsafeRunSync()
+        dao.updateSynchronizedDateAndVersion(defaultGroup, samRequestContext).unsafeRunSync()
 
         val loadedDate = dao.getSynchronizedDate(defaultGroup.id, samRequestContext).unsafeRunSync().getOrElse(fail("failed to load date"))
         loadedDate.getTime should equal(new Date().getTime +- 2.seconds.toMillis)
@@ -1332,7 +1359,7 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
         policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
 
-        dao.updateSynchronizedDate(defaultPolicy.id, samRequestContext).unsafeRunSync()
+        dao.updateSynchronizedDateAndVersion(defaultPolicy, samRequestContext).unsafeRunSync()
 
         val loadedDate = dao.getSynchronizedDate(defaultPolicy.id, samRequestContext).unsafeRunSync().getOrElse(fail("failed to load date"))
         loadedDate.getTime should equal(new Date().getTime +- 2.seconds.toMillis)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -17,8 +17,8 @@ import org.broadinstitute.dsde.workbench.sam.TestSupport.{genSamDependencies, ge
 import org.broadinstitute.dsde.workbench.sam.api.SamRoutes
 import org.broadinstitute.dsde.workbench.sam.config.GoogleServicesConfig
 import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
-import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
+import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.api._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -192,7 +192,12 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
       added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
       removed.foreach(email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
-      verify(mockDirectoryDAO).updateSynchronizedDateAndVersion(target, samRequestContext)
+
+      target match {
+        case _: BasicWorkbenchGroup => verify(mockDirectoryDAO).updateSynchronizedDateAndVersion(target, samRequestContext)
+        case p: AccessPolicy =>
+          verify(mockDirectoryDAO).updateSynchronizedDateAndVersion(p.copy(members = p.members + CloudExtensions.allUsersGroupName), samRequestContext)
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -142,7 +142,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
         case p: AccessPolicy =>
           when(mockAccessPolicyDAO.loadPolicy(p.id, samRequestContext)).thenReturn(IO.pure(Option(testPolicy)))
       }
-      when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.unit)
+      when(mockDirectoryDAO.updateSynchronizedDateAndVersion(any[WorkbenchGroup], any[SamRequestContext])).thenReturn(IO.unit)
       when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext]))
         .thenReturn(IO.pure(Some(new GregorianCalendar(2017, 11, 22).getTime())))
 
@@ -192,7 +192,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
       added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
       removed.foreach(email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(target.email, WorkbenchEmail(email.value.toLowerCase)))
-      verify(mockDirectoryDAO).updateSynchronizedDate(target.id, samRequestContext)
+      verify(mockDirectoryDAO).updateSynchronizedDateAndVersion(target, samRequestContext)
     }
   }
 
@@ -299,7 +299,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
     when(mockDirectoryDAO.listIntersectionGroupUsers(Set(managedGroupId, testPolicy.id), samRequestContext))
       .thenReturn(IO.pure(Set(intersectionSamUserId, authorizedGoogleUserId, subIntersectionSamGroupUserId, subAuthorizedGoogleGroupUserId, addError)))
 
-    when(mockDirectoryDAO.updateSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext])).thenReturn(IO.unit)
+    when(mockDirectoryDAO.updateSynchronizedDateAndVersion(any[WorkbenchGroup], any[SamRequestContext])).thenReturn(IO.unit)
     when(mockDirectoryDAO.getSynchronizedDate(any[WorkbenchGroupIdentity], any[SamRequestContext]))
       .thenReturn(IO.pure(Some(new GregorianCalendar(2017, 11, 22).getTime())))
 
@@ -331,7 +331,7 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
     added.foreach(email => verify(mockGoogleDirectoryDAO).addMemberToGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)))
     removed.foreach(email => verify(mockGoogleDirectoryDAO).removeMemberFromGroup(testPolicy.email, WorkbenchEmail(email.value.toLowerCase)))
-    verify(mockDirectoryDAO).updateSynchronizedDate(testPolicy.id, samRequestContext)
+    verify(mockDirectoryDAO).updateSynchronizedDateAndVersion(testPolicy, samRequestContext)
   }
 
   it should "break out of cycle" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserService.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserService.scala
@@ -93,8 +93,8 @@ class MockUserService(
   def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] =
     directoryDAO.getAllPetServiceAccountsForUser(userId, samRequestContext)
 
-  def updateSynchronizedDate(groupId: WorkbenchGroupIdentity, samRequestContext: SamRequestContext): IO[Unit] =
-    directoryDAO.updateSynchronizedDate(groupId, samRequestContext)
+  def updateSynchronizedDateAndVersion(group: WorkbenchGroup, samRequestContext: SamRequestContext): IO[Unit] =
+    directoryDAO.updateSynchronizedDateAndVersion(group, samRequestContext)
 
   def loadSubjectEmail(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     directoryDAO.loadSubjectEmail(subject, samRequestContext)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -2216,7 +2216,7 @@ class ResourceServiceSpec
     policyDAO.overwritePolicy(policy.get.copy(members = Set(dummyUser.id)), samRequestContext).unsafeRunSync()
     val policy2 = policyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).unsafeRunSync()
     policy2.map(_.copy(email = WorkbenchEmail(""))) should equal(
-      Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false))
+      Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false, version = 2))
     )
 
     // call it again to ensure it does not fail
@@ -2225,7 +2225,7 @@ class ResourceServiceSpec
     // verify the policy has not changed
     val policy3 = policyDAO.loadPolicy(resourceAndPolicyName, samRequestContext).unsafeRunSync()
     policy3.map(_.copy(email = WorkbenchEmail(""))) should equal(
-      Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false))
+      Some(AccessPolicy(resourceAndPolicyName, Set(dummyUser.id), WorkbenchEmail(""), Set(ownerRoleName), Set.empty, Set.empty, public = false, version = 2))
     )
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1324

What:

We make a LOT of calls to the google groups api, a lot of which are duplicated and unnecessary. This PR aims to reduce the number of calls to google group apis during the group syncing 

Why:

We are hitting the quota for listing group memberships every day and ended up with a prod incident over the weekend. 

How:

The plan is to record the last synchronized version and current version of group, only synchronize group if group version is greater than last synchronized version.

Pseudocode:

```
Pull message from pubsub, check current version of group against last synchronized version
if equal:
	do nothing
if the group version is greater than last synchronized version
	sychronize the group

	update last sycnronized version to the version of the group when the synchronization started
```

In DB migration set initial values of current group version to 1 and last synchronized version to 0


Testing/monitoring notes:
* can test manually by pushing our own messages into the queue
* add unit tests in GoogleExtensionSpec
* add some telemetry around no-ops and list group membership 
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
