### PR TITLE
[DDO-3704] Don't try to create pets in inactive projects

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -356,8 +356,8 @@ class GoogleExtensions(
         // SA does not exist in google, create it and add it to the proxy group
         case None =>
           for {
-            _ <- assertProjectIsActive(project)
             _ <- assertProjectInTerraOrg(project)
+            _ <- assertProjectIsActive(project)
             sa <- IO.fromFuture(IO(googleIamDAO.createServiceAccount(project, petSaName, petSaDisplayName)))
             _ <- withProxyEmail(user.id) { proxyEmail =>
               // Add group member by uniqueId instead of email to avoid race condition


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-3704

What:

Throw a sensible error and don't retry if a GCP pet is requested for an inactive project.

Why:

Janitor deletes GCP projects for workspaces in BEE environments to save costs. Unfortunately project-less workspaces are undeletable in Terra UI, in part because the Sam `getPetServiceAccount` retries for a long time and eventually returns 500/502. This PR makes Sam `getPetServiceAccount` APIs handle this situation more gracefully.

How:

This PR changes `getPetServiceAccount` to fail fast with 400 for an inactive project, instead of retrying and eventually returning 500/502.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
