### PR TITLE
[CORE-40] add read_spend_report action to workspace owners

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -150,6 +150,9 @@ resourceTypes = {
       },
       read_job_result = {
         description = "allows reading the result of a job"
+      },
+      read_spend_report = {
+        description = "allows user to read spend report on the workspace"
       }
     }
     ownerRoleName = "owner"
@@ -165,7 +168,7 @@ resourceTypes = {
         includedRoles = ["owner"]
       }
       owner = {
-        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "update_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status", "read_job_result"]
+        roleActions = ["delete", "read_policies", "share_policy::owner", "share_policy::application", "share_policy::writer", "share_policy::reader", "share_policy::discoverer", "own", "write", "read", "discover", "compute", "share_policy::share-reader", "share_policy::share-writer", "share_policy::can-compute", "share_policy::can-catalog", "read_auth_domain", "update_auth_domain", "create_controlled_user_shared", "create_controlled_user_private", "create_referenced_resource", "update_referenced_resource", "delete_referenced_resource", "list_children", "remove_child", "add_child", "migrate", "view_migration_status", "read_job_result", "read_spend_report"]
         # Workspace Manager also maintains a mapping of workspace roles to controlled resource roles. If you change this mapping, check that service's mapping as well.
         descendantRoles = {
           google-project = ["owner"]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-40

What:

Adds a `read_spend_report` action on workspaces, and grants it to workspace owners.  

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
