### PR TITLE
[CORE-153] Scala Steward config changes

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -33,6 +33,39 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 # Defaults to no labels (no labels are added).
 pullRequests.customLabels = [ "Scala_Steward" ]
 
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and patch updates - ${artifactVersions}", filter = [ { version = "minor" }, { version = "patch" } ] } ]
+
 # Only these dependencies which match the given patterns are updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
@@ -55,6 +88,7 @@ updates.ignore = []
 # If set, Scala Steward will only attempt to create or update `n` PRs.
 # Useful if running frequently and/or CI build are costly
 # Default: None
+updates.limit = 5
 
 # By default, Scala Steward does not update scala version since its tricky, error-prone
 # and results in bad PRs and/or failed builds
@@ -73,7 +107,7 @@ updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md",
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "always"
+updatePullRequests = "on-conflicts"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}


### PR DESCRIPTION
Ticket: [CORE-153](https://broadworkbench.atlassian.net/browse/CORE-153)
* Batch Scala Steward PRs for minor and patch version bumps
* Limit total number of Scala Steward PRs
* Only update Scala Steward PRs when there's a conflict with `develop`


What:

  \<For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).\>

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[CORE-153]: https://broadworkbench.atlassian.net/browse/CORE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