### PR TITLE
Revert "[ID-1371] Update workbench-libs version"

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "3c223be"
+  val workbenchLibV = "9138393"
 
-  val workbenchGoogleV = s"0.33-$workbenchLibV"
+  val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
   val workbenchServiceTestV = s"5.0-$workbenchLibV"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,13 +11,13 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "3c223be" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "8d55689" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.20-$workbenchLibV"
-  val workbenchGoogleV = s"0.33-$workbenchLibV"
+  val workbenchGoogleV = s"0.32-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
-  val workbenchNotificationsV = s"0.7-$workbenchLibV"
+  val workbenchNotificationsV = s"0.6-$workbenchLibV"
   val workbenchOauth2V = s"0.7-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.30-SNAPSHOT"


### PR DESCRIPTION
Reverts broadinstitute/sam#1526

We think this is causing the sam-google-key-cache pubsub queue to build up, havent gotten to the root cause yet but this change going in lines up pretty perfectly with seeing the issue. 