### PR TITLE
Remove project-specific Pet Service Accounts

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/provider/SamProviderSpec.scala
@@ -135,7 +135,7 @@ class SamProviderSpec
   private def mockGetArbitraryPetServiceAccountToken(): IO[Unit] = for {
     _ <- IO(
       when {
-        googleExt.getArbitraryPetServiceAccountToken(any[SamUser], any[Set[String]], any[SamRequestContext])
+        googleExt.getSingletonPetServiceAccountToken(any[SamUser], any[Set[String]], any[SamRequestContext])
       } thenReturn {
         IO.pure("aToken")
       }

--- a/render_config.sh
+++ b/render_config.sh
@@ -2,21 +2,22 @@ ENV=${1:-dev}
 SERVICE_OUTPUT_LOCATION="$(dirname "$0")/src/main/resources/rendered"
 SECRET_ENV_VARS_LOCATION="${SERVICE_OUTPUT_LOCATION}/secrets.env"
 
+gcloud container clusters get-credentials --zone us-central1-a --project broad-dsde-"${ENV}" terra-"${ENV}"
+
+kubectl -n terra-"${ENV}" get secret sam-sa-secret -o 'go-template={{index .data "sam-account.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/sam-account.json
+kubectl -n terra-"${ENV}" get secret sam-sa-secret -o 'go-template={{index .data "sam-account.pem"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/sam-account.pem
+
+kubectl -n terra-"${ENV}" get secret admin-one-sa-secret -o 'go-template={{index .data "admin-service-account-1.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-1.json
+kubectl -n terra-"${ENV}" get secret admin-two-sa-secret -o 'go-template={{index .data "admin-service-account-2.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-2.json
+kubectl -n terra-"${ENV}" get secret admin-three-sa-secret -o 'go-template={{index .data "admin-service-account-3.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-3.json
+kubectl -n terra-"${ENV}" get secret admin-four-sa-secret -o 'go-template={{index .data "admin-service-account-4.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-4.json
+kubectl -n terra-"${ENV}" get secret admin-five-sa-secret -o 'go-template={{index .data "admin-service-account-5.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-5.json
+
+kubectl -n terra-"${ENV}" get configmap sam-oauth2-configmap -o 'go-template={{index .data "oauth2-config"}}' > ${SERVICE_OUTPUT_LOCATION}/oauth2.conf
+# Local dev uses a macOS-specific docker replacement hostname for localhost, so replace all instances in the proxy config.
+kubectl -n terra-"${ENV}" get configmap sam-proxy-configmap -o 'go-template={{index .data "apache-httpd-proxy-config"}}' | sed 's/localhost/host\.docker\.internal/g' > ${SERVICE_OUTPUT_LOCATION}/site.conf
+
 gcloud container clusters get-credentials --zone us-central1-a --project broad-dsde-dev terra-dev
-
-kubectl -n terra-dev get secret sam-sa-secret -o 'go-template={{index .data "sam-account.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/sam-account.json
-kubectl -n terra-dev get secret sam-sa-secret -o 'go-template={{index .data "sam-account.pem"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/sam-account.pem
-
-kubectl -n terra-dev get secret admin-one-sa-secret -o 'go-template={{index .data "admin-service-account-1.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-1.json
-kubectl -n terra-dev get secret admin-two-sa-secret -o 'go-template={{index .data "admin-service-account-2.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-2.json
-kubectl -n terra-dev get secret admin-three-sa-secret -o 'go-template={{index .data "admin-service-account-3.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-3.json
-kubectl -n terra-dev get secret admin-four-sa-secret -o 'go-template={{index .data "admin-service-account-4.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-4.json
-kubectl -n terra-dev get secret admin-five-sa-secret -o 'go-template={{index .data "admin-service-account-5.json"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/admin-service-account-5.json
-
-kubectl -n terra-dev get configmap sam-oauth2-configmap -o 'go-template={{index .data "oauth2-config"}}' > ${SERVICE_OUTPUT_LOCATION}/oauth2.conf
-# Local dev uses a macOS-specific docker replacement hostname for locahost, so replace all instances in the proxy config.
-kubectl -n terra-dev get configmap sam-proxy-configmap -o 'go-template={{index .data "apache-httpd-proxy-config"}}' | sed 's/localhost/host\.docker\.internal/g' > ${SERVICE_OUTPUT_LOCATION}/site.conf
-
 kubectl -n local-dev get secrets local-dev-cert -o 'go-template={{index .data "tls.crt"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/server.crt
 kubectl -n local-dev get secrets local-dev-cert -o 'go-template={{index .data "tls.key"}}' | base64 --decode > ${SERVICE_OUTPUT_LOCATION}/server.key
 
@@ -25,11 +26,11 @@ if [ -f "${SECRET_ENV_VARS_LOCATION}" ]; then
 fi
 
 {
-echo export AZURE_MANAGED_APP_CLIENT_ID="$(vault read -field=client-id secret/dsde/terra/azure/dev/sam/managed-app-publisher)";
-echo export AZURE_MANAGED_APP_CLIENT_SECRET="$(vault read -field=client-secret secret/dsde/terra/azure/dev/sam/managed-app-publisher)";
-echo export AZURE_MANAGED_APP_TENANT_ID="$(vault read -field=tenant-id secret/dsde/terra/azure/dev/sam/managed-app-publisher)";
-echo export LEGACY_GOOGLE_CLIENT_ID="$(vault read -format=json -field=data secret/dsde/firecloud/dev/common/refresh-token-oauth-credential.json | jq -r '.web.client_id')";
-echo export OIDC_CLIENT_ID="$(vault read -field=value secret/dsde/terra/azure/dev/b2c/application_id)";
+echo export AZURE_MANAGED_APP_CLIENT_ID="$(vault read -field=client-id secret/dsde/terra/azure/"${ENV}"/sam/managed-app-publisher)";
+echo export AZURE_MANAGED_APP_CLIENT_SECRET="$(vault read -field=client-secret secret/dsde/terra/azure/"${ENV}"/sam/managed-app-publisher)";
+echo export AZURE_MANAGED_APP_TENANT_ID="$(vault read -field=tenant-id secret/dsde/terra/azure/"${ENV}"/sam/managed-app-publisher)";
+echo export LEGACY_GOOGLE_CLIENT_ID="$(vault read -format=json -field=data secret/dsde/firecloud/"${ENV}"/common/refresh-token-oauth-credential.json | jq -r '.web.client_id')";
+echo export OIDC_CLIENT_ID="$(vault read -field=value secret/dsde/terra/azure/"${ENV}"/b2c/application_id)";
 
 echo export SERVICE_ACCOUNT_CLIENT_EMAIL="$(cat ${SERVICE_OUTPUT_LOCATION}/sam-account.json | jq .client_email)";
 echo export SERVICE_ACCOUNT_CLIENT_ID="$(cat ${SERVICE_OUTPUT_LOCATION}/sam-account.json | jq .client_id)";

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -33,4 +33,5 @@
     <include file="changesets/20240701_add_group_version_and_last_synchronized_version.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240809_sam_user_favorite_resources_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240820_descendant_auth_domains.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240911_sam_pet_service_agents_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240911_sam_pet_service_agents_table.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20240911_sam_pet_service_agents_table.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet logicalFilePath="dummy" author="tlangs" id="add_sam_pet_service_agents_table">
+    <createTable tableName="SAM_PET_SERVICE_AGENTS">
+      <column name="sam_user_id" type="VARCHAR">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="pet_service_account_project" type="VARCHAR">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="destination_project" type="VARCHAR">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="destination_project_number" type="VARCHAR">
+        <constraints primaryKey="false" nullable="false"/>
+      </column>
+      <column name="service_agents" type="VARCHAR []">
+        <constraints primaryKey="false" nullable="false"/>
+      </column>
+      <column name="updated_at" type="timestamptz"/>
+    </createTable>
+
+    <addForeignKeyConstraint baseTableName="SAM_PET_SERVICE_AGENTS" baseColumnNames="SAM_USER_ID, PET_SERVICE_ACCOUNT_PROJECT" constraintName="FK_PSA_SERVICE_AGENT"
+                             referencedTableName="SAM_PET_SERVICE_ACCOUNT"
+                             referencedColumnNames="USER_ID, PROJECT" deleteCascade="true" onDelete="CASCADE"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -117,6 +117,8 @@ googleServices {
     samplingProbability = ${?OPENCENSUS_SAMPLING_PROBABILITY} # for backwards compatibility
     samplingProbability = ${?GOOGLE_TRACE_SAMPLING_PROBABILITY}
   }
+
+  serviceAgents = ${?SERVICE_AGENTS}
 }
 
 db {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -122,9 +122,10 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
               val googleProject = GoogleProject(project)
               deleteWithTelemetry(samRequestContext, userIdParam(workbenchUserId), googleProjectParam(googleProject)) {
                 complete {
-                  cloudExtensions
-                    .deleteUserPetServiceAccount(workbenchUserId, googleProject, samRequestContext)
-                    .map(_ => NoContent)
+                  for {
+                    _ <- cloudExtensions.removeProjectServiceAgents(workbenchUserId, GoogleProject(project), samRequestContext)
+                    _ <- cloudExtensions.deleteUserPetServiceAccount(workbenchUserId, GoogleProject(project), samRequestContext)
+                  } yield StatusCodes.NoContent
                 }
               }
             }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -33,7 +33,8 @@ final case class GoogleServicesConfig(
     adminSdkServiceAccountPaths: Option[NonEmptyList[String]],
     googleKms: GoogleKmsConfig,
     terraGoogleOrgNumber: String,
-    traceExporter: TraceExporterConfig
+    traceExporter: TraceExporterConfig,
+    serviceAgents: Set[String]
 )
 
 object GoogleServicesConfig {
@@ -98,7 +99,8 @@ object GoogleServicesConfig {
       config.as[Option[NonEmptyList[String]]]("adminSdkServiceAccountPaths"),
       config.as[GoogleKmsConfig]("kms"),
       config.getString("terraGoogleOrgNumber"),
-      config.as[TraceExporterConfig]("traceExporter")
+      config.as[TraceExporterConfig]("traceExporter"),
+      config.as[Option[String]]("serviceAgents").map(_.split(",").toSet).getOrElse(Set.empty)
     )
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam.azure.{
   ActionManagedIdentity,
   ActionManagedIdentityId,
@@ -12,7 +12,15 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
   PetManagedIdentityId
 }
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, ResourceTypeName, SamUserTos}
+import org.broadinstitute.dsde.workbench.sam.model.{
+  BasicWorkbenchGroup,
+  FullyQualifiedResourceId,
+  PetServiceAgents,
+  ResourceAction,
+  ResourceTypeName,
+  SamUserTos,
+  ServiceAgent
+}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
@@ -190,4 +198,29 @@ trait DirectoryDAO {
       resourceTypeName: ResourceTypeName,
       samRequestContext: SamRequestContext
   ): IO[Set[FullyQualifiedResourceId]]
+
+  def getPetServiceAgents(
+      userId: WorkbenchUserId,
+      petServiceAccountProject: GoogleProject,
+      destinationProject: GoogleProject,
+      samRequestContext: SamRequestContext
+  ): IO[Option[PetServiceAgents]]
+
+  def addPetServiceAgent(
+      userId: WorkbenchUserId,
+      petServiceAccountProject: GoogleProject,
+      destinationProject: GoogleProject,
+      destinationProjectNumber: Long,
+      serviceAgent: String,
+      samRequestContext: SamRequestContext
+  ): IO[Set[ServiceAgent]]
+
+  def removePetServiceAgent(
+      userId: WorkbenchUserId,
+      petServiceAccountProject: GoogleProject,
+      destinationProject: GoogleProject,
+      destinationProjectNumber: Long,
+      serviceAgent: String,
+      samRequestContext: SamRequestContext
+  ): IO[Set[ServiceAgent]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/SamTypeBinders.scala
@@ -183,4 +183,9 @@ object SamTypeBinders {
     def apply(rs: ResultSet, index: Int): LastQuotaErrorPK = LastQuotaErrorPK(rs.getLong(index))
   }
 
+  implicit def setTypeBinder[A]: TypeBinder[Set[A]] = new TypeBinder[Set[A]] {
+    def apply(rs: ResultSet, label: String): Set[A] = rs.getArray(label).getArray.asInstanceOf[Array[A]].toSet
+    def apply(rs: ResultSet, index: Int): Set[A] = rs.getArray(index).getArray.asInstanceOf[Array[A]].toSet
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetServiceAgentsTable.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/db/tables/PetServiceAgentsTable.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsde.workbench.sam.db.tables
+
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import org.broadinstitute.dsde.workbench.sam.db.{DatabaseArray, SamTypeBinders}
+import org.broadinstitute.dsde.workbench.sam.model.ServiceAgent
+import scalikejdbc._
+
+import java.time.Instant
+
+final case class PetServiceAgentsRecord(
+    samUserId: WorkbenchUserId,
+    petServiceAccountProject: GoogleProject,
+    destinationProject: GoogleProject,
+    destinationProjectNumber: Long,
+    serviceAgents: Set[String],
+    updatedAt: Instant
+)
+
+final case class ServiceAgentsArray(serviceAgents: Set[ServiceAgent]) extends DatabaseArray {
+  override val baseTypeName: String = "VARCHAR"
+  override def asJavaArray: Array[Object] = serviceAgents.toArray.map(_.name.asInstanceOf[Object])
+}
+
+object PetServiceAgentsTable extends SQLSyntaxSupportWithDefaultSamDB[PetServiceAgentsRecord] {
+  override def tableName: String = "SAM_PET_SERVICE_AGENTS"
+
+  import SamTypeBinders._
+
+  def apply(e: ResultName[PetServiceAgentsRecord])(rs: WrappedResultSet): PetServiceAgentsRecord = PetServiceAgentsRecord(
+    rs.get(e.samUserId),
+    rs.get(e.petServiceAccountProject),
+    rs.get(e.destinationProject),
+    rs.get(e.destinationProjectNumber),
+    rs.get(e.serviceAgents),
+    rs.get(e.updatedAt)
+  )
+
+  def apply(p: SyntaxProvider[PetServiceAgentsRecord])(rs: WrappedResultSet): PetServiceAgentsRecord = apply(p.resultName)(rs)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -227,7 +227,10 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   } ~
                     deleteWithTelemetry(samRequestContext, "googleProject" -> projectResourceId) {
                       complete {
-                        googleExtensions.deleteUserPetServiceAccount(samUser.id, GoogleProject(project), samRequestContext).map(_ => StatusCodes.NoContent)
+                        for {
+                          _ <- googleExtensions.removeProjectServiceAgents(samUser.id, GoogleProject(project), samRequestContext)
+                          _ <- googleExtensions.deleteUserPetServiceAccount(samUser.id, GoogleProject(project), samRequestContext)
+                        } yield StatusCodes.NoContent
                       }
                     }
                 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -48,9 +48,9 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
               getWithTelemetry(samRequestContext, "userEmail" -> email) {
                 complete {
                   import spray.json._
-                  googleExtensions.getArbitraryPetServiceAccountKey(email, samRequestContext) map {
+                  googleExtensions.getSingletonPetServiceAccountAndKeyForUser(email, None, samRequestContext) map {
                     // parse json to ensure it is json and tells akka http the right content-type
-                    case Some(key) => StatusCodes.OK -> key.parseJson
+                    case Some((_, key)) => StatusCodes.OK -> key.parseJson
                     case None =>
                       throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
                   }
@@ -61,7 +61,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 postWithTelemetry(samRequestContext, "userEmail" -> email) {
                   entity(as[Set[String]]) { scopes =>
                     complete {
-                      googleExtensions.getArbitraryPetServiceAccountToken(email, scopes, samRequestContext).map {
+                      googleExtensions.getSingletonPetServiceAccountToken(email, scopes, samRequestContext).map {
                         case Some(token) => StatusCodes.OK -> JsString(token)
                         case None =>
                           throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
@@ -78,9 +78,9 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 getWithTelemetry(samRequestContext, "userEmail" -> email, "googleProject" -> googleProject) {
                   complete {
                     import spray.json._
-                    googleExtensions.getPetServiceAccountKey(email, googleProject, samRequestContext) map {
+                    googleExtensions.getSingletonPetServiceAccountAndKeyForUser(email, Some(googleProject), samRequestContext) map {
                       // parse json to ensure it is json and tells akka http the right content-type
-                      case Some(key) => StatusCodes.OK -> key.parseJson
+                      case Some((_, key)) => StatusCodes.OK -> key.parseJson
                       case None =>
                         throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
                     }
@@ -91,7 +91,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   postWithTelemetry(samRequestContext, "userEmail" -> email) {
                     entity(as[Set[String]]) { scopes =>
                       complete {
-                        googleExtensions.getPetServiceAccountToken(email, googleProject, scopes, samRequestContext).map {
+                        googleExtensions.getSingletonPetServiceAccountToken(email, scopes, samRequestContext).map {
                           case Some(token) => StatusCodes.OK -> JsString(token)
                           case None =>
                             throw new WorkbenchExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "pet service account not found"))
@@ -111,8 +111,8 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 complete {
                   import spray.json._
                   googleExtensions
-                    .getArbitraryPetServiceAccountKey(samUser, samRequestContext)
-                    .map(key => StatusCodes.OK -> key.parseJson)
+                    .getSingletonPetServiceAccountAndKeyForUser(samUser, None, samRequestContext)
+                    .map(tup => StatusCodes.OK -> tup._2.parseJson)
                 }
               }
             }
@@ -122,7 +122,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 postWithTelemetry(samRequestContext) {
                   entity(as[Set[String]]) { scopes =>
                     complete {
-                      googleExtensions.getArbitraryPetServiceAccountToken(samUser, scopes, samRequestContext).map { token =>
+                      googleExtensions.getSingletonPetServiceAccountToken(samUser, scopes, samRequestContext).map { token =>
                         StatusCodes.OK -> JsString(token)
                       }
                     }
@@ -144,9 +144,9 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                       import spray.json._
                       // parse json to ensure it is json and tells akka http the right content-type
                       googleExtensions
-                        .getPetServiceAccountKey(samUser, GoogleProject(project), samRequestContext)
-                        .map { key =>
-                          StatusCodes.OK -> key.parseJson
+                        .getSingletonPetServiceAccountAndKeyForUser(samUser, Some(GoogleProject(project)), samRequestContext)
+                        .map { tup =>
+                          StatusCodes.OK -> tup._2.parseJson
                         }
                     }
                   }
@@ -219,8 +219,8 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                   ) {
                     getWithTelemetry(samRequestContext, "googleProject" -> projectResourceId) {
                       complete {
-                        googleExtensions.createUserPetServiceAccount(samUser, GoogleProject(project), samRequestContext).map { petSA =>
-                          StatusCodes.OK -> petSA.serviceAccount.email
+                        googleExtensions.getSingletonPetServiceAccountAndKeyForUser(samUser, Some(GoogleProject(project)), samRequestContext).map { petSA =>
+                          StatusCodes.OK -> petSA._1.serviceAccount.email
                         }
                       }
                     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -30,7 +30,6 @@ import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, CloudExtensionsInitializer, ManagedGroupService, SamApplication}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
-import org.broadinstitute.dsde.workbench.sam.util.AsyncLogging.{FutureWithLogging, IOWithLogging}
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, SubsystemStatus, Subsystems}
 import org.broadinstitute.dsde.workbench.util.{FutureSupport, Retry}
 import spray.json._

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -289,6 +289,7 @@ class GoogleExtensions(
       }
       allUsersGroup <- getOrCreateAllUsersGroup(directoryDAO, samRequestContext)
       _ <- IO.fromFuture(IO(googleDirectoryDAO.addMemberToGroup(allUsersGroup.email, proxyEmail)))
+      _ <- getSingletonPetServiceAccountForUser(user, None, samRequestContext)
 
     } yield ()
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -30,6 +30,7 @@ import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
 import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, CloudExtensionsInitializer, ManagedGroupService, SamApplication}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.broadinstitute.dsde.workbench.sam.util.AsyncLogging.{FutureWithLogging, IOWithLogging}
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, SubsystemStatus, Subsystems}
 import org.broadinstitute.dsde.workbench.util.{FutureSupport, Retry}
 import spray.json._
@@ -606,6 +607,7 @@ class GoogleExtensions(
       petServiceAgents <- directoryDAO.getPetServiceAgents(user.id, petServiceAccount.id.project, destinationProject, samRequestContext)
       existingServiceAgents = petServiceAgents.map(_.serviceAgents.map(_.name)).getOrElse(Set.empty)
       serviceAgentsToAdd = googleServicesConfig.serviceAgents -- existingServiceAgents
+      _ = logger.info(s"Adding $serviceAgentsToAdd to $petServiceAccount")
       _ <- assertProjectInTerraOrg(destinationProject)
       _ <- assertProjectIsActive(destinationProject)
       destinationProjectNumber <- petServiceAgents
@@ -642,6 +644,7 @@ class GoogleExtensions(
         } yield ()
       }
       serviceAgentsToRemove = existingServiceAgents -- googleServicesConfig.serviceAgents
+      _ = logger.info(s"Removing $serviceAgentsToRemove from $petServiceAccount")
       _ <- serviceAgentsToRemove.toList.traverse { serviceAgentName =>
 //                val serviceAgent = ServiceAgent(serviceAgentName, destinationProjectNumber)
         for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -562,6 +562,10 @@ class GoogleExtensions(
         .map(psa => IO.pure(Option(psa.destinationProjectNumber)))
         .getOrElse(IO.fromFuture(IO(googleProjectDAO.getProjectNumber(destinationProject.value))))
         .map(_.getOrElse(throw new WorkbenchException(s"Could not find project number for project ${destinationProject.value}")))
+      ancestry <- IO.fromFuture(IO(googleProjectDAO.getAncestry(destinationProject.value)))
+      organization = ancestry.find(_.getResourceId.getType.equals("organization")).map(_.getResourceId)
+      _ <- IO.raiseWhen(organization.isEmpty)(new WorkbenchException(s"Project $destinationProject is not in an organization"))
+      _ <- IO.raiseUnless(organization.exists(_.getId.equals(googleServicesConfig.terraGoogleOrgNumber)))(new WorkbenchException(s"Project $destinationProject is not in organization ${googleServicesConfig.terraGoogleOrgNumber}"))
       _ <- serviceAgentsToAdd.toList.traverse { serviceAgentName =>
         val serviceAgent = ServiceAgent(serviceAgentName, destinationProjectNumber)
         for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -565,7 +565,9 @@ class GoogleExtensions(
       ancestry <- IO.fromFuture(IO(googleProjectDAO.getAncestry(destinationProject.value)))
       organization = ancestry.find(_.getResourceId.getType.equals("organization")).map(_.getResourceId)
       _ <- IO.raiseWhen(organization.isEmpty)(new WorkbenchException(s"Project $destinationProject is not in an organization"))
-      _ <- IO.raiseUnless(organization.exists(_.getId.equals(googleServicesConfig.terraGoogleOrgNumber)))(new WorkbenchException(s"Project $destinationProject is not in organization ${googleServicesConfig.terraGoogleOrgNumber}"))
+      _ <- IO.raiseUnless(organization.exists(_.getId.equals(googleServicesConfig.terraGoogleOrgNumber)))(
+        new WorkbenchException(s"Project $destinationProject is not in organization ${googleServicesConfig.terraGoogleOrgNumber}")
+      )
       _ <- serviceAgentsToAdd.toList.traverse { serviceAgentName =>
         val serviceAgent = ServiceAgent(serviceAgentName, destinationProjectNumber)
         for {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.model
 
 import monocle.macros.Lenses
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AccessPolicyMembershipResponse, SamUser}
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat}
 
@@ -274,6 +275,19 @@ final case class SamUserTos(id: WorkbenchUserId, version: String, action: String
   }
   def toHistoryRecord: TermsOfServiceHistoryRecord = TermsOfServiceHistoryRecord(action, version, createdAt)
 }
+
+final case class PetServiceAgents(
+    userId: WorkbenchUserId,
+    petServiceAccountProject: GoogleProject,
+    destinationProject: GoogleProject,
+    destinationProjectNumber: Long,
+    serviceAgents: Set[ServiceAgent]
+)
+
+final case class ServiceAgent(name: String, projectNumber: Long) {
+  val email: WorkbenchEmail = WorkbenchEmail(s"service-$projectNumber@$name.iam.gserviceaccount.com")
+}
+
 object SamLenses {
   val resourceIdentityAccessPolicy = AccessPolicy.id composeLens FullyQualifiedPolicyId.resource
   val resourceTypeNameInAccessPolicy = resourceIdentityAccessPolicy composeLens FullyQualifiedResourceId.resourceTypeName

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -53,6 +53,8 @@ trait CloudExtensions {
 
   def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean]
 
+  def removeProjectServiceAgents(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean]
+
   def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
 
   def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit
@@ -99,6 +101,8 @@ trait NoExtensions extends CloudExtensions {
   override def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
   override def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
+
+  override def removeProjectServiceAgents(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
 
   override def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     IO.pure(Option(userEmail))

--- a/src/test/resources/sam.conf
+++ b/src/test/resources/sam.conf
@@ -6,6 +6,10 @@ admin {
   serviceAccountAdmins = ${?SERVICE_ACCOUNT_ADMINS}
 }
 
+googleServices {
+  serviceAgents = "compute-service"
+}
+
 resourceAccessPolicies {
   resource_type_admin {
     workspace {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -248,6 +248,7 @@ object TestSupport extends TestSupport {
           GroupMemberTable,
           GroupMemberFlatTable,
           PetServiceAccountTable,
+          PetServiceAgentsTable,
           AzureManagedResourceGroupTable,
           PetManagedIdentityTable,
           UserTable,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -24,6 +24,7 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.mock.MockSamGoogleProjectDAO
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -100,7 +101,7 @@ object TestSupport extends TestSupport {
     val googleDisableUsersPubSubDAO = new MockGooglePubSubDAO()
     val googleKeyCachePubSubDAO = new MockGooglePubSubDAO()
     val googleStorageDAO = new MockGoogleStorageDAO()
-    val googleProjectDAO = googProjectDAO.getOrElse(new MockGoogleProjectDAO())
+    val googleProjectDAO = googProjectDAO.getOrElse(new MockSamGoogleProjectDAO())
     val notificationDAO = new PubSubNotificationDAO(notificationPubSubDAO, "foo")
     val cloudKeyCache = new GoogleKeyCache(
       distributedLock,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.google.mock._
 import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.broadinstitute.dsde.workbench.sam.api._
@@ -285,6 +286,12 @@ object TestSupport extends TestSupport {
 
   val enabledMapNoTosAccepted = Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> false, "adminEnabled" -> true)
   val enabledMapTosAccepted = Map("ldap" -> true, "allUsersGroup" -> true, "google" -> true, "tosAccepted" -> true, "adminEnabled" -> true)
+
+  def singletonServiceAccountForUser(user: SamUser) =
+    s"pet-${user.id.value}@${singletonServiceAccountProject(user).value}.iam.gserviceaccount.com"
+
+  def singletonServiceAccountProject(user: SamUser): GoogleProject =
+    GoogleProject(s"fc-${googleServicesConfig.environment.substring(0, Math.min(googleServicesConfig.environment.length(), 5))}-${user.id.value}")
 }
 
 final case class SamDependencies(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -498,13 +498,6 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
 
   def setupSignedUrlTest(): (SamUser, SamRoutes, String) = {
     val googleIamDAO = new RealKeyMockGoogleIamDAO
-//    val googleProjectDAO = new MockGoogleProjectDAO() {
-//      override def pollOperation(operationId: String): Future[Operation] = {
-//        val operation = new com.google.api.services.cloudresourcemanager.model.Operation
-//        operation.setDone(true)
-//        Future.successful(operation)
-//      }
-//    }
     val samUser = Generator.genWorkbenchUserGoogle.sample.get
     val (user, samDeps, routes) = createTestUser(
       configResourceTypes,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesSpec.scala
@@ -464,9 +464,6 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
     googleIamDAO
   }
 
-  def singletonServiceAccountForUser(user: SamUser) =
-    s"pet-${user.id.value}@fc-${googleServicesConfig.environment.substring(0, Math.min(googleServicesConfig.environment.length(), 5))}-${user.id.value}.iam.gserviceaccount.com"
-
   def createMockGoogleIamDaoForSAKeyTests: (GoogleIamDAO, String, SamUser => Unit) = {
     val googleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
     val expectedJson = """{"json":"yes I am"}"""
@@ -492,6 +489,9 @@ trait GoogleExtensionRoutesSpecHelper extends AnyFlatSpec with Matchers with Sca
     lenient().when(googleIamDAO.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail])).thenReturn(Future.successful(Seq.empty))
     lenient()
       .when(googleIamDAO.addServiceAccountUserRoleForUser(any[GoogleProject], any[WorkbenchEmail], any[WorkbenchEmail]))
+      .thenReturn(Future.successful(()))
+    lenient
+      .when(googleIamDAO.addIamPolicyBindingOnServiceAccount(any[GoogleProject], any[WorkbenchEmail], any[WorkbenchEmail], any[Set[String]]))
       .thenReturn(Future.successful(()))
     (googleIamDAO, expectedJson, mockWithUser)
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -34,14 +34,14 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"${user.id.value}.iam.gserviceaccount.com")
     }
 
     // same result a second time
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"${user.id.value}.iam.gserviceaccount.com")
     }
   }
 
@@ -62,7 +62,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     val petEmail = Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"${user.id.value}.iam.gserviceaccount.com")
       response.value
     }
 
@@ -168,15 +168,17 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val (googleIamDAO, expectedJson: String, mockWithUser) = createMockGoogleIamDaoForSAKeyTests
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
+
+    mockWithUser(user)
 
     // create a pet service account
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"${user.id.value}.iam.gserviceaccount.com")
     }
 
     // create a pet service account key
@@ -191,15 +193,17 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val (googleIamDAO, expectedJson: String) = createMockGoogleIamDaoForSAKeyTests
+    val (googleIamDAO, expectedJson: String, mockWithUser) = createMockGoogleIamDaoForSAKeyTests
 
     val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
+
+    mockWithUser(user)
 
     // create a pet service account
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
       status shouldEqual StatusCodes.OK
       val response = responseAs[WorkbenchEmail]
-      response.value should endWith(s"@myproject.iam.gserviceaccount.com")
+      response.value should endWith(s"${user.id.value}.iam.gserviceaccount.com")
     }
 
     // create a pet service account key

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -168,11 +168,8 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val (googleIamDAO, expectedJson: String, mockWithUser) = createMockGoogleIamDaoForSAKeyTests
 
-    val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
-
-    mockWithUser(user)
+    val (user, _, routes) = createTestUser(resourceTypes)
 
     // create a pet service account
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {
@@ -193,11 +190,8 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     assume(databaseEnabled, databaseEnabledClue)
 
     val resourceTypes = Map(resourceType.name -> resourceType)
-    val (googleIamDAO, expectedJson: String, mockWithUser) = createMockGoogleIamDaoForSAKeyTests
 
-    val (user, _, routes) = createTestUser(resourceTypes, Some(googleIamDAO))
-
-    mockWithUser(user)
+    val (user, _, routes) = createTestUser(resourceTypes)
 
     // create a pet service account
     Get("/api/google/v1/user/petServiceAccount/myproject") ~> routes.route ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleKmsService, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.model.google.GoogleResourceTypes.GoogleParentResourceType
 import org.broadinstitute.dsde.workbench.model.{PetServiceAccountId, TraceId}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccountName}
 import org.broadinstitute.dsde.workbench.sam.Generator.{
@@ -38,6 +39,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inside, OptionValues}
 
 import java.net.URL
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.{ExecutionContextExecutor, Future}
 
@@ -67,6 +69,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
 
     val mockGoogleKeyCache = mock[GoogleKeyCache](RETURNS_SMART_NULLS)
     val mockGoogleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+    val mockGoogleProjectDAO = mock[GoogleProjectDAO](RETURNS_SMART_NULLS)
 
     lazy val petServiceAccountConfig = TestSupport.petServiceAccountConfig
     lazy val googleServicesConfig = TestSupport.googleServicesConfig
@@ -82,7 +85,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mock[GoogleIamDAO](RETURNS_SMART_NULLS),
         mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
-        mock[GoogleProjectDAO](RETURNS_SMART_NULLS),
+        mockGoogleProjectDAO,
         mockGoogleKeyCache,
         mock[NotificationDAO](RETURNS_SMART_NULLS),
         mock[GoogleKmsService[IO]](RETURNS_SMART_NULLS),
@@ -91,12 +94,17 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         petServiceAccountConfig,
         Map.empty[ResourceTypeName, ResourceType],
         genFirecloudEmail.sample.get
-      )
+      ),
+      lenient = true
     )
 
     doReturn(IO.pure(petServiceAccount))
       .when(googleExtensions)
-      .createUserPetServiceAccount(eqTo(newGoogleUser), eqTo(googleProject), any[SamRequestContext])
+      .createUserPetServiceAccount(eqTo(newGoogleUser), eqTo(TestSupport.singletonServiceAccountProject(newGoogleUser)), any[SamRequestContext])
+
+    doReturn(IO.pure(petServiceAccount))
+      .when(googleExtensions)
+      .getSingletonPetServiceAccountForUser(eqTo(newGoogleUser), any[Option[GoogleProject]], any[SamRequestContext])
 
     doReturn(IO.pure(petServiceAccountKey))
       .when(mockGoogleKeyCache)
@@ -114,6 +122,15 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         any[TimeUnit],
         any[Map[String, String]]
       )
+
+    doReturn(Future.successful(true))
+      .when(googleExtensions)
+      .pollShellProjectCreation(any[String])
+
+    doReturn(Future.successful(UUID.randomUUID().toString))
+      .when(mockGoogleProjectDAO)
+      .createProject(any[String], any[String], any[GoogleParentResourceType])
+
     "getSignedUrl" - {
       "generates a signed URL for a GCS Object" in {
         val signedUrl =
@@ -121,7 +138,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
 
         signedUrl should be(expectedUrl)
 
-        verify(googleExtensions).createUserPetServiceAccount(eqTo(newGoogleUser), eqTo(googleProject), any[SamRequestContext])
+        verify(googleExtensions).getSingletonPetServiceAccountKeyForUser(eqTo(newGoogleUser), eqTo(Some(googleProject)), any[SamRequestContext])
 
         verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
 
@@ -223,6 +240,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
     val mockDirectoryDAO = mock[DirectoryDAO](RETURNS_SMART_NULLS)
     val mockGoogleKeyCache = mock[GoogleKeyCache](RETURNS_SMART_NULLS)
     val mockGoogleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS)
+    val mockGoogleProjectDAO = mock[GoogleProjectDAO](RETURNS_SMART_NULLS)
 
     val googleExtensions: GoogleExtensions = spy(
       new GoogleExtensions(
@@ -235,7 +253,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mockGoogleIamDAO,
         mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
-        mock[GoogleProjectDAO](RETURNS_SMART_NULLS),
+        mockGoogleProjectDAO,
         mockGoogleKeyCache,
         mock[NotificationDAO](RETURNS_SMART_NULLS),
         mock[GoogleKmsService[IO]](RETURNS_SMART_NULLS),
@@ -244,7 +262,8 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         TestSupport.petServiceAccountConfig,
         Map.empty[ResourceTypeName, ResourceType],
         genFirecloudEmail.sample.get
-      )
+      ),
+      lenient = true
     )
 
     doReturn(IO.some(subject))
@@ -263,6 +282,10 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
       .when(googleExtensions)
       .createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
 
+    doReturn(IO.pure(petServiceAccount))
+      .when(googleExtensions)
+      .getSingletonPetServiceAccountForUser(eqTo(user), any[Option[GoogleProject]], any[SamRequestContext])
+
     doReturn(Future.successful(expectedToken))
       .when(googleExtensions)
       .getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
@@ -275,6 +298,14 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
       .when(mockGoogleKeyCache)
       .getKey(eqTo(petServiceAccount))
 
+    doReturn(Future.successful(true))
+      .when(googleExtensions)
+      .pollShellProjectCreation(any[String])
+
+    doReturn(Future.successful(UUID.randomUUID().toString))
+      .when(mockGoogleProjectDAO)
+      .createProject(any[String], any[String], any[GoogleParentResourceType])
+
     "getPetServiceAccountKey" - {
       "gets a key for an email" in {
         clearInvocations(mockDirectoryDAO, googleExtensions, mockGoogleKeyCache)
@@ -284,7 +315,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         key should be(Some(expectedKey))
 
         verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
-        verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+        verify(googleExtensions).getSingletonPetServiceAccountForUser(eqTo(user), eqTo(Some(googleProject)), any[SamRequestContext])
         verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
       }
 
@@ -296,7 +327,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         key should be(expectedKey)
 
         verifyNoInteractions(mockDirectoryDAO)
-        verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+        verify(googleExtensions).getSingletonPetServiceAccountForUser(eqTo(user), eqTo(Some(googleProject)), any[SamRequestContext])
         verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
       }
 
@@ -309,7 +340,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
           token should be(Some(expectedToken))
 
           verify(mockDirectoryDAO).loadSubjectFromEmail(eqTo(email), any[SamRequestContext])
-          verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+          verify(googleExtensions).getSingletonPetServiceAccountForUser(eqTo(user), eqTo(Some(googleProject)), any[SamRequestContext])
           verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
           verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
 
@@ -322,7 +353,7 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
           token should be(expectedToken)
 
           verifyNoInteractions(mockDirectoryDAO)
-          verify(googleExtensions).createUserPetServiceAccount(eqTo(user), eqTo(googleProject), any[SamRequestContext])
+          verify(googleExtensions).getSingletonPetServiceAccountForUser(eqTo(user), eqTo(Some(googleProject)), any[SamRequestContext])
           verify(mockGoogleKeyCache).getKey(eqTo(petServiceAccount))
           verify(googleExtensions).getAccessTokenUsingJson(eqTo(expectedKey), eqTo(scopes))
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/mock/MockSamGoogleProjectDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/mock/MockSamGoogleProjectDAO.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.workbench.sam.mock
+
+import com.google.api.services.cloudresourcemanager.model.Operation
+import org.broadinstitute.dsde.workbench.google.mock.MockGoogleProjectDAO
+
+import scala.concurrent.Future
+
+class MockSamGoogleProjectDAO extends MockGoogleProjectDAO {
+
+  override def pollOperation(operationId: String): Future[Operation] = {
+    val operation = new com.google.api.services.cloudresourcemanager.model.Operation
+    operation.setDone(true)
+    Future.successful(operation)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/MockCloudExtensionsBuilder.scala
@@ -27,6 +27,7 @@ case class MockCloudExtensionsBuilder(allUsersGroup: WorkbenchGroup) extends Idi
   mockedCloudExtensions.allSubSystems returns Set.empty
   mockedCloudExtensions.checkStatus returns Map.empty
   mockedCloudExtensions.deleteUserPetServiceAccount(any[WorkbenchUserId], any[GoogleProject], any[SamRequestContext]) returns IO(true)
+  mockedCloudExtensions.removeProjectServiceAgents(any[WorkbenchUserId], any[GoogleProject], any[SamRequestContext]) returns IO(true)
 
   def withEnabledUser(samUser: SamUser): MockCloudExtensionsBuilder = withEnabledUsers(Set(samUser))
   def withEnabledUsers(samUsers: Iterable[SamUser]): MockCloudExtensionsBuilder = {


### PR DESCRIPTION
Testing the removal of project-specific Pet Service Accounts.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
