### PR TITLE
[WOR-865] Allow rawls to specify the user it is acting on behalf of

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -36,6 +36,9 @@ resourceTypes = {
       admin_read_summary_information = {
         description = "view summary information on resources of this resource type"
       }
+      admin_specify_acting_user = {
+        description = "specify a different user that is preforming a given action on the resource"
+      }
     }
 
     ownerRoleName = "owner"
@@ -1176,6 +1179,8 @@ resourceTypes = {
           "delete"
           # leonardo creates a pet even for a shared app
           "create-pet"
+          # able to specify the user for async processes
+          "admin_specify_acting_user"
         ]
       }
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1179,8 +1179,6 @@ resourceTypes = {
           "delete"
           # leonardo creates a pet even for a shared app
           "create-pet"
-          # able to specify the user for async processes
-          "admin_specify_acting_user"
         ]
       }
     }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -333,6 +333,7 @@ resourceAccessPolicies {
         memberEmails = [
           ${?RAWLS_SERVICE_ACCOUNT}
         ]
+        actions = ["admin_specify_acting_user"]
         descendantPermissions = [
           {
             resourceTypeName = "spend-profile",


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-865

Add admin action to specify the acting user
Add the new action to the rawls role

What:

Add a resource admin action to rawls to specify the user it is acting on behalf of, when creating billing profiles (`spend-profile`)

Why:
After changes to [allow rawls to perform background processes as itself](https://broadworkbench.atlassian.net/browse/WOR-1797), we need to be able to specify the user that initiated the request, for audit logging purposes.

How:



---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
