### PR TITLE
[CORE-105] Verify github actor in auto-approve-broadbot-prs.yml

### DIFF
--- a/.github/workflows/auto-approve-broadbot-prs.yml
+++ b/.github/workflows/auto-approve-broadbot-prs.yml
@@ -5,6 +5,13 @@ permissions:
   pull-requests: write
 
 jobs:
+  getActor:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Echo github actor"
+      env:
+        GH_ACTOR: ${{ github.actor }}
+      run: echo "$GH_ACTOR"
   broadbot:
     runs-on: ubuntu-latest
     if: github.actor == 'broadbot'


### PR DESCRIPTION
For some reason, this github action is not getting triggered on broadbot PRs, so this will confirm who the github.actor is in those cases.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
