### PR TITLE
[DCJ-400] #major pre-releases use `-snapshot` suffix

### DIFF
--- a/codegen_java/project/Version.scala
+++ b/codegen_java/project/Version.scala
@@ -15,8 +15,6 @@ object Version {
 
     // The project isSnapshot string passed in via command line settings, if desired.
     val isSnapshot = sys.props.getOrElse("project.isSnapshot", "true").toBoolean
-
-    // For now, obfuscate SNAPSHOTs from sbt's developers: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
-    if (isSnapshot) s"$semVer-SNAP" else semVer
+    if (isSnapshot) s"$semVer-snapshot" else semVer
   }
 }

--- a/codegen_java_old/project/Version.scala
+++ b/codegen_java_old/project/Version.scala
@@ -15,8 +15,6 @@ object Version {
 
     // The project isSnapshot string passed in via command line settings, if desired.
     val isSnapshot = sys.props.getOrElse("project.isSnapshot", "true").toBoolean
-
-    // For now, obfuscate SNAPSHOTs from sbt's developers: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
-    if (isSnapshot) s"$semVer-SNAP" else semVer
+    if (isSnapshot) s"$semVer-snapshot" else semVer
   }
 }


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/DCJ-400

**What:**

 <!-- For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).-->

Sam clients published as part of commits to PRs will now be suffixed with `-snapshot` rather than `-SNAP`.

**Why:**

 <!-- For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves. -->

Many Terra services use Dependabot to automate dependency upgrades. Dependabot will ignore new versions with `-snapshot` suffix and rightfully interpret them as prereleases. https://github.com/dependabot/dependabot-core/blob/8f9e4734020e0029a9ec53e1d38163bbcc6235c7/gradle/lib/dependabot/gradle/version.rb#L25

Also tagging this as a major release to bring Sam client versions up to 1.0.0, past older versions pre-semver.  My earlier attempt to do so did not properly trigger client publication on account of being a no-code commit: https://github.com/broadinstitute/sam/pull/1527

**How:**

<!--For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.-->

<!--If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).-->

Updated client version suffix in codegen directories.


---

**PR checklist**

- [X] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [X] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
