### PR TITLE
ID-1324 Adjust response body of group sync endpoint

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -249,7 +249,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                     .synchronizeGroupMembers(policyId, samRequestContext = samRequestContext)
                     .recover {
                       // If the group sync was already done previously, then no need to return any sync report items, just return 200
-                      case _: GroupAlreadySynchronized => Map.empty[WorkbenchEmail, Seq[SyncReportItem]]
+                      case exception: GroupAlreadySynchronized => Map(exception.group.email -> Seq.empty[SyncReportItem])
                     }
                     .map { syncReport =>
                       StatusCodes.OK -> syncReport

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -15,8 +15,10 @@ import org.broadinstitute.dsde.workbench.sam.util.OpenTelemetryIOUtils._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.FutureSupport
 
-class GroupAlreadySynchronized(errorReport: ErrorReport = ErrorReport(StatusCodes.Conflict, "Group has already been synchronized"))
-    extends WorkbenchExceptionWithErrorReport(errorReport)
+case class GroupAlreadySynchronized(
+    group: WorkbenchGroup,
+    override val errorReport: ErrorReport = ErrorReport(StatusCodes.Conflict, "Group has already been synchronized")
+) extends WorkbenchExceptionWithErrorReport(errorReport)
 
 /** This class makes sure that our google groups have the right members.
   *
@@ -61,7 +63,7 @@ class GoogleGroupSynchronizer(
           if (group.version > group.lastSynchronizedVersion.getOrElse(0)) {
             IO.unit
           } else {
-            IO.raiseError(new GroupAlreadySynchronized)
+            IO.raiseError(new GroupAlreadySynchronized(group))
           }
         members <- calculateAuthDomainIntersectionIfRequired(group, samRequestContext)
         subGroupSyncs <- syncSubGroupsIfRequired(group, visitedGroups, samRequestContext)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1324


What:

Changes the response body of the group sync endpoint to match what TDR integration tests expect.

Why:

When we made change to the sync logic it changed the response of the sync endpoint in a way we didn't foresee. 

How:

Instead of an empty response, return a map of the group email to an empty list (of sync reports)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
