### PR TITLE
CORE-137 Optimize filter resources

### DIFF
--- a/pact4s/README.md
+++ b/pact4s/README.md
@@ -13,8 +13,8 @@ On the command line, you can try the following:
 source env/local.env
 source src/main/resources/rendered/secrets.env
 export PACT_BROKER_URL="https://pact-broker.dsp-eng-tools.broadinstitute.org/"
-export PACT_BROKER_USERNAME=$(vault read -field=basic_auth_read_only_username secret/dsp/pact-broker/users/read-only)
-export PACT_BROKER_PASSWORD=$(vault read -field=basic_auth_read_only_password secret/dsp/pact-broker/users/read-only)
+export PACT_BROKER_USERNAME="$(gcloud secrets versions access latest --project 'broad-dsp-eng-tools' --secret 'pact-broker-users-read-only' | jq -r '.basic_auth_read_only_username')"
+export PACT_BROKER_PASSWORD="$(gcloud secrets versions access latest --project 'broad-dsp-eng-tools' --secret 'pact-broker-users-read-only' | jq -r '.basic_auth_read_only_password')"
 ```
 
 In IntelliJ, you can create a Run Configuration for `SamProviderSpec.scala` and save `Environment Variables` for:

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -158,7 +158,7 @@ object MockTestSupport extends MockTestSupport {
       policyDAO,
       googleExt,
       FakeOpenIDConnectConfiguration,
-      azureService:Option[AzureService]
+      azureService: Option[AzureService]
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -171,6 +171,8 @@ object Dependencies {
   // was included transitively before, now explicit
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.15"
 
+  val caffeine: ModuleID = "com.github.ben-manes.caffeine" % "caffeine" % "3.1.8"
+
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
@@ -222,7 +224,8 @@ object Dependencies {
     sentry,
     sentryLogback,
     okio,
-    terraCommonLib
+    terraCommonLib,
+    caffeine
   )
 
   // Needed because it looks like the dependency overrides of wb-libs doesn't propagate to the importing project...

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/AccessPolicyDAO.scala
@@ -125,7 +125,6 @@ trait AccessPolicyDAO {
       resourceTypeNames: Set[ResourceTypeName],
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
-      actions: Set[ResourceAction],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1780,9 +1780,8 @@ from ${GroupMemberTable as groupMemberTable}
     }
   }
 
-  private val publicResourcesCache: ConcurrentMap[ResourceTypeName, Seq[FilterResourcesResult]] = {
+  private val publicResourcesCache: ConcurrentMap[ResourceTypeName, Seq[FilterResourcesResult]] =
     Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build[ResourceTypeName, Seq[FilterResourcesResult]]().asMap()
-  }
 
   private def getPublicResourcesOfType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Seq[FilterResourcesResult]] = {
     val resourcePolicy = PolicyTable.syntax("resourcePolicy")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1798,8 +1798,8 @@ from ${GroupMemberTable as groupMemberTable}
         select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
           join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
-          join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
-          join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
+          left join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
+          left join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
           join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
         where ${resourcePolicy.public}
           $resourceTypeConstraint
@@ -1810,8 +1810,8 @@ from ${GroupMemberTable as groupMemberTable}
         select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
           join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
-          join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
-          join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
+          left join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
+          left join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
           join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
         where ${resourcePolicy.public}
           $resourceTypeConstraint
@@ -1820,32 +1820,35 @@ from ${GroupMemberTable as groupMemberTable}
     readOnlyTransaction("filterResourcesPublic", samRequestContext) { implicit session =>
       publicResourcesCache.computeIfAbsent(
         resourceTypeName,
-        resourceTypeName =>
-          publicRoleActionQuery
+        resourceTypeName => {
+          val roles = publicRoleActionQuery
             .map(rs =>
               FilterResourcesResult(
                 rs.get[ResourceId](resource.resultName.name),
                 resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
                 rs.get[AccessPolicyName](resourcePolicy.resultName.name),
-                Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
-                rs.get[Boolean](resourcePolicy.resultName.public),
-                rs.booleanOpt("inherited").getOrElse(false)
-              )
-            )
-            .list()
-            .apply() ++ publicPolicyActionQuery
-            .map(rs =>
-              FilterResourcesResult(
-                rs.get[ResourceId](resource.resultName.name),
-                resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
-                rs.get[AccessPolicyName](resourcePolicy.resultName.name),
-                Right(rs.get[ResourceAction](resourceAction.resultName.action)),
+                rs.stringOpt(resourceRole.resultName.role).map(r => Left[ResourceRoleName, ResourceAction](ResourceRoleName(r))),
                 rs.get[Boolean](resourcePolicy.resultName.public),
                 rs.booleanOpt("inherited").getOrElse(false)
               )
             )
             .list()
             .apply()
+          val actions = publicPolicyActionQuery
+            .map(rs =>
+              FilterResourcesResult(
+                rs.get[ResourceId](resource.resultName.name),
+                resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
+                rs.get[AccessPolicyName](resourcePolicy.resultName.name),
+                rs.stringOpt(resourceAction.resultName.action).map(a => Right[ResourceRoleName, ResourceAction](ResourceAction(a))),
+                rs.get[Boolean](resourcePolicy.resultName.public),
+                rs.booleanOpt("inherited").getOrElse(false)
+              )
+            )
+            .list()
+            .apply()
+          roles ++ actions
+        }
       )
     }
   }
@@ -1878,9 +1881,9 @@ from ${GroupMemberTable as groupMemberTable}
           from ${GroupMemberFlatTable as groupMemberFlat}
             join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
-            join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
-            join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
             join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
+            left join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
+            left join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
           where ${groupMemberFlat.memberUserId} = ${samUserId}
             $resourceTypeConstraint
             $policyConstraint
@@ -1893,9 +1896,9 @@ from ${GroupMemberTable as groupMemberTable}
           from ${GroupMemberFlatTable as groupMemberFlat}
             join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
-            join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
-            join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
             join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
+            left join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
+            left join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
           where ${groupMemberFlat.memberUserId} = ${samUserId}
             $resourceTypeConstraint
             $policyConstraint
@@ -1908,7 +1911,7 @@ from ${GroupMemberTable as groupMemberTable}
             rs.get[ResourceId](resource.resultName.name),
             resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
             rs.get[AccessPolicyName](resourcePolicy.resultName.name),
-            Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
+            rs.stringOpt(resourceRole.resultName.role).map(r => Left[ResourceRoleName, ResourceAction](ResourceRoleName(r))),
             rs.get[Boolean](resourcePolicy.resultName.public),
             rs.booleanOpt("inherited").getOrElse(false)
           )
@@ -1926,7 +1929,7 @@ from ${GroupMemberTable as groupMemberTable}
               rs.get[ResourceId](resource.resultName.name),
               resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
               rs.get[AccessPolicyName](resourcePolicy.resultName.name),
-              Right(rs.get[ResourceAction](resourceAction.resultName.action)),
+              rs.stringOpt(resourceAction.resultName.action).map(a => Right[ResourceRoleName, ResourceAction](ResourceAction(a))),
               rs.get[Boolean](resourcePolicy.resultName.public),
               rs.booleanOpt("inherited").getOrElse(false)
             )
@@ -1958,7 +1961,7 @@ from ${GroupMemberTable as groupMemberTable}
       privateResources <- filterPrivateResources(samUserId, resourceTypeNames, policies, roles, samRequestContext)
     } yield publicResources
       .filter(r => policies.isEmpty || policies.contains(r.policy))
-      .filter(r => roles.isEmpty || r.roleOrAction.left.exists(role => roles.contains(role))) ++ privateResources
+      .filter(r => roles.isEmpty || r.roleOrAction.exists(_.left.exists(role => roles.contains(role)))) ++ privateResources
 
   private def recreateEffectivePolicyRolesTableEntry(resourceTypeNames: Set[ResourceTypeName])(implicit session: DBSession): Int = {
     val resource = ResourceTable.syntax("resource")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1831,8 +1831,6 @@ from ${GroupMemberTable as groupMemberTable}
                 rs.get[AccessPolicyName](resourcePolicy.resultName.name),
                 Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
                 rs.get[Boolean](resourcePolicy.resultName.public),
-                None,
-                false,
                 rs.booleanOpt("inherited").getOrElse(false)
               )
             )
@@ -1845,8 +1843,6 @@ from ${GroupMemberTable as groupMemberTable}
                 rs.get[AccessPolicyName](resourcePolicy.resultName.name),
                 Right(rs.get[ResourceAction](resourceAction.resultName.action)),
                 rs.get[Boolean](resourcePolicy.resultName.public),
-                None,
-                false,
                 rs.booleanOpt("inherited").getOrElse(false)
               )
             )
@@ -1871,9 +1867,6 @@ from ${GroupMemberTable as groupMemberTable}
     val roleAction = RoleActionTable.syntax("roleAction")
     val resourceAction = ResourceActionTable.syntax("resourceAction")
     val resource = ResourceTable.syntax("resource")
-    val authDomain = AuthDomainTable.syntax("authDomain")
-    val authDomainGroup = GroupTable.syntax("authDomainGroup")
-    val authDomainGroupMemberFlat = GroupMemberFlatTable.syntax("authDomainGroupMemberFlat")
 
     val resourceTypeConstraint =
       if (resourceTypeNames.nonEmpty) samsqls"and ${resource.resourceTypeId} in (${resourceTypeNames.flatMap(resourceTypePKsByName.get)})"
@@ -1883,16 +1876,13 @@ from ${GroupMemberTable as groupMemberTable}
 
     val policyRoleActionQuery =
       samsql"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
             join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
             join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
             join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
             join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
-            left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
-            left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
-            left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
           where ${groupMemberFlat.memberUserId} = ${samUserId}
             $resourceTypeConstraint
             $policyConstraint
@@ -1901,16 +1891,13 @@ from ${GroupMemberTable as groupMemberTable}
 
     val policyActionQuery =
       samsql"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
             join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
             join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
             join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
             join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
             join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
-            left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
-            left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
-            left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
           where ${groupMemberFlat.memberUserId} = ${samUserId}
             $resourceTypeConstraint
             $policyConstraint
@@ -1925,8 +1912,6 @@ from ${GroupMemberTable as groupMemberTable}
             rs.get[AccessPolicyName](resourcePolicy.resultName.name),
             Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
             rs.get[Boolean](resourcePolicy.resultName.public),
-            rs.stringOpt(authDomainGroup.resultName.name).map(WorkbenchGroupName(_)),
-            rs.booleanOpt("in_auth_domain").getOrElse(false),
             rs.booleanOpt("inherited").getOrElse(false)
           )
         )
@@ -1945,8 +1930,6 @@ from ${GroupMemberTable as groupMemberTable}
               rs.get[AccessPolicyName](resourcePolicy.resultName.name),
               Right(rs.get[ResourceAction](resourceAction.resultName.action)),
               rs.get[Boolean](resourcePolicy.resultName.public),
-              rs.stringOpt(authDomainGroup.resultName.name).map(WorkbenchGroupName(_)),
-              rs.booleanOpt("in_auth_domain").getOrElse(false),
               rs.booleanOpt("inherited").getOrElse(false)
             )
           )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -22,10 +22,11 @@ import scalikejdbc._
 import scala.collection.concurrent.TrieMap
 import scala.util.{Failure, Try}
 import cats.effect.Temporal
+import com.github.benmanes.caffeine.cache.Caffeine
 import org.apache.commons.collections4.map.PassiveExpiringMap
 
 import java.util.Collections
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ConcurrentMap, TimeUnit}
 
 class PostgresAccessPolicyDAO(
     protected val writeDbRef: DbReference,
@@ -1779,8 +1780,9 @@ from ${GroupMemberTable as groupMemberTable}
     }
   }
 
-  private val publicResourcesCache: java.util.Map[ResourceTypeName, Seq[FilterResourcesResult]] =
-    Collections.synchronizedMap(new PassiveExpiringMap(1, TimeUnit.HOURS))
+  private val publicResourcesCache: ConcurrentMap[ResourceTypeName, Seq[FilterResourcesResult]] = {
+    Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build[ResourceTypeName, Seq[FilterResourcesResult]]().asMap()
+  }
 
   private def getPublicResourcesOfType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Seq[FilterResourcesResult]] = {
     val resourcePolicy = PolicyTable.syntax("resourcePolicy")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -23,9 +23,6 @@ import scala.collection.concurrent.TrieMap
 import scala.util.{Failure, Try}
 import cats.effect.Temporal
 import com.github.benmanes.caffeine.cache.Caffeine
-import org.apache.commons.collections4.map.PassiveExpiringMap
-
-import java.util.Collections
 import java.util.concurrent.{ConcurrentMap, TimeUnit}
 
 class PostgresAccessPolicyDAO(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAO.scala
@@ -1794,53 +1794,56 @@ from ${GroupMemberTable as groupMemberTable}
 
     val resourceTypeConstraint =
       samsqls"and ${resource.resourceTypeId} = ${resourceTypePKsByName.get(resourceTypeName)}"
-    val notNullConstraintRoleAction =
-      samsqls"and not (${resourceRole.role} is null and ${resourceAction.action} is null)"
-    val notNullConstraintPolicyAction = samsqls"and not (${resourceAction.action} is null)"
 
     val publicRoleActionQuery =
-      samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+      samsql"""
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
-          left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
-          left join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
-          left join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
-          left join ${RoleActionTable as roleAction} on ${effectivePolicyRole.resourceRoleId} = ${roleAction.resourceRoleId}
-          left join ${ResourceActionTable as resourceAction} on ${roleAction.resourceActionId} = ${resourceAction.id}
-          left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
+          join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
+          join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
+          join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
+          join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
         where ${resourcePolicy.public}
           $resourceTypeConstraint
-          $notNullConstraintRoleAction
           """
 
     val publicPolicyActionQuery =
-      samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+      samsql"""
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${resourcePolicy.resourceId} != ${resource.id} as inherited
         from ${PolicyTable as resourcePolicy}
-          left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
-          left join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
-          left join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
-          left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
+          join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId} and ${resourcePolicy.public}
+          join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
+          join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
+          join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id} $resourceTypeConstraint
         where ${resourcePolicy.public}
           $resourceTypeConstraint
-          $notNullConstraintPolicyAction
                 """
-
-    val includePublicPolicyActionQuery = samsqls"union all $publicPolicyActionQuery"
-    val publicResourcesQuery = samsql"$publicRoleActionQuery $includePublicPolicyActionQuery"
 
     readOnlyTransaction("filterResourcesPublic", samRequestContext) { implicit session =>
       publicResourcesCache.computeIfAbsent(
         resourceTypeName,
         resourceTypeName =>
-          publicResourcesQuery
+          publicRoleActionQuery
             .map(rs =>
               FilterResourcesResult(
                 rs.get[ResourceId](resource.resultName.name),
                 resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
-                rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
-                rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
-                rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),
+                rs.get[AccessPolicyName](resourcePolicy.resultName.name),
+                Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
+                rs.get[Boolean](resourcePolicy.resultName.public),
+                None,
+                false,
+                rs.booleanOpt("inherited").getOrElse(false)
+              )
+            )
+            .list()
+            .apply() ++ publicPolicyActionQuery
+            .map(rs =>
+              FilterResourcesResult(
+                rs.get[ResourceId](resource.resultName.name),
+                resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
+                rs.get[AccessPolicyName](resourcePolicy.resultName.name),
+                Right(rs.get[ResourceAction](resourceAction.resultName.action)),
                 rs.get[Boolean](resourcePolicy.resultName.public),
                 None,
                 false,
@@ -1857,7 +1860,6 @@ from ${GroupMemberTable as groupMemberTable}
       resourceTypeNames: Set[ResourceTypeName],
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
-      actions: Set[ResourceAction],
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] = {
     val groupMemberFlat = GroupMemberFlatTable.syntax("groupMemberFlat")
@@ -1878,22 +1880,16 @@ from ${GroupMemberTable as groupMemberTable}
       else samsqls"and ${resource.resourceTypeId} in (${resourceTypeNamesByPK.keys.map(_.value)})"
     val policyConstraint = if (policies.nonEmpty) samsqls"and ${resourcePolicy.name} in (${policies})" else samsqls""
     val roleConstraint = if (roles.nonEmpty) samsqls"and ${resourceRole.role} in (${roles})" else samsqls""
-    val actionConstraint = if (actions.nonEmpty) samsqls"and ${resourceAction.action} in (${actions})" else samsqls""
-    val notNullConstraintRoleAction =
-      samsqls"and not (${resourceRole.role} is null and ${resourceAction.action} is null)"
-    val notNullConstraintPolicyAction = samsqls"and not (${resourceAction.action} is null)"
 
     val policyRoleActionQuery =
-      samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+      samsql"""
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceRole.result.role}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
-            left join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
-            left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
-            left join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
-            left join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
-            left join ${RoleActionTable as roleAction} on ${effectivePolicyRole.resourceRoleId} = ${roleAction.resourceRoleId}
-            left join ${ResourceActionTable as resourceAction} on ${roleAction.resourceActionId} = ${resourceAction.id}
-            left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
+            join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
+            join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
+            join ${EffectivePolicyRoleTable as effectivePolicyRole} on ${effectiveResourcePolicy.id} = ${effectivePolicyRole.effectiveResourcePolicyId}
+            join ${ResourceRoleTable as resourceRole} on ${effectivePolicyRole.resourceRoleId} = ${resourceRole.id}
+            join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
             left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
             left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
             left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
@@ -1901,43 +1897,33 @@ from ${GroupMemberTable as groupMemberTable}
             $resourceTypeConstraint
             $policyConstraint
             $roleConstraint
-            $actionConstraint
-            $notNullConstraintRoleAction
             """
 
     val policyActionQuery =
-      samsqls"""
-        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, null as ${resourceRole.resultName.role}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
+      samsql"""
+        select ${resource.result.name}, ${resource.result.resourceTypeId}, ${resourcePolicy.result.name}, ${resourceAction.result.action}, ${resourcePolicy.result.public}, ${authDomainGroup.result.name}, ${authDomainGroupMemberFlat.memberUserId} is not null as in_auth_domain, ${resourcePolicy.resourceId} != ${resource.id} as inherited
           from ${GroupMemberFlatTable as groupMemberFlat}
-            left join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
-            left join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
-            left join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
-            left join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
-            left join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
+            join ${PolicyTable as resourcePolicy} on ${groupMemberFlat.groupId} = ${resourcePolicy.groupId}
+            join ${EffectiveResourcePolicyTable as effectiveResourcePolicy} on ${resourcePolicy.id} = ${effectiveResourcePolicy.sourcePolicyId}
+            join ${EffectivePolicyActionTable as effectivePolicyAction} on ${effectiveResourcePolicy.id} = ${effectivePolicyAction.effectiveResourcePolicyId}
+            join ${ResourceActionTable as resourceAction} on ${effectivePolicyAction.resourceActionId} = ${resourceAction.id}
+            join ${ResourceTable as resource} on ${effectiveResourcePolicy.resourceId} = ${resource.id}
             left join ${AuthDomainTable as authDomain} on ${authDomain.resourceId} = ${resource.id}
             left join ${GroupTable as authDomainGroup} on ${authDomainGroup.id} = ${authDomain.groupId}
             left join ${GroupMemberFlatTable as authDomainGroupMemberFlat} on ${authDomainGroup.id} = ${authDomainGroupMemberFlat.groupId} and ${authDomainGroupMemberFlat.memberUserId} = ${samUserId}
           where ${groupMemberFlat.memberUserId} = ${samUserId}
             $resourceTypeConstraint
             $policyConstraint
-            $actionConstraint
-            $notNullConstraintPolicyAction
             """
 
-    val includePolicyActionQuery = if (roles.isEmpty) samsqls"union all $policyActionQuery" else samsqls""
-    val query =
-      samsqls"""$policyRoleActionQuery
-                            $includePolicyActionQuery"""
-
     readOnlyTransaction("filterResources", samRequestContext) { implicit session =>
-      samsql"$query"
+      val rolesResult = policyRoleActionQuery
         .map(rs =>
           FilterResourcesResult(
             rs.get[ResourceId](resource.resultName.name),
             resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
-            rs.stringOpt(resourcePolicy.resultName.name).map(AccessPolicyName(_)),
-            rs.stringOpt(resourceRole.resultName.role).map(ResourceRoleName(_)),
-            rs.stringOpt(resourceAction.resultName.action).map(ResourceAction(_)),
+            rs.get[AccessPolicyName](resourcePolicy.resultName.name),
+            Left(rs.get[ResourceRoleName](resourceRole.resultName.role)),
             rs.get[Boolean](resourcePolicy.resultName.public),
             rs.stringOpt(authDomainGroup.resultName.name).map(WorkbenchGroupName(_)),
             rs.booleanOpt("in_auth_domain").getOrElse(false),
@@ -1946,6 +1932,29 @@ from ${GroupMemberTable as groupMemberTable}
         )
         .list()
         .apply()
+
+      // if roles is not empty that means we are filtering by roles and we don't need to query for actions directly on a policy since they have no roles
+      val actionsResult = if (roles.nonEmpty) {
+        List.empty
+      } else {
+        policyActionQuery
+          .map(rs =>
+            FilterResourcesResult(
+              rs.get[ResourceId](resource.resultName.name),
+              resourceTypeNamesByPK(rs.get[ResourceTypePK](resource.resultName.resourceTypeId)),
+              rs.get[AccessPolicyName](resourcePolicy.resultName.name),
+              Right(rs.get[ResourceAction](resourceAction.resultName.action)),
+              rs.get[Boolean](resourcePolicy.resultName.public),
+              rs.stringOpt(authDomainGroup.resultName.name).map(WorkbenchGroupName(_)),
+              rs.booleanOpt("in_auth_domain").getOrElse(false),
+              rs.booleanOpt("inherited").getOrElse(false)
+            )
+          )
+          .list()
+          .apply()
+      }
+      rolesResult ++ actionsResult
+
     }
   }
 
@@ -1954,7 +1963,6 @@ from ${GroupMemberTable as groupMemberTable}
       resourceTypeNames: Set[ResourceTypeName],
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
-      actions: Set[ResourceAction],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] =
@@ -1966,11 +1974,10 @@ from ${GroupMemberTable as groupMemberTable}
             .sequence
             .map(_.flatten)
         } else IO.pure(List.empty)
-      privateResources <- filterPrivateResources(samUserId, resourceTypeNames, policies, roles, actions, samRequestContext)
+      privateResources <- filterPrivateResources(samUserId, resourceTypeNames, policies, roles, samRequestContext)
     } yield publicResources
-      .filter(r => policies.isEmpty || r.policy.exists(p => policies.contains(p)))
-      .filter(r => roles.isEmpty || r.role.exists(role => roles.contains(role)))
-      .filter(r => actions.isEmpty || r.action.exists(action => actions.contains(action))) ++ privateResources
+      .filter(r => policies.isEmpty || policies.contains(r.policy))
+      .filter(r => roles.isEmpty || r.roleOrAction.left.exists(role => roles.contains(role))) ++ privateResources
 
   private def recreateEffectivePolicyRolesTableEntry(resourceTypeNames: Set[ResourceTypeName])(implicit session: DBSession): Int = {
     val resource = ResourceTable.syntax("resource")

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
@@ -5,9 +5,8 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 case class FilterResourcesResult(
     resourceId: ResourceId,
     resourceTypeName: ResourceTypeName,
-    policy: Option[AccessPolicyName],
-    role: Option[ResourceRoleName],
-    action: Option[ResourceAction],
+    policy: AccessPolicyName,
+    roleOrAction: Either[ResourceRoleName, ResourceAction],
     isPublic: Boolean,
     authDomain: Option[WorkbenchGroupName],
     inAuthDomain: Boolean,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
@@ -1,14 +1,10 @@
 package org.broadinstitute.dsde.workbench.sam.model
 
-import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
-
 case class FilterResourcesResult(
     resourceId: ResourceId,
     resourceTypeName: ResourceTypeName,
     policy: AccessPolicyName,
     roleOrAction: Either[ResourceRoleName, ResourceAction],
     isPublic: Boolean,
-    authDomain: Option[WorkbenchGroupName],
-    inAuthDomain: Boolean,
     inherited: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/FilterResourcesResult.scala
@@ -4,7 +4,7 @@ case class FilterResourcesResult(
     resourceId: ResourceId,
     resourceTypeName: ResourceTypeName,
     policy: AccessPolicyName,
-    roleOrAction: Either[ResourceRoleName, ResourceAction],
+    roleOrAction: Option[Either[ResourceRoleName, ResourceAction]],
     isPublic: Boolean,
     inherited: Boolean
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -1042,11 +1042,11 @@ class ResourceService(
       .map { tuple =>
         val (k, v) = tuple
         val grouped = v.foldLeft(GroupedDbRows()) { (acc: GroupedDbRows, r: FilterResourcesResult) =>
-          val role = r.roleOrAction.left.toOption
+          val role = r.roleOrAction.flatMap(_.left.toOption)
           val roleActions = role.flatMap(roleName => getRoleActions(r.resourceTypeName, roleName, filterActions)).getOrElse(Set.empty)
           // if filterActions is not emtpy, we only want to include roles that still have actions
           val filteredRole = if (filterActions.isEmpty) role else role.filter(_ => roleActions.nonEmpty)
-          val policyActions = r.roleOrAction.toOption.toSet
+          val policyActions = r.roleOrAction.flatMap(_.toOption).toSet
           // if filterActions is not emtpy, we only want to include actions that are in the filterActions set
           val filteredPolicyActions = if (filterActions.isEmpty) policyActions else policyActions.intersect(filterActions)
           acc.copy(
@@ -1092,10 +1092,10 @@ class ResourceService(
           .map { policyTuple =>
             val (policyName, policyRows) = policyTuple
             // if filterActions is not emtpy, we only want to include actions that are in the filterActions set
-            val policyActions = policyRows.flatMap(_.roleOrAction.toOption).toSet
+            val policyActions = policyRows.flatMap(_.roleOrAction.flatMap(_.toOption)).toSet
             val filteredPolicyActions = if (filterActions.isEmpty) policyActions else policyActions.intersect(filterActions)
             val roles = policyRows
-              .flatMap(_.roleOrAction.left.toOption)
+              .flatMap(_.roleOrAction.flatMap(_.left.toOption))
               .map { roleName =>
                 FilteredResourceHierarchicalRole(
                   roleName,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -116,7 +116,10 @@ class ResourceService(
                 samRequestContext
               )
             }
-        } yield upsertedPolicy
+        } yield {
+          logger.info(s"Upserted policy $fullyQualifiedPolicyId")
+          upsertedPolicy
+        }
         upsertIO.attempt.map(fullyQualifiedPolicyId -> _)
       }
       .map(_.toMap)
@@ -1028,19 +1031,26 @@ class ResourceService(
       authDomainGroups: Map[WorkbenchGroupName, Boolean] = Map.empty
   )
 
-  private def groupFlat(dbResult: Seq[FilterResourcesResult]): FilteredResourcesFlat = {
+  private def groupFlat(dbResult: Seq[FilterResourcesResult], filterActions: Set[ResourceAction]): FilteredResourcesFlat = {
     val groupedFilteredResource = dbResult
       .groupBy(_.resourceId)
       .map { tuple =>
         val (k, v) = tuple
-        val grouped = v.foldLeft(GroupedDbRows())((acc: GroupedDbRows, r: FilterResourcesResult) =>
+        val grouped = v.foldLeft(GroupedDbRows()) { (acc: GroupedDbRows, r: FilterResourcesResult) =>
+          val role = r.roleOrAction.left.toOption
+          val roleActions = role.flatMap(roleName => getRoleActions(r.resourceTypeName, roleName, filterActions)).getOrElse(Set.empty)
+          // if filterActions is not emtpy, we only want to include roles that still have actions
+          val filteredRole = if (filterActions.isEmpty) role else role.filter(_ => roleActions.nonEmpty)
+          val policyActions = r.roleOrAction.toOption.toSet
+          // if filterActions is not emtpy, we only want to include actions that are in the filterActions set
+          val filteredPolicyActions = if (filterActions.isEmpty) policyActions else policyActions.intersect(filterActions)
           acc.copy(
-            policies = acc.policies ++ r.policy.map(p => FilteredResourceFlatPolicy(p, r.isPublic, r.inherited)),
-            roles = acc.roles ++ r.role,
-            actions = acc.actions ++ r.action,
+            policies = acc.policies + FilteredResourceFlatPolicy(r.policy, r.isPublic, r.inherited),
+            roles = acc.roles ++ filteredRole,
+            actions = acc.actions ++ filteredPolicyActions ++ roleActions,
             authDomainGroups = acc.authDomainGroups ++ r.authDomain.map(_ -> r.inAuthDomain)
           )
-        )
+        }
 
         FilteredResourceFlat(
           resourceId = k,
@@ -1056,25 +1066,36 @@ class ResourceService(
     FilteredResourcesFlat(resources = groupedFilteredResource)
   }
 
-  private def groupHierarchical(dbResult: Seq[FilterResourcesResult]): FilteredResourcesHierarchical = {
+  private def getRoleActions(resourceTypeName: ResourceTypeName, roleName: ResourceRoleName, filterActions: Set[ResourceAction]) =
+    // if filterActions is not emtpy, we only want to include actions that are in the filterActions set
+    resourceTypes(resourceTypeName).roles
+      .find(_.roleName == roleName)
+      .map(actions => if (filterActions.isEmpty) actions.actions else actions.actions.intersect(filterActions))
+
+  private def groupHierarchical(dbResult: Seq[FilterResourcesResult], filterActions: Set[ResourceAction]): FilteredResourcesHierarchical = {
     val groupedFilteredResources = dbResult
       .groupBy(_.resourceId)
       .map { tuple =>
         val (resourceId, resourceRows) = tuple
         val policies = resourceRows
-          .groupBy(_.policy.get)
+          .groupBy(_.policy)
           .map { policyTuple =>
             val (policyName, policyRows) = policyTuple
-            val actionsWithoutRoles = policyRows.filter(_.role.isEmpty).flatMap(_.action).toSet
-            val actionsWithRoles = policyRows.filter(_.role.nonEmpty)
-            val roles = actionsWithRoles
-              .groupBy(_.role.get)
-              .map { roleTuple =>
-                val (roleName, roleRows) = roleTuple
-                FilteredResourceHierarchicalRole(roleName, roleRows.flatMap(_.action).toSet)
+            // if filterActions is not emtpy, we only want to include actions that are in the filterActions set
+            val policyActions = policyRows.flatMap(_.roleOrAction.toOption).toSet
+            val filteredPolicyActions = if (filterActions.isEmpty) policyActions else policyActions.intersect(filterActions)
+            val roles = policyRows
+              .flatMap(_.roleOrAction.left.toOption)
+              .map { roleName =>
+                FilteredResourceHierarchicalRole(
+                  roleName,
+                  getRoleActions(policyRows.head.resourceTypeName, roleName, filterActions).getOrElse(Set.empty)
+                )
               }
               .toSet
-            FilteredResourceHierarchicalPolicy(policyName, roles, actionsWithoutRoles, policyRows.head.isPublic, policyRows.head.inherited)
+            // if filterActions is not emtpy, we only want to include roles that still have actions
+            val filteredRoles = if (filterActions.isEmpty) roles else roles.filter(_.actions.nonEmpty)
+            FilteredResourceHierarchicalPolicy(policyName, filteredRoles, filteredPolicyActions, policyRows.head.isPublic, policyRows.head.inherited)
           }
           .toSet
         val authDomainGroupMemberships = resourceRows.flatMap(r => r.authDomain.map(_ -> r.inAuthDomain)).toMap
@@ -1125,7 +1146,20 @@ class ResourceService(
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesFlat] =
-    accessPolicyDAO.filterResources(samUserId, resourceTypeNames, policies, roles, actions, includePublic, samRequestContext).map(groupFlat)
+    // note that filtering by actions is implemented by application logic, not by the database query
+    // adding actions to the query would make return many more rows than necessary because roles can have many actions
+    // and those actions are static and already in memory
+    accessPolicyDAO
+      .filterResources(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext)
+      .map(groupFlat(_, actions))
+      .map(results =>
+        // If we are filtering by actions, remove any resources that don't have the actions
+        if (actions.nonEmpty) {
+          results.copy(resources = results.resources.map(resource => resource.copy(actions = actions.intersect(resource.actions))).filter(_.actions.nonEmpty))
+        } else {
+          results
+        }
+      )
 
   def listResourcesHierarchical(
       samUserId: WorkbenchUserId,
@@ -1136,7 +1170,18 @@ class ResourceService(
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesHierarchical] =
+    // note that filtering by actions is implemented by application logic, not by the database query
+    // adding actions to the query would make return many more rows than necessary because roles can have many actions
+    // and those actions are static and already in memory
     accessPolicyDAO
-      .filterResources(samUserId, resourceTypeNames, policies, roles, actions, includePublic, samRequestContext)
-      .map(groupHierarchical)
+      .filterResources(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext)
+      .map(groupHierarchical(_, actions))
+      .map(results =>
+        // If we are filtering by actions, remove any resources that don't have the actions either directly or through a role
+        if (actions.nonEmpty) {
+          results.copy(resources = results.resources.filter(resource => resource.policies.exists(policy => policy.actions.nonEmpty || policy.roles.nonEmpty)))
+        } else {
+          results
+        }
+      )
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceService.scala
@@ -1031,7 +1031,12 @@ class ResourceService(
       authDomainGroups: Map[WorkbenchGroupName, Boolean] = Map.empty
   )
 
-  private def groupFlat(dbResult: Seq[FilterResourcesResult], filterActions: Set[ResourceAction]): FilteredResourcesFlat = {
+  private def groupFlat(
+      dbResult: Seq[FilterResourcesResult],
+      filterActions: Set[ResourceAction],
+      resourceAuthDomains: Map[FullyQualifiedResourceId, Set[WorkbenchGroupName]],
+      userGroups: Set[WorkbenchGroupName]
+  ): FilteredResourcesFlat = {
     val groupedFilteredResource = dbResult
       .groupBy(_.resourceId)
       .map { tuple =>
@@ -1047,19 +1052,19 @@ class ResourceService(
           acc.copy(
             policies = acc.policies + FilteredResourceFlatPolicy(r.policy, r.isPublic, r.inherited),
             roles = acc.roles ++ filteredRole,
-            actions = acc.actions ++ filteredPolicyActions ++ roleActions,
-            authDomainGroups = acc.authDomainGroups ++ r.authDomain.map(_ -> r.inAuthDomain)
+            actions = acc.actions ++ filteredPolicyActions ++ roleActions
           )
         }
 
+        val authDomainGroups = resourceAuthDomains.getOrElse(FullyQualifiedResourceId(v.head.resourceTypeName, k), Set.empty)
         FilteredResourceFlat(
           resourceId = k,
           resourceType = v.head.resourceTypeName,
           policies = grouped.policies,
           roles = grouped.roles,
           actions = grouped.actions,
-          authDomainGroups = grouped.authDomainGroups.keySet,
-          missingAuthDomainGroups = grouped.authDomainGroups.filter(!_._2).keySet // Get only the auth domains where the user is not a member.
+          authDomainGroups = authDomainGroups,
+          missingAuthDomainGroups = authDomainGroups -- userGroups
         )
       }
       .toSet
@@ -1072,7 +1077,12 @@ class ResourceService(
       .find(_.roleName == roleName)
       .map(actions => if (filterActions.isEmpty) actions.actions else actions.actions.intersect(filterActions))
 
-  private def groupHierarchical(dbResult: Seq[FilterResourcesResult], filterActions: Set[ResourceAction]): FilteredResourcesHierarchical = {
+  private def groupHierarchical(
+      dbResult: Seq[FilterResourcesResult],
+      filterActions: Set[ResourceAction],
+      resourceAuthDomains: Map[FullyQualifiedResourceId, Set[WorkbenchGroupName]],
+      userGroups: Set[WorkbenchGroupName]
+  ): FilteredResourcesHierarchical = {
     val groupedFilteredResources = dbResult
       .groupBy(_.resourceId)
       .map { tuple =>
@@ -1098,13 +1108,14 @@ class ResourceService(
             FilteredResourceHierarchicalPolicy(policyName, filteredRoles, filteredPolicyActions, policyRows.head.isPublic, policyRows.head.inherited)
           }
           .toSet
-        val authDomainGroupMemberships = resourceRows.flatMap(r => r.authDomain.map(_ -> r.inAuthDomain)).toMap
+        val fullyQualifiedResourceId = FullyQualifiedResourceId(resourceRows.head.resourceTypeName, resourceId)
+        val authDomainGroups = resourceAuthDomains.getOrElse(fullyQualifiedResourceId, Set.empty)
         FilteredResourceHierarchical(
           resourceId = resourceId,
           resourceType = resourceRows.head.resourceTypeName,
           policies = policies,
-          authDomainGroups = authDomainGroupMemberships.keySet,
-          missingAuthDomainGroups = authDomainGroupMemberships.filter(!_._2).keySet // Get only the auth domains where the user is not a member.
+          authDomainGroups = authDomainGroups,
+          missingAuthDomainGroups = authDomainGroups -- userGroups
         )
       }
       .toSet
@@ -1146,20 +1157,16 @@ class ResourceService(
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesFlat] =
-    // note that filtering by actions is implemented by application logic, not by the database query
-    // adding actions to the query would make return many more rows than necessary because roles can have many actions
-    // and those actions are static and already in memory
-    accessPolicyDAO
-      .filterResources(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext)
-      .map(groupFlat(_, actions))
-      .map(results =>
-        // If we are filtering by actions, remove any resources that don't have the actions
+    listResourcesAndTransform(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext) {
+      case (filterResults, resourceAuthDomains, userGroups) =>
+        val groupedResults = groupFlat(filterResults, actions, resourceAuthDomains, userGroups)
+        // If we are filtering by actions, remove any resources that don't have the actions either directly or through a role
         if (actions.nonEmpty) {
-          results.copy(resources = results.resources.map(resource => resource.copy(actions = actions.intersect(resource.actions))).filter(_.actions.nonEmpty))
+          groupedResults.copy(resources = groupedResults.resources.filter(resource => resource.roles.nonEmpty || resource.actions.nonEmpty))
         } else {
-          results
+          groupedResults
         }
-      )
+    }
 
   def listResourcesHierarchical(
       samUserId: WorkbenchUserId,
@@ -1170,18 +1177,72 @@ class ResourceService(
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[FilteredResourcesHierarchical] =
+    listResourcesAndTransform(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext) {
+      case (filterResults, resourceAuthDomains, userGroups) =>
+        val groupedResults = groupHierarchical(filterResults, actions, resourceAuthDomains, userGroups)
+        // If we are filtering by actions, remove any resources that don't have the actions either directly or through a role
+        if (actions.nonEmpty) {
+          groupedResults.copy(resources =
+            groupedResults.resources.filter(resource => resource.policies.exists(policy => policy.actions.nonEmpty || policy.roles.nonEmpty))
+          )
+        } else {
+          groupedResults
+        }
+    }
+
+  private def listResourcesAndTransform[T](
+      samUserId: WorkbenchUserId,
+      resourceTypeNames: Set[ResourceTypeName],
+      policies: Set[AccessPolicyName],
+      roles: Set[ResourceRoleName],
+      includePublic: Boolean,
+      samRequestContext: SamRequestContext
+  )(transform: (Seq[FilterResourcesResult], Map[FullyQualifiedResourceId, Set[WorkbenchGroupName]], Set[WorkbenchGroupName]) => T): IO[T] =
     // note that filtering by actions is implemented by application logic, not by the database query
     // adding actions to the query would make return many more rows than necessary because roles can have many actions
     // and those actions are static and already in memory
-    accessPolicyDAO
-      .filterResources(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext)
-      .map(groupHierarchical(_, actions))
-      .map(results =>
-        // If we are filtering by actions, remove any resources that don't have the actions either directly or through a role
-        if (actions.nonEmpty) {
-          results.copy(resources = results.resources.filter(resource => resource.policies.exists(policy => policy.actions.nonEmpty || policy.roles.nonEmpty)))
+    for {
+      filterResults <- accessPolicyDAO.filterResources(samUserId, resourceTypeNames, policies, roles, includePublic, samRequestContext)
+      resourceAuthDomains <- listResourceAuthDomains(filterResults, samRequestContext)
+      // only load user groups is there are auth domains
+      userGroups <-
+        if (resourceAuthDomains.values.exists(_.nonEmpty)) {
+          listUserManagedGroups(samUserId, samRequestContext)
         } else {
-          results
+          IO.pure(Set.empty[WorkbenchGroupName])
         }
-      )
+    } yield transform(filterResults, resourceAuthDomains, userGroups)
+
+  private def listResourceAuthDomains(
+      filteredResources: Seq[FilterResourcesResult],
+      samRequestContext: SamRequestContext
+  ): IO[Map[FullyQualifiedResourceId, Set[WorkbenchGroupName]]] =
+    filteredResources
+      .groupBy(_.resourceTypeName)
+      .toList
+      .traverse { case (resourceTypeName, resources) =>
+        for {
+          resourceTypeOpt <- getResourceType(resourceTypeName)
+          authDomainsByResourceId <- resourceTypeOpt match {
+            case Some(resourceType) if resourceType.isAuthDomainConstrainable =>
+              accessPolicyDAO.listResourcesWithAuthdomains(resourceTypeName, resources.map(_.resourceId).toSet, samRequestContext).map { authDomainResults =>
+                authDomainResults.map { authDomainResult =>
+                  authDomainResult.fullyQualifiedId -> authDomainResult.authDomain
+                }.toMap
+              }
+            case _ =>
+              IO.pure(Map.empty[FullyQualifiedResourceId, Set[WorkbenchGroupName]])
+          }
+        } yield authDomainsByResourceId
+      }
+      .map(_.flatten.toMap)
+
+  private def listUserManagedGroups(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Set[WorkbenchGroupName]] =
+    for {
+      groupPolicies <- accessPolicyDAO.listAccessPolicies(ManagedGroupService.managedGroupTypeName, userId, samRequestContext)
+    } yield {
+      val membershipPolicies =
+        groupPolicies.filter(p => ManagedGroupService.userMembershipRoleNames.contains(ManagedGroupService.getRoleName(p.accessPolicyName.value)))
+      membershipPolicies.map(policy => WorkbenchGroupName(policy.resourceId.value))
+    }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -376,8 +376,6 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                 fqPolicyId.accessPolicyName,
                 Left(role),
                 accessPolicy.public,
-                None,
-                false,
                 false
               )
             }
@@ -389,8 +387,6 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                 fqPolicyId.accessPolicyName,
                 Right(action),
                 accessPolicy.public,
-                None,
-                false,
                 false
               )
             }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -361,7 +361,6 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
       resourceTypeNames: Set[ResourceTypeName],
       policies: Set[AccessPolicyName],
       roles: Set[ResourceRoleName],
-      actions: Set[ResourceAction],
       includePublic: Boolean,
       samRequestContext: SamRequestContext
   ): IO[Seq[FilterResourcesResult]] = IO {
@@ -370,38 +369,32 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
         this.policies.collect {
           case (fqPolicyId @ FullyQualifiedPolicyId(FullyQualifiedResourceId(`resourceTypeName`, _), _), accessPolicy: AccessPolicy)
               if accessPolicy.members.contains(samUserId) || accessPolicy.public =>
-            val rolesAndActions = RolesAndActions.fromPolicy(accessPolicy)
-            rolesAndActions.roles.flatMap { role =>
-              if (actions.isEmpty) {
-                Set(
-                  FilterResourcesResult(
-                    fqPolicyId.resource.resourceId,
-                    fqPolicyId.resource.resourceTypeName,
-                    Some(fqPolicyId.accessPolicyName),
-                    Some(role),
-                    None,
-                    accessPolicy.public,
-                    None,
-                    false,
-                    false
-                  )
-                )
-              } else {
-                rolesAndActions.actions.map { action =>
-                  FilterResourcesResult(
-                    fqPolicyId.resource.resourceId,
-                    fqPolicyId.resource.resourceTypeName,
-                    Some(fqPolicyId.accessPolicyName),
-                    Some(role),
-                    Some(action),
-                    accessPolicy.public,
-                    None,
-                    false,
-                    false
-                  )
-                }
-              }
+            val roleResults = accessPolicy.roles.map { role =>
+              FilterResourcesResult(
+                fqPolicyId.resource.resourceId,
+                fqPolicyId.resource.resourceTypeName,
+                fqPolicyId.accessPolicyName,
+                Left(role),
+                accessPolicy.public,
+                None,
+                false,
+                false
+              )
             }
+
+            val actionResults = accessPolicy.actions.map { action =>
+              FilterResourcesResult(
+                fqPolicyId.resource.resourceId,
+                fqPolicyId.resource.resourceTypeName,
+                fqPolicyId.accessPolicyName,
+                Right(action),
+                accessPolicy.public,
+                None,
+                false,
+                false
+              )
+            }
+            roleResults ++ actionResults
         }
       }
       .flatten

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockAccessPolicyDAO.scala
@@ -374,7 +374,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                 fqPolicyId.resource.resourceId,
                 fqPolicyId.resource.resourceTypeName,
                 fqPolicyId.accessPolicyName,
-                Left(role),
+                Option(Left(role)),
                 accessPolicy.public,
                 false
               )
@@ -385,7 +385,7 @@ class MockAccessPolicyDAO(private val resourceTypes: mutable.Map[ResourceTypeNam
                 fqPolicyId.resource.resourceId,
                 fqPolicyId.resource.resourceTypeName,
                 fqPolicyId.accessPolicyName,
-                Right(action),
+                Option(Right(action)),
                 accessPolicy.public,
                 false
               )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -3436,50 +3436,6 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
         publicNestedReaderRoles.size should be(6)
         publicNestedReaderRoles.filter(_.isPublic).map(_.resourceId).toSet should be(Set(publicResource.resourceId, publicChildResource.resourceId))
       }
-
-      "includes Authorization Domain information in its queries" in {
-        assume(databaseEnabled, databaseEnabledClue)
-
-        val user = Generator.genWorkbenchUserGoogle.sample.get
-
-        val subGroup = BasicWorkbenchGroup(WorkbenchGroupName("subGroup"), Set(user.id), WorkbenchEmail("sub@groups.com"))
-        val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName("parent"), Set(subGroup.id), WorkbenchEmail("parent@groups.com"))
-        val authDomainGroup1 = BasicWorkbenchGroup(WorkbenchGroupName("authDomainGroup1"), Set(parentGroup.id), WorkbenchEmail("authDomainGroup1@groups.com"))
-        val authDomainGroup2 = BasicWorkbenchGroup(WorkbenchGroupName("authDomainGroup2"), Set.empty, WorkbenchEmail("authDomainGroup2@groups.com"))
-
-        dirDao.createUser(user, samRequestContext).unsafeRunSync()
-        dirDao.createGroup(subGroup, samRequestContext = samRequestContext).unsafeRunSync()
-        dirDao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
-        dirDao.createGroup(authDomainGroup1, samRequestContext = samRequestContext).unsafeRunSync()
-        dirDao.createGroup(authDomainGroup2, samRequestContext = samRequestContext).unsafeRunSync()
-        dirDao.addGroupMember(subGroup.id, user.id, samRequestContext).unsafeRunSync()
-        dirDao.addGroupMember(parentGroup.id, subGroup.id, samRequestContext).unsafeRunSync()
-        dao.createResourceType(resourceType, samRequestContext).unsafeRunSync()
-        dao.createResourceType(otherResourceType, samRequestContext).unsafeRunSync()
-
-        // can access via auth domain
-        val resource1 = createResource(Option(user.id), Set(writeAction), Set(readerRole.roleName), public = false, authDomainGroups = Set(authDomainGroup1))
-        // cannot access via auth domain
-        val resource2 =
-          createResource(Option(user.id), Set(writeAction), Set(readerRole.roleName), false, authDomainGroups = Set(authDomainGroup1, authDomainGroup2))
-
-        val byResource = dao
-          .filterResources(user.id, Set(resourceType.name), Set.empty, Set(readerRole.roleName), false, samRequestContext)
-          .unsafeRunSync()
-          .groupBy(_.resourceId)
-
-        val resource1Results = byResource(resource1.resourceId)
-        resource1Results.length should be(1)
-        resource1Results.head.authDomain should be(Some(authDomainGroup1.id))
-        resource1Results.head.inAuthDomain should be(true)
-
-        val resource2Results = byResource(resource2.resourceId)
-        resource2Results.length should be(2)
-        resource2Results.flatMap(_.authDomain).toSet should be(Set(authDomainGroup1.id, authDomainGroup2.id))
-        resource2Results.map(_.inAuthDomain).toSet should be(Set(true, false))
-        resource2Results.filter(_.inAuthDomain).head.authDomain should be(Some(authDomainGroup1.id))
-        resource2Results.filter(!_.inAuthDomain).head.authDomain should be(Some(authDomainGroup2.id))
-      }
     }
 
     "listResourcesUsingAuthDomain" - {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresAccessPolicyDAOSpec.scala
@@ -3277,14 +3277,9 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
     "filterResources" - {
 
-      def verify(
-          dbResultRows: Seq[FilterResourcesResult],
-          roles: Set[ResourceRoleName],
-          roleActions: Set[ResourceAction],
-          policyActions: Set[ResourceAction]
-      ) = {
-        val testRoles: Set[ResourceRoleName] = dbResultRows.flatMap(_.roleOrAction.left.toOption).toSet
-        val testPolicyActions: Set[ResourceAction] = dbResultRows.flatMap(_.roleOrAction.toOption).toSet
+      def verify(dbResultRows: Seq[FilterResourcesResult], roles: Set[ResourceRoleName], policyActions: Set[ResourceAction]): Any = {
+        val testRoles: Set[ResourceRoleName] = dbResultRows.flatMap(_.roleOrAction.flatMap(_.left.toOption)).toSet
+        val testPolicyActions: Set[ResourceAction] = dbResultRows.flatMap(_.roleOrAction.flatMap(_.toOption)).toSet
 
         testRoles should be(roles)
         testPolicyActions should be(policyActions)
@@ -3333,17 +3328,27 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
           false
         )
         // No roles available
-        val publicProbePolicy = AccessPolicy(
+        val publicProbeEmptyPolicy = AccessPolicy(
           FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
           Set.empty,
           WorkbenchEmail(s"${uuid}@policy.com"),
-          Set(actionlessRole.roleName),
+          Set.empty,
           Set.empty,
           Set.empty,
           true
         )
+        val privateProbeEmptyPolicy = AccessPolicy(
+          FullyQualifiedPolicyId(kitchenSink.fullyQualifiedId, AccessPolicyName(uuid)),
+          Set(user.id),
+          WorkbenchEmail(s"${uuid}@policy.com"),
+          Set.empty,
+          Set.empty,
+          Set.empty,
+          false
+        )
         dao.createPolicy(directProbePolicy, samRequestContext).unsafeRunSync()
-        dao.createPolicy(publicProbePolicy, samRequestContext).unsafeRunSync()
+        dao.createPolicy(publicProbeEmptyPolicy, samRequestContext).unsafeRunSync()
+        dao.createPolicy(privateProbeEmptyPolicy, samRequestContext).unsafeRunSync()
 
         val readerRoles =
           dao.filterResources(user.id, Set(resourceType.name), Set.empty, Set(readerRole.roleName), false, samRequestContext).unsafeRunSync()
@@ -3371,24 +3376,19 @@ class PostgresAccessPolicyDAOSpec extends AnyFreeSpec with Matchers with BeforeA
 
         val filtered = dao.filterResources(user.id, Set(resourceType.name), Set.empty, Set.empty, true, samRequestContext).unsafeRunSync()
 
+        val emptyPublicResults = filtered.filter(_.policy == publicProbeEmptyPolicy.id.accessPolicyName)
+        emptyPublicResults.map(_.roleOrAction) should contain only None
+        val emptyPrivateResults = filtered.filter(_.policy == privateProbeEmptyPolicy.id.accessPolicyName)
+        emptyPrivateResults.map(_.roleOrAction) should contain only None
+
         val readRoleWriteActionResources =
           Seq(userReadRoleWriteAction, groupReadRoleWriteAction, childResource1, childResource2, publicResource, publicChildResource)
 
         readRoleWriteActionResources
           .map(resource =>
-            verify(
-              filtered.filter(_.resourceId.equals(resource.resourceId)),
-              roles = Set(readerRole.roleName),
-              roleActions = Set(readAction),
-              policyActions = Set(writeAction)
-            )
+            verify(filtered.filter(_.resourceId.equals(resource.resourceId)), roles = Set(readerRole.roleName), policyActions = Set(writeAction))
           )
-        verify(
-          filtered.filter(_.resourceId.equals(kitchenSink.resourceId)),
-          roles = Set(readerRole.roleName, ownerRole.roleName, actionlessRole.roleName),
-          roleActions = Set(readAction, writeAction),
-          policyActions = Set.empty
-        )
+        verify(filtered.filter(_.resourceId.equals(kitchenSink.resourceId)), roles = Set(readerRole.roleName, ownerRole.roleName), policyActions = Set.empty)
       }
 
       "filters on the user's policies, roles, and actions when using nested roles" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
@@ -92,7 +92,6 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         ArgumentMatchers.eq(Set(policy.id.resource.resourceTypeName)),
         ArgumentMatchers.eq(Set.empty),
         ArgumentMatchers.eq(Set.empty),
-        ArgumentMatchers.eq(Set.empty),
         ArgumentMatchers.eq(true),
         any[SamRequestContext]
       )
@@ -116,66 +115,30 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
     }
 
   private def constructFilterResourcesResult(accessPolicy: AccessPolicy): Seq[FilterResourcesResult] =
-    if (accessPolicy.roles.isEmpty) {
-      Seq(
-        FilterResourcesResult(
-          accessPolicy.id.resource.resourceId,
-          accessPolicy.id.resource.resourceTypeName,
-          Some(accessPolicy.id.accessPolicyName),
-          None,
-          None,
-          accessPolicy.public,
-          None,
-          false,
-          false
-        )
+    accessPolicy.roles.map { role =>
+      FilterResourcesResult(
+        accessPolicy.id.resource.resourceId,
+        accessPolicy.id.resource.resourceTypeName,
+        accessPolicy.id.accessPolicyName,
+        Left(role),
+        accessPolicy.public,
+        None,
+        false,
+        false
       )
-    } else
-      {
-        accessPolicy.roles.map { role =>
-          FilterResourcesResult(
-            accessPolicy.id.resource.resourceId,
-            accessPolicy.id.resource.resourceTypeName,
-            Some(accessPolicy.id.accessPolicyName),
-            Some(role),
-            None,
-            accessPolicy.public,
-            None,
-            false,
-            false
-          )
-        }.toSeq
-      } ++
-        (if (accessPolicy.actions.isEmpty) {
-           Seq(
-             FilterResourcesResult(
-               accessPolicy.id.resource.resourceId,
-               accessPolicy.id.resource.resourceTypeName,
-               Some(accessPolicy.id.accessPolicyName),
-               None,
-               None,
-               accessPolicy.public,
-               None,
-               false,
-               false
-             )
-           )
-         } else {
-           accessPolicy.actions.map { action =>
-             FilterResourcesResult(
-               accessPolicy.id.resource.resourceId,
-               accessPolicy.id.resource.resourceTypeName,
-               Some(accessPolicy.id.accessPolicyName),
-               None,
-               Some(action),
-               accessPolicy.public,
-               None,
-               false,
-               false
-             )
+    }.toSeq ++ accessPolicy.actions.map { action =>
+      FilterResourcesResult(
+        accessPolicy.id.resource.resourceId,
+        accessPolicy.id.resource.resourceTypeName,
+        accessPolicy.id.accessPolicyName,
+        Right(action),
+        accessPolicy.public,
+        None,
+        false,
+        false
+      )
 
-           }.toSeq
-         })
+    }.toSeq
 
   def withRandomAccessPolicy(resourceTypeName: ResourceTypeName, members: Set[WorkbenchSubject]): StatefulMockAccessPolicyDaoBuilder = {
     val policy = AccessPolicy(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
@@ -114,13 +114,13 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
       )
     }
 
-  private def constructFilterResourcesResult(accessPolicy: AccessPolicy): Seq[FilterResourcesResult] =
-    accessPolicy.roles.map { role =>
+  private def constructFilterResourcesResult(accessPolicy: AccessPolicy): Seq[FilterResourcesResult] = {
+    val results = accessPolicy.roles.map { role =>
       FilterResourcesResult(
         accessPolicy.id.resource.resourceId,
         accessPolicy.id.resource.resourceTypeName,
         accessPolicy.id.accessPolicyName,
-        Left(role),
+        Option(Left(role)),
         accessPolicy.public,
         false
       )
@@ -129,12 +129,27 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         accessPolicy.id.resource.resourceId,
         accessPolicy.id.resource.resourceTypeName,
         accessPolicy.id.accessPolicyName,
-        Right(action),
+        Option(Right(action)),
         accessPolicy.public,
         false
       )
 
     }.toSeq
+    if (results.isEmpty) {
+      Seq(
+        FilterResourcesResult(
+          accessPolicy.id.resource.resourceId,
+          accessPolicy.id.resource.resourceTypeName,
+          accessPolicy.id.accessPolicyName,
+          None,
+          accessPolicy.public,
+          false
+        )
+      )
+    } else {
+      results
+    }
+  }
 
   def withRandomAccessPolicy(resourceTypeName: ResourceTypeName, members: Set[WorkbenchSubject]): StatefulMockAccessPolicyDaoBuilder = {
     val policy = AccessPolicy(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/StatefulMockAccessPolicyDaoBuilder.scala
@@ -122,8 +122,6 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         accessPolicy.id.accessPolicyName,
         Left(role),
         accessPolicy.public,
-        None,
-        false,
         false
       )
     }.toSeq ++ accessPolicy.actions.map { action =>
@@ -133,8 +131,6 @@ case class StatefulMockAccessPolicyDaoBuilder() extends MockitoSugar {
         accessPolicy.id.accessPolicyName,
         Right(action),
         accessPolicy.public,
-        None,
-        false,
         false
       )
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -41,7 +41,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
       AccessPolicyName(UUID.randomUUID().toString),
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       true,
       false
     ),
@@ -49,17 +49,17 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       ResourceId(UUID.randomUUID().toString),
       resourceTypeName,
       AccessPolicyName(UUID.randomUUID().toString),
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       false,
       false
     ),
     // Testable DB Results
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy1, Left(readerRoleName), false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy1, Option(Left(readerRoleName)), false, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
       testPolicy1,
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       false,
       false
     ), // testing duplicate row results
@@ -67,19 +67,20 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       testResourceId,
       resourceTypeName,
       testPolicy1,
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       false,
       false
     ), // testing duplicate row results
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy2, Left(nothingRoleName), true, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy5, Right(readAction), true, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy2, Option(Left(nothingRoleName)), true, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy3, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Option(Left(ownerRoleName)), false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Option(Left(ownerRoleName)), false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy5, Option(Right(readAction)), true, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
       testPolicy5,
-      Right(readAction),
+      Option(Right(readAction)),
       true,
       false
     ), // testing duplicate row results
@@ -88,7 +89,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       testResourceId2,
       resourceTypeName,
       testPolicy6,
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       false,
       false
     ),
@@ -96,7 +97,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       testResourceId2,
       resourceTypeName,
       testPolicy6,
-      Left(readerRoleName),
+      Option(Left(readerRoleName)),
       false,
       false
     )
@@ -149,6 +150,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       Set(
         FilteredResourceFlatPolicy(testPolicy1, false, false),
         FilteredResourceFlatPolicy(testPolicy2, true, false),
+        FilteredResourceFlatPolicy(testPolicy3, false, false),
         FilteredResourceFlatPolicy(testPolicy4, false, false),
         FilteredResourceFlatPolicy(testPolicy5, true, false)
       )
@@ -174,7 +176,7 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     oneResource.resourceType should be(resourceTypeName)
 
     val policies = oneResource.policies
-    policies.map(_.policy) should be(Set(testPolicy1, testPolicy2, testPolicy4, testPolicy5))
+    policies.map(_.policy) should be(Set(testPolicy1, testPolicy2, testPolicy3, testPolicy4, testPolicy5))
     val policyWithAction = policies.filter(_.policy.equals(testPolicy5)).head
     policyWithAction.roles should be(Set.empty)
     policyWithAction.actions should be(Set(readAction))
@@ -183,6 +185,9 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     val role = policyWithRoles.roles.head
     role.role should be(ownerRoleName)
     role.actions should be(Set(readAction, writeAction))
+
+    policies.filter(_.policy.equals(testPolicy3)).flatMap(_.roles) should be(empty)
+    policies.filter(_.policy.equals(testPolicy3)).flatMap(_.actions) should be(empty)
 
     val authDomainResource = filteredResources.resources.filter(_.resourceId.equals(testResourceId2)).head
     authDomainResource.resourceType should be(resourceTypeName)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ResourceServiceUnitSpec.scala
@@ -43,8 +43,6 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       AccessPolicyName(UUID.randomUUID().toString),
       Left(readerRoleName),
       true,
-      None,
-      false,
       false
     ),
     FilterResourcesResult(
@@ -53,19 +51,15 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       AccessPolicyName(UUID.randomUUID().toString),
       Left(readerRoleName),
       false,
-      None,
-      false,
       false
     ),
     // Testable DB Results
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy1, Left(readerRoleName), false, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy1, Left(readerRoleName), false, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
       testPolicy1,
       Left(readerRoleName),
-      false,
-      None,
       false,
       false
     ), // testing duplicate row results
@@ -75,22 +69,18 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       testPolicy1,
       Left(readerRoleName),
       false,
-      None,
-      false,
       false
     ), // testing duplicate row results
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy2, Left(nothingRoleName), true, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, None, false, false),
-    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy5, Right(readAction), true, None, false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy2, Left(nothingRoleName), true, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy4, Left(ownerRoleName), false, false),
+    FilterResourcesResult(testResourceId, resourceTypeName, testPolicy5, Right(readAction), true, false),
     FilterResourcesResult(
       testResourceId,
       resourceTypeName,
       testPolicy5,
       Right(readAction),
       true,
-      None,
-      false,
       false
     ), // testing duplicate row results
     // Auth Domain Results
@@ -100,8 +90,6 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       testPolicy6,
       Left(readerRoleName),
       false,
-      Some(authDomainGroup1),
-      true,
       false
     ),
     FilterResourcesResult(
@@ -109,8 +97,6 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
       resourceTypeName,
       testPolicy6,
       Left(readerRoleName),
-      false,
-      Some(authDomainGroup2),
       false,
       false
     )
@@ -128,12 +114,16 @@ class ResourceServiceUnitSpec extends AnyFlatSpec with Matchers with ScalaFuture
     )
   )
     .thenReturn(IO.pure(dbResult))
+  when(mockAccessPolicyDAO.listResourcesWithAuthdomains(any[ResourceTypeName], any[Set[ResourceId]], any[SamRequestContext]))
+    .thenReturn(IO.pure(Set(Resource(resourceTypeName, testResourceId2, Set(authDomainGroup1, authDomainGroup2), Set.empty))))
+  when(mockAccessPolicyDAO.listAccessPolicies(eqTo(ManagedGroupService.managedGroupTypeName), any[WorkbenchUserId], any[SamRequestContext]))
+    .thenReturn(IO.pure(Set(ResourceIdAndPolicyName(ResourceId(authDomainGroup1.value), ManagedGroupService.memberPolicyName))))
 
   val resourceService = new ResourceService(
     Map(
       resourceTypeName -> ResourceType(
         resourceTypeName,
-        Set.empty,
+        Set(ResourceActionPattern(readAction.value, "", true)),
         Set(
           ResourceRole(readerRoleName, Set(readAction)),
           ResourceRole(ownerRoleName, Set(readAction, writeAction)),


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-137

What:

The query implemented in `PostgresAccessPolicyDAO.filterPrivateResources` has been highlighted by query insights as far and away the biggest load by time on the database. It is called on average 1.1 million times per day! It is the query behind the [api to list user resources](https://sam.dsde-prod.broadinstitute.org/#/Resources/listResourcesAndPoliciesV2). Around the beginning of October, we also noticed in dev that this query was [causing stability](https://broadinstitute.slack.com/archives/C03GMG4DUSE/p1728403148967779) issues because the AoU user had access to too many google-project resources. Those were cleaned up but the vulnerability remains.


How:

There were 2 main observations:
1. including actions associated to roles for each resource in the query results multiplied the number of rows returned, for the AoU case there were millions. But the role to action mapping is static from Sam config and is already loaded in memory. Moving all this extra data around is wasteful and is probably leading to excess garbage collection.
2. removing the joins to figure out auth domain information sped up the AoU queries. Prior versions of this query loaded auth domains separately especially because not all resource types are affected by them. Revert to that.

Overall, the workhorse query is much smaller in terms of joins.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
