### PR TITLE
ID-1353 Use Appropriate Response Codes in User Favorite Resources

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3308,7 +3308,7 @@ paths:
           schema:
             type: string
       responses:
-        202:
+        204:
           description: Favorite resource added
           content: { }
         404:
@@ -3336,7 +3336,7 @@ paths:
           schema:
             type: string
       responses:
-        202:
+        204:
           description: Favorite resource removed
           content: { }
   /api/users/v2/{sam_user_id}:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2.scala
@@ -263,7 +263,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives wi
         requireAnyAction(resource, samUser.id, samRequestContext) {
           complete {
             resourceService.addUserFavoriteResource(samUser.id, resource, samRequestContext).map {
-              case true => StatusCodes.Accepted
+              case true => StatusCodes.NoContent
               case false => StatusCodes.NotFound
             }
           }
@@ -274,7 +274,7 @@ trait UserRoutesV2 extends SamUserDirectives with SamRequestContextDirectives wi
   private def removeFavoriteResource(samUser: SamUser, resource: FullyQualifiedResourceId, samRequestContext: SamRequestContext): Route =
     deleteWithTelemetry(samRequestContext) {
       complete {
-        resourceService.removeUserFavoriteResource(samUser.id, resource, samRequestContext).map(_ => StatusCodes.Accepted)
+        resourceService.removeUserFavoriteResource(samUser.id, resource, samRequestContext).map(_ => StatusCodes.NoContent)
       }
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/UserRoutesV2Spec.scala
@@ -510,7 +510,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with TimeMatchers with 
 
     // Act and Assert
     Put(s"/api/users/v2/self/favoriteResources/$resourceType/$resourceId") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
+      status shouldEqual StatusCodes.NoContent
     }
   }
 
@@ -585,7 +585,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with TimeMatchers with 
 
     // Act and Assert
     Delete(s"/api/users/v2/self/favoriteResources/$resourceType/$resourceId") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
+      status shouldEqual StatusCodes.NoContent
     }
   }
 
@@ -609,7 +609,7 @@ class UserRoutesV2Spec extends AnyFlatSpec with Matchers with TimeMatchers with 
 
     // Act and Assert
     Delete(s"/api/users/v2/self/favoriteResources/$resourceType/$resourceId") ~> samRoutes.route ~> check {
-      status shouldEqual StatusCodes.Accepted
+      status shouldEqual StatusCodes.NoContent
     }
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1353

I realized that I used `202 Accepted` instead of `204 No Content` for the new Favorite Resources endpoints. `202` is meant to mean a successful request that kicked off an async process, whereas `204` denotes that the request was successful and the requested action is completed with no response body. 
---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
