### PR TITLE
ID-1300 Admin Get Users by ID

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -70,7 +70,7 @@ paths:
     get:
       tags:
         - Admin
-      summary: Retrieves a user record, by user id
+      summary: Retrieves a user record, by user id. Limited to 1000 user IDs.
       operationId: adminGetUser
       parameters:
         - name: userId

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -189,9 +189,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+        400:
+          description: Request invalid. Request body must be a list of less than 1000 Sam User IDs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         403:
           description: You do not have service admin privileges
-          content: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           description: Internal Server Error
           content:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -168,6 +168,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+    post:
+      tags:
+        - Admin
+      summary: Gets a list of users for a list of Sam User IDs
+      operationId: adminGetUsersByIDs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        200:
+          description: list of matching users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        403:
+          description: You do not have service admin privileges
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/admin/v1/user/{userId}/disable:
     put:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutes.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.service.ResourceService
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import spray.json.DefaultJsonProtocol._
 
 trait ServiceAdminRoutes extends SecurityDirectives with SamRequestContextDirectives with SamUserDirectives with SamModelDirectives {
@@ -51,6 +52,13 @@ trait ServiceAdminRoutes extends SecurityDirectives with SamRequestContextDirect
                 samRequestContext
               )
               .map(users => (if (users.nonEmpty) OK else NotFound) -> users)
