### PR TITLE
CORE-232: create 'user' resource type

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1810,6 +1810,18 @@ resourceTypes = {
     allowLeaving = false
     reuseIds = true
   }
+
+  user = {
+    actionPatterns = {}
+    ownerRoleName = "admin"
+    roles = {
+      admin = {
+        roleActions = []
+      }
+    }
+    allowLeaving = false
+    reuseIds = false
+  }
 }
 
 

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -424,5 +424,11 @@ resourceAccessPolicies {
         ]
       }
     }
+    user {
+      support {
+        memberEmails = ${terra.support.emails}
+        roles = ["support"]
+      }
+    }
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-232

What:

Create a new `user` resource type for the sole purpose of being able to query for support permissions on the `resource_type_admin/user` resource.

As of this writing, we don't expect anything to create `user` resources themselves.

This PR is an offshoot of #1617 - see comment threads in that other PR for context.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
