### PR TITLE
[WOR-1706] Allow leaving billing project and spend profile

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -739,6 +739,7 @@ resourceTypes = {
         }
       }
     }
+    allowLeaving = true
     reuseIds = true
   }
   notebook-cluster = {
@@ -1130,6 +1131,7 @@ resourceTypes = {
         roleActions = ["read_profile"]
       }
     }
+    allowLeaving = true
     reuseIds = true
   }
   study = {


### PR DESCRIPTION
Jira ticket: [https://broadworkbench.atlassian.net/browse/WOR-1706](https://broadworkbench.atlassian.net/browse/WOR-1706)

This change allows the `leaveResource` endpoint to be used for spend profiles and billing projects, so that BPM can utilize it when owners request to leave a billing profile.