### PR TITLE
CORE-232: user supportSummary should use resource_type_admin

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4268,20 +4268,12 @@ components:
         directSynchronized:
           type: integer
           description: |
-            Number of groups to which the user is a direct member
-            and which have been successfully synchronized to the cloud.
+            Number of groups to which the user is a direct member.
             Does not include groups from public resources.
         totalSynchronized:
           type: integer
           description: |
-            Number of groups to which the user is a direct or indirect member
-            and which have been successfully synchronized to the cloud.
-            Does not include groups from public resources.
-        unsynchronized:
-          type: integer
-          description: |
-            Number of groups to which the user is a direct or indirect member
-            and which have not yet been synchronized to the cloud.
+            Number of groups to which the user is a direct or indirect member.
             Does not include groups from public resources.
     ManagedGroupMembershipEntry:
       required:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -47,18 +47,14 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
 
   def adminUserRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     pathPrefix("user") {
-      // routes requiring resource_type_admin/user admin_read_summary_information:
-      withResourceType(UserService.userTypeName) { userType =>
-        requireAdminResourceAction(SamResourceActions.adminReadSummaryInformation, userType, samUser, samRequestContext) {
-          pathPrefix("email" / Segment) { email =>
+      // routes requiring resource_type_admin/user actions:
+      path("email" / Segment / "supportSummary") { email =>
+        withResourceType(UserService.userTypeName) { userType =>
+          requireAdminResourceAction(SamResourceActions.adminReadSummaryInformation, userType, samUser, samRequestContext) {
             val workbenchEmail = WorkbenchEmail(email)
-            pathPrefix("supportSummary") {
-              pathEndOrSingleSlash {
-                getWithTelemetry(samRequestContext, emailParam(workbenchEmail)) {
-                  complete {
-                    userService.getSamUserCombinedState(workbenchEmail, samRequestContext, resourceService)
-                  }
-                }
+            getWithTelemetry(samRequestContext, emailParam(workbenchEmail)) {
+              complete {
+                userService.getSamUserCombinedState(workbenchEmail, samRequestContext, resourceService)
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions.{adminAddM
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceTypes.resourceTypeAdminName
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AccessPolicyMembershipRequest, AdminUpdateUserRequest, SamUser}
-import org.broadinstitute.dsde.workbench.sam.service.{ManagedGroupService, ResourceService}
+import org.broadinstitute.dsde.workbench.sam.service.{ManagedGroupService, ResourceService, UserService}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsBoolean
@@ -47,6 +47,24 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
 
   def adminUserRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     pathPrefix("user") {
+      // routes requiring resource_type_admin/user admin_read_summary_information:
+      withResourceType(UserService.userTypeName) { userType =>
+        requireAdminResourceAction(SamResourceActions.adminReadSummaryInformation, userType, samUser, samRequestContext) {
+          pathPrefix("email" / Segment) { email =>
+            val workbenchEmail = WorkbenchEmail(email)
+            pathPrefix("supportSummary") {
+              pathEndOrSingleSlash {
+                getWithTelemetry(samRequestContext, emailParam(workbenchEmail)) {
+                  complete {
+                    userService.getSamUserCombinedState(workbenchEmail, samRequestContext, resourceService)
+                  }
+                }
+              }
+            }
+          }
+        }
+      } ~
+      // routes requiring admin:
       asWorkbenchAdmin(samUser) {
         pathPrefix("email" / Segment) { email =>
           val workbenchEmail = WorkbenchEmail(email)
@@ -56,15 +74,6 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
                 userService
                   .getUserStatusFromEmail(workbenchEmail, samRequestContext)
                   .map(status => (if (status.isDefined) OK else NotFound) -> status)
-              }
-            }
-          } ~
-          pathPrefix("supportSummary") {
-            pathEndOrSingleSlash {
-              getWithTelemetry(samRequestContext, emailParam(workbenchEmail)) {
-                complete {
-                  userService.getSamUserCombinedState(workbenchEmail, samRequestContext, resourceService)
-                }
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -100,11 +100,15 @@ trait DirectoryDAO {
 
   def listFlattenedGroupMembers(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Set[WorkbenchUserId]]
 
+  /** @return
+    *   the number of groups to which the user is a direct member, not including public resources.
+    */
   def countDirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int]
 
+  /** @return
+    *   the number of groups to which the user is a direct or indirect member, not including public resources.
+    */
   def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int]
-
-  def countUnsynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int]
 
   def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -756,10 +757,13 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
   override def countUnsynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
     readOnlyTransaction("countUnsynchronizedGroupMemberships", samRequestContext) { implicit session =>
+      // this query special-cases for the All_Users group, which otherwise appears out of sync
       val query = samsql"""select count(distinct g.id) unsynchronizedMembershipCount
                           from sam_group g
                           join sam_group_member_flat gmf on g.id = gmf.group_id
-                          where g.synchronized_date is null
+                          where g.synchronized_date is not null
+                          and g.version > g.last_synchronized_version
+                          and g.name != ${CloudExtensions.allUsersGroupName}
                           and gmf.member_user_id = ${samUser.id}"""
 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -759,7 +760,8 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val query = samsql"""select count(distinct g.id) unsynchronizedMembershipCount
                           from sam_group g
                           join sam_group_member_flat gmf on g.id = gmf.group_id
-                          where g.synchronized_date is null
+                          where g.updated_date > g.synchronized_date
+                          and g.name != ${CloudExtensions.allUsersGroupName}
                           and gmf.member_user_id = ${samUser.id}"""
 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -25,7 +25,6 @@ import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -750,20 +749,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                           from sam_group g
                           join sam_group_member_flat gmf on g.id = gmf.group_id
                           where g.synchronized_date is not null
-                          and gmf.member_user_id = ${samUser.id}"""
-
-      query.map(rs => rs.int(1)).single().apply().getOrElse(0)
-    }
-
-  override def countUnsynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
-    readOnlyTransaction("countUnsynchronizedGroupMemberships", samRequestContext) { implicit session =>
-      // this query special-cases for the All_Users group, which otherwise appears out of sync
-      val query = samsql"""select count(distinct g.id) unsynchronizedMembershipCount
-                          from sam_group g
-                          join sam_group_member_flat gmf on g.id = gmf.group_id
-                          where g.synchronized_date is not null
-                          and g.version > g.last_synchronized_version
-                          and g.name != ${CloudExtensions.allUsersGroupName}
                           and gmf.member_user_id = ${samUser.id}"""
 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -25,7 +25,6 @@ import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
-import org.broadinstitute.dsde.workbench.sam.service.CloudExtensions
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -760,8 +759,7 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       val query = samsql"""select count(distinct g.id) unsynchronizedMembershipCount
                           from sam_group g
                           join sam_group_member_flat gmf on g.id = gmf.group_id
-                          where g.updated_date > g.synchronized_date
-                          and g.name != ${CloudExtensions.allUsersGroupName}
+                          where g.synchronized_date is null
                           and gmf.member_user_id = ${samUser.id}"""
 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/GroupMembershipCounts.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/GroupMembershipCounts.scala
@@ -4,10 +4,9 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 object GroupMembershipCounts {
-  implicit val GroupMembershipCountsFormat: RootJsonFormat[GroupMembershipCounts] = jsonFormat3(GroupMembershipCounts.apply)
+  implicit val GroupMembershipCountsFormat: RootJsonFormat[GroupMembershipCounts] = jsonFormat2(GroupMembershipCounts.apply)
 }
 final case class GroupMembershipCounts(
     directSynchronized: Int,
-    totalSynchronized: Int,
-    unsynchronized: Int
+    totalSynchronized: Int
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -516,9 +516,6 @@ class UserService(
   def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
     directoryDAO.countIndirectSynchronizedGroupMemberships(samUser, samRequestContext)
 
-  def countUnsynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
-    directoryDAO.countUnsynchronizedGroupMemberships(samUser, samRequestContext)
-
   def getSamUserCombinedState(
       workbenchEmail: WorkbenchEmail,
       samRequestContext: SamRequestContext,
@@ -536,7 +533,6 @@ class UserService(
       maybeAttributes <- getUserAttributes(samUser.id, samRequestContext)
       directGroupMemberships <- countDirectSynchronizedGroupMemberships(samUser, samRequestContext)
       indirectGroupMemberships <- countIndirectSynchronizedGroupMemberships(samUser, samRequestContext)
-      unsynchronizedGroupMemberships <- countUnsynchronizedGroupMemberships(samUser, samRequestContext)
       termsOfServiceDetails <- tosService.getTermsOfServiceDetailsForUser(samUser.id, samRequestContext)
       enterpriseFeatures <- resourceService
         .listResourcesFlat(
@@ -556,8 +552,7 @@ class UserService(
       termsOfServiceDetails.getOrElse(TermsOfServiceDetails(None, None, permitsSystemUsage = false, isCurrentVersion = false)),
       GroupMembershipCounts(
         directSynchronized = directGroupMemberships,
-        totalSynchronized = indirectGroupMemberships,
-        unsynchronized = unsynchronizedGroupMemberships
+        totalSynchronized = indirectGroupMemberships
       ),
       Map("enterpriseFeatures" -> enterpriseFeatures.toJson),
       favoriteResources

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -567,6 +567,9 @@ class UserService(
 
 object UserService {
 
+  // the "user" resource type is only used for resource_type_admin checks
+  val userTypeName: ResourceTypeName = ResourceTypeName("user")
+
   val random = SecureRandom.getInstance("NativePRNGNonBlocking")
 
   // from https://www.regular-expressions.info/email.html

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -342,8 +342,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] = ???
 
-  override def countUnsynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] = ???
-
   override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(users.values.find(_.azureB2CId.contains(userId)))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -756,12 +756,19 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
       "calculate the unsynchronized count" in {
         assume(databaseEnabled, databaseEnabledClue)
 
-        // create but do not synchronize the test groups;
-        // countUnsynchronizedGroupMemberships() only counts unsynchronized groups.
-        createDirectAndIndirectGroups(syncGroups = false)
+        val (parentGroup, _) = createDirectAndIndirectGroups(syncGroups = true)
 
+        // with all groups synced, unsynchronized count should be 0
         val unsyncedCount = dao.countUnsynchronizedGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
-        unsyncedCount shouldBe 2
+        unsyncedCount shouldBe 0
+
+        // add a user to the group, causing it to be out of sync
+        dao.addGroupMember(parentGroup.id, defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
+
+        // unsynchronized count should now find the unsynced group
+        val unsyncedCount2 = dao.countUnsynchronizedGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
+        unsyncedCount2 shouldBe 1
+
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -752,26 +752,6 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
       }
     }
 
-    "countUnsynchronizedGroupMemberships" - {
-      "calculate the unsynchronized count" in {
-        assume(databaseEnabled, databaseEnabledClue)
-
-        val (parentGroup, _) = createDirectAndIndirectGroups(syncGroups = true)
-
-        // with all groups synced, unsynchronized count should be 0
-        val unsyncedCount = dao.countUnsynchronizedGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
-        unsyncedCount shouldBe 0
-
-        // add a user to the group, causing it to be out of sync
-        dao.addGroupMember(parentGroup.id, defaultUser.id, samRequestContext).unsafeRunSync() shouldBe true
-
-        // unsynchronized count should now find the unsynced group
-        val unsyncedCount2 = dao.countUnsynchronizedGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
-        unsyncedCount2 shouldBe 1
-
-      }
-    }
-
     "createPetServiceAccount" - {
       "create pet service accounts" in {
         assume(databaseEnabled, databaseEnabledClue)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
@@ -86,10 +86,6 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       .doReturn(IO.pure(42))
       .when(directoryDAO)
       .countIndirectSynchronizedGroupMemberships(any[SamUser], any[SamRequestContext])
-    lenient()
-      .doReturn(IO.pure(1234))
-      .when(directoryDAO)
-      .countUnsynchronizedGroupMemberships(any[SamUser], any[SamRequestContext])
 
     // TOS
     lenient()
@@ -108,7 +104,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = true),
         Option(SamUserAttributes(testUser.id, marketingConsent = true)),
         TermsOfServiceDetails(Option("v1"), Option(nowInstant), permitsSystemUsage = true, isCurrentVersion = true),
-        GroupMembershipCounts(7, 42, 1234),
+        GroupMembershipCounts(7, 42),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )
@@ -128,7 +124,6 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       response.favoriteResources should be(favoriteResources)
       response.groupMembershipCounts.directSynchronized should be(7)
       response.groupMembershipCounts.totalSynchronized should be(42)
-      response.groupMembershipCounts.unsynchronized should be(1234)
     }
     it("return null attributes if the user has no attributes") {
       // Arrange
@@ -144,7 +139,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = true),
         None,
         TermsOfServiceDetails(Option("v1"), Option(nowInstant), permitsSystemUsage = true, isCurrentVersion = true),
-        GroupMembershipCounts(7, 42, 1234),
+        GroupMembershipCounts(7, 42),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )
@@ -164,7 +159,6 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       response.favoriteResources should be(favoriteResources)
       response.groupMembershipCounts.directSynchronized should be(7)
       response.groupMembershipCounts.totalSynchronized should be(42)
-      response.groupMembershipCounts.unsynchronized should be(1234)
     }
     it("return falsy terms of service if the user has no tos history") {
       // Arrange
@@ -182,7 +176,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = false),
         Option(SamUserAttributes(testUser.id, marketingConsent = true)),
         TermsOfServiceDetails(None, None, permitsSystemUsage = false, isCurrentVersion = false),
-        GroupMembershipCounts(7, 42, 1234),
+        GroupMembershipCounts(7, 42),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )
@@ -202,7 +196,6 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       response.favoriteResources should be(favoriteResources)
       response.groupMembershipCounts.directSynchronized should be(7)
       response.groupMembershipCounts.totalSynchronized should be(42)
-      response.groupMembershipCounts.unsynchronized should be(1234)
     }
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-232

What:

* change the `GET /api/admin/v1/user/email/{email}/supportSummary` API to require the `admin_read_summary_information` action on the `user` `resource_type_admin` instead of requiring workbench admin
* remove the `groupMembershipCounts.unsynchronized` count from the support summary. This number was incorrect and unhelpful.

See #1617 for the original implementation.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
