### PR TITLE
IA-5062 fix: switch to using descendent roles instead of actions

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -251,7 +251,7 @@ resourceTypes = {
         ]
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
+      # This role can be removed after the migration is complete.
       leo_migration = {
         roleActions = ["read_policies", "add_child"]
       }
@@ -685,7 +685,7 @@ resourceTypes = {
         roleActions = ["create-pet"]
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
+      # This role can be removed after the migration is complete.
       leo_mgiration = {
         roleActions = ["read_policies", "add_child"]
       }
@@ -840,7 +840,7 @@ resourceTypes = {
         roleActions = ["status", "delete", "read_policies"]
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
+      # This role can be removed after the migration is complete.
       leo_migration = {
         roleActions = ["read_policies", "get_parent", "set_parent"]
       }
@@ -881,7 +881,7 @@ resourceTypes = {
         roleActions = ["delete", "read", "read_policies"]
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
+      # This role can be removed after the migration is complete.
       leo_migration = {
         roleActions = ["read_policies", "get_parent", "set_parent"]
       }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -250,6 +250,11 @@ resourceTypes = {
           "read"
         ]
       }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration = {
+        roleActions = ["read_policies", "add_child"]
+      }
     }
     authDomainConstrainable = true
     allowLeaving = true
@@ -679,6 +684,11 @@ resourceTypes = {
       pet-creator = {
         roleActions = ["create-pet"]
       }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_mgiration = {
+        roleActions = ["read_policies", "add_child"]
+      }
     }
     reuseIds = true
   }
@@ -829,6 +839,11 @@ resourceTypes = {
       manager = {
         roleActions = ["status", "delete", "read_policies"]
       }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration = {
+        roleActions = ["read_policies", "get_parent", "set_parent"]
+      }
     }
     reuseIds = false
   }
@@ -864,6 +879,11 @@ resourceTypes = {
       }
       manager = {
         roleActions = ["delete", "read", "read_policies"]
+      }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration = {
+        roleActions = ["read_policies", "get_parent", "set_parent"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -252,7 +252,7 @@ resourceTypes = {
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This role can be removed after the migration is complete.
-      leo_migration = {
+      leo_migrator = {
         roleActions = ["read_policies", "add_child"]
       }
     }
@@ -686,7 +686,7 @@ resourceTypes = {
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This role can be removed after the migration is complete.
-      leo_mgiration = {
+      leo_migrator = {
         roleActions = ["read_policies", "add_child"]
       }
     }
@@ -841,7 +841,7 @@ resourceTypes = {
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This role can be removed after the migration is complete.
-      leo_migration = {
+      leo_migrator = {
         roleActions = ["read_policies", "get_parent", "set_parent"]
       }
     }
@@ -882,7 +882,7 @@ resourceTypes = {
       }
       # See https://broadworkbench.atlassian.net/browse/IA-5062
       # This role can be removed after the migration is complete.
-      leo_migration = {
+      leo_migrator = {
         roleActions = ["read_policies", "get_parent", "set_parent"]
       }
     }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -305,7 +305,7 @@ resourceAccessPolicies {
         descendantPermissions = [
           {
             resourceTypeName = "workspace",
-            roles = ["leo_migration"]
+            roles = ["leo_migrator"]
           }
         ]
       }
@@ -450,7 +450,7 @@ resourceAccessPolicies {
         descendantPermissions = [
           {
             resourceTypeName = "notebook-cluster",
-            roles = ["leo_migration"]
+            roles = ["leo_migrator"]
           }
         ]
       }
@@ -463,7 +463,7 @@ resourceAccessPolicies {
         descendantPermissions = [
           {
             resourceTypeName = "persistent-disk",
-            roles = ["leo_migration"]
+            roles = ["leo_migrator"]
           }
         ]
       }
@@ -476,7 +476,7 @@ resourceAccessPolicies {
         descendantPermissions = [
           {
             resourceTypeName = "google-project",
-            roles = ["leo_migration"]
+            roles = ["leo_migrator"]
           }
         ]
       }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -298,6 +298,17 @@ resourceAccessPolicies {
           }
         ]
       }
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = ${terra.leo.migration.emails}
+        descendantPermissions = [
+          {
+            resourceTypeName = "workspace",
+            roles = ["leo_migration"]
+          }
+        ]
+      }
     }
     managed-group {
       support {
@@ -427,6 +438,45 @@ resourceAccessPolicies {
               # leo checks for user or owner role, rawls really only needs delete and status actions
               "owner"
             ]
+          }
+        ]
+      }
+    }
+    notebook-cluster {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = ${terra.leo.migration.emails}
+        descendantPermissions = [
+          {
+            resourceTypeName = "notebook-cluster",
+            roles = ["leo_migration"]
+          }
+        ]
+      }
+    }
+    persistent-disk {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = ${terra.leo.migration.emails}
+        descendantPermissions = [
+          {
+            resourceTypeName = "persistent-disk",
+            roles = ["leo_migration"]
+          }
+        ]
+      }
+    }
+    google-project {
+      # See https://broadworkbench.atlassian.net/browse/IA-5062
+      # This policy can be removed after the migration is complete.
+      leo_migration {
+        memberEmails = ${terra.leo.migration.emails}
+        descendantPermissions = [
+          {
+            resourceTypeName = "google-project",
+            roles = ["leo_migration"]
           }
         ]
       }

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -298,20 +298,6 @@ resourceAccessPolicies {
           }
         ]
       }
-      # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
-      leo_migration {
-        memberEmails = ${terra.leo.migration.emails}
-        descendantPermissions = [
-          {
-            resourceTypeName = "workspace",
-            actions = [
-              "read_policies",
-              "add_child"
-            ]
-          }
-        ]
-      }
     }
     managed-group {
       support {
@@ -440,56 +426,6 @@ resourceAccessPolicies {
             roles = [
               # leo checks for user or owner role, rawls really only needs delete and status actions
               "owner"
-            ]
-          }
-        ]
-      }
-    }
-    notebook-cluster {
-      # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
-      leo_migration {
-        memberEmails = ${terra.leo.migration.emails}
-        descendantPermissions = [
-          {
-            resourceTypeName = "notebook-cluster",
-            actions = [
-              "read_policies",
-              "get_parent",
-              "set_parent"
-            ]
-          }
-        ]
-      }
-    }
-    persistent-disk {
-      # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
-      leo_migration {
-        memberEmails = ${terra.leo.migration.emails}
-        descendantPermissions = [
-          {
-            resourceTypeName = "persistent-disk",
-            actions = [
-              "read_policies",
-              "get_parent",
-              "set_parent"
-            ]
-          }
-        ]
-      }
-    }
-    google-project {
-      # See https://broadworkbench.atlassian.net/browse/IA-5062
-      # This policy can be removed after the migration is complete.
-      leo_migration {
-        memberEmails = ${terra.leo.migration.emails}
-        descendantPermissions = [
-          {
-            resourceTypeName = "google-project",
-            actions = [
-              "read_policies",
-              "add_child"
             ]
           }
         ]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-5062

What:

https://github.com/broadinstitute/sam/pull/1543 added the `leo_migration` resource access policies to Sam. We think it was generating a lot of inserts by using descendent actions instead of roles, which was causing issues in Sam dev. Switching to roles to be more performant.

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
