### PR TITLE
[TEST] IA-4996: Add application create roles to workspace owner

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -162,7 +162,7 @@ resourceTypes = {
         includedRoles = ["owner"]
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "update_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status", "read_job_result"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "update_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status", "read_job_result", "create_controlled_application_shared", "create_controlled_application_private"]
         # Workspace Manager also maintains a mapping of workspace roles to controlled resource roles. If you change this mapping, check that service's mapping as well.
         descendantRoles = {
           google-project = ["owner"]


### PR DESCRIPTION
Ticket: IA-4996

What:

Allow Leo to check whether a user can create an app disk in a workspace

Why:

Currently workspace owners don't have this permission

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
