### PR TITLE
AJ-1920 Add system role for spend-profile, grant to leo and wsm

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1124,7 +1124,7 @@ resourceTypes = {
         roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete", "read_profile"]
       }
       pet-creator = {
-        roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator"]
+        roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator", "read_profile"]
       }
       system = {
         roleActions = ["read_profile"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1124,7 +1124,7 @@ resourceTypes = {
         roleActions = ["share_policy::owner", "read_policies", "alter_policies", "delete", "read_profile"]
       }
       pet-creator = {
-        roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator", "read_profile"]
+        roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator"]
       }
       system = {
         roleActions = ["read_profile"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1126,6 +1126,9 @@ resourceTypes = {
       pet-creator = {
         roleActions = ["create-pet", "share_policy::pet-creator", "read_policy::pet-creator", "read_profile"]
       }
+      system = {
+        roleActions = ["read_profile"]
+      }
     }
     reuseIds = true
   }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -290,5 +290,19 @@ resourceAccessPolicies {
         roles = ["support"]
       }
     }
+    spend-profile {
+      system {
+        memberEmails = [
+          ${?LEO_SERVICE_ACCOUNT_EMAIL}
+          ${?WSM_SERVICE_ACCOUNT_EMAIL}
+        ]
+        descendantPermissions = [
+          {
+            resourceTypeName = "spend-profile",
+            roles = ["system"]
+          }
+        ]
+      }
+    }
   }
 }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -293,8 +293,8 @@ resourceAccessPolicies {
     spend-profile {
       system {
         memberEmails = [
-          ${?LEO_SERVICE_ACCOUNT_EMAIL}
-          ${?WSM_SERVICE_ACCOUNT_EMAIL}
+          ${?LEONARDO_PET_SERVICE_ACCOUNT}
+          ${?WSM_PET_SERVICE_ACCOUNT}
         ]
         descendantPermissions = [
           {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1920

For AnVIL Lite, we will need Leo and WSM to read billing profiles in order to know if there are any limits to apply when creating cloud resources.  This PR creates a system role on spend profiles and grants it to Leo's and WSM's service accounts.

Relies on https://github.com/broadinstitute/terra-helmfile/pull/5711 to add the WSM service account.

I convinced myself that this works by deploying this and https://github.com/DataBiosphere/leonardo/pull/4631 to my BEE, and seeing that Leo can still fetch the limits map from BPM directly.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
