### PR TITLE
[IA-5062] Add resource access policies for Leo resource migration

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -817,6 +817,9 @@ resourceTypes = {
       set_parent = {
         description = "set parent of notebook cluster"
       }
+      get_parent = {
+        description = "get parent of notebook cluster"
+      }
     }
     ownerRoleName = "creator"
     roles = {
@@ -849,6 +852,9 @@ resourceTypes = {
       }
       set_parent = {
         description = "set parent of persistent disk"
+      }
+      get_parent = {
+        description = "get parent of persistent disk"
       }
     }
     ownerRoleName = "creator"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -824,7 +824,7 @@ resourceTypes = {
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify", "set_parent"]
+        roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify", "set_parent", "get_parent"]
       }
       manager = {
         roleActions = ["status", "delete", "read_policies"]
@@ -860,7 +860,7 @@ resourceTypes = {
     ownerRoleName = "creator"
     roles = {
       creator = {
-        roleActions = ["read", "attach", "modify", "delete", "read_policies", "set_parent"]
+        roleActions = ["read", "attach", "modify", "delete", "read_policies", "set_parent", "get_parent"]
       }
       manager = {
         roleActions = ["delete", "read", "read_policies"]

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -306,6 +306,7 @@ resourceAccessPolicies {
           {
             resourceTypeName = "workspace",
             actions = [
+              "read_policies",
               "add_child"
             ]
           }
@@ -487,6 +488,7 @@ resourceAccessPolicies {
           {
             resourceTypeName = "google-project",
             actions = [
+              "read_policies",
               "add_child"
             ]
           }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -298,9 +298,7 @@ resourceAccessPolicies {
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This policy can be removed after the migration is complete.
       leo_migration {
-        memberEmails = [
-          ${terra.leo.migration.emails}
-        ]
+        memberEmails = ${terra.leo.migration.emails}
         descendantPermissions = [
           {
             resourceTypeName = "workspace",
@@ -447,9 +445,7 @@ resourceAccessPolicies {
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This policy can be removed after the migration is complete.
       leo_migration {
-        memberEmails = [
-          ${terra.leo.migration.emails}
-        ]
+        memberEmails = ${terra.leo.migration.emails}
         descendantPermissions = [
           {
             resourceTypeName = "notebook-cluster",
@@ -466,9 +462,7 @@ resourceAccessPolicies {
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This policy can be removed after the migration is complete.
       leo_migration {
-        memberEmails = [
-          ${terra.leo.migration.emails}
-        ]
+        memberEmails = ${terra.leo.migration.emails}
         descendantPermissions = [
           {
             resourceTypeName = "persistent-disk",
@@ -485,9 +479,7 @@ resourceAccessPolicies {
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This policy can be removed after the migration is complete.
       leo_migration {
-        memberEmails = [
-          ${terra.leo.migration.emails}
-        ]
+        memberEmails = ${terra.leo.migration.emails}
         descendantPermissions = [
           {
             resourceTypeName = "google-project",

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -3,6 +3,9 @@ akka {
     server {
       idle-timeout = 180 s
       request-timeout = 60 s
+      parsing {
+        max-uri-length = 16k
+      }
     }
     host-connection-pool {
       max-open-requests = 16384

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -248,20 +248,30 @@ janitor {
   trackResourceTopicId = ${?JANITOR_TRACK_RESOURCE_TOPIC_ID}
 }
 
-terra.support.emails = [
-  // dynamically configuring lists is hard, so 10 slots are provided for support emails
-  // add more if more than 10 are ever needed
-  ${?TERRA_SUPPORT_EMAIL_0}
-  ${?TERRA_SUPPORT_EMAIL_1}
-  ${?TERRA_SUPPORT_EMAIL_2}
-  ${?TERRA_SUPPORT_EMAIL_3}
-  ${?TERRA_SUPPORT_EMAIL_4}
-  ${?TERRA_SUPPORT_EMAIL_5}
-  ${?TERRA_SUPPORT_EMAIL_6}
-  ${?TERRA_SUPPORT_EMAIL_7}
-  ${?TERRA_SUPPORT_EMAIL_8}
-  ${?TERRA_SUPPORT_EMAIL_9}
-]
+terra {
+  support.emails = [
+    // dynamically configuring lists is hard, so 10 slots are provided for support emails
+    // add more if more than 10 are ever needed
+    ${?TERRA_SUPPORT_EMAIL_0}
+    ${?TERRA_SUPPORT_EMAIL_1}
+    ${?TERRA_SUPPORT_EMAIL_2}
+    ${?TERRA_SUPPORT_EMAIL_3}
+    ${?TERRA_SUPPORT_EMAIL_4}
+    ${?TERRA_SUPPORT_EMAIL_5}
+    ${?TERRA_SUPPORT_EMAIL_6}
+    ${?TERRA_SUPPORT_EMAIL_7}
+    ${?TERRA_SUPPORT_EMAIL_8}
+    ${?TERRA_SUPPORT_EMAIL_9}
+  ]
+
+  # See https://broadworkbench.atlassian.net/browse/IA-5062
+  # These emails can be removed after the migration is complete.
+  leo.migration.emails = [
+    ${?TERRA_LEO_MIGRATION_EMAIL_0}
+    ${?TERRA_LEO_MIGRATION_EMAIL_1}
+    ${?TERRA_LEO_MIGRATION_EMAIL_2}
+  ]
+}
 
 resourceAccessPolicies {
   resource_type_admin {
@@ -281,6 +291,21 @@ resourceAccessPolicies {
               "rawls"
               # WSM requires one of the roles in its hierarchy, discoverer is the lowest but reader is the lowest that leo understands
               "reader"
+            ]
+          }
+        ]
+      }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = [
+          ${terra.leo.migration.emails}
+        ]
+        descendantPermissions = [
+          {
+            resourceTypeName = "workspace",
+            actions = [
+              "add_child"
             ]
           }
         ]
@@ -413,6 +438,61 @@ resourceAccessPolicies {
             roles = [
               # leo checks for user or owner role, rawls really only needs delete and status actions
               "owner"
+            ]
+          }
+        ]
+      }
+    }
+    notebook-cluster {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = [
+          ${terra.leo.migration.emails}
+        ]
+        descendantPermissions = [
+          {
+            resourceTypeName = "notebook-cluster",
+            actions = [
+              "read_policies",
+              "get_parent",
+              "set_parent"
+            ]
+          }
+        ]
+      }
+    }
+    persistent-disk {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = [
+          ${terra.leo.migration.emails}
+        ]
+        descendantPermissions = [
+          {
+            resourceTypeName = "persistent-disk",
+            actions = [
+              "read_policies",
+              "get_parent",
+              "set_parent"
+            ]
+          }
+        ]
+      }
+    }
+    google-project {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = [
+          ${terra.leo.migration.emails}
+        ]
+        descendantPermissions = [
+          {
+            resourceTypeName = "google-project",
+            actions = [
+              "add_child"
             ]
           }
         ]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-5062

[Design doc](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/3364683793/IA-5062+Migrate+existing+notebook-cluster+and+persistent-disk+resources+to+have+parents)

What:

This PR configures resource access policies in Sam conf to add a `leo_migration` policy containing configurable privileged emails.

Why:

To simplify Leo access control logic, we are running a migration script to set parents for historical `notebook-cluster` and `persistent-disk` Sam resources without a parent. We plan to run the migration as a privileged `@firecloud.org` user, which will need administrative permissions on those Sam resource types.

How:

This approach leverages Sam resource access policies and inheritance of `resource_type_admin` permissions.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
