### PR TITLE
ID-1328 system resource access policy creation on boot

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -243,3 +243,52 @@ janitor {
   trackResourceTopicId = ${?JANITOR_TRACK_RESOURCE_TOPIC_ID}
 }
 
+terra.support.emails = [
+  // dynamically configuring lists is hard, so 10 slots are provided for support emails
+  // add more if more than 10 are ever needed
+  ${?TERRA_SUPPORT_EMAIL_0}
+  ${?TERRA_SUPPORT_EMAIL_1}
+  ${?TERRA_SUPPORT_EMAIL_2}
+  ${?TERRA_SUPPORT_EMAIL_3}
+  ${?TERRA_SUPPORT_EMAIL_4}
+  ${?TERRA_SUPPORT_EMAIL_5}
+  ${?TERRA_SUPPORT_EMAIL_6}
+  ${?TERRA_SUPPORT_EMAIL_7}
+  ${?TERRA_SUPPORT_EMAIL_8}
+  ${?TERRA_SUPPORT_EMAIL_9}
+]
+
+resourceAccessPolicies {
+  resource_type_admin {
+    workspace {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
+    managed-group {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
+    billing-project {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
+    dataset {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
+    datasnapshot {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -90,34 +90,36 @@ class ResourceService(
   def upsertResourceAccessPolicies(
       resourceAccessPolicies: Map[FullyQualifiedPolicyId, AccessPolicyMembershipRequest],
       samRequestContext: SamRequestContext = SamRequestContext()
-  ): IO[List[Either[Throwable, AccessPolicy]]] =
-    resourceAccessPolicies.toList.traverse { case (fullyQualifiedPolicyId, accessPolicyMembershipRequest) =>
-      val upsertIO = for {
-        resourceTypeOption <- getResourceType(fullyQualifiedPolicyId.resource.resourceTypeName)
-        resourceType = resourceTypeOption.getOrElse(
-          throw new WorkbenchException(s"Resource type ${fullyQualifiedPolicyId.resource.resourceTypeName} not found")
-        )
-        upsertedPolicy <-
-          if (resourceType.name.isResourceTypeAdmin) {
-            overwriteAdminPolicy(
-              resourceType,
-              fullyQualifiedPolicyId.accessPolicyName,
-              fullyQualifiedPolicyId.resource,
-              accessPolicyMembershipRequest,
-              samRequestContext
-            )
-          } else {
-            overwritePolicy(
-              resourceType,
-              fullyQualifiedPolicyId.accessPolicyName,
-              fullyQualifiedPolicyId.resource,
-              accessPolicyMembershipRequest,
-              samRequestContext
-            )
-          }
-      } yield upsertedPolicy
-      upsertIO.attempt
-    }
+  ): IO[Map[FullyQualifiedPolicyId, Either[Throwable, AccessPolicy]]] =
+    resourceAccessPolicies.toList
+      .traverse { case (fullyQualifiedPolicyId, accessPolicyMembershipRequest) =>
+        val upsertIO = for {
+          resourceTypeOption <- getResourceType(fullyQualifiedPolicyId.resource.resourceTypeName)
+          resourceType = resourceTypeOption.getOrElse(
+            throw new WorkbenchException(s"Resource type ${fullyQualifiedPolicyId.resource.resourceTypeName} not found")
+          )
+          upsertedPolicy <-
+            if (resourceType.name.isResourceTypeAdmin) {
+              overwriteAdminPolicy(
+                resourceType,
+                fullyQualifiedPolicyId.accessPolicyName,
+                fullyQualifiedPolicyId.resource,
+                accessPolicyMembershipRequest,
+                samRequestContext
+              )
+            } else {
+              overwritePolicy(
+                resourceType,
+                fullyQualifiedPolicyId.accessPolicyName,
+                fullyQualifiedPolicyId.resource,
+                accessPolicyMembershipRequest,
+                samRequestContext
+              )
+            }
+        } yield upsertedPolicy
+        upsertIO.attempt.map(fullyQualifiedPolicyId -> _)
+      }
+      .map(_.toMap)
 
   def createResourceType(resourceType: ResourceType, samRequestContext: SamRequestContext): IO[ResourceType] =
     accessPolicyDAO.createResourceType(resourceType, samRequestContext)

--- a/src/test/resources/sam.conf
+++ b/src/test/resources/sam.conf
@@ -5,3 +5,25 @@ prometheus {
 admin {
   serviceAccountAdmins = ${?SERVICE_ACCOUNT_ADMINS}
 }
+
+resourceAccessPolicies {
+  resource_type_admin {
+    workspace {
+      rawls-policy {
+        memberEmails = ["rawls@test.firecloud.org"]
+        descendantPermissions = [
+          {
+            resourceTypeName = "workspace",
+            roles = ["owner"]
+          }
+        ]
+      }
+    }
+    kubernetes-app {
+      leo-policy {
+        memberEmails = ["leo@test.firecloud.org"]
+        roles = ["support"]
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfigSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfigSpec.scala
@@ -51,7 +51,7 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
 
   it should "load resourceAccessPolicies" in {
     val appConfig = AppConfig.load
-    appConfig.resourceAccessPolicies should contain theSameElementsAs Map(
+    appConfig.resourceAccessPolicies should contain allElementsOf Map(
       FullyQualifiedPolicyId(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId("workspace")), AccessPolicyName("rawls-policy")) ->
         AccessPolicyMembershipRequest(
           Set(WorkbenchEmail("rawls@test.firecloud.org")),

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfigSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/config/AppConfigSpec.scala
@@ -1,6 +1,18 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
 import com.typesafe.config.{ConfigException, ConfigFactory, ConfigValueFactory}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.model.api.AccessPolicyMembershipRequest
+import org.broadinstitute.dsde.workbench.sam.model.{
+  AccessPolicyDescendantPermissions,
+  AccessPolicyName,
+  FullyQualifiedPolicyId,
+  FullyQualifiedResourceId,
+  ResourceId,
+  ResourceRoleName,
+  ResourceTypeName,
+  SamResourceTypes
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -35,5 +47,29 @@ class AppConfigSpec extends AnyFlatSpec with Matchers {
     intercept[ConfigException.Missing] {
       AppConfig.readConfig(combinedConfig.withoutPath("googleServices.appName"))
     }
+  }
+
+  it should "load resourceAccessPolicies" in {
+    val appConfig = AppConfig.load
+    appConfig.resourceAccessPolicies should contain theSameElementsAs Map(
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId("workspace")), AccessPolicyName("rawls-policy")) ->
+        AccessPolicyMembershipRequest(
+          Set(WorkbenchEmail("rawls@test.firecloud.org")),
+          Set.empty,
+          Set.empty,
+          Some(
+            Set(
+              AccessPolicyDescendantPermissions(
+                ResourceTypeName("workspace"),
+                Set.empty,
+                Set(ResourceRoleName("owner"))
+              )
+            )
+          ),
+          None
+        ),
+      FullyQualifiedPolicyId(FullyQualifiedResourceId(SamResourceTypes.resourceTypeAdminName, ResourceId("kubernetes-app")), AccessPolicyName("leo-policy")) ->
+        AccessPolicyMembershipRequest(Set(WorkbenchEmail("leo@test.firecloud.org")), Set.empty, Set(ResourceRoleName("support")), None, None)
+    )
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -3116,7 +3116,7 @@ class ResourceServiceSpec
         )
       )
       .unsafeRunSync()
-      .collect { case Right(policy) =>
+      .collect { case (_, Right(policy)) =>
         policy.copy(email = WorkbenchEmail(""))
       }
 
@@ -3151,7 +3151,7 @@ class ResourceServiceSpec
       .unsafeRunSync()
 
     returnedPolicies.size shouldBe 1
-    returnedPolicies.head.isLeft shouldBe true
+    returnedPolicies.head._2.isLeft shouldBe true
   }
 
   /** Sets up a test log appender attached to the audit logger, runs the `test` IO, ensures that `events` were appended. If tryTwice` run `test` again to make

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceSpec.scala
@@ -81,7 +81,7 @@ class ResourceServiceSpec
   private val resourceTypeAdmin = ResourceType(
     SamResourceTypes.resourceTypeAdminName,
     Set.empty,
-    Set.empty,
+    Set(ResourceRole(ownerRoleName, Set.empty)),
     ownerRoleName
   )
 
@@ -3091,6 +3091,67 @@ class ResourceServiceSpec
       .unsafeRunSync()
 
     runAuditLogTest(service.overwritePolicyMembers(policy.id, Set(dummyUser.email), samRequestContext), List(AccessAdded))
+  }
+
+  "upsertResourceAccessPolicies" should "upsert a policy" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val resourceName = ResourceId("resource")
+    val resource = FullyQualifiedResourceId(defaultResourceType.name, resourceName)
+
+    service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
+
+    service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext).unsafeRunSync()
+
+    val testPolicyId = FullyQualifiedPolicyId(resource, AccessPolicyName(UUID.randomUUID().toString))
+    val expectedPolicy = AccessPolicy(testPolicyId, Set(dummyUser.id), WorkbenchEmail(""), Set.empty, Set.empty, Set.empty, false)
+    val returnedPolicies = service
+      .upsertResourceAccessPolicies(
+        Map(
+          testPolicyId -> AccessPolicyMembershipRequest(
+            Set(dummyUser.email),
+            Set.empty,
+            Set.empty
+          )
+        )
+      )
+      .unsafeRunSync()
+      .collect { case Right(policy) =>
+        policy.copy(email = WorkbenchEmail(""))
+      }
+
+    returnedPolicies should contain theSameElementsAs Set(expectedPolicy)
+
+    policyDAO.loadPolicy(testPolicyId, samRequestContext).unsafeRunSync().map(_.copy(email = WorkbenchEmail(""))) shouldBe Some(expectedPolicy)
+  }
+
+  it should "validate admin policies" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val resourceName = ResourceId(defaultResourceType.name.value)
+    val resource = FullyQualifiedResourceId(resourceTypeAdmin.name, resourceName)
+
+    service.createResourceType(resourceTypeAdmin, samRequestContext).unsafeRunSync()
+    service.createResourceType(defaultResourceType, samRequestContext).unsafeRunSync()
+
+    service.createResource(resourceTypeAdmin, resourceName, dummyUser, samRequestContext).unsafeRunSync()
+    service.createResource(defaultResourceType, resourceName, dummyUser, samRequestContext).unsafeRunSync()
+
+    val testPolicyId = FullyQualifiedPolicyId(resource, AccessPolicyName(UUID.randomUUID().toString))
+    val returnedPolicies = service
+      .upsertResourceAccessPolicies(
+        Map(
+          testPolicyId -> AccessPolicyMembershipRequest(
+            Set(dummyUser.email),
+            Set.empty,
+            Set.empty
+          )
+        )
+      )
+      .unsafeRunSync()
+
+    returnedPolicies.size shouldBe 1
+    returnedPolicies.head.isLeft shouldBe true
   }
 
   /** Sets up a test log appender attached to the audit logger, runs the `test` IO, ensures that `events` were appended. If tryTwice` run `test` again to make


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1328

What:

create resource access policies from config at creation tome

Why:

Terra requires some system access policies for it's services, e.g. rawls, leo, etc. To date, there have only been a couple and they have been trivial. We expect more and more complicated policies soon. Better to manage them in code.

How:

A new config stanza called `resourceAccessPolicies` is read at boot time and fed into existing code to overwrite policies. The config has the same structure as the api to create policies.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
