### PR TITLE
CORE-278: optimize google key cache; more aggressive cleanup

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -111,6 +111,7 @@ class GoogleKeyCache(
       } yield key
 
     val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 20 seconds)
+    // TODO CORE-278: withLock() allows multiple simultaneous requests for the same pet, enabling race conditions below
     maybeCreateKey((_, _) => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(cleanupAndCreateKey)))
   }
 
@@ -155,6 +156,7 @@ class GoogleKeyCache(
   private def furnishNewKey(pet: PetServiceAccount): IO[String] =
     for {
       key <- IO.fromFuture(IO(googleIamDAO.createServiceAccountKey(pet.id.project, pet.serviceAccount.email))) recover {
+        // TODO CORE-278: verify this is still the exception thrown by Google
         case e: GoogleJsonResponseException if e.getDetails.getCode == StatusCodes.TooManyRequests.intValue =>
           throw new WorkbenchException("You have reached the 10 key limit on service accounts. Please remove one to create another.")
       }
@@ -179,46 +181,40 @@ class GoogleKeyCache(
   /** Clean up keys for the given pet. This will delete:
     *   - any keys present in IAM but not present in the key cache
     *   - any keys in the key cache but not present in IAM
-    *   - any expired keys
     */
   private def cleanupKeys(pet: PetServiceAccount, cachedKeyObjects: List[GcsObjectName], serviceAccountKeys: List[ServiceAccountKey]): Future[Unit] = {
+    val cachedKeyIds: Set[ServiceAccountKeyId] = cachedKeyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
+    val iamKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet
 
-    def keyObjectsToIds(keyObjects: List[GcsObjectName]) =
-      keyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
+    // keys in IAM but not in cache
+    val uncachedKeyIds: Set[ServiceAccountKeyId] = iamKeyIds -- cachedKeyIds
 
-    // separate cache objects into active vs. inactive.
-    // The inactive objects will include any keys which are active in cache but not in IAM
-    val (activeCachedKeys, inactiveCachedKeys) = cachedKeyObjects.partition(keyObject => isKeyActive(keyObject, serviceAccountKeys))
+    // keys in cache but not in IAM
+    val orphanedKeyIds: Set[ServiceAccountKeyId] = cachedKeyIds -- iamKeyIds
 
-    // extract the key ids from the cache objects
-    val activeCachedKeyIds: Set[ServiceAccountKeyId] = keyObjectsToIds(activeCachedKeys)
-    val inactiveCachedKeyIds: Set[ServiceAccountKeyId] = keyObjectsToIds(inactiveCachedKeys)
-
-    // keys in IAM but not active in cache
-    val uncachedKeys: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet -- activeCachedKeyIds
-
-    // delete from cache and IAM any keys which are too old or which exist only in cache
-    inactiveCachedKeyIds
+    // delete from cache any keys which exist only in cache
+    orphanedKeyIds
       .parUnorderedTraverse { keyId =>
-        removeKey(pet, keyId)
-          // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion
-          // of other keys. Google will prevent us creating too many keys anyway.
+        googleStorageAlg
+          .removeObject(googleServicesConfig.googleKeyCacheConfig.bucketName, keyNameFull(pet.id.project, pet.serviceAccount.email, keyId))
+          .compile
+          .drain
           .recover {
             case gjre: GoogleJsonResponseException =>
               logger.warn(
-                s"Error while removing service account key: '${gjre.getDetails.getCode}:${gjre.getMessage}' error, project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+                s"Error while removing key cache entry: '${gjre.getDetails.getCode}:${gjre.getMessage}' error, project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
               )
             case t: Throwable =>
               logger.warn(
-                s"Error while removing service account key: '${t.getMessage}', project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+                s"Error while removing key cache entry: '${t.getMessage}', project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
               )
           }
       }
       .unsafeRunSync()
 
-    // delete from IAM any keys which are not active in cache
+    // delete from IAM any keys which exist only in IAM
     Future
-      .traverse(uncachedKeys) { keyId =>
+      .traverse(uncachedKeyIds) { keyId =>
         googleIamDAO
           .removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
           // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -128,7 +128,7 @@ class GoogleKeyCache(
         logger.warn(s"danger: pet ${pet.serviceAccount.displayName.value} has ${keysFromIam.length} keys")
       maybeActiveKey = keysFromCache.sortBy(_.timeCreated.toEpochMilli).findLast(x => isKeyActive(x, keysFromIam))
       activeKey <- maybeActiveKey match {
-        case Some(mostRecentKey) if isKeyActive(mostRecentKey, keysFromIam) =>
+        case Some(mostRecentKey) =>
           googleStorageAlg
             .unsafeGetBlobBody(googleServicesConfig.googleKeyCacheConfig.bucketName, GcsBlobName(mostRecentKey.value))
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -4,6 +4,7 @@ import java.nio.charset.Charset
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.storage.{BucketInfo, StorageException}
@@ -32,7 +33,7 @@ class GoogleKeyCache(
     val googleKeyCachePubSubDao: GooglePubSubDAO,
     val googleServicesConfig: GoogleServicesConfig,
     val petServiceAccountConfig: PetServiceAccountConfig
-)(implicit val executionContext: ExecutionContext)
+)(implicit val executionContext: ExecutionContext, ioRuntime: IORuntime)
     extends KeyCache
     with LazyLogging {
   val keyPathPattern = """([^\/]+)\/([^\/]+)\/([^\/]+)""".r
@@ -200,9 +201,28 @@ class GoogleKeyCache(
     // keys active in cache but not in IAM
     val nonExistentKeys: Set[ServiceAccountKeyId] = activeCachedKeyIds -- iamKeyIds
 
-    // to delete: all inactive keys and all keys where cache and IAM disagree
+    // delete from cache and IAM any keys which are inactive or which exist only in cache
+    (inactiveCachedKeyIds ++ nonExistentKeys)
+      .parUnorderedTraverse { keyId =>
+        removeKey(pet, keyId)
+          // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion
+          // of other keys. Google will prevent us creating too many keys anyway.
+          .recover {
+            case gjre: GoogleJsonResponseException =>
+              logger.warn(
+                s"Error while removing service account key: '${gjre.getDetails.getCode}:${gjre.getMessage}' error, project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+              )
+            case t: Throwable =>
+              logger.warn(
+                s"Error while removing service account key: '${t.getMessage}', project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+              )
+          }
+      }
+      .unsafeRunSync()
+
+    // delete from IAM any keys which are not active in cache
     Future
-      .traverse(uncachedKeys ++ nonExistentKeys ++ inactiveCachedKeyIds) { keyId =>
+      .traverse(uncachedKeys) { keyId =>
         googleIamDAO
           .removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
           // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -4,7 +4,6 @@ import java.nio.charset.Charset
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.storage.{BucketInfo, StorageException}
@@ -20,6 +19,8 @@ import org.broadinstitute.dsde.workbench.sam.service.KeyCache
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{LockDetails, PostgresDistributedLockDAO}
 
+import cats.effect.unsafe.implicits.global
+
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,7 +34,7 @@ class GoogleKeyCache(
     val googleKeyCachePubSubDao: GooglePubSubDAO,
     val googleServicesConfig: GoogleServicesConfig,
     val petServiceAccountConfig: PetServiceAccountConfig
-)(implicit val executionContext: ExecutionContext, ioRuntime: IORuntime)
+)(implicit val executionContext: ExecutionContext)
     extends KeyCache
     with LazyLogging {
   val keyPathPattern = """([^\/]+)\/([^\/]+)\/([^\/]+)""".r

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -111,7 +111,6 @@ class GoogleKeyCache(
       } yield key
 
     val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 20 seconds)
-    // TODO CORE-278: withLock() allows multiple simultaneous requests for the same pet, enabling race conditions below
     maybeCreateKey((_, _) => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(cleanupAndCreateKey)))
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -203,7 +203,20 @@ class GoogleKeyCache(
     // to delete: all inactive keys and all keys where cache and IAM disagree
     Future
       .traverse(uncachedKeys ++ nonExistentKeys ++ inactiveCachedKeyIds) { keyId =>
-        googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
+        googleIamDAO
+          .removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
+          // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion
+          // of other keys. Google will prevent us creating too many keys anyway.
+          .recover {
+            case gjre: GoogleJsonResponseException =>
+              logger.warn(
+                s"Error while removing service account key: '${gjre.getDetails.getCode}:${gjre.getMessage}' error, project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+              )
+            case t: Throwable =>
+              logger.warn(
+                s"Error while removing service account key: '${t.getMessage}', project ${pet.id.project}, sa email ${pet.serviceAccount.email}, sa key id $keyId"
+              )
+          }
       }
       .void
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -186,10 +186,8 @@ class GoogleKeyCache(
     def keyObjectsToIds(keyObjects: List[GcsObjectName]) =
       keyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
 
-    // perform .toSet once so we can reuse it multiple times later
-    val iamKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet
-
-    // separate cached keys into active vs. inactive
+    // separate cache objects into active vs. inactive.
+    // The inactive objects will include any keys which are active in cache but not in IAM
     val (activeCachedKeys, inactiveCachedKeys) = cachedKeyObjects.partition(keyObject => isKeyActive(keyObject, serviceAccountKeys))
 
     // extract the key ids from the cache objects
@@ -197,13 +195,10 @@ class GoogleKeyCache(
     val inactiveCachedKeyIds: Set[ServiceAccountKeyId] = keyObjectsToIds(inactiveCachedKeys)
 
     // keys in IAM but not active in cache
-    val uncachedKeys: Set[ServiceAccountKeyId] = iamKeyIds -- activeCachedKeyIds
+    val uncachedKeys: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet -- activeCachedKeyIds
 
-    // keys active in cache but not in IAM
-    val nonExistentKeys: Set[ServiceAccountKeyId] = activeCachedKeyIds -- iamKeyIds
-
-    // delete from cache and IAM any keys which are inactive or which exist only in cache
-    (inactiveCachedKeyIds ++ nonExistentKeys)
+    // delete from cache and IAM any keys which are too old or which exist only in cache
+    inactiveCachedKeyIds
       .parUnorderedTraverse { keyId =>
         removeKey(pet, keyId)
           // Don't let a failure in key deletion prevent creation of new keys, or prevent deletion

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -180,25 +180,29 @@ class GoogleKeyCache(
     *   - any expired keys
     */
   private def cleanupKeys(pet: PetServiceAccount, cachedKeyObjects: List[GcsObjectName], serviceAccountKeys: List[ServiceAccountKey]): Future[Unit] = {
-    val cachedKeyIds: Set[ServiceAccountKeyId] = cachedKeyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
+
+    def keyObjectsToIds(keyObjects: List[GcsObjectName]) =
+      keyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
+
+    // perform .toSet once so we can reuse it multiple times later
     val iamKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet
 
-    // keys in IAM but not in cache
-    val uncachedKeys: Set[ServiceAccountKeyId] = iamKeyIds -- cachedKeyIds
+    // separate cached keys into active vs. inactive
+    val (activeCachedKeys, inactiveCachedKeys) = cachedKeyObjects.partition(keyObject => isKeyActive(keyObject, serviceAccountKeys))
 
-    // keys in cache but not in IAM
-    val nonExistentKeys: Set[ServiceAccountKeyId] = cachedKeyIds -- iamKeyIds
+    // extract the key ids from the cache objects
+    val activeCachedKeyIds: Set[ServiceAccountKeyId] = keyObjectsToIds(activeCachedKeys)
+    val inactiveCachedKeyIds: Set[ServiceAccountKeyId] = keyObjectsToIds(inactiveCachedKeys)
 
-    // expired keys
-    val expiredKeys: Set[ServiceAccountKeyId] = cachedKeyObjects
-      .collect {
-        case key: GcsObjectName if !isKeyActive(key, serviceAccountKeys) => key.value
-      }
-      .collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
-      .toSet
+    // keys in IAM but not active in cache
+    val uncachedKeys: Set[ServiceAccountKeyId] = iamKeyIds -- activeCachedKeyIds
 
+    // keys active in cache but not in IAM
+    val nonExistentKeys: Set[ServiceAccountKeyId] = activeCachedKeyIds -- iamKeyIds
+
+    // to delete: all inactive keys and all keys where cache and IAM disagree
     Future
-      .traverse(uncachedKeys ++ nonExistentKeys ++ expiredKeys) { keyId =>
+      .traverse(uncachedKeys ++ nonExistentKeys ++ inactiveCachedKeyIds) { keyId =>
         googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
       }
       .void

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -104,7 +104,7 @@ class GoogleKeyCache(
 
     def cleanupAndCreateKey(keysFromCache: List[GcsObjectName], keysFromIam: List[ServiceAccountKey]): IO[String] =
       for {
-        _ <- IO.fromFuture(IO(cleanupUnknownKeys(pet, keysFromCache, keysFromIam)))
+        _ <- IO.fromFuture(IO(cleanupKeys(pet, keysFromCache, keysFromIam)))
         key <- furnishNewKey(pet)
       } yield key
 
@@ -123,15 +123,18 @@ class GoogleKeyCache(
   private def retrieveActiveKey(pet: PetServiceAccount): IO[(Option[String], List[GcsObjectName], List[ServiceAccountKey])] =
     for {
       (keysFromCache, keysFromIam) <- fetchKeysFromCacheAndIam(pet)
-      maybeMostRecentKey = keysFromCache.sortBy(_.timeCreated.toEpochMilli).lastOption
-      mostRecentKey <- maybeMostRecentKey match {
+      // TODO CORE-278: this could result in log spam
+      _ = if (keysFromIam.length >= 10)
+        logger.warn(s"danger: pet ${pet.serviceAccount.displayName.value} has ${keysFromIam.length} keys")
+      maybeActiveKey = keysFromCache.sortBy(_.timeCreated.toEpochMilli).findLast(x => isKeyActive(x, keysFromIam))
+      activeKey <- maybeActiveKey match {
         case Some(mostRecentKey) if isKeyActive(mostRecentKey, keysFromIam) =>
           googleStorageAlg
             .unsafeGetBlobBody(googleServicesConfig.googleKeyCacheConfig.bucketName, GcsBlobName(mostRecentKey.value))
 
         case _ => IO.pure(None)
       }
-    } yield (mostRecentKey, keysFromCache, keysFromIam)
+    } yield (activeKey, keysFromCache, keysFromIam)
 
   override def removeKey(pet: PetServiceAccount, keyId: ServiceAccountKeyId): IO[Unit] =
     for {
@@ -171,12 +174,31 @@ class GoogleKeyCache(
     !keyRetired && keyExistsForSA
   }
 
-  private def cleanupUnknownKeys(pet: PetServiceAccount, cachedKeyObjects: List[GcsObjectName], serviceAccountKeys: List[ServiceAccountKey]): Future[Unit] = {
-    val cachedKeyIds = cachedKeyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
-    val unknownKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet -- cachedKeyIds.toSet
+  /** Clean up keys for the given pet. This will delete:
+    *   - any keys present in IAM but not present in the key cache
+    *   - any keys in the key cache but not present in IAM
+    *   - any expired keys
+    */
+  private def cleanupKeys(pet: PetServiceAccount, cachedKeyObjects: List[GcsObjectName], serviceAccountKeys: List[ServiceAccountKey]): Future[Unit] = {
+    val cachedKeyIds: Set[ServiceAccountKeyId] = cachedKeyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }.toSet
+    val iamKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet
+
+    // keys in IAM but not in cache
+    val uncachedKeys: Set[ServiceAccountKeyId] = iamKeyIds -- cachedKeyIds
+
+    // keys in cache but not in IAM
+    val nonExistentKeys: Set[ServiceAccountKeyId] = cachedKeyIds -- iamKeyIds
+
+    // expired keys
+    val expiredKeys: Set[ServiceAccountKeyId] = cachedKeyObjects
+      .collect {
+        case key: GcsObjectName if !isKeyActive(key, serviceAccountKeys) => key.value
+      }
+      .collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
+      .toSet
 
     Future
-      .traverse(unknownKeyIds) { keyId =>
+      .traverse(uncachedKeys ++ nonExistentKeys ++ expiredKeys) { keyId =>
         googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
       }
       .void

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -156,7 +156,9 @@ class GoogleKeyCache(
   private def furnishNewKey(pet: PetServiceAccount): IO[String] =
     for {
       key <- IO.fromFuture(IO(googleIamDAO.createServiceAccountKey(pet.id.project, pet.serviceAccount.email))) recover {
-        // TODO CORE-278: verify this is still the exception thrown by Google
+        // TODO CORE-278: Google now returns a 400 with "message": "Precondition check failed.",
+        //    "status": "FAILED_PRECONDITION" instead of the 429. Update this exception handling.
+        // TODO CORE-278: on error, check the number of existing keys and purge as necessary
         case e: GoogleJsonResponseException if e.getDetails.getCode == StatusCodes.TooManyRequests.intValue =>
           throw new WorkbenchException("You have reached the 10 key limit on service accounts. Please remove one to create another.")
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
@@ -32,7 +32,7 @@ class DistributedLockSpec extends AsyncFlatSpec with Matchers with TestSupport {
     res.attempt.map(r => r.isRight shouldBe true).unsafeToFuture()
   }
 
-  it should "fail if there's same lock has already been set within 30 seconds" in {
+  it should "fail on acquireLock if there's same lock has already been set within 30 seconds" in {
     assume(databaseEnabled, databaseEnabledClue)
 
     val lockDetails = genLock.sample.get
@@ -41,6 +41,20 @@ class DistributedLockSpec extends AsyncFlatSpec with Matchers with TestSupport {
         _ <- lock.acquireLock(lockDetails)
         _ <- IO.sleep(2 seconds)
         failed <- lock.acquireLock(lockDetails).attempt
+      } yield failed.swap.toOption.get.asInstanceOf[FailToObtainLock].getMessage shouldBe s"can't get lock: $lockDetails"
+    }
+    res.unsafeToFuture()
+  }
+
+  it should "fail on withLock if there's same lock has already been set within 30 seconds" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val lockDetails = genLock.sample.get
+    val res = lockResource.use { lock =>
+      for {
+        _ <- lock.withLock(lockDetails).use(_ => IO.pure(()))
+        _ <- IO.sleep(2 seconds)
+        failed <- lock.withLock(lockDetails).use(_ => IO.pure(())).attempt
       } yield failed.swap.toOption.get.asInstanceOf[FailToObtainLock].getMessage shouldBe s"can't get lock: $lockDetails"
     }
     res.unsafeToFuture()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
@@ -46,20 +46,6 @@ class DistributedLockSpec extends AsyncFlatSpec with Matchers with TestSupport {
     res.unsafeToFuture()
   }
 
-  it should "fail on withLock if the same lock has already been set within 30 seconds" in {
-    assume(databaseEnabled, databaseEnabledClue)
-
-    val lockDetails = genLock.sample.get
-    val res = lockResource.use { lock =>
-      for {
-        _ <- lock.withLock(lockDetails).use(_ => IO.unit)
-        _ <- IO.sleep(2 seconds)
-        failed <- lock.withLock(lockDetails).use(_ => IO.unit).attempt
-      } yield failed.swap.toOption.get.asInstanceOf[FailToObtainLock].getMessage shouldBe s"can't get lock: $lockDetails"
-    }
-    res.unsafeToFuture()
-  }
-
   "releaseLock" should "remove lockDetails" in {
     assume(databaseEnabled, databaseEnabledClue)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/util/DistributedLockSpec.scala
@@ -32,7 +32,7 @@ class DistributedLockSpec extends AsyncFlatSpec with Matchers with TestSupport {
     res.attempt.map(r => r.isRight shouldBe true).unsafeToFuture()
   }
 
-  it should "fail on acquireLock if there's same lock has already been set within 30 seconds" in {
+  it should "fail on acquireLock if the same lock has already been set within 30 seconds" in {
     assume(databaseEnabled, databaseEnabledClue)
 
     val lockDetails = genLock.sample.get
@@ -46,15 +46,15 @@ class DistributedLockSpec extends AsyncFlatSpec with Matchers with TestSupport {
     res.unsafeToFuture()
   }
 
-  it should "fail on withLock if there's same lock has already been set within 30 seconds" in {
+  it should "fail on withLock if the same lock has already been set within 30 seconds" in {
     assume(databaseEnabled, databaseEnabledClue)
 
     val lockDetails = genLock.sample.get
     val res = lockResource.use { lock =>
       for {
-        _ <- lock.withLock(lockDetails).use(_ => IO.pure(()))
+        _ <- lock.withLock(lockDetails).use(_ => IO.unit)
         _ <- IO.sleep(2 seconds)
-        failed <- lock.withLock(lockDetails).use(_ => IO.pure(())).attempt
+        failed <- lock.withLock(lockDetails).use(_ => IO.unit).attempt
       } yield failed.swap.toOption.get.asInstanceOf[FailToObtainLock].getMessage shouldBe s"can't get lock: $lockDetails"
     }
     res.unsafeToFuture()


### PR DESCRIPTION
_experimental, do not review yet_

---

Ticket: https://broadworkbench.atlassian.net/browse/CORE-278

At a high level, the logic in the Google key cache is:
1. Look for an active cached key
2. If found: use that key
3. If not found: clean up old keys, create a new key, use the new key

This PR contains improvements to the implementation of this logic:

* When looking for an active cached key, consider all cached keys and not just the most recent one
* When cleaning up old keys, clean up more cases of invalid keys
* When cleaning up old keys, catch errors on key deletion. Previously, an error during key deletion could stop the whole flow and prevent the user from receiving a valid key



---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
