### PR TITLE
CORE-69: update TCL, CRL, grpc-core; fix assembly

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,8 +20,8 @@ object Dependencies {
   val workbenchNotificationsV = s"0.8-$workbenchLibV"
   val workbenchOauth2V = s"0.8-$workbenchLibV"
   val monocleVersion = "2.0.5"
-  val crlVersion = "1.2.30-SNAPSHOT"
-  val tclVersion = "1.1.12-SNAPSHOT"
+  val crlVersion = "1.2.33-SNAPSHOT"
+  val tclVersion = "1.1.24-SNAPSHOT"
   val slf4jVersion = "2.0.6"
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
@@ -68,7 +68,7 @@ object Dependencies {
   val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.2.0"
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
-  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.68.1"
+  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.68.2"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll excludIoGrpc
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20241008-2.0.0" excludeAll excludIoGrpc // force this version

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -10,6 +10,7 @@ object Merging {
     case PathList("org", "bouncycastle", _ @_*) => MergeStrategy.first
     case x if x.endsWith("/ModuleUtil.class") => MergeStrategy.first
     case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.first
+    case PathList("META-INF", "versions", "11", "module-info.class") => MergeStrategy.first
     case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
     case PathList("META-INF", "kotlin-result.kotlin_module") => MergeStrategy.first
     case PathList("META-INF", "kotlin-stdlib.kotlin_module") => MergeStrategy.first


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

What:

Supersedes #1605. This PR has the same set of dependency updates, but also includes a fix for `sbt assembly` which breaks the build in #1605.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
