### PR TITLE
ID-1369 Repair cloud access followup: fix swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -99,7 +99,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
   /api/admin/v2/user/{userId}/repairCloudAccess:
-    get:
+    put:
       tags:
         - Admin
       summary: Ensures that a user's proxy group exists and that it is added to any google groups that it should be in.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -496,6 +496,7 @@ class UserService(
       case Some(user) =>
         for {
           _ <- cloudExtensions.onUserCreate(user, samRequestContext)
+          _ <- cloudExtensions.onUserEnable(user, samRequestContext)
           groups <- directoryDAO.listUserDirectMemberships(user.id, samRequestContext)
           _ <- cloudExtensions.onGroupUpdate(groups, Set(user.id), samRequestContext)
         } yield IO.pure(())

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpec.scala
@@ -747,8 +747,8 @@ class OldUserServiceSpec(_system: ActorSystem)
     // Run test
     service.repairCloudAccess(invitedUserId, samRequestContext).unsafeRunSync()
 
-    verify(googleExtensions).onUserCreate(SamUser(invitedUserId, registeringUser.googleSubjectId, inviteeEmail, None, true), samRequestContext)
-
+    verify(googleExtensions).onUserCreate(updatedUserInPostgres.get, samRequestContext)
+    verify(googleExtensions).onUserEnable(updatedUserInPostgres.get, samRequestContext)
     verify(googleExtensions).onGroupUpdate(Seq(allUsersGroup.id), Set(invitedUserId), samRequestContext)
   }
 }


### PR DESCRIPTION
Changing get -> put in swagger and add cloudExtensions.onUserEnable call to the new endpoint. This is what actually adds stuff to the user's proxy group after it is created. 