+          }
+        }
+      } ~
+      postWithTelemetry(samRequestContext) {
+        entity(as[Seq[WorkbenchUserId]]) { samUserIds =>
+          complete {
+            userService.getUsersByIds(samUserIds, samRequestContext)
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -63,6 +63,11 @@ trait DirectoryDAO {
 
   def loadUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 
+  def batchLoadUsers(
+      samUserIds: Set[WorkbenchUserId],
+      samRequestContext: SamRequestContext
+  ): IO[Seq[SamUser]]
+
   def loadUsersByQuery(
       userId: Option[WorkbenchUserId],
       googleSubjectId: Option[GoogleSubjectId],

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -173,6 +173,9 @@ class UserService(
   def getUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     directoryDAO.loadUser(userId, samRequestContext)
 
+  def getUsersByIds(samUserIds: Seq[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+    directoryDAO.batchLoadUsers(samUserIds.toSet, samRequestContext)
+
   def getUsersByQuery(
       userId: Option[WorkbenchUserId],
       googleSubjectId: Option[GoogleSubjectId],

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutesSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol.immSetFormat
 
-class AdminServiceUserRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
+class ServiceAdminRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
   val defaultUser: SamUser = Generator.genWorkbenchUserBoth.sample.get
   val defaultUserId: WorkbenchUserId = defaultUser.id
   val defaultUserEmail: WorkbenchEmail = defaultUser.email

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/ServiceAdminRoutesSpec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
@@ -12,7 +13,8 @@ import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import spray.json.DefaultJsonProtocol.immSetFormat
+import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
 class ServiceAdminRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with MockitoSugar with TestSupport {
   val defaultUser: SamUser = Generator.genWorkbenchUserBoth.sample.get
@@ -127,4 +129,32 @@ class ServiceAdminRoutesSpec extends AnyFlatSpec with Matchers with ScalatestRou
     }
   }
 
+  "POST /admin/v2/users" should "get the matching user records when provided a list of user IDs when called as a service admin" in {
+    // Arrange
+    val users = Seq.range(0, 10).map(_ => genWorkbenchUserBoth.sample.get)
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .callAsAdminServiceUser() // enabled "admin" user who is making the http request
+      .withEnabledUsers(users)
+      .build
+
+    // Act and Assert
+    Post(s"/api/admin/v2/users", users.map(_.id)) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Seq[SamUser]] should contain theSameElementsAs users
+    }
+  }
+
+  it should "reject a request for more than 1000 users" in {
+    // Arrange
+    val users = Seq.range(0, 1001).map(_ => genWorkbenchUserBoth.sample.get)
+    val samRoutes = new MockSamRoutesBuilder(allUsersGroup)
+      .callAsAdminServiceUser() // enabled "admin" user who is making the http request
+      .withEnabledUsers(users)
+      .build
+
+    // Act and Assert
+    Post(s"/api/admin/v2/users", users.map(_.id)) ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -115,6 +115,11 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
     users.get(userId)
   }
 
+  override def batchLoadUsers(
+      samUserIds: Set[WorkbenchUserId],
+      samRequestContext: SamRequestContext
+  ): IO[Seq[SamUser]] = IO(samUserIds.flatMap(users.get).toSeq)
+
   override def loadUsersByQuery(
       userId: Option[WorkbenchUserId],
       googleSubjectId: Option[GoogleSubjectId],

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -625,6 +625,16 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
       }
     }
 
+    "batchLoadUsers" - {
+      "loads a list of users" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        val users = Seq.range(0, 10).map(_ => Generator.genWorkbenchUserBoth.sample.get)
+        users.foreach(user => dao.createUser(user, samRequestContext).unsafeRunSync())
+        val loadedUsers = dao.batchLoadUsers(users.map(_.id).toSet, samRequestContext).unsafeRunSync()
+        loadedUsers should contain theSameElementsAs users
+      }
+    }
+
     "deleteUser" - {
       "delete users" in {
         assume(databaseEnabled, databaseEnabledClue)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockDirectoryDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockDirectoryDaoBuilder.scala
@@ -162,6 +162,9 @@ case class StatefulMockDirectoryDaoBuilder() extends MockitoSugar {
           .toSet
       )
     )
+    mockedDirectoryDAO.batchLoadUsers(any[Set[WorkbenchUserId]], any[SamRequestContext]) answers ((samUserIds: Set[WorkbenchUserId], _: SamRequestContext) =>
+      IO(samUsers.filter(user => samUserIds.contains(user.id)).toSeq)
+    )
     this
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockUserServiceBuilder.scala
@@ -174,6 +174,10 @@ case class MockUserServiceBuilder() extends IdiomaticMockito {
           .toSet
       )
     )
+
+    mockUserService.getUsersByIds(any[Seq[WorkbenchUserId]], any[SamRequestContext]) answers ((userIds: Seq[WorkbenchUserId]) =>
+      IO(samUsers.filter(user => userIds.contains(user.id)).toSeq)
+    )
   }
 
   private def makeUserAppearEnabled(samUser: SamUser, mockUserService: UserService): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUsersByIdsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/GetUsersByIdsSpec.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsde.workbench.sam.service.UserServiceSpecs
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.sam.Generator.genWorkbenchUserBoth
+import org.broadinstitute.dsde.workbench.sam.model.BasicWorkbenchGroup
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, TestUserServiceBuilder}
+
+import scala.concurrent.ExecutionContextExecutor
+
+class GetUsersByIdsSpec extends UserServiceTestTraits {
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+  val allUsersGroup: BasicWorkbenchGroup = BasicWorkbenchGroup(CloudExtensions.allUsersGroupName, Set(), WorkbenchEmail("all_users@fake.com"))
+
+  describe("When getting") {
+    describe("users by IDs") {
+      it("should be successful") {
+        // Arrange
+        val users = Seq.range(0, 10).map(_ => genWorkbenchUserBoth.sample.get)
+        val userService = TestUserServiceBuilder()
+          .withAllUsersGroup(allUsersGroup)
+          .withExistingUsers(users)
+          .withEnabledUsers(users)
+          .build
+        // Act
+        val response = runAndWait(userService.getUsersByIds(users.map(_.id), samRequestContext))
+
+        // Assert
+        assert(response.nonEmpty, "Getting users by ID should return a list of users")
+        response should contain theSameElementsAs users
+      }
+    }
+
+  }
+  describe("a user that does not exist") {
+    it("should be unsuccessful") {
+      // Arrange
+      val userWithBothIds = genWorkbenchUserBoth.sample.get
+      val userService = TestUserServiceBuilder()
+        .withAllUsersGroup(allUsersGroup)
+        .build
+      // Act
+      val response = runAndWait(userService.getUser(userWithBothIds.id, samRequestContext))
+
+      // Assert
+      assert(response.isEmpty, "Getting a nonexistent user should not find a user")
+    }
+  }
+
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1300

In order for Orchestration to modify group membership using Sam User ID from ECM, it needs to be able to add users from the response to Sam Groups. Since Sam Group Endpoints only deal in email addresses, we need a way to get emails from Sam User IDs.

This is an admin-only functionality, as Sam User IDs should not be discoverable by other users. IE: A user can know their own Sam User ID, but should not be able to find out the Sam User IDs of others. Because of this, only authorized Terra Services will be able to call this API endpoint. In this case, its Thurloe and Orch.

Another idea is to make a V2 Sam Group API, which deals only in Sam User IDs, but that’s a much larger change and not necessary to accomplish the goal of deprecating Shibboleth and Thurloe.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
