### PR TITLE
[IA-4295] Add API to get a pet service account token for a user

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -137,7 +137,7 @@ class SamProviderSpec
       when {
         googleExt.getArbitraryPetServiceAccountToken(any[SamUser], any[Set[String]], any[SamRequestContext])
       } thenReturn {
-        Future.successful("aToken")
+        IO.pure("aToken")
       }
     )
   } yield ()

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1082,7 +1082,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/petServiceAccount/{project}/{email}/token:
-    get:
+    post:
       tags:
         - Google
       summary: gets a token for the user's pet service account, get_pet_private_key
@@ -1177,10 +1177,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/petServiceAccount/{email}/token:
-    get:
+    post:
       tags:
         - Google
-      summary: gets a token for the user's arbitrary pet service account, get_pet_private_key action on cloud-extension/google required
+      summary: gets a token for the user's arbitrary pet service account, get_pet_private_key
+        action on cloud-extension/google required
       operationId: getUserArbitraryPetServiceAccountToken
       parameters:
         - name: email

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1034,7 +1034,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /api/google/v1/petServiceAccount/{project}/{email}:
+  /api/google/v1/petServiceAccount/{project}/{email}/key:
     get:
       tags:
         - Google
@@ -1081,6 +1081,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/google/v1/petServiceAccount/{project}/{email}/token:
+    get:
+      tags:
+        - Google
+      summary: gets a token for the user's pet service account, get_pet_private_key
+        action on cloud-extension/google required
+      operationId: getUserPetServiceAccountToken
+      parameters:
+        - name: project
+          in: path
+          description: Google project of the pet
+          required: true
+          schema:
+            type: string
+        - name: email
+          in: path
+          description: User's email address
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Scopes for the token
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ArrayOfScopes'
+        required: true
+      responses:
+        200:
+          description: an access token for the users pet service account
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: caller has some access to cloud-extension/google but not to
+            the get_pet_private_key action
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: user does not exist or caller does not have any access to cloud-extension/google
+            resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+      x-codegen-request-body-name: scopes
   /api/google/v1/petServiceAccount/{email}/key:
     get:
       tags:
@@ -1121,6 +1176,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/google/v1/petServiceAccount/{email}/token:
+    get:
+      tags:
+        - Google
+      summary: gets a token for the user's arbitrary pet service account, get_pet_private_key action on cloud-extension/google required
+      operationId: getUserArbitraryPetServiceAccountToken
+      parameters:
+        - name: email
+          in: path
+          description: User's email address
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Scopes for the token
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ArrayOfScopes'
+        required: true
+      responses:
+        200:
+          description: an access token for the users pet service account
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: caller has some access to cloud-extension/google but not to
+            the get_pet_private_key action
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: user does not exist or caller does not have any access to cloud-extension/google
+            resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        x-codegen-request-body-name: scopes
   /api/google/v1/user/signedUrlForBlob:
     post:
       tags:
@@ -1774,8 +1877,8 @@ paths:
       tags:
         - Resources
       summary: List resources the calling user has been granted policies/roles/actions on.
-        This endpoint MUST NOT be used to determine if a user has an action on a resource. 
-        This endpoint is ONLY for determining the state of the user's permissions. 
+        This endpoint MUST NOT be used to determine if a user has an action on a resource.
+        This endpoint is ONLY for determining the state of the user's permissions.
         It does not take into account enabled status, or Terms of Service Compliance, nor does it take into account Auth Domains.
         To check if a user is allowed to execute an action on a resource, use /api/resources/v2/{resourceTypeName}/{resourceId}/action/{action}
         By default, public resources are not included. Including public resources incurs a 3x cost of DB performance.
@@ -4490,7 +4593,7 @@ components:
           type: boolean
           description: true if there is a rolling acceptance window active. This
             means that users who have not accepted the latest terms of service
-            version (and who have accepted the previous version) will be allowed to use the system 
+            version (and who have accepted the previous version) will be allowed to use the system
             for a period of time after the terms of service have been updated.
     UserTermsOfServiceDetails:
       required:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1034,7 +1034,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-  /api/google/v1/petServiceAccount/{project}/{email}/key:
+  /api/google/v1/petServiceAccount/{project}/{email}:
     get:
       tags:
         - Google

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -74,7 +74,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
             pathPrefix(Segment / Segment) { (project, userEmail) =>
               val email = WorkbenchEmail(userEmail)
               val googleProject = GoogleProject(project)
-              (pathEndOrSingleSlash | path("key")) {
+              pathEndOrSingleSlash {
                 getWithTelemetry(samRequestContext, "userEmail" -> email, "googleProject" -> googleProject) {
                   complete {
                     import spray.json._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -42,27 +42,13 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
           samUser.id,
           samRequestContext
         ) {
-          path(Segment / "key") { userEmail =>
+          pathPrefix(Segment) { userEmail =>
             val email = WorkbenchEmail(userEmail)
-            getWithTelemetry(samRequestContext, "userEmail" -> email) {
-              complete {
-                import spray.json._
-                googleExtensions.getArbitraryPetServiceAccountKey(email, samRequestContext) map {
-                  // parse json to ensure it is json and tells akka http the right content-type
-                  case Some(key) => StatusCodes.OK -> key.parseJson
-                  case None =>
-                    throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
-                }
-              }
-            }
-          } ~
-            path(Segment / Segment) { (project, userEmail) =>
-              val email = WorkbenchEmail(userEmail)
-              val googleProject = GoogleProject(project)
-              getWithTelemetry(samRequestContext, "userEmail" -> email, "googleProject" -> googleProject) {
+            path("key") {
+              getWithTelemetry(samRequestContext, "userEmail" -> email) {
                 complete {
                   import spray.json._
-                  googleExtensions.getPetServiceAccountKey(email, googleProject, samRequestContext) map {
+                  googleExtensions.getArbitraryPetServiceAccountKey(email, samRequestContext) map {
                     // parse json to ensure it is json and tells akka http the right content-type
                     case Some(key) => StatusCodes.OK -> key.parseJson
                     case None =>
@@ -70,6 +56,50 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   }
                 }
               }
+            } ~
+              path("token") {
+                postWithTelemetry(samRequestContext, "userEmail" -> email) {
+                  entity(as[Set[String]]) { scopes =>
+                    complete {
+                      googleExtensions.getArbitraryPetServiceAccountToken(email, scopes, samRequestContext).map {
+                        case Some(token) => StatusCodes.OK -> JsString(token)
+                        case None =>
+                          throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
+                      }
+                    }
+                  }
+                }
+              }
+          } ~
+            pathPrefix(Segment / Segment) { (project, userEmail) =>
+              val email = WorkbenchEmail(userEmail)
+              val googleProject = GoogleProject(project)
+              (pathEndOrSingleSlash | path("key")) {
+                getWithTelemetry(samRequestContext, "userEmail" -> email, "googleProject" -> googleProject) {
+                  complete {
+                    import spray.json._
+                    googleExtensions.getPetServiceAccountKey(email, googleProject, samRequestContext) map {
+                      // parse json to ensure it is json and tells akka http the right content-type
+                      case Some(key) => StatusCodes.OK -> key.parseJson
+                      case None =>
+                        throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
+                    }
+                  }
+                }
+              } ~
+                path("token") {
+                  postWithTelemetry(samRequestContext, "userEmail" -> email) {
+                    entity(as[Set[String]]) { scopes =>
+                      complete {
+                        googleExtensions.getPetServiceAccountToken(email, googleProject, scopes, samRequestContext).map {
+                          case Some(token) => StatusCodes.OK -> JsString(token)
+                          case None =>
+                            throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
+                        }
+                      }
+                    }
+                  }
+                }
             }
         }
       } ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -455,6 +455,11 @@ class GoogleExtensions(
       key <- googleKeyCache.getKey(pet)
     } yield key
 
+  def getPetServiceAccountToken(user: SamUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): IO[String] =
+    getPetServiceAccountKey(user, project, samRequestContext).flatMap { key =>
+      IO.fromFuture(IO(getAccessTokenUsingJson(key, scopes)))
+    }
+
   def getPetServiceAccountToken(
       userEmail: WorkbenchEmail,
       project: GoogleProject,
@@ -469,11 +474,6 @@ class GoogleExtensions(
         case _ => IO.pure(None)
       }
     } yield token
-
-  def getPetServiceAccountToken(user: SamUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): IO[String] =
-    getPetServiceAccountKey(user, project, samRequestContext).flatMap { key =>
-      IO.fromFuture(IO(getAccessTokenUsingJson(key, scopes)))
-    }
 
   def getArbitraryPetServiceAccountKey(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[String]] =
     for {
@@ -503,7 +503,7 @@ class GoogleExtensions(
       IO.fromFuture(IO(getAccessTokenUsingJson(key, scopes)))
     }
 
-  private def getDefaultServiceAccountForShellProject(user: SamUser, samRequestContext: SamRequestContext): Future[String] = {
+  private[google] def getDefaultServiceAccountForShellProject(user: SamUser, samRequestContext: SamRequestContext): Future[String] = {
     val projectName =
       s"fc-${googleServicesConfig.environment.substring(0, Math.min(googleServicesConfig.environment.length(), 5))}-${user.id.value}" // max 30 characters. subject ID is 21
     for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -455,9 +455,24 @@ class GoogleExtensions(
       key <- googleKeyCache.getKey(pet)
     } yield key
 
-  def getPetServiceAccountToken(user: SamUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
-    getPetServiceAccountKey(user, project, samRequestContext).unsafeToFuture().flatMap { key =>
-      getAccessTokenUsingJson(key, scopes)
+  def getPetServiceAccountToken(
+      userEmail: WorkbenchEmail,
+      project: GoogleProject,
+      scopes: Set[String],
+      samRequestContext: SamRequestContext
+  ): IO[Option[String]] =
+    for {
+      subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
+      token <- subject match {
+        case Some(userId: WorkbenchUserId) =>
+          getPetServiceAccountToken(SamUser(userId, None, userEmail, None, false), project, scopes, samRequestContext).map(Option(_))
+        case _ => IO.pure(None)
+      }
+    } yield token
+
+  def getPetServiceAccountToken(user: SamUser, project: GoogleProject, scopes: Set[String], samRequestContext: SamRequestContext): IO[String] =
+    getPetServiceAccountKey(user, project, samRequestContext).flatMap { key =>
+      IO.fromFuture(IO(getAccessTokenUsingJson(key, scopes)))
     }
 
   def getArbitraryPetServiceAccountKey(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[String]] =
@@ -465,17 +480,27 @@ class GoogleExtensions(
       subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
       key <- subject match {
         case Some(userId: WorkbenchUserId) =>
-          IO.fromFuture(IO(getArbitraryPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), samRequestContext))).map(Option(_))
+          getArbitraryPetServiceAccountKey(SamUser(userId, None, userEmail, None, false), samRequestContext).map(Option(_))
         case _ => IO.none
       }
     } yield key
 
-  def getArbitraryPetServiceAccountKey(user: SamUser, samRequestContext: SamRequestContext): Future[String] =
-    getDefaultServiceAccountForShellProject(user, samRequestContext)
+  def getArbitraryPetServiceAccountKey(user: SamUser, samRequestContext: SamRequestContext): IO[String] =
+    IO.fromFuture(IO(getDefaultServiceAccountForShellProject(user, samRequestContext)))
 
-  def getArbitraryPetServiceAccountToken(user: SamUser, scopes: Set[String], samRequestContext: SamRequestContext): Future[String] =
+  def getArbitraryPetServiceAccountToken(userEmail: WorkbenchEmail, scopes: Set[String], samRequestContext: SamRequestContext): IO[Option[String]] =
+    for {
+      subject <- directoryDAO.loadSubjectFromEmail(userEmail, samRequestContext)
+      token <- subject match {
+        case Some(userId: WorkbenchUserId) =>
+          getArbitraryPetServiceAccountToken(SamUser(userId, None, userEmail, None, false), scopes, samRequestContext).map(Option(_))
+        case _ => IO.none
+      }
+    } yield token
+
+  def getArbitraryPetServiceAccountToken(user: SamUser, scopes: Set[String], samRequestContext: SamRequestContext): IO[String] =
     getArbitraryPetServiceAccountKey(user, samRequestContext).flatMap { key =>
-      getAccessTokenUsingJson(key, scopes)
+      IO.fromFuture(IO(getAccessTokenUsingJson(key, scopes)))
     }
 
   private def getDefaultServiceAccountForShellProject(user: SamUser, samRequestContext: SamRequestContext): Future[String] = {
@@ -690,7 +715,7 @@ class GoogleExtensions(
     val bucket = GcsBucketName(blobId.getBucket)
     val objectName = GcsBlobName(blobId.getName)
     for {
-      petKey <- IO.fromFuture(IO(getArbitraryPetServiceAccountKey(samUser, samRequestContext)))
+      petKey <- getArbitraryPetServiceAccountKey(samUser, samRequestContext)
       serviceAccountCredentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(petKey.getBytes()))
       url <- getSignedUrl(samUser, bucket, objectName, duration, urlParamsMap, serviceAccountCredentials)
     } yield url

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -4,11 +4,13 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import cats.effect.IO
 import com.google.auth.oauth2.ServiceAccountCredentials
+import fs2.Stream
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleKmsService, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.sam.Generator.{
   genFirecloudEmail,
   genGcsBlobName,
@@ -22,20 +24,18 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, Direct
 import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceType, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.ArgumentMatchersSugar._
 import org.mockito.IdiomaticMockito
 import org.mockito.Mockito.{RETURNS_SMART_NULLS, doReturn}
-import fs2.Stream
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-import org.scalatest.{Inside, OptionValues}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.mockito.ArgumentMatchersSugar._
 import org.mockito.MockitoSugar.verify
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Inside, OptionValues}
 
 import java.net.URL
 import java.util.concurrent.TimeUnit
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.ExecutionContextExecutor
 
 class NewGoogleExtensionsSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -16,17 +16,21 @@ import org.broadinstitute.dsde.workbench.sam.Generator.{
   genGcsBlobName,
   genGcsBucketName,
   genGoogleProject,
+  genNonPetEmail,
+  genOAuth2BearerToken,
   genPetServiceAccount,
-  genWorkbenchUserGoogle
+  genWorkbenchUserGoogle,
+  genWorkbenchUserId
 }
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{AccessPolicyDAO, DirectoryDAO, PostgresDistributedLockDAO}
 import org.broadinstitute.dsde.workbench.sam.mock.RealKeyMockGoogleIamDAO
+import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.model.{ResourceType, ResourceTypeName}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchersSugar._
 import org.mockito.IdiomaticMockito
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, doReturn}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, clearInvocations, doReturn, verifyNoInteractions}
 import org.mockito.MockitoSugar.verify
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpecLike
@@ -35,7 +39,7 @@ import org.scalatest.{Inside, OptionValues}
 
 import java.net.URL
 import java.util.concurrent.TimeUnit
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 class NewGoogleExtensionsSpec(_system: ActorSystem)
     extends TestKit(_system)
@@ -203,6 +207,170 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
           eqTo(TimeUnit.MINUTES),
           eqTo(Map("requestedBy" -> newGoogleUser.email.value))
         )
+      }
+    }
+  }
+  "GoogleExtensions: Pet Service Accounts" - {
+    val subject = genWorkbenchUserId.sample.get
+    val email = genNonPetEmail.sample.get
+    val user = SamUser(subject, None, email, None, false)
+    val googleProject = genGoogleProject.sample.get
+    val scopes = Set("scope1", "scope2")
+    val petServiceAccount = genPetServiceAccount.sample.get
+    val expectedKey = RealKeyMockGoogleIamDAO.generateNewRealKey(petServiceAccount.serviceAccount.email)._2
+    val expectedToken = genOAuth2BearerToken.sample.get.token
+
+    val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
+    val mockGoogleKeyCache = mock[GoogleKeyCache](RETURNS_SMART_NULLS)
+
+    val googleExtensions: GoogleExtensions = spy(
+      new GoogleExtensions(
+        mock[PostgresDistributedLockDAO[IO]](RETURNS_SMART_NULLS),
+        mockDirectoryDAO,
+        mock[AccessPolicyDAO](RETURNS_SMART_NULLS),
+        mock[GoogleDirectoryDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
+        mock[GoogleIamDAO](RETURNS_SMART_NULLS),
+        mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
+        mock[GoogleProjectDAO](RETURNS_SMART_NULLS),
+        mockGoogleKeyCache,
+        mock[NotificationDAO](RETURNS_SMART_NULLS),
+        mock[GoogleKmsService[IO]](RETURNS_SMART_NULLS),
+        mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS),
+        TestSupport.googleServicesConfig,
+        TestSupport.petServiceAccountConfig,
+        Map.empty[ResourceTypeName, ResourceType],
+        genFirecloudEmail.sample.get
+      )
+    )
+
+    doReturn(IO.some(subject))
+      .when(mockDirectoryDAO)
+      .loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
+
+    doReturn(IO.pure(petServiceAccount))
+      .when(googleExtensions)
+      .createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+
+    doReturn(Future.successful(expectedToken))
+      .when(googleExtensions)
+      .getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
+
+    doReturn(Future.successful(expectedKey))
+      .when(googleExtensions)
+      .getDefaultServiceAccountForShellProject(eqTo(user), any[SamRequestContext])
+
+    doReturn(IO.pure(expectedKey))
+      .when(mockGoogleKeyCache)
+      .getKey(eqTo(petServiceAccount))
+
+    "getPetServiceAccountKey" - {
+      "gets a key for an email" in {
+        clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+        val key = runAndWait(googleExtensions.getPetServiceAccountKey(email, googleProject, samRequestContext))
+
+        key should be(Some(expectedKey))
+
+        verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
+        verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+        verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
+      }
+
+      "gets a key for a SamUser" in {
+        clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+        val key = runAndWait(googleExtensions.getPetServiceAccountKey(user, googleProject, samRequestContext))
+
+        key should be(expectedKey)
+
+        verifyNoInteractions(mockDirectoryDAO)
+        verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+        verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
+      }
+
+      "getPetServiceAccountToken" - {
+        "gets a token for an email" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val token = runAndWait(googleExtensions.getPetServiceAccountToken(email, googleProject, scopes, samRequestContext))
+
+          token should be(Some(expectedToken))
+
+          verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
+          verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+          verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
+          verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
+
+        }
+        "gets a token for a SamUser" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val token = runAndWait(googleExtensions.getPetServiceAccountToken(user, googleProject, scopes, samRequestContext))
+
+          token should be(expectedToken)
+
+          verifyNoInteractions(mockDirectoryDAO)
+          verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+          verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
+          verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
+        }
+      }
+
+      "getArbitraryPetServiceAccountKey" - {
+        "gets a key for an email" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val key = runAndWait(googleExtensions.getArbitraryPetServiceAccountKey(email, samRequestContext))
+
+          key should be(Some(expectedKey))
+
+          verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
+          verifyNoInteractions(mockGoogleKeyCache)
+          verify(googleExtensions).getDefaultServiceAccountForShellProject(eqTo(user), any[SamRequestContext])
+        }
+
+        "gets a key for a SamUser" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val key = runAndWait(googleExtensions.getArbitraryPetServiceAccountKey(user, samRequestContext))
+
+          key should be(expectedKey)
+
+          verifyNoInteractions(mockDirectoryDAO)
+          verifyNoInteractions(mockGoogleKeyCache)
+          verify(googleExtensions).getDefaultServiceAccountForShellProject(eqTo(user), any[SamRequestContext])
+        }
+      }
+
+      "getArbitraryPetServiceAccountToken" - {
+        "gets a token for an email" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val token = runAndWait(googleExtensions.getArbitraryPetServiceAccountToken(email, scopes, samRequestContext))
+
+          token should be(Some(expectedToken))
+
+          verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
+          verifyNoInteractions(mockGoogleKeyCache)
+          verify(googleExtensions).getDefaultServiceAccountForShellProject(eqTo(user), any[SamRequestContext])
+          verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
+        }
+
+        "gets a token for a SamUser" in {
+          clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
+
+          val token = runAndWait(googleExtensions.getArbitraryPetServiceAccountToken(user, scopes, samRequestContext))
+
+          token should be(expectedToken)
+
+          verifyNoInteractions(mockDirectoryDAO)
+          verifyNoInteractions(mockGoogleKeyCache)
+          verify(googleExtensions).getDefaultServiceAccountForShellProject(eqTo(user), any[SamRequestContext])
+          verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
+        }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -166,7 +166,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
       val arbitraryPetServiceAccount = genPetServiceAccount.sample.get
       val arbitraryPetServiceAccountKey = RealKeyMockGoogleIamDAO.generateNewRealKey(arbitraryPetServiceAccount.serviceAccount.email)._2
 
-      doReturn(Future.successful(arbitraryPetServiceAccountKey))
+      doReturn(IO.pure(arbitraryPetServiceAccountKey))
         .when(googleExtensions)
         .getArbitraryPetServiceAccountKey(eqTo(newGoogleUser), any[SamRequestContext])
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-4295

What:

Sam has APIs to get pet keys and pet tokens as users. However the "admin" pet routes (the ones that require the  `cloud-extension/google` permission and take an email) only support pet keys. This PR adds admin pet routes to get pet tokens.

Why:

Leonardo relies on the admin pet routes to get pet tokens for users. Today Leonardo is requesting keys from Sam and using those to generate tokens. However Leonardo is doing some refactoring of its auth layer (including switching to use the Sam client), and it would be nice to remove the key logic and just fetch tokens from Sam directly. 

How:

Updated swagger docs, `GoogleExtensionRoutes`, and `GoogleExtensions` to implement the new APIs.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
