### PR TITLE
CORE-266: use GroupAccessRequestNotificationV2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,14 +11,14 @@ object Dependencies {
   val postgresDriverVersion = "42.7.4"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "fa46370" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "4292239" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
-  val workbenchModelV = s"0.20-$workbenchLibV"
-  val workbenchGoogleV = s"0.33-$workbenchLibV"
-  val workbenchGoogle2V = s"0.36-$workbenchLibV"
-  val workbenchNotificationsV = s"0.8-$workbenchLibV"
-  val workbenchOauth2V = s"0.8-$workbenchLibV"
+  val workbenchModelV = s"0.21-$workbenchLibV"
+  val workbenchGoogleV = s"0.34-$workbenchLibV"
+  val workbenchGoogle2V = s"0.37-$workbenchLibV"
+  val workbenchNotificationsV = s"0.10-$workbenchLibV"
+  val workbenchOauth2V = s"0.9-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.34-SNAPSHOT"
   val tclVersion = "1.1.30-SNAPSHOT"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupService.scala
@@ -235,7 +235,7 @@ class ManagedGroupService(
           }
         } yield {
           val notifications = adminUserIds.map { recipientUserId =>
-            Notifications.GroupAccessRequestNotification(recipientUserId, WorkbenchGroupName(resourceId.value).value, adminUserIds, requesterSubjectId)
+            Notifications.GroupAccessRequestNotificationV2(recipientUserId, WorkbenchGroupName(resourceId.value).value, requesterSubjectId, requesterSubjectId)
           }
           cloudExtensions.fireAndForgetNotifications(notifications)
         }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -2137,10 +2137,10 @@ class GoogleExtensionSpec(_system: ActorSystem)
     )
 
     val messages = Set(
-      Notifications.GroupAccessRequestNotification(
+      Notifications.GroupAccessRequestNotificationV2(
         WorkbenchUserId("Bob"),
         WorkbenchGroupName("bobs_buds").value,
-        Set(WorkbenchUserId("reply_to_address")),
+        WorkbenchUserId("requesters_id"),
         WorkbenchUserId("requesters_id")
       )
     )

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/ManagedGroupServiceSpec.scala
@@ -543,12 +543,14 @@ class ManagedGroupServiceSpec
         .value
     )
 
+    val requesterId = requester.googleSubjectId.map(id => WorkbenchUserId(id.value)).getOrElse(fail("no requester google subject id"))
+
     val expectedNotificationMessages = Set(
-      Notifications.GroupAccessRequestNotification(
+      Notifications.GroupAccessRequestNotificationV2(
         adminGoogleSubjectId,
         WorkbenchGroupName(resourceId.value).value,
-        Set(adminGoogleSubjectId),
-        requester.googleSubjectId.map(id => WorkbenchUserId(id.value)).getOrElse(fail("no requester google subject id"))
+        requesterId,
+        requesterId
       )
     )
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-266

What:

When sending a group access request notification, use `GroupAccessRequestNotificationV2` instead of the deprecated `GroupAccessRequestNotification`. This enforces, in code, that notifications only use a single reply-to address.

Context of the overall rollout plan to [adopt the SendGrid v3 APIs by February 10](https://www.twilio.com/docs/sendgrid/for-developers/sending-email/migrating-from-v2-to-v3-mail-send):

1. [DONE] https://github.com/broadinstitute/thurloe/pull/369, which ensures all email notifications use a single reply-to~
2. [DONE] https://github.com/broadinstitute/thurloe/pull/368, which adopts the latest `sendgrid-java` and v3 APIs
3. [DONE] Modify workbench-libs to deprecate the `GroupAccessRequestNotification` used by Sam which allows multiple reply-tos; provide a replacement `GroupAccessRequestNotificationV2` that only allows a single reply-to. See https://github.com/broadinstitute/workbench-libs/pull/1717 (this PR)
4. [DONE] Support the new `GroupAccessRequestNotificationV2` model in Thurloe. See https://github.com/broadinstitute/thurloe/pull/372
5. [this PR] Use the new `GroupAccessRequestNotificationV2` model in Sam. After this step, Thurloe would no longer ignore the reply-to value sent by Sam; Sam would once again be in control of the reply-to.
6. Remove support for the deprecated `GroupAccessRequestNotification` from Thurloe
7. Delete the deprecated `GroupAccessRequestNotification` from workbench-libs

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
