### PR TITLE
CORE-246 Upgrading to cache v4

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -194,7 +194,7 @@ jobs:
       # Any changes to these files will result in a different cache key, triggering a cache update.
       - name: Coursier cache
         id: coursier-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache
@@ -220,7 +220,7 @@ jobs:
       # Any changes to these files will result in a different cache key, triggering a cache update.
       - name: Cache .sbt directory
         id: sbt-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt
@@ -250,7 +250,7 @@ jobs:
       # consistent and reproducible build outputs.
       - name: Cache sbt targets
         id: sbt-targets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             **/target
@@ -272,7 +272,7 @@ jobs:
       # This is similar to sbt-targets cache but limited to pact4s targets.
       - name: Cache pact4s targets
         id: sbt-pact4s-targets
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             pact4s/**/target


### PR DESCRIPTION
Jira: [\<Link to Jira ticket\>](https://broadworkbench.atlassian.net/browse/CORE-246)

What:

Upgrades all actions/cache to v4

Why:

  The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.

The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.

More info here: https://github.com/marketplace/actions/cache

How:

This makes all our repos use the same version of actions/cache.
  
