### PR TITLE
[DC-1142] Add delete permission to snapshot stewards on requests

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1361,7 +1361,7 @@ resourceTypes = {
         roleActions = ["get", "update", "delete", "create_with_parent"]
       }
       approver = {
-        roleActions = ["get", "approve"]
+        roleActions = ["get", "approve", "delete"]
       }
     }
     reuseIds = false


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DC-1142

What:
This adds delete to the approver role, so that snapshot stewards have the ability to delete snapshot access requests. 

Why:

This allows cleanup of requests to unblock deletion of snapshots. Mostly important for tests and local development.

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
