### PR TITLE
[CORE-105] Enable Single Reviewer Approval for Broadbot PRs

### DIFF
--- a/.github/workflows/auto-approve-broadbot-prs.yml
+++ b/.github/workflows/auto-approve-broadbot-prs.yml
@@ -1,0 +1,21 @@
+name: Broadbot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'broadbot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-approve-broadbot-prs.yml
+++ b/.github/workflows/auto-approve-broadbot-prs.yml
@@ -9,13 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'broadbot[bot]'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-105

Background:
Automatically give one approval on broadbot dependency upgrade PRs, so that only one person from the team needs to review/approve.