### PR TITLE
CORE-67 CORE-30 update workbench libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,14 +11,14 @@ object Dependencies {
   val postgresDriverVersion = "42.7.2"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "8d55689" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "9405803" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.20-$workbenchLibV"
-  val workbenchGoogleV = s"0.32-$workbenchLibV"
+  val workbenchGoogleV = s"0.33-$workbenchLibV"
   val workbenchGoogle2V = s"0.36-$workbenchLibV"
-  val workbenchNotificationsV = s"0.6-$workbenchLibV"
-  val workbenchOauth2V = s"0.7-$workbenchLibV"
+  val workbenchNotificationsV = s"0.8-$workbenchLibV"
+  val workbenchOauth2V = s"0.8-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.30-SNAPSHOT"
   val tclVersion = "1.1.12-SNAPSHOT"


### PR DESCRIPTION
Ticket:
https://broadworkbench.atlassian.net/browse/CORE-67
https://broadworkbench.atlassian.net/browse/CORE-30

What:

update workbench libs

Why:

pulls in changes to address CORE-30 (swagger UI header) and CORE-67 (handle 403 from google when getting a service account in a deleted google project)

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
