### PR TITLE
ID-1327 revert synchronous group removals and refactor

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -245,15 +245,9 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
               postWithTelemetry(samRequestContext, params: _*) {
                 complete {
                   import SamGoogleModelJsonSupport._
-                  googleGroupSynchronizer
-                    .synchronizeGroupMembers(policyId, samRequestContext = samRequestContext)
-                    .recover {
-                      // If the group sync was already done previously, then no need to return any sync report items, just return 200
-                      case _: GroupAlreadySynchronized => Map.empty[WorkbenchEmail, Seq[SyncReportItem]]
-                    }
-                    .map { syncReport =>
-                      StatusCodes.OK -> syncReport
-                    }
+                  googleGroupSynchronizer.synchronizeGroupMembers(policyId, samRequestContext = samRequestContext).map { syncReport =>
+                    StatusCodes.OK -> syncReport
+                  }
                 }
               } ~
                 getWithTelemetry(samRequestContext, params: _*) {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.workbench.sam.audit.SamAuditModelJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.audit._
 import org.broadinstitute.dsde.workbench.sam.azure.AzureService
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, LoadResourceAuthDomainResult}
-import org.broadinstitute.dsde.workbench.sam.google.GoogleExtensions
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -463,10 +462,8 @@ class ResourceService(
               case None => IO.raiseError(new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"policy $policyId does not exist")))
               case Some(existingPolicy) =>
                 Applicative[IO].whenA(existingPolicy.members != newMembers) {
-                  val membersToRemove = existingPolicy.members -- newMembers
                   for {
                     _ <- accessPolicyDAO.overwritePolicyMembers(policyId, newMembers, samRequestContext)
-                    _ <- membersToRemove.toList.map(member => removeSubjectFromPolicyGoogleGroupsIfChanged(policyId, member, samRequestContext)).sequence_
                     _ <- onPolicyUpdate(policyId, originalPolicies, samRequestContext)
                   } yield ()
                 }
@@ -519,9 +516,7 @@ class ResourceService(
             // short cut if access policy is unchanged
             IO.pure(newAccessPolicy)
           } else {
-            val membersToRemove = existingAccessPolicy.members -- newAccessPolicy.members
             for {
-              _ <- membersToRemove.toList.map(member => removeSubjectFromPolicyGoogleGroupsIfChanged(policyIdentity, member, samRequestContext)).sequence_
               result <- accessPolicyDAO.overwritePolicy(newAccessPolicy, samRequestContext)
               _ <- onPolicyUpdate(policyIdentity, originalPolicies, samRequestContext)
             } yield result
@@ -710,19 +705,8 @@ class ResourceService(
       originalPolicies <- accessPolicyDAO.listAccessPolicies(policyIdentity.resource, samRequestContext)
       _ <- failWhenPolicyNotExists(originalPolicies, policyIdentity)
       policyChanged <- directoryDAO.removeGroupMember(policyIdentity, subject, samRequestContext)
-      _ <- Applicative[IO].whenA(policyChanged)(removeSubjectFromPolicyGoogleGroupsIfChanged(policyIdentity, subject, samRequestContext))
       _ <- onPolicyUpdateIfChanged(policyIdentity, originalPolicies, samRequestContext)(policyChanged)
     } yield policyChanged
-
-  private def removeSubjectFromPolicyGoogleGroupsIfChanged(
-      policyId: FullyQualifiedPolicyId,
-      subject: WorkbenchSubject,
-      samRequestContext: SamRequestContext
-  ): IO[Unit] =
-    cloudExtensions match {
-      case extensions: GoogleExtensions => extensions.synchronouslyRemoveMemberFromGoogleGroup(policyId, subject, samRequestContext)
-      case _ => IO.unit
-    }
 
   def failWhenPolicyNotExists(policies: Iterable[AccessPolicy], policyId: FullyQualifiedPolicyId): IO[Unit] =
     IO.raiseUnless(policies.exists(_.id == policyId)) {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -307,7 +307,9 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
     // A duplicate call should return OK and an empty response
     Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
-      responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]] shouldBe empty
+      val response = responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
+      response.keys should not be empty
+      response.values.flatten shouldBe empty
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -304,11 +304,14 @@ class GoogleExtensionRoutesSpec extends GoogleExtensionRoutesSpecHelper with Sca
       responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]] should not be empty
     }
 
-    // A duplicate call should return OK and an empty response
+    // A duplicate call should return OK and the email with no sync report items
     Post(s"/api/google/resource/${resourceType.name}/foo/${resourceType.ownerRoleName.value}/sync") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[Map[WorkbenchEmail, Seq[SyncReportItem]]]
-      response.keys should not be empty
+      response.keys should have size 1
+      val email = response.keys.head.value
+      email should startWith("policy-")
+      email should endWith("example.com")
       response.values.flatten shouldBe empty
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1327

Reverting the synchronous group sync for policy removals. This was a band-aid, but has the potential to create long request latencies. Now that google group synchronization is fixed, its no longer needed.

Also did a little refactor of the sync de-duplication. Instead of relying on an exception for control flow, we now rely on an `Option`. This is best-practice, since using exceptions for control flow incurs a significant performance penalty in JVM languages.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
