### PR TITLE
[CORE-105] Update auto-approve-broadbot-prs.yml

### DIFF
--- a/.github/workflows/auto-approve-broadbot-prs.yml
+++ b/.github/workflows/auto-approve-broadbot-prs.yml
@@ -5,9 +5,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  broadbot:
     runs-on: ubuntu-latest
-    if: github.actor == 'broadbot[bot]'
+    if: github.actor == 'broadbot'
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-105

What:
The Github action was skipped when I tested it on a Broadbot PR. Broadbot is actually a Github account, not a bot so I think the problem is with checking the github actor.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
