### PR TITLE
ID-1338 Better Google Group Sync Message Format

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleModel.scala
@@ -1,15 +1,23 @@
 package org.broadinstitute.dsde.workbench.sam.google
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, WorkbenchEmail, WorkbenchIdentityJsonSupport}
 import spray.json.DefaultJsonProtocol
 
 object SamGoogleModelJsonSupport {
   import DefaultJsonProtocol._
   import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+  import WorkbenchIdentityJsonSupport._
 
   implicit val SyncReportItemFormat = jsonFormat4(SyncReportItem.apply)
+  implicit val SyncedPolicyFormat = jsonFormat2(SyncedPolicy.apply)
+  implicit val SyncReportFormat = jsonFormat1(SyncReport.apply)
+
 }
+
+case class SyncReport(syncedPolicies: Seq[SyncedPolicy])
+
+case class SyncedPolicy(policyEmail: WorkbenchEmail, changes: Seq[SyncReportItem])
 
 /** A SyncReportItem represents the results of synchronizing a single member of a google group. Synchronizing a google group will result in a collection of
   * these.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1338

Currently, we log Google Group Sync messages in this format:
```json
"syncDetail": {
 	"policy-f55433f3-1aea-44f7-833a-987f4f6820ef@dev.test.firecloud.org": [
		{
			"email": "proxy_2664214201478bbf312d5@dev.test.firecloud.org",
			"operation": "added",
			"workbenchGroupIdentity": "member.tlangsTestGroup.managed-group"
		}
	]
}
```

This presents a problem for log storage. If ingesting to BigQuery, all unique keys become discrete columns. In this format, every single policy synced would become a new column in the BigQuery table! Considering there are hundreds of thousands of synced policies in Sam, that becomes untenable.

I've changed the messages to have a new format:

```json
"syncDetail": {
	"syncedPolicies": [
		{
			"policyEmail": "policy-f55433f3-1aea-44f7-833a-987f4f6820ef@dev.test.firecloud.org",
			"changes": [
				{
      					"email": "proxy_2664214201478bbf312d5@dev.test.firecloud.org",
      					"operation": "added",
      					"workbenchGroupIdentity": "member.tlangsTestGroup.managed-group"
    				}
			]
		}
	]
}
```

Because of the stable keys, the BigQuery table would have a constant number of columns. This would also greatly improve the query-ability of group sync logs, helping us to diagnose problems and reconstruct what happened in the event of an incident.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
