### PR TITLE
CORE-25: hide akka-http's default `Server` header

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -6,6 +6,7 @@ akka {
       parsing {
         max-uri-length = 16k
       }
+      server-header = ""
     }
     host-connection-pool {
       max-open-requests = 16384


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-25

### What:

Disables the default `Server` header as provided by akka-http. See https://doc.akka.io/docs/akka-http/current/configuration.html for details on the config change.

Note that once akka-http's header is suppressed, the `Server` header from the Apache proxy takes effect, and in practice Apache's header is shown instead.

Reviewer: I see `akka.http.server` config values in both sam.conf ([here](https://github.com/broadinstitute/sam/blob/20cb8c16cfcbd4a064c6c44104394c6165ff43eb/src/main/resources/sam.conf#L3-L9)) and reference.conf ([here](https://github.com/broadinstitute/sam/blob/20cb8c16cfcbd4a064c6c44104394c6165ff43eb/src/main/resources/reference.conf#L3-L4)). Is one preferred over the other?

Before this PR:
![Screenshot 11-10-2024 at 15 56](https://github.com/user-attachments/assets/a20327c9-1ed6-488e-9e31-7366940b80bd)

After this PR:
![Screenshot 11-10-2024 at 15 58](https://github.com/user-attachments/assets/c65dc5cb-c81a-45c0-97d3-8871001991f0)

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
