### PR TITLE
PROD-972 ID-1324 Swallow sync deduplication errors in endpoint.

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -259,6 +259,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def updateSynchronizedDateAndVersion(group: WorkbenchGroup, samRequestContext: SamRequestContext): IO[Unit] = {
     groupSynchronizedDates += group.id -> new Date()
+    groups.get(group.id).foreach {
+      case g: BasicWorkbenchGroup => groups.put(g.id, g.copy(lastSynchronizedVersion = Option(g.lastSynchronizedVersion.getOrElse(0) + 1)))
+      case p: AccessPolicy => groups.put(p.id, p.copy(lastSynchronizedVersion = Option(p.lastSynchronizedVersion.getOrElse(0) + 1)))
+      case _ => ()
+    }
     IO.unit
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1324

What: 
https://github.com/broadinstitute/sam/pull/1472

 We merged this pr yesterday to fix a prod incident that added new behavior and a new error to the group sync code. The new error broke TDR's integration tests, and we really should be keeping the behavior of the sync endpoint the same unless we are versioning a new one.

Why:

TDR is prevented from merging code, deploying currently.

How:

Swallow up the error in the endpoint and return OK instead of returning a 409.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
