### PR TITLE
[IA-5060] Inherit manager roles to notebook-cluster and persistent-disk

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -175,6 +175,8 @@ resourceTypes = {
           wds-instance = ["owner"]
           kubernetes-app = ["manager"]
           kubernetes-app-shared = ["owner", "user"]
+          notebook-cluster = ["manager"]
+          persistent-disk = ["manager"]
         }
       }
       application = {
@@ -610,17 +612,8 @@ resourceTypes = {
       read_policies = {
         description = "list all policies and policy details for this google-project"
       }
-      list_notebook_cluster = {
-        description = "list all notebook clusters in this google-project"
-      }
       launch_notebook_cluster = {
         description = "launch a new notebook cluster in this google-project"
-      }
-      delete_notebook_cluster = {
-        description = ""
-      }
-      stop_start_notebook_cluster = {
-        description = "stop and start notebook clusters in this google-project"
       }
       list_persistent_disk = {
         description = "list all persistent disks in this google-project"
@@ -656,10 +649,12 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "list_children"]
+        roleActions = ["read_policies", "delete", "get_parent", "set_parent", "list_children"]
         includedRoles = ["notebook-user", "pet-creator"]
         descendantRoles = {
           kubernetes-app = ["manager"]
+          notebook-cluster = ["manager"]
+          persistent-disk = ["manager"]
         }
       }
       notebook-user = {
@@ -790,6 +785,7 @@ resourceTypes = {
       }
       connect = {
         description = "connect to the Jupyter notebook running on the notebook cluster"
+        authDomainConstrainable = true
       }
       delete = {
         description = "delete the notebook cluster"
@@ -803,22 +799,30 @@ resourceTypes = {
       modify = {
         description = "modify attributes of the cluster"
       }
+      set_parent = {
+        description = "set parent of notebook cluster"
+      }
     }
     ownerRoleName = "creator"
     roles = {
       creator = {
         roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify"]
       }
+      manager = {
+        roleActions = ["status", "delete", "read_policies"]
+      }
     }
     reuseIds = false
+    authDomainConstrainable = true
   }
   persistent-disk = {
     actionPatterns = {
       read = {
-        description = "read metadata and contents of persistent disk"
+        description = "read metadata of persistent disk"
       }
       attach = {
         description = "attach persistent disk to a VM"
+        authDomainConstrainable = true
       }
       modify = {
         description = "modify persistent disk"
@@ -835,8 +839,12 @@ resourceTypes = {
       creator = {
         roleActions = ["read", "attach", "modify", "delete", "read_policies"]
       }
+      manager = {
+        roleActions = ["delete", "read", "read_policies"]
+      }
     }
     reuseIds = false
+    authDomainConstrainable = true
   }
   kubernetes-app = {
     actionPatterns = {
@@ -845,6 +853,7 @@ resourceTypes = {
       }
       connect = {
         description = "connect to kubernetes application"
+        authDomainConstrainable = true
       }
       update = {
         description = "update kubernetes application"
@@ -875,6 +884,7 @@ resourceTypes = {
       }
     }
     reuseIds = false
+    authDomainConstrainable = true
   }
   kubernetes-app-shared = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -608,15 +608,36 @@ resourceTypes = {
     reuseIds = false
   }
   google-project = {
+    # TODO: remove the following actions when notebook-cluster and persistent-disk have migrated to have parent resources.
+    # - list_notebook_cluster
+    # - delete_notebook_cluster
+    # - stop_start_notebook_cluster
+    # - list_persistent_disk
+    # - delete_persistent_disk
     actionPatterns = {
       read_policies = {
         description = "list all policies and policy details for this google-project"
       }
+      list_notebook_cluster = {
+        description = "list all notebook clusters in this google-project"
+      }
       launch_notebook_cluster = {
         description = "launch a new notebook cluster in this google-project"
       }
+      delete_notebook_cluster = {
+        description = ""
+      }
+      stop_start_notebook_cluster = {
+        description = "stop and start notebook clusters in this google-project"
+      }
+      list_persistent_disk = {
+        description = "list all persistent disks in this google-project"
+      }
       create_persistent_disk = {
         description = "create persistent disk in this google-project"
+      }
+      delete_persistent_disk = {
+        description = "delete persistent disk in this google-project"
       }
       create_kubernetes_app = {
         description = "create kubernetes application in this google-project"
@@ -643,7 +664,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "delete", "get_parent", "set_parent", "list_children"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "list_children"]
         includedRoles = ["notebook-user", "pet-creator"]
         descendantRoles = {
           kubernetes-app = ["manager"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -828,7 +828,6 @@ resourceTypes = {
       }
     }
     reuseIds = false
-    authDomainConstrainable = true
   }
   persistent-disk = {
     actionPatterns = {
@@ -862,7 +861,6 @@ resourceTypes = {
       }
     }
     reuseIds = false
-    authDomainConstrainable = true
   }
   kubernetes-app = {
     actionPatterns = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -615,14 +615,8 @@ resourceTypes = {
       launch_notebook_cluster = {
         description = "launch a new notebook cluster in this google-project"
       }
-      list_persistent_disk = {
-        description = "list all persistent disks in this google-project"
-      }
       create_persistent_disk = {
         description = "create persistent disk in this google-project"
-      }
-      delete_persistent_disk = {
-        description = "delete persistent disk in this google-project"
       }
       create_kubernetes_app = {
         description = "create kubernetes application in this google-project"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -900,7 +900,6 @@ resourceTypes = {
       }
     }
     reuseIds = false
-    authDomainConstrainable = true
   }
   kubernetes-app-shared = {
     actionPatterns = {
@@ -909,6 +908,7 @@ resourceTypes = {
       }
       connect = {
         description = "connect to kubernetes application"
+        authDomainConstrainable = true
       }
       update = {
         description = "update kubernetes application"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -821,7 +821,7 @@ resourceTypes = {
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify"]
+        roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify", "set_parent"]
       }
       manager = {
         roleActions = ["status", "delete", "read_policies"]
@@ -848,11 +848,14 @@ resourceTypes = {
       read_policies = {
         description = "view all policies and policy details for the persistent disk"
       }
+      set_parent = {
+        description = "set parent of persistent disk"
+      }
     }
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["read", "attach", "modify", "delete", "read_policies"]
+        roleActions = ["read", "attach", "modify", "delete", "read_policies", "set_parent"]
       }
       manager = {
         roleActions = ["delete", "read", "read_policies"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-5060

What:

Phase 1 of the [Simplify Leo Access Control](https://broadworkbench.atlassian.net/browse/IA-5059) epic.

This PR: 
* Allows `notebook-cluster` and `perstistent-disk` resource types to inherit from `google-project` or workspace.
* Makes `notebook-cluster/connect` and `persistent-disk/attach` actions auth domain constrainable.

Why:

We are trying to clean up/simplify Leonardo access control logic. Part of this is standardizing on consistent Sam resource types and using inheritance to propagate permissions. This PR sets up the Sam model; subsequent Leonardo changes will be made to migrate to it.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
