### PR TITLE
CORE-232: count indirect public resource group memberships

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4318,6 +4318,10 @@ components:
           description: |
             Number of groups to which the user is a direct or indirect member.
             Does not include groups from public resources.
+        indirectPublic:
+          type: integer
+          description: |
+            Number of groups, belonging to public resources, to which the user is an indirect member.
     ManagedGroupMembershipEntry:
       required:
         - groupEmail

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -110,6 +110,11 @@ trait DirectoryDAO {
     */
   def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int]
 
+  /** @return
+    *   the number of groups to which the user is an indirect member via the All_Users group on public resources.
+    */
+  def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int]
+
   def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]
 
   def disableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -754,6 +754,13 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)
     }
 
+  override def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
+    readOnlyTransaction("countIndirectPublicGroupMemberships", samRequestContext) { implicit session =>
+      val query = samsql"""select count(group_id) from sam_resource_policy where public = TRUE"""
+
+      query.map(rs => rs.int(1)).single().apply().getOrElse(0)
+    }
+
   override def enableIdentity(subject: WorkbenchSubject, samRequestContext: SamRequestContext): IO[Unit] =
     subject match {
       case userId: WorkbenchUserId =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/GroupMembershipCounts.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/api/GroupMembershipCounts.scala
@@ -4,9 +4,10 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 object GroupMembershipCounts {
-  implicit val GroupMembershipCountsFormat: RootJsonFormat[GroupMembershipCounts] = jsonFormat2(GroupMembershipCounts.apply)
+  implicit val GroupMembershipCountsFormat: RootJsonFormat[GroupMembershipCounts] = jsonFormat3(GroupMembershipCounts.apply)
 }
 final case class GroupMembershipCounts(
     directSynchronized: Int,
-    totalSynchronized: Int
+    totalSynchronized: Int,
+    indirectPublic: Int
 )

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -516,6 +516,9 @@ class UserService(
   def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
     directoryDAO.countIndirectSynchronizedGroupMemberships(samUser, samRequestContext)
 
+  def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
+    directoryDAO.countIndirectPublicGroupMemberships(samUser, samRequestContext)
+
   def getSamUserCombinedState(
       workbenchEmail: WorkbenchEmail,
       samRequestContext: SamRequestContext,
@@ -533,6 +536,7 @@ class UserService(
       maybeAttributes <- getUserAttributes(samUser.id, samRequestContext)
       directGroupMemberships <- countDirectSynchronizedGroupMemberships(samUser, samRequestContext)
       indirectGroupMemberships <- countIndirectSynchronizedGroupMemberships(samUser, samRequestContext)
+      indirectPublicMemberships <- countIndirectPublicGroupMemberships(samUser, samRequestContext)
       termsOfServiceDetails <- tosService.getTermsOfServiceDetailsForUser(samUser.id, samRequestContext)
       enterpriseFeatures <- resourceService
         .listResourcesFlat(
@@ -552,7 +556,8 @@ class UserService(
       termsOfServiceDetails.getOrElse(TermsOfServiceDetails(None, None, permitsSystemUsage = false, isCurrentVersion = false)),
       GroupMembershipCounts(
         directSynchronized = directGroupMemberships,
-        totalSynchronized = indirectGroupMemberships
+        totalSynchronized = indirectGroupMemberships,
+        indirectPublic = indirectPublicMemberships
       ),
       Map("enterpriseFeatures" -> enterpriseFeatures.toJson),
       favoriteResources

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -342,6 +342,8 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def countIndirectSynchronizedGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] = ???
 
+  override def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] = ???
+
   override def loadUserByAzureB2CId(userId: AzureB2CId, samRequestContext: SamRequestContext): IO[Option[SamUser]] =
     IO.pure(users.values.find(_.azureB2CId.contains(userId)))
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -752,6 +752,30 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
       }
     }
 
+    "countIndirectPublicGroupMemberships" - {
+      "calculate the indirect count for public resources" in {
+        assume(databaseEnabled, databaseEnabledClue)
+
+        policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
+        policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
+        policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
+
+        // add user to policy to ensure direct membership doesn't affect the public count
+        policyDAO.addAndRemovePolicyMembers(defaultPolicy.id, Set(defaultUser.id), Set(), samRequestContext)
+
+        // resource is not public, so count should be zero
+        val indirectCountBefore = dao.countIndirectPublicGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
+        indirectCountBefore shouldBe 0
+
+        // set the resource's policy to be public
+        policyDAO.setPolicyIsPublic(defaultPolicy.id, isPublic = true, samRequestContext).unsafeRunSync()
+
+        // count should now be 1
+        val indirectCountAfter = dao.countIndirectPublicGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
+        indirectCountAfter shouldBe 1
+      }
+    }
+
     "createPetServiceAccount" - {
       "create pet service accounts" in {
         assume(databaseEnabled, databaseEnabledClue)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
@@ -86,6 +86,10 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       .doReturn(IO.pure(42))
       .when(directoryDAO)
       .countIndirectSynchronizedGroupMemberships(any[SamUser], any[SamRequestContext])
+    lenient()
+      .doReturn(IO.pure(101))
+      .when(directoryDAO)
+      .countIndirectPublicGroupMemberships(any[SamUser], any[SamRequestContext])
 
     // TOS
     lenient()
@@ -104,7 +108,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = true),
         Option(SamUserAttributes(testUser.id, marketingConsent = true)),
         TermsOfServiceDetails(Option("v1"), Option(nowInstant), permitsSystemUsage = true, isCurrentVersion = true),
-        GroupMembershipCounts(7, 42),
+        GroupMembershipCounts(7, 42, 101),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )
@@ -139,7 +143,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = true),
         None,
         TermsOfServiceDetails(Option("v1"), Option(nowInstant), permitsSystemUsage = true, isCurrentVersion = true),
-        GroupMembershipCounts(7, 42),
+        GroupMembershipCounts(7, 42, 101),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )
@@ -176,7 +180,7 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
         SamUserAllowances(enabled = true, termsOfService = false),
         Option(SamUserAttributes(testUser.id, marketingConsent = true)),
         TermsOfServiceDetails(None, None, permitsSystemUsage = false, isCurrentVersion = false),
-        GroupMembershipCounts(7, 42),
+        GroupMembershipCounts(7, 42, 101),
         Map("enterpriseFeatures" -> FilteredResourcesFlat(Set(enterpriseFeature)).toJson),
         favoriteResources
       )


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-232

What:

Add the count of indirect group memberships due to public resources to the `getSamUserCombinedState` API and to the supportSummary user-lookup API.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
