### PR TITLE
AJ-1915: align rawls-swat-test-job to what Rawls currently does

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -13,6 +13,7 @@ on:
 env:
   BEE_CREATE_RUN_NAME: 'bee-create-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   BEE_DESTROY_RUN_NAME: 'bee-destroy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
+  RAWLS_SWAT_TESTS_RUN_NAME: 'rawls-swat-tests-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:
   tag:
@@ -211,6 +212,7 @@ jobs:
           test-context: ${{ needs.prepare-configs.outputs.test-context }}
         uses: broadinstitute/workflow-dispatch@v4
         with:
+          run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}"
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
@@ -218,6 +220,7 @@ jobs:
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
             "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"\"}",
+            "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",
             "test-group-name": "${{ matrix.test-group.group_name }}",

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -209,7 +209,7 @@ jobs:
         env:
           rawls_base_test_entrypoint: "testOnly -- -l ProdTest -l NotebooksCanaryTest"
           test-context: ${{ needs.prepare-configs.outputs.test-context }}
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -196,8 +196,8 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
         test-group: [
-          { group_name: workspaces, tag: "-n org.broadinstitute.dsde.test.api.AuthDomainsTest -n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesTest" },
-          { group_name: analysis_journeys, tag: "-n org.broadinstitute.dsde.test.api.DataRepoSnapshotsTest" },
+          { group_name: workspaces, tag: "-n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesTest" },
+          { group_name: workspacesAuthDomains, tag: "-n org.broadinstitute.dsde.test.api.AuthDomainsTest" },
           { group_name: workflows, tag: "-n org.broadinstitute.dsde.test.api.MethodsTest" }
         ] # Rawls test groups
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Ticket: https://broadworkbench.atlassian.net/browse/AJ-1915


### What:

three changes to the `rawls-swat-test-job` github action in this PR:
1. Upgrade `broadinstitute/workflow-dispatch` from v3 to v4. I have not tackled upgrading all usages of `broadinstitute/workflow-dispatch` in Sam; there are others still on v3.
2. Set a `run-name` value for each iteration of the test matrix. This solves the problem where the github action UI linked to the same `terra-github-workflows` test run for all three iterations of the matrix, making it much easier to navigate directly to a specific test suite.
3. Align the test matrix to what Rawls is currently using. Specifically, this removes the AJ tests which were running 0 tests and were removed in Rawls back in https://github.com/broadinstitute/rawls/pull/2800, and it splits the workspaces tests into two groups for concurrency; this was done in https://github.com/broadinstitute/rawls/pull/2897.

See Rawls' implementation at https://github.com/broadinstitute/rawls/blob/cf8c3fcff774dca5346e5596554098e1852ba78c/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml#L158-L204.

### Why:

Make swat tests more performant and more useful.

### How:

Assuming Sam will continue to run Rawls and Orch swat tests, it would be great to centralize code to prevent divergence like this. I have not tried to tackle that in this PR.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
