### PR TITLE
CORE-131 adminGetUsersByIDs searches more kinds of ids

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -199,7 +199,7 @@ paths:
     post:
       tags:
         - Admin
-      summary: Gets a list of users for a list of Sam User IDs
+      summary: Gets a list of users for a list of Sam, Azure B2C, or Google Subject IDs
       operationId: adminGetUsersByIDs
       requestBody:
         content:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -430,7 +430,19 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
     } else {
       readOnlyTransaction("batchLoadUsers", samRequestContext) { implicit session =>
         val userTable = UserTable.syntax
-        val loadUserQuery = samsql"select ${userTable.resultAll} from ${UserTable as userTable} where ${userTable.id} in (${samUserIds})"
+        // the with clause is to keep the query size down, we only send the samUserIds once and reuse it in each unioned query
+        val loadUserQuery =
+          samsql"""
+                  with sam_user_ids (user_id) as (values ${samUserIds.map(id => samsqls"($id)")})
+                  select ${userTable.resultAll} from ${UserTable as userTable}
+                  join sam_user_ids ids on ids.user_id = ${userTable.id}
+                  union
+                  select ${userTable.resultAll} from ${UserTable as userTable}
+                  join sam_user_ids ids on ids.user_id = ${userTable.azureB2cId}
+                  union
+                  select ${userTable.resultAll} from ${UserTable as userTable}
+                  join sam_user_ids ids on ids.user_id = ${userTable.googleSubjectId}
+                  """
 
         loadUserQuery
           .map(UserTable(userTable))

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -630,8 +630,19 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
         assume(databaseEnabled, databaseEnabledClue)
         val users = Seq.range(0, 10).map(_ => Generator.genWorkbenchUserBoth.sample.get)
         users.foreach(user => dao.createUser(user, samRequestContext).unsafeRunSync())
-        val loadedUsers = dao.batchLoadUsers(users.map(_.id).toSet, samRequestContext).unsafeRunSync()
-        loadedUsers should contain theSameElementsAs users
+        val loadedUsersBySamId = dao.batchLoadUsers(users.map(_.id).toSet, samRequestContext).unsafeRunSync()
+        loadedUsersBySamId should contain theSameElementsAs users
+
+        val b2cIds = users.flatMap(_.azureB2CId.map(id => WorkbenchUserId(id.value))).toSet
+        val loadedUsersByAzureB2cId = dao.batchLoadUsers(b2cIds, samRequestContext).unsafeRunSync()
+        loadedUsersByAzureB2cId should contain theSameElementsAs users
+
+        val googleSubjectIds = users.flatMap(_.googleSubjectId.map(id => WorkbenchUserId(id.value))).toSet
+        val loadedUsersByGoogleSubjectId = dao.batchLoadUsers(googleSubjectIds, samRequestContext).unsafeRunSync()
+        loadedUsersByGoogleSubjectId should contain theSameElementsAs users
+
+        val loadedBy2Ids = dao.batchLoadUsers(googleSubjectIds ++ b2cIds, samRequestContext).unsafeRunSync()
+        loadedBy2Ids should contain theSameElementsAs users
       }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-131

What:

Make the `adminGetUsersByIDs` api accept azure b2c and google subject ids in addition to already supported sam ids.

Why:

Orch needs to resolve email addresses for ids returned from Thurloe and at this point there is no telling which id Thurloe will return. Orch currently asks Thurloe for these email addresses but after a change in August, NIH user ids and user emails are stored under different ids. This api will be used to resolve the correct email regardless of which id Thurloe returns.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
