### PR TITLE
CORE-232: don't include unsynchronized groups in public count

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -756,7 +756,12 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
 
   override def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
     readOnlyTransaction("countIndirectPublicGroupMemberships", samRequestContext) { implicit session =>
-      val query = samsql"""select count(group_id) from sam_resource_policy where public = TRUE"""
+      val query =
+        samsql"""select count(p.group_id)
+                from sam_resource_policy p
+                join sam_group g on p.group_id = g.id
+                where g.synchronized_date is not null
+                and p.public"""
 
       query.map(rs => rs.int(1)).single().apply().getOrElse(0)
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -769,10 +769,23 @@ class PostgresDirectoryDAOSpec extends RetryableAnyFreeSpec with Matchers with B
 
         // set the resource's policy to be public
         policyDAO.setPolicyIsPublic(defaultPolicy.id, isPublic = true, samRequestContext).unsafeRunSync()
+        // and synchronize its group
+        dao.updateSynchronizedDateAndVersion(defaultPolicy, samRequestContext).unsafeRunSync()
 
         // count should now be 1
         val indirectCountAfter = dao.countIndirectPublicGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
         indirectCountAfter shouldBe 1
+      }
+
+      "ignore unsynchronized groups" in {
+        assume(databaseEnabled, databaseEnabledClue)
+
+        // managed groups have an admin-notifier policy&group which is not synchronized
+        createDirectAndIndirectGroups(syncGroups = true)
+
+        // resource is not public, so count should be zero
+        val indirectCount = dao.countIndirectPublicGroupMemberships(defaultUser, samRequestContext).unsafeRunSync()
+        indirectCount shouldBe 0
       }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-232

What:

Builds on #1625. This PR excludes non-synchronized groups from the count of groups from public resources.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
