### PR TITLE
WOR-1765 add spend-profile.read_job_result

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1099,6 +1099,9 @@ resourceTypes = {
       "read_spend_report" = {
         description = "read spend report for this spend profile"
       }
+      "read_job_result" = {
+        description = "allows reading the result of a job"
+      }
     }
     ownerRoleName = "owner"
     roles = {
@@ -1106,13 +1109,13 @@ resourceTypes = {
         descendantRoles = {
           landing-zone = ["owner"]
         }
-        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::pet-creator", "read_policies", "add_child", "list_children", "view_journal", "set_managed_resource_group", "create-pet", "read_spend_report"]
+        roleActions = ["update_billing_account", "update_metadata", "delete", "link", "share_policy::owner", "share_policy::user", "share_policy::pet-creator", "read_policies", "add_child", "list_children", "view_journal", "set_managed_resource_group", "create-pet", "read_spend_report", "read_job_result"]
       }
       user = {
         descendantRoles = {
           landing-zone = ["user"]
         }
-        roleActions = ["link", "share_policy::user", "share_policy::pet-creator", "read_policy::pet-creator", "add_child", "create-pet"]
+        roleActions = ["link", "share_policy::user", "share_policy::pet-creator", "read_policy::pet-creator", "add_child", "create-pet", "read_job_result"]
       }
       admin = {
         roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1765

What:

add a new action for spend-profile

Why:

see ticket


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
