### PR TITLE
CORE-278: more resilience when retrieving pet keys

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -84,6 +84,7 @@ googleServices {
     bucketName = ${?GOOGLE_KEY_CACHE_BUCKET_NAME}
     activeKeyMaxAge = 12
     retiredKeyMaxAge = 60
+    nascentKeyMinAgeMinutes = 15
     monitor {
       pubSubProject = ${?GOOGLE_PROJECT}
       # Historically, there was a single bucket per google project, so a single pub/sub topic

--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -82,8 +82,12 @@ googleServices {
   }
   googleKeyCache {
     bucketName = ${?GOOGLE_KEY_CACHE_BUCKET_NAME}
+    # duration, in days, that a key is considered fresh enough to return from API calls
     activeKeyMaxAge = 12
+    # duration, in days, after which a key will be deleted
     retiredKeyMaxAge = 60
+    # duration, in minutes, that a newly-created key is considered eventually-consistent in the cloud and should
+    # be avoided if possible
     nascentKeyMinAgeMinutes = 15
     monitor {
       pubSubProject = ${?GOOGLE_PROJECT}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleKeyCacheConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleKeyCacheConfig.scala
@@ -3,13 +3,23 @@ package org.broadinstitute.dsde.workbench.sam.config
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
 /** Created by mbemis on 1/22/18.
-  */
-/** Google Key Cache configuration.
+  *
+  * Google Key Cache configuration.
   * @param bucketName
   *   The name of the bucket to store all pet service account keys in
   * @param activeKeyMaxAge
   *   The number of days to keep a key active
   * @param retiredKeyMaxAge
   *   The number of days to keep a key before deleting it
+  * @param nascentKeyMinAgeMinutes
+  *   The number of minutes old a key must be before considering it consistently usable
+  * @param monitorPubSubConfig
+  *   Pub/Sub config
   */
-case class GoogleKeyCacheConfig(bucketName: GcsBucketName, activeKeyMaxAge: Int, retiredKeyMaxAge: Int, monitorPubSubConfig: GooglePubSubConfig)
+case class GoogleKeyCacheConfig(
+    bucketName: GcsBucketName,
+    activeKeyMaxAge: Int,
+    retiredKeyMaxAge: Int,
+    nascentKeyMinAgeMinutes: Int,
+    monitorPubSubConfig: GooglePubSubConfig
+)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -50,6 +50,7 @@ object GoogleServicesConfig {
       GcsBucketName(config.getString("bucketName")),
       config.getInt("activeKeyMaxAge"),
       config.getInt("retiredKeyMaxAge"),
+      config.getInt("nascentKeyMinAgeMinutes"),
       config.as[GooglePubSubConfig]("monitor")
     )
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -278,7 +278,7 @@ class GoogleKeyCache(
       logger.info(
         s"cleanupKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is reaping ${toDelete.size} keys due to quota"
       )
-      toDelete.parTraverse(cachedKey => removeKey(pet, cachedKey.keyId))
+      toDelete.traverse(cachedKey => removeKey(pet, cachedKey.keyId))
     } else {
       IO.unit
     }
@@ -291,7 +291,7 @@ class GoogleKeyCache(
       logger.info(
         s"cleanupKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is reaping ${unknownKeyIds.size} orphaned keys"
       )
-      unknownKeyIds.toList.parTraverse(keyId => IO.fromFuture(IO(googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId))))
+      unknownKeyIds.toList.traverse(keyId => IO.fromFuture(IO(googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId))))
     } else {
       IO.unit
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -97,21 +97,28 @@ class GoogleKeyCache(
   /** Retrieve a key for this pet, creating keys as necessary.
     */
   override def getKey(pet: PetServiceAccount): IO[String] = {
-    def maybeCreateKey(withinLock: Boolean, fallback: () => IO[String]): IO[String] =
-      for {
-        maybeActiveKey <- findActiveKey(pet, withinLock)
-        activeKey <- maybeActiveKey match {
-          case Some(existingActiveKey) => IO.pure(existingActiveKey)
-          case None => fallback()
-        }
-      } yield activeKey
-
-    def failed(): IO[String] =
-      throw new WorkbenchException("Could not create or retrieve key")
-
     // 5 minute lock timeout chosen to match how long key creation polling can take
+    // TODO CORE-278: when we remove polling from workbench-libs, turn this lock time back down
     val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 5 minutes)
-    maybeCreateKey(withinLock = false, () => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(withinLock = true, () => failed())))
+
+    for {
+      // try to find a key using read-only logic by specifying withinLock = false
+      maybeActiveKey <- findActiveKey(pet, withinLock = false)
+      activeKey <- maybeActiveKey match {
+        case Some(key) => IO.pure(key)
+        case None =>
+          // obtain a lock, then try again to find a key, allowing key creation by specifying withinLock = true
+          distributedLock
+            .withLock(lockDetails)
+            .use(_ => findActiveKey(pet, withinLock = true).attempt)
+            .map {
+              case Right(Some(key)) => key
+              case Right(None) => throw new WorkbenchException("Could not create or retrieve key: unexpected problem")
+              case Left(t) =>
+                throw new WorkbenchException(s"Could not create or retrieve key: ${t.getMessage}")
+            }
+      }
+    } yield activeKey
   }
 
   /** List all cached keys from the Google bucket for this pet.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -166,9 +166,9 @@ class GoogleKeyCache(
       // if not within lock, return None. This will signal callers to obtain a lock and re-call this function.
       None
     } else if (nascentKeys.isEmpty && retiredKeys.nonEmpty) {
-      // if within lock, retired keys exist, and no nascent keys exist: return newest retired key and trigger key creation
-      // TODO CORE-278: trigger new-key creation; can be async
-      newestOf(retiredKeys)
+      // if within lock, retired keys exist, and no nascent keys exist:
+      // return newest retired key and trigger key creation
+      furnishNewKey(pet).map(_ => newestOf(retiredKeys)).unsafeRunSync()
     } else {
       // no keys exist; create one and return it
       Option(furnishNewKey(pet).unsafeRunSync())

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -26,6 +26,8 @@ import org.broadinstitute.dsde.workbench.sam.model.CachedKey.keyPathPattern
 
 import java.time.Instant
 
+import cats.effect.unsafe.implicits.global
+
 /** Created by mbemis on 1/10/18.
   */
 class GoogleKeyCache(
@@ -128,30 +130,28 @@ class GoogleKeyCache(
   private def findActiveKey(pet: PetServiceAccount, withinLock: Boolean): IO[Option[String]] =
     for {
       keysInCache <- fetchKeysFromCache(pet)
-      maybeActiveKey = searchCachedKeys(keysInCache, withinLock).map(_.value)
+      maybeActiveKey = searchCachedKeys(pet, keysInCache, withinLock)
     } yield maybeActiveKey
 
-  protected[google] def searchCachedKeys(keysInCache: List[CachedKey], withinLock: Boolean): Option[CachedKey] = {
+  protected[google] def searchCachedKeys(pet: PetServiceAccount, keysInCache: List[CachedKey], withinLock: Boolean): Option[String] = {
+    // helpers
+    def oldestOf(keys: List[CachedKey]): Option[String] =
+      Option(keys.minBy(_.timeCreated).value)
+    def newestOf(keys: List[CachedKey]): Option[String] =
+      Option(keys.maxBy(_.timeCreated).value)
+
     /* segment cached keys into ideal, retired, and nascent keys
         ideal: keys between 15 minutes and 12 days old. Use these whenever possible.
         retired: keys older than 12 days. Avoid if possible, but prefer these over nascent keys.
         nascent: keys newer than 15 minutes. Only use if nothing else is available; these may cause errors due to Google
           eventual consistency.
      */
-
-    def oldestOf(keys: List[CachedKey]): Option[CachedKey] =
-      Option(keys.minBy(_.timeCreated))
-
-    def newestOf(keys: List[CachedKey]): Option[CachedKey] =
-      Option(keys.maxBy(_.timeCreated))
-
     val now = Instant.now()
-
     val retirementTime = now.minusSeconds(googleServicesConfig.googleKeyCacheConfig.activeKeyMaxAge * (24L * 60 * 60))
-    val nascentInstant = now.minusSeconds(googleServicesConfig.googleKeyCacheConfig.nascentKeyMinAgeMinutes * 60L)
+    val nascentTime = now.minusSeconds(googleServicesConfig.googleKeyCacheConfig.nascentKeyMinAgeMinutes * 60L)
 
     val (retiredKeys, unretiredKeys) = keysInCache.partition(_.isBefore(retirementTime))
-    val (idealKeys, nascentKeys) = unretiredKeys.partition(_.isBefore(nascentInstant))
+    val (idealKeys, nascentKeys) = unretiredKeys.partition(_.isBefore(nascentTime))
 
     if (idealKeys.nonEmpty) {
       // if any ideal keys exist, return the newest of those
@@ -171,8 +171,7 @@ class GoogleKeyCache(
       newestOf(retiredKeys)
     } else {
       // no keys exist; create one and return it
-      // TODO CORE-278: trigger new-key creation and return its result
-      None
+      Option(furnishNewKey(pet).unsafeRunSync())
     }
 
   }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -18,11 +18,13 @@ import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetSe
 import org.broadinstitute.dsde.workbench.sam.service.KeyCache
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{LockDetails, PostgresDistributedLockDAO}
+import org.broadinstitute.dsde.workbench.sam.model.CachedKey
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-
 import org.broadinstitute.dsde.workbench.sam.model.CachedKey.keyPathPattern
+
+import java.time.Instant
 
 /** Created by mbemis on 1/10/18.
   */
@@ -118,6 +120,64 @@ class GoogleKeyCache(
     maybeCreateKey((_, _) => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(cleanupAndCreateKey)))
   }
 
+  private def fetchKeysFromCache(pet: PetServiceAccount): IO[List[CachedKey]] =
+    googleStorageAlg
+      .unsafeListObjectsWithPrefix(googleServicesConfig.googleKeyCacheConfig.bucketName, keyNamePrefix(pet.id.project, pet.serviceAccount.email))
+      .map(gcsObjectList => gcsObjectList.map(CachedKey(_)))
+
+  private def findActiveKey(pet: PetServiceAccount, withinLock: Boolean): IO[Option[String]] =
+    for {
+      keysInCache <- fetchKeysFromCache(pet)
+      maybeActiveKey = searchCachedKeys(keysInCache, withinLock).map(_.value)
+    } yield maybeActiveKey
+
+  protected[google] def searchCachedKeys(keysInCache: List[CachedKey], withinLock: Boolean): Option[CachedKey] = {
+    /* segment cached keys into ideal, retired, and nascent keys
+        ideal: keys between 15 minutes and 12 days old. Use these whenever possible.
+        retired: keys older than 12 days. Avoid if possible, but prefer these over nascent keys.
+        nascent: keys newer than 15 minutes. Only use if nothing else is available; these may cause errors due to Google
+          eventual consistency.
+     */
+
+    def oldestOf(keys: List[CachedKey]): Option[CachedKey] =
+      Option(keys.minBy(_.timeCreated))
+
+    def newestOf(keys: List[CachedKey]): Option[CachedKey] =
+      Option(keys.maxBy(_.timeCreated))
+
+    val now = Instant.now()
+
+    val retirementTime = now.minusSeconds(googleServicesConfig.googleKeyCacheConfig.activeKeyMaxAge * (24L * 60 * 60))
+    val nascentInstant = now.minusSeconds(googleServicesConfig.googleKeyCacheConfig.nascentKeyMinAgeMinutes * 60L)
+
+    val (retiredKeys, unretiredKeys) = keysInCache.partition(_.isBefore(retirementTime))
+    val (idealKeys, nascentKeys) = unretiredKeys.partition(_.isBefore(nascentInstant))
+
+    if (idealKeys.nonEmpty) {
+      // if any ideal keys exist, return the newest of those
+      newestOf(idealKeys)
+    } else if (nascentKeys.nonEmpty && retiredKeys.isEmpty) {
+      // if any nascent keys exist but no retired keys exist, return the oldest nascent key
+      oldestOf(nascentKeys)
+    } else if (nascentKeys.nonEmpty && retiredKeys.nonEmpty) {
+      // if both nascent and retired keys exist, return the newest retired key
+      newestOf(retiredKeys)
+    } else if (!withinLock) {
+      // if not within lock, return None. This will signal callers to obtain a lock and re-call this function.
+      None
+    } else if (nascentKeys.isEmpty && retiredKeys.nonEmpty) {
+      // if within lock, retired keys exist, and no nascent keys exist: return newest retired key and trigger key creation
+      // TODO CORE-278: trigger new-key creation; can be async
+      newestOf(retiredKeys)
+    } else {
+      // no keys exist; create one and return it
+      // TODO CORE-278: trigger new-key creation and return its result
+      None
+    }
+
+  }
+
+  @deprecated
   private def fetchKeysFromCacheAndIam(pet: PetServiceAccount): IO[(List[GcsObjectName], List[ServiceAccountKey])] = {
     val fetchKeyFromCache = googleStorageAlg
       .unsafeListObjectsWithPrefix(googleServicesConfig.googleKeyCacheConfig.bucketName, keyNamePrefix(pet.id.project, pet.serviceAccount.email))
@@ -126,6 +186,8 @@ class GoogleKeyCache(
     (fetchKeyFromCache, fetchKeyFromIam).parTupled
   }
 
+  // TODO CORE-278: refactor this
+  @deprecated
   private def retrieveActiveKey(pet: PetServiceAccount): IO[(Option[String], List[GcsObjectName], List[ServiceAccountKey])] =
     for {
       (keysFromCache, keysFromIam) <- fetchKeysFromCacheAndIam(pet)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -153,12 +153,6 @@ class GoogleKeyCache(
     def newestOf(keys: List[CachedKey]): IO[Option[String]] =
       readFromCache(keys.maxBy(_.timeCreated))
 
-    keysInCache.foreach { cachedKey =>
-      logger.warn(
-        s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} has cached key ${cachedKey.value}"
-      )
-    }
-
     /* segment cached keys into ideal, retired, and nascent keys
         ideal: keys between 15 minutes and 12 days old. Use these whenever possible.
         retired: keys older than 12 days. Avoid if possible, but prefer these over nascent keys.
@@ -177,11 +171,10 @@ class GoogleKeyCache(
       newestOf(idealKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.isEmpty) {
       // if any nascent keys exist but no retired keys exist, return the oldest nascent key
-      val key = oldestOf(nascentKeys)
       logger.warn(
         s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a nascent key"
       )
-      key
+      oldestOf(nascentKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.nonEmpty) {
       // if both nascent and retired keys exist, return the newest retired key
       logger.warn(
@@ -269,9 +262,6 @@ class GoogleKeyCache(
           throw new WorkbenchException(s"Error creating key for service account: ${t.getMessage}")
       }
       decodedKey <- IO.fromEither(key.privateKeyData.decode.toRight(new WorkbenchException("Failed to decode retrieved key")))
-      _ = logger.warn(
-        s"furnishNewKey: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} writing key to cache: $decodedKey"
-      )
       _ <- (Stream.emits(decodedKey.getBytes(utf8Charset)).covary[IO] through googleStorageAlg.streamUploadBlob(
         googleServicesConfig.googleKeyCacheConfig.bucketName,
         keyNameFull(pet.id.project, pet.serviceAccount.email, key.id)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -25,8 +25,6 @@ import scala.concurrent.ExecutionContext
 
 import java.time.Instant
 
-import cats.effect.unsafe.implicits.global
-
 /** Created by mbemis on 1/10/18.
   */
 class GoogleKeyCache(
@@ -133,7 +131,7 @@ class GoogleKeyCache(
   private def findActiveKey(pet: PetServiceAccount, withinLock: Boolean): IO[Option[String]] =
     for {
       keysInCache <- fetchKeysFromCache(pet)
-      maybeActiveKey = searchCachedKeys(pet, keysInCache, withinLock)
+      maybeActiveKey <- searchCachedKeys(pet, keysInCache, withinLock)
     } yield maybeActiveKey
 
   /** Given a list of cached keys, return the most appropriate cached key. The priority order of keys is:
@@ -145,12 +143,21 @@ class GoogleKeyCache(
     *
     * When executing inside a lock, based on the withinLock parameter, this function operates in read/write mode. It will create new keys when necessary.
     */
-  protected[google] def searchCachedKeys(pet: PetServiceAccount, keysInCache: List[CachedKey], withinLock: Boolean): Option[String] = {
+  protected[google] def searchCachedKeys(pet: PetServiceAccount, keysInCache: List[CachedKey], withinLock: Boolean): IO[Option[String]] = {
     // helpers
-    def oldestOf(keys: List[CachedKey]): Option[String] =
-      Option(keys.minBy(_.timeCreated).value)
-    def newestOf(keys: List[CachedKey]): Option[String] =
-      Option(keys.maxBy(_.timeCreated).value)
+    def readFromCache(key: CachedKey): IO[Option[String]] =
+      googleStorageAlg
+        .unsafeGetBlobBody(googleServicesConfig.googleKeyCacheConfig.bucketName, GcsBlobName(key.value))
+    def oldestOf(keys: List[CachedKey]): IO[Option[String]] =
+      readFromCache(keys.minBy(_.timeCreated))
+    def newestOf(keys: List[CachedKey]): IO[Option[String]] =
+      readFromCache(keys.maxBy(_.timeCreated))
+
+    keysInCache.foreach { cachedKey =>
+      logger.warn(
+        s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} has cached key ${cachedKey.value}"
+      )
+    }
 
     /* segment cached keys into ideal, retired, and nascent keys
         ideal: keys between 15 minutes and 12 days old. Use these whenever possible.
@@ -170,10 +177,11 @@ class GoogleKeyCache(
       newestOf(idealKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.isEmpty) {
       // if any nascent keys exist but no retired keys exist, return the oldest nascent key
+      val key = oldestOf(nascentKeys)
       logger.warn(
         s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a nascent key"
       )
-      oldestOf(nascentKeys)
+      key
     } else if (nascentKeys.nonEmpty && retiredKeys.nonEmpty) {
       // if both nascent and retired keys exist, return the newest retired key
       logger.warn(
@@ -182,30 +190,29 @@ class GoogleKeyCache(
       newestOf(retiredKeys)
     } else if (!withinLock) {
       // if not within lock, return None. This will signal callers to obtain a lock and re-call this function.
-      None
+      IO.pure(None)
     } else if (nascentKeys.isEmpty && retiredKeys.nonEmpty) {
       // if within lock, retired keys exist, and no nascent keys exist:
-      // return newest retired key and trigger key creation
-      cleanupAndCreateKey(pet, keysInCache)
-        .map { _ =>
-          logger.warn(
-            s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; no nascent keys exist"
-          )
-          newestOf(retiredKeys)
-        }
-        .unsafeRunSync()
+      // trigger key creation and then return newest retired key
+      for {
+        _ <- cleanupAndCreateKey(pet, keysInCache)
+        retiredKey <- newestOf(retiredKeys)
+      } yield {
+        logger.warn(
+          s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; no nascent keys exist"
+        )
+        retiredKey
+      }
     } else {
       // no keys exist; create one and return it
-      Option(
-        cleanupAndCreateKey(pet, keysInCache)
-          .map { createdKey =>
-            logger.warn(
-              s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a just-created key"
-            )
-            createdKey
-          }
-          .unsafeRunSync()
-      )
+      for {
+        newKey <- cleanupAndCreateKey(pet, keysInCache)
+      } yield {
+        logger.warn(
+          s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a just-created key"
+        )
+        Option(newKey)
+      }
     }
 
   }
@@ -262,6 +269,9 @@ class GoogleKeyCache(
           throw new WorkbenchException(s"Error creating key for service account: ${t.getMessage}")
       }
       decodedKey <- IO.fromEither(key.privateKeyData.decode.toRight(new WorkbenchException("Failed to decode retrieved key")))
+      _ = logger.warn(
+        s"furnishNewKey: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} writing key to cache: $decodedKey"
+      )
       _ <- (Stream.emits(decodedKey.getBytes(utf8Charset)).covary[IO] through googleStorageAlg.streamUploadBlob(
         googleServicesConfig.googleKeyCacheConfig.bucketName,
         keyNameFull(pet.id.project, pet.serviceAccount.email, key.id)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -178,13 +178,13 @@ class GoogleKeyCache(
       newestOf(idealKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.isEmpty) {
       // if any nascent keys exist but no retired keys exist, return the oldest nascent key
-      logger.warn(
+      logger.info(
         s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a nascent key"
       )
       oldestOf(nascentKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.nonEmpty) {
       // if both nascent and retired keys exist, return the newest retired key
-      logger.warn(
+      logger.info(
         s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; nascent keys exist"
       )
       newestOf(retiredKeys)
@@ -198,7 +198,7 @@ class GoogleKeyCache(
         _ <- cleanupAndCreateKey(pet, keysInCache)
         retiredKey <- newestOf(retiredKeys)
       } yield {
-        logger.warn(
+        logger.info(
           s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; no nascent keys exist"
         )
         retiredKey
@@ -208,7 +208,7 @@ class GoogleKeyCache(
       for {
         newKey <- cleanupAndCreateKey(pet, keysInCache)
       } yield {
-        logger.warn(
+        logger.info(
           s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a just-created key"
         )
         Option(newKey)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -22,6 +22,8 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{LockDetails, PostgresDi
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
+import org.broadinstitute.dsde.workbench.sam.model.CachedKey.keyPathPattern
+
 /** Created by mbemis on 1/10/18.
   */
 class GoogleKeyCache(
@@ -35,7 +37,6 @@ class GoogleKeyCache(
 )(implicit val executionContext: ExecutionContext)
     extends KeyCache
     with LazyLogging {
-  val keyPathPattern = """([^\/]+)\/([^\/]+)\/([^\/]+)""".r
   val utf8Charset = Charset.forName("UTF-8")
 
   override def onBoot()(implicit system: ActorSystem): IO[Unit] = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -13,7 +13,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GooglePubSubDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, GoogleProject, ServiceAccountKey, ServiceAccountKeyId}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId}
 import org.broadinstitute.dsde.workbench.sam.config.{GoogleServicesConfig, PetServiceAccountConfig}
 import org.broadinstitute.dsde.workbench.sam.service.KeyCache
 import fs2.Stream
@@ -21,8 +21,7 @@ import org.broadinstitute.dsde.workbench.sam.dataAccess.{LockDetails, PostgresDi
 import org.broadinstitute.dsde.workbench.sam.model.CachedKey
 
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
-import org.broadinstitute.dsde.workbench.sam.model.CachedKey.keyPathPattern
+import scala.concurrent.ExecutionContext
 
 import java.time.Instant
 
@@ -97,42 +96,55 @@ class GoogleKeyCache(
     } yield ()
   }
 
+  /** Retrieve a key for this pet, creating keys as necessary.
+    */
   override def getKey(pet: PetServiceAccount): IO[String] = {
-    def maybeCreateKey(createKey: (List[GcsObjectName], List[ServiceAccountKey]) => IO[String]): IO[String] =
+    def maybeCreateKey(withinLock: Boolean, fallback: () => IO[String]): IO[String] =
       for {
-        (maybeActiveKey, keysFromCache, keysFromIam) <- retrieveActiveKey(pet)
+        maybeActiveKey <- findActiveKey(pet, withinLock)
         activeKey <- maybeActiveKey match {
           case Some(existingActiveKey) => IO.pure(existingActiveKey)
-          case None => createKey(keysFromCache, keysFromIam)
+          case None => fallback()
         }
       } yield activeKey
 
-    def cleanupAndCreateKey(keysFromCache: List[GcsObjectName], keysFromIam: List[ServiceAccountKey]): IO[String] = {
-      logger.info(
-        s"cleanupAndCreateKey: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} with ${keysFromCache.length} in cache and ${keysFromIam.length} in IAM"
-      )
-      for {
-        _ <- IO.fromFuture(IO(cleanupUnknownKeys(pet, keysFromCache, keysFromIam)))
-        key <- furnishNewKey(pet)
-      } yield key
-    }
+    def failed(): IO[String] =
+      throw new WorkbenchException("Could not create or retrieve key")
 
     // 5 minute lock timeout chosen to match how long key creation polling can take
     val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 5 minutes)
-    maybeCreateKey((_, _) => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(cleanupAndCreateKey)))
+    maybeCreateKey(withinLock = false, () => distributedLock.withLock(lockDetails).use(_ => maybeCreateKey(withinLock = true, () => failed())))
   }
 
+  /** List all cached keys from the Google bucket for this pet.
+    */
   private def fetchKeysFromCache(pet: PetServiceAccount): IO[List[CachedKey]] =
     googleStorageAlg
       .unsafeListObjectsWithPrefix(googleServicesConfig.googleKeyCacheConfig.bucketName, keyNamePrefix(pet.id.project, pet.serviceAccount.email))
       .map(gcsObjectList => gcsObjectList.map(CachedKey(_)))
 
+  /** List all keys in IAM for this pet.
+    */
+  private def fetchKeysFromIam(pet: PetServiceAccount): IO[List[ServiceAccountKey]] =
+    IO.fromFuture(IO(googleIamDAO.listUserManagedServiceAccountKeys(pet.id.project, pet.serviceAccount.email).map(_.toList)))
+
+  /** List all cached keys from the Google bucket, then try to find a usable key from that list.
+    */
   private def findActiveKey(pet: PetServiceAccount, withinLock: Boolean): IO[Option[String]] =
     for {
       keysInCache <- fetchKeysFromCache(pet)
       maybeActiveKey = searchCachedKeys(pet, keysInCache, withinLock)
     } yield maybeActiveKey
 
+  /** Given a list of cached keys, return the most appropriate cached key. The priority order of keys is:
+    *   1. keys older than 15 minutes but younger than 12 days 2. keys older than 12 days, which may be nearing the end of their life 3. keys younger than 15
+    *      minutes, which may not yet be functional due to Google eventual-consistency
+    *
+    * When executing outside a lock, based on the withinLock parameter, this function operates in read-only mode and will return None in any cases where we
+    * should be creating a new key.
+    *
+    * When executing inside a lock, based on the withinLock parameter, this function operates in read/write mode. It will create new keys when necessary.
+    */
   protected[google] def searchCachedKeys(pet: PetServiceAccount, keysInCache: List[CachedKey], withinLock: Boolean): Option[String] = {
     // helpers
     def oldestOf(keys: List[CachedKey]): Option[String] =
@@ -158,9 +170,15 @@ class GoogleKeyCache(
       newestOf(idealKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.isEmpty) {
       // if any nascent keys exist but no retired keys exist, return the oldest nascent key
+      logger.warn(
+        s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a nascent key"
+      )
       oldestOf(nascentKeys)
     } else if (nascentKeys.nonEmpty && retiredKeys.nonEmpty) {
       // if both nascent and retired keys exist, return the newest retired key
+      logger.warn(
+        s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; nascent keys exist"
+      )
       newestOf(retiredKeys)
     } else if (!withinLock) {
       // if not within lock, return None. This will signal callers to obtain a lock and re-call this function.
@@ -168,43 +186,32 @@ class GoogleKeyCache(
     } else if (nascentKeys.isEmpty && retiredKeys.nonEmpty) {
       // if within lock, retired keys exist, and no nascent keys exist:
       // return newest retired key and trigger key creation
-      furnishNewKey(pet).map(_ => newestOf(retiredKeys)).unsafeRunSync()
+      cleanupAndCreateKey(pet, keysInCache)
+        .map { _ =>
+          logger.warn(
+            s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a retired key; no nascent keys exist"
+          )
+          newestOf(retiredKeys)
+        }
+        .unsafeRunSync()
     } else {
       // no keys exist; create one and return it
-      Option(furnishNewKey(pet).unsafeRunSync())
+      Option(
+        cleanupAndCreateKey(pet, keysInCache)
+          .map { createdKey =>
+            logger.warn(
+              s"searchCachedKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is using a just-created key"
+            )
+            createdKey
+          }
+          .unsafeRunSync()
+      )
     }
 
   }
 
-  @deprecated
-  private def fetchKeysFromCacheAndIam(pet: PetServiceAccount): IO[(List[GcsObjectName], List[ServiceAccountKey])] = {
-    val fetchKeyFromCache = googleStorageAlg
-      .unsafeListObjectsWithPrefix(googleServicesConfig.googleKeyCacheConfig.bucketName, keyNamePrefix(pet.id.project, pet.serviceAccount.email))
-    val fetchKeyFromIam = IO.fromFuture(IO(googleIamDAO.listUserManagedServiceAccountKeys(pet.id.project, pet.serviceAccount.email).map(_.toList)))
-
-    (fetchKeyFromCache, fetchKeyFromIam).parTupled
-  }
-
-  // TODO CORE-278: refactor this
-  @deprecated
-  private def retrieveActiveKey(pet: PetServiceAccount): IO[(Option[String], List[GcsObjectName], List[ServiceAccountKey])] =
-    for {
-      (keysFromCache, keysFromIam) <- fetchKeysFromCacheAndIam(pet)
-
-      // TODO CORE-278: this could result in log spam
-      _ = if (keysFromIam.length >= 10)
-        logger.warn(s"danger: pet ${pet.serviceAccount.displayName.value} has ${keysFromIam.length} keys (cache has ${keysFromCache.length})")
-
-      maybeActiveKey = keysFromCache.sortBy(_.timeCreated.toEpochMilli).findLast(isKeyActive(_, keysFromIam))
-      activeKey <- maybeActiveKey
-        .map { key =>
-          googleStorageAlg
-            .unsafeGetBlobBody(googleServicesConfig.googleKeyCacheConfig.bucketName, GcsBlobName(key.value))
-        }
-        .getOrElse(IO.pure(None))
-
-    } yield (activeKey, keysFromCache, keysFromIam)
-
+  /** Delete a key from IAM and cache.
+    */
   override def removeKey(pet: PetServiceAccount, keyId: ServiceAccountKeyId): IO[Unit] =
     for {
       _ <- googleStorageAlg
@@ -219,19 +226,40 @@ class GoogleKeyCache(
   private def keyNameFull(project: GoogleProject, saEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): GcsBlobName =
     GcsBlobName(s"${keyNamePrefix(project, saEmail)}${keyId.value}")
 
+  /** Cleans up keys by deleting orphans and bringing total key count down to 9, then creates a new key.
+    */
+  private def cleanupAndCreateKey(pet: PetServiceAccount, cachedKeyObjects: List[CachedKey]): IO[String] =
+    for {
+      keysInIam <- fetchKeysFromIam(pet)
+      _ <- cleanupKeys(pet, cachedKeyObjects, keysInIam)
+      newKey <- furnishNewKey(pet)
+    } yield newKey
+
+  /** Create a new key for this pet. Do not call this directly, as it has no protection against running over the 10-key limit. Call cleanupAndCreateKey()
+    * instead.
+    */
   private def furnishNewKey(pet: PetServiceAccount): IO[String] =
     for {
       key <- IO.fromFuture(IO(googleIamDAO.createServiceAccountKey(pet.id.project, pet.serviceAccount.email))) recover {
-        // TODO CORE-278: on error, check the number of existing keys and purge as necessary
         case e: GoogleJsonResponseException =>
+          logger.error(
+            s"furnishNewKey: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} ${e.getMessage}",
+            e
+          )
           if (e.getDetails.getCode == StatusCodes.TooManyRequests.intValue)
-            // 2025-01-29: TooManyRequests is not returned by Google for this error any more. Leaving this in place
+            // 2025-01-29: TooManyRequests is not returned by Google for this error anymore. Leaving this in place
             //  in case Google switches back to it
             throw new WorkbenchException("You have reached the 10 key limit on service accounts. Please remove one to create another.")
           else if (e.getDetails.getCode == StatusCodes.BadRequest.intValue && e.getDetails.getMessage == "Precondition check failed.")
             throw new WorkbenchException("You may have reached the 10 key limit on service accounts.")
           else
             throw new WorkbenchException(s"Error creating key for service account: ${e.getDetails.getCode}: ${e.getDetails.getMessage}")
+        case t: Throwable =>
+          logger.error(
+            s"furnishNewKey: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} ${t.getMessage}",
+            t
+          )
+          throw new WorkbenchException(s"Error creating key for service account: ${t.getMessage}")
       }
       decodedKey <- IO.fromEither(key.privateKeyData.decode.toRight(new WorkbenchException("Failed to decode retrieved key")))
       _ <- (Stream.emits(decodedKey.getBytes(utf8Charset)).covary[IO] through googleStorageAlg.streamUploadBlob(
@@ -240,25 +268,39 @@ class GoogleKeyCache(
       )).compile.drain
     } yield decodedKey
 
-  private def isKeyActive(mostRecentKey: GcsObjectName, serviceAccountKeys: List[ServiceAccountKey]): Boolean = {
-    val keyRetired = System.currentTimeMillis() - mostRecentKey.timeCreated.toEpochMilli > 86400000L * googleServicesConfig.googleKeyCacheConfig.activeKeyMaxAge
+  /** Cleans up keys by deleting orphans and bringing total key count down to 9.
+    */
+  private def cleanupKeys(pet: PetServiceAccount, cachedKeyObjects: List[CachedKey], serviceAccountKeys: List[ServiceAccountKey]): IO[Unit] = {
+    // if 10 or more keys, delete until we are below 10.
+    val tooManyFunction: IO[_] = if (cachedKeyObjects.size >= 10) {
+      val numToDelete = cachedKeyObjects.size - 9
+      val toDelete = cachedKeyObjects.sortBy(_.timeCreated).takeRight(numToDelete)
+      logger.info(
+        s"cleanupKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is reaping ${toDelete.size} keys due to quota"
+      )
+      toDelete.parTraverse(cachedKey => removeKey(pet, cachedKey.keyId))
+    } else {
+      IO.unit
+    }
 
-    val keyPathPattern(project, petSaEmail, keyId) = mostRecentKey.value
+    // if any keys in IAM which are not in cache, delete those orphans.
+    val cachedKeyIds: Set[ServiceAccountKeyId] = cachedKeyObjects.map(_.keyId).toSet
+    val unknownKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet -- cachedKeyIds
 
-    // The key may exist in the Google bucket cache, but could have been deleted from the SA directly
-    val keyExistsForSA = serviceAccountKeys.exists(_.id.value.contentEquals(keyId))
+    val orphansFunction: IO[_] = if (unknownKeyIds.nonEmpty) {
+      logger.info(
+        s"cleanupKeys: ${pet.id.project.value}-${pet.serviceAccount.subjectId.value} is reaping ${unknownKeyIds.size} orphaned keys"
+      )
+      unknownKeyIds.toList.parTraverse(keyId => IO.fromFuture(IO(googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId))))
+    } else {
+      IO.unit
+    }
 
-    !keyRetired && keyExistsForSA
+    for {
+      _ <- tooManyFunction
+      _ <- orphansFunction
+    } yield ()
+
   }
 
-  private def cleanupUnknownKeys(pet: PetServiceAccount, cachedKeyObjects: List[GcsObjectName], serviceAccountKeys: List[ServiceAccountKey]): Future[Unit] = {
-    val cachedKeyIds = cachedKeyObjects.map(_.value).collect { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
-    val unknownKeyIds: Set[ServiceAccountKeyId] = serviceAccountKeys.map(_.id).toSet -- cachedKeyIds.toSet
-
-    Future
-      .traverse(unknownKeyIds) { keyId =>
-        googleIamDAO.removeServiceAccountKey(pet.id.project, pet.serviceAccount.email, keyId)
-      }
-      .void
-  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKey.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKey.scala
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsde.workbench.sam.model
+
+import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, ServiceAccountKeyId}
+
+import java.time.Instant
+import scala.util.matching.Regex
+
+object CachedKey {
+  val keyPathPattern: Regex = """([^/]+)/([^/]+)/([^/]+)""".r
+
+  def apply(gcsObject: GcsObjectName): CachedKey = {
+    val timeCreated = gcsObject.timeCreated
+    val keyId = gcsObject.value match { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
+    new CachedKey(timeCreated, keyId)
+  }
+}
+
+case class CachedKey(timeCreated: Instant, keyId: ServiceAccountKeyId) {
+
+  def isBefore(other: Instant): Boolean = timeCreated.isBefore(other)
+
+  def isAfterOrEqual(other: Instant): Boolean = timeCreated.isAfter(other) || timeCreated.equals(other)
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKey.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKey.scala
@@ -11,11 +11,11 @@ object CachedKey {
   def apply(gcsObject: GcsObjectName): CachedKey = {
     val timeCreated = gcsObject.timeCreated
     val keyId = gcsObject.value match { case keyPathPattern(_, _, keyId) => ServiceAccountKeyId(keyId) }
-    new CachedKey(timeCreated, keyId)
+    new CachedKey(timeCreated, gcsObject.value, keyId)
   }
 }
 
-case class CachedKey(timeCreated: Instant, keyId: ServiceAccountKeyId) {
+case class CachedKey(timeCreated: Instant, value: String, keyId: ServiceAccountKeyId) {
 
   def isBefore(other: Instant): Boolean = timeCreated.isBefore(other)
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.sam.google
 
+import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
@@ -21,17 +22,33 @@ import java.util.Base64
 import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.concurrent.Future
 import scala.util.Random
+import cats.effect.unsafe.implicits.global
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.google2.Generators.utf8Charset
+import org.scalatest.BeforeAndAfterAll
 
-class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
+class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
 
   val pet = genPetServiceAccount.sample.get
+
+  val storageInterp = FakeGoogleStorageInterpreter
+
+  override protected def beforeAll(): Unit =
+    // set up google storage for the test cases below
+    List("nascent-1", "nascent-2", "ideal-1", "ideal-2", "ideal-3", "retired-1", "retired-2") foreach { obj =>
+      (Stream.emits(obj.getBytes(utf8Charset)).covary[IO] through storageInterp.streamUploadBlob(
+        TestSupport.googleServicesConfig.googleKeyCacheConfig.bucketName,
+        GcsBlobName(obj)
+      )).compile.drain.unsafeRunSync()
+    }
 
   def newKeyCache(iamDAO: GoogleIamDAO = new MockGoogleIamDAO): GoogleKeyCache =
     new GoogleKeyCache(
       TestSupport.distributedLock,
       iamDAO,
       new MockGoogleStorageDAO,
-      FakeGoogleStorageInterpreter,
+      storageInterp,
       new MockGooglePubSubDAO,
       TestSupport.googleServicesConfig,
       TestSupport.petServiceAccountConfig
@@ -52,7 +69,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
 
       val input = List(nascentKey, idealKey, retiredKey)
-      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
       actual should contain("ideal-1")
     }
 
@@ -60,7 +77,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
 
       val input = List(idealKey)
-      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
       actual should contain("ideal-1")
     }
 
@@ -72,7 +89,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
 
       val input = List(nascentKey, idealKey3, idealKey2, idealKey1, retiredKey)
-      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
       actual should contain("ideal-1")
     }
 
@@ -83,7 +100,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
       val input = List(retiredKey2, nascentKey2, retiredKey1, nascentKey1)
-      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
       actual should contain("retired-1")
     }
 
@@ -92,7 +109,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "nascent-2", ServiceAccountKeyId("nascent-2"))
 
       val input = List(nascentKey2, nascentKey1)
-      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
       actual should contain("nascent-2")
     }
   }
@@ -105,14 +122,14 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
     val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
     val input = List(retiredKey2, retiredKey1)
-    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false)
+    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false).unsafeRunSync()
     actual shouldBe None
   }
 
   it should "return None when no keys exist in cache" in {
     // this case triggers creation of a new key, so it returns None when not within a lock
     val input: List[CachedKey] = List()
-    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false)
+    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false).unsafeRunSync()
     actual shouldBe None
   }
 
@@ -149,7 +166,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
     val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
     val input = List(retiredKey2, retiredKey1)
-    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true)
+    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true).unsafeRunSync()
     actual should contain("retired-1")
     Mockito
       .verify(mockIamDao, times(1))
@@ -183,7 +200,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
 
     val input: List[CachedKey] = List()
-    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true)
+    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true).unsafeRunSync()
     Mockito
       .verify(mockIamDao, times(1))
       .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -119,11 +119,27 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
   behavior of "GoogleKeyCache.searchCachedKeys(), when within a lock"
 
   it should "return None when only retired keys exist" in {
-    val spiedIamDao = Mockito.spy(new MockGoogleIamDAO)
-    val keyCache = newKeyCache(spiedIamDao)
+    val mockIamDao = mock[GoogleIamDAO]
+    val mockKeyDataString = s"abcdefg:${System.currentTimeMillis}${Random.nextLong()}"
+    val mockKeyData = ServiceAccountPrivateKeyData(
+      Base64.getEncoder
+        .encodeToString(mockKeyDataString.getBytes(StandardCharsets.UTF_8))
+    )
+    when(mockIamDao.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail]))
+      .thenReturn(
+        Future.successful(
+          ServiceAccountKey(
+            ServiceAccountKeyId("new-id"),
+            mockKeyData,
+            None,
+            None
+          )
+        )
+      )
+    val keyCache = newKeyCache(mockIamDao)
 
     Mockito
-      .verify(spiedIamDao, times(0))
+      .verify(mockIamDao, times(0))
       .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
 
     // this case triggers creation of a new key, so it returns None when not within a lock
@@ -131,10 +147,10 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
     val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
     val input = List(retiredKey2, retiredKey1)
-    val actual = keyCache.searchCachedKeys(pet, input, withinLock = false)
-    actual shouldBe defined
+    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true)
+    actual should contain("retired-1")
     Mockito
-      .verify(spiedIamDao, times(1))
+      .verify(mockIamDao, times(1))
       .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)
   }
 
@@ -169,7 +185,6 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
       .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)
     actual shouldBe defined
     actual.get shouldBe mockKeyDataString
-
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -1,0 +1,125 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountKeyId
+import org.broadinstitute.dsde.workbench.sam.TestSupport
+import org.broadinstitute.dsde.workbench.sam.model.CachedKey
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
+
+class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
+
+  def newKeyCache(iamDAO: GoogleIamDAO = new MockGoogleIamDAO): GoogleKeyCache =
+    new GoogleKeyCache(
+      TestSupport.distributedLock,
+      iamDAO,
+      new MockGoogleStorageDAO,
+      FakeGoogleStorageInterpreter,
+      new MockGooglePubSubDAO,
+      TestSupport.googleServicesConfig,
+      TestSupport.petServiceAccountConfig
+    )
+
+  // number of seconds before which a key is considered nascent
+  private val idealSecondsStart = TestSupport.googleServicesConfig.googleKeyCacheConfig.nascentKeyMinAgeMinutes * 60L
+  // number of seconds after which a key is considered retired
+  private val idealSecondsEnd = TestSupport.googleServicesConfig.googleKeyCacheConfig.activeKeyMaxAge * 24L * 60 * 60
+
+  behavior of "GoogleKeyCache.searchCachedKeys()"
+
+  // these tests behave the same both within and outside a lock
+  List(false, true) foreach { withinLock =>
+    it should s"return an ideally-aged key even when others exist (withinLock=$withinLock)" in {
+      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+
+      val input = List(nascentKey, idealKey, retiredKey)
+      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
+      actual should contain(idealKey)
+    }
+
+    it should s"return an ideally-aged key when it's the only one to exist (withinLock=$withinLock)" in {
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
+
+      val input = List(idealKey)
+      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
+      actual should contain(idealKey)
+    }
+
+    it should s"return the newest of multiple ideal keys (withinLock=$withinLock)" in {
+      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
+      val idealKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
+      val idealKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 20), "value", ServiceAccountKeyId("ideal-2"))
+      val idealKey3 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 30), "value", ServiceAccountKeyId("ideal-3"))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+
+      val input = List(nascentKey, idealKey3, idealKey2, idealKey1, retiredKey)
+      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
+      actual should contain(idealKey1)
+    }
+
+    it should s"return the newest retired key when only retired and nascent keys exist (withinLock=$withinLock)" in {
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "value", ServiceAccountKeyId("nascent-1"))
+      val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+      val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+
+      val input = List(retiredKey2, nascentKey2, retiredKey1, nascentKey1)
+      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
+      actual should contain(retiredKey1)
+    }
+
+    it should s"return the oldest nascent key when only nascent keys exist (withinLock=$withinLock)" in {
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "value", ServiceAccountKeyId("nascent-1"))
+
+      val input = List(nascentKey2, nascentKey1)
+      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
+      actual should contain(nascentKey2)
+    }
+  }
+
+  behavior of "GoogleKeyCache.searchCachedKeys(), when outside a lock"
+
+  it should "return None when only retired keys exist" in {
+    // this case triggers creation of a new key, so it returns None when not within a lock
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+
+    val input = List(retiredKey2, retiredKey1)
+    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    actual shouldBe None
+  }
+
+  it should "return None when no keys exist in cache" in {
+    // this case triggers creation of a new key, so it returns None when not within a lock
+    val input: List[CachedKey] = List()
+    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    actual shouldBe None
+  }
+
+  behavior of "GoogleKeyCache.searchCachedKeys(), when within a lock"
+
+  it should "return None when only retired keys exist" in {
+    // this case triggers creation of a new key, so it returns None when not within a lock
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+
+    val input = List(retiredKey2, retiredKey1)
+    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    actual shouldBe defined
+  }
+
+  it should "return a newly-created key when no keys exist in cache" in {
+    val input: List[CachedKey] = List()
+    val actual = newKeyCache().searchCachedKeys(input, withinLock = true)
+    actual shouldBe defined
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -143,7 +143,7 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAft
 
   behavior of "GoogleKeyCache.searchCachedKeys(), when within a lock"
 
-  it should "return None when only retired keys exist" in {
+  it should "return a retired key and trigger creation of a new key when only retired keys exist" in {
     val mockIamDao = mock[GoogleIamDAO]
     val mockKeyDataString = s"abcdefg:${System.currentTimeMillis}${Random.nextLong()}"
     val mockKeyData = ServiceAccountPrivateKeyData(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -136,6 +136,8 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
           )
         )
       )
+    when(mockIamDao.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail]))
+      .thenReturn(Future.successful(Seq()))
     val keyCache = newKeyCache(mockIamDao)
 
     Mockito
@@ -172,6 +174,8 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
           )
         )
       )
+    when(mockIamDao.listUserManagedServiceAccountKeys(any[GoogleProject], any[WorkbenchEmail]))
+      .thenReturn(Future.successful(Seq()))
     val keyCache = newKeyCache(mockIamDao)
 
     Mockito

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -3,16 +3,28 @@ package org.broadinstitute.dsde.workbench.sam.google
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountKeyId
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId, ServiceAccountPrivateKeyData}
+import org.broadinstitute.dsde.workbench.sam.Generator.genPetServiceAccount
 import org.broadinstitute.dsde.workbench.sam.TestSupport
 import org.broadinstitute.dsde.workbench.sam.model.CachedKey
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{times, when}
+import org.mockito.MockitoSugar.mock
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.charset.StandardCharsets
 import java.time.Instant
+import java.util.Base64
 import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
+import scala.concurrent.Future
+import scala.util.Random
 
 class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
+
+  val pet = genPetServiceAccount.sample.get
 
   def newKeyCache(iamDAO: GoogleIamDAO = new MockGoogleIamDAO): GoogleKeyCache =
     new GoogleKeyCache(
@@ -36,52 +48,52 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
   List(false, true) foreach { withinLock =>
     it should s"return an ideally-aged key even when others exist (withinLock=$withinLock)" in {
       val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
-      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
 
       val input = List(nascentKey, idealKey, retiredKey)
-      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
-      actual should contain(idealKey)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      actual should contain("ideal-1")
     }
 
     it should s"return an ideally-aged key when it's the only one to exist (withinLock=$withinLock)" in {
-      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
 
       val input = List(idealKey)
-      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
-      actual should contain(idealKey)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      actual should contain("ideal-1")
     }
 
     it should s"return the newest of multiple ideal keys (withinLock=$withinLock)" in {
       val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val idealKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "value", ServiceAccountKeyId("ideal-1"))
-      val idealKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 20), "value", ServiceAccountKeyId("ideal-2"))
-      val idealKey3 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 30), "value", ServiceAccountKeyId("ideal-3"))
-      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
+      val idealKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
+      val idealKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 20), "ideal-2", ServiceAccountKeyId("ideal-2"))
+      val idealKey3 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 30), "ideal-3", ServiceAccountKeyId("ideal-3"))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
 
       val input = List(nascentKey, idealKey3, idealKey2, idealKey1, retiredKey)
-      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
-      actual should contain(idealKey1)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      actual should contain("ideal-1")
     }
 
     it should s"return the newest retired key when only retired and nascent keys exist (withinLock=$withinLock)" in {
-      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "value", ServiceAccountKeyId("nascent-1"))
-      val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
-      val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "nascent-1", ServiceAccountKeyId("nascent-1"))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "nascent-2", ServiceAccountKeyId("nascent-2"))
+      val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
+      val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
       val input = List(retiredKey2, nascentKey2, retiredKey1, nascentKey1)
-      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
-      actual should contain(retiredKey1)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      actual should contain("retired-1")
     }
 
     it should s"return the oldest nascent key when only nascent keys exist (withinLock=$withinLock)" in {
-      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "value", ServiceAccountKeyId("nascent-1"))
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "nascent-1", ServiceAccountKeyId("nascent-1"))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "nascent-2", ServiceAccountKeyId("nascent-2"))
 
       val input = List(nascentKey2, nascentKey1)
-      val actual = newKeyCache().searchCachedKeys(input, withinLock = withinLock)
-      actual should contain(nascentKey2)
+      val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock)
+      actual should contain("nascent-2")
     }
   }
 
@@ -89,37 +101,75 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers {
 
   it should "return None when only retired keys exist" in {
     // this case triggers creation of a new key, so it returns None when not within a lock
-    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
-    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
     val input = List(retiredKey2, retiredKey1)
-    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false)
     actual shouldBe None
   }
 
   it should "return None when no keys exist in cache" in {
     // this case triggers creation of a new key, so it returns None when not within a lock
     val input: List[CachedKey] = List()
-    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false)
     actual shouldBe None
   }
 
   behavior of "GoogleKeyCache.searchCachedKeys(), when within a lock"
 
   it should "return None when only retired keys exist" in {
+    val spiedIamDao = Mockito.spy(new MockGoogleIamDAO)
+    val keyCache = newKeyCache(spiedIamDao)
+
+    Mockito
+      .verify(spiedIamDao, times(0))
+      .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
+
     // this case triggers creation of a new key, so it returns None when not within a lock
-    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "value", ServiceAccountKeyId("retired-1"))
-    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "value", ServiceAccountKeyId("retired-1"))
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
 
     val input = List(retiredKey2, retiredKey1)
-    val actual = newKeyCache().searchCachedKeys(input, withinLock = false)
+    val actual = keyCache.searchCachedKeys(pet, input, withinLock = false)
     actual shouldBe defined
+    Mockito
+      .verify(spiedIamDao, times(1))
+      .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)
   }
 
   it should "return a newly-created key when no keys exist in cache" in {
+    val mockIamDao = mock[GoogleIamDAO]
+    val mockKeyDataString = s"abcdefg:${System.currentTimeMillis}${Random.nextLong()}"
+    val mockKeyData = ServiceAccountPrivateKeyData(
+      Base64.getEncoder
+        .encodeToString(mockKeyDataString.getBytes(StandardCharsets.UTF_8))
+    )
+    when(mockIamDao.createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail]))
+      .thenReturn(
+        Future.successful(
+          ServiceAccountKey(
+            ServiceAccountKeyId("new-id"),
+            mockKeyData,
+            None,
+            None
+          )
+        )
+      )
+    val keyCache = newKeyCache(mockIamDao)
+
+    Mockito
+      .verify(mockIamDao, times(0))
+      .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
+
     val input: List[CachedKey] = List()
-    val actual = newKeyCache().searchCachedKeys(input, withinLock = true)
+    val actual = keyCache.searchCachedKeys(pet, input, withinLock = true)
+    Mockito
+      .verify(mockIamDao, times(1))
+      .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)
     actual shouldBe defined
+    actual.get shouldBe mockKeyDataString
+
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -30,13 +30,21 @@ import org.scalatest.BeforeAndAfterAll
 
 class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfterAll {
 
-  val pet = genPetServiceAccount.sample.get
+  private val pet = genPetServiceAccount.sample.get
 
-  val storageInterp = FakeGoogleStorageInterpreter
+  private val storageInterp = FakeGoogleStorageInterpreter
+
+  private val nascent1 = "nascent-1"
+  private val nascent2 = "nascent-2"
+  private val ideal1 = "ideal-1"
+  private val ideal2 = "ideal-2"
+  private val ideal3 = "ideal-3"
+  private val retired1 = "retired-1"
+  private val retired2 = "retired-2"
 
   override protected def beforeAll(): Unit =
     // set up google storage for the test cases below
-    List("nascent-1", "nascent-2", "ideal-1", "ideal-2", "ideal-3", "retired-1", "retired-2") foreach { obj =>
+    List(nascent1, nascent2, ideal1, ideal2, ideal3, retired1, retired2) foreach { obj =>
       (Stream.emits(obj.getBytes(utf8Charset)).covary[IO] through storageInterp.streamUploadBlob(
         TestSupport.googleServicesConfig.googleKeyCacheConfig.bucketName,
         GcsBlobName(obj)
@@ -64,53 +72,53 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAft
   // these tests behave the same both within and outside a lock
   List(false, true) foreach { withinLock =>
     it should s"return an ideally-aged key even when others exist (withinLock=$withinLock)" in {
-      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
-      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
+      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), nascent1, ServiceAccountKeyId(nascent1))
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), ideal1, ServiceAccountKeyId(ideal1))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), retired1, ServiceAccountKeyId(retired1))
 
       val input = List(nascentKey, idealKey, retiredKey)
       val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
-      actual should contain("ideal-1")
+      actual should contain(ideal1)
     }
 
     it should s"return an ideally-aged key when it's the only one to exist (withinLock=$withinLock)" in {
-      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
+      val idealKey = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), ideal1, ServiceAccountKeyId(ideal1))
 
       val input = List(idealKey)
       val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
-      actual should contain("ideal-1")
+      actual should contain(ideal1)
     }
 
     it should s"return the newest of multiple ideal keys (withinLock=$withinLock)" in {
-      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId("nascent-1"))
-      val idealKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), "ideal-1", ServiceAccountKeyId("ideal-1"))
-      val idealKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 20), "ideal-2", ServiceAccountKeyId("ideal-2"))
-      val idealKey3 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 30), "ideal-3", ServiceAccountKeyId("ideal-3"))
-      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
+      val nascentKey = new CachedKey(Instant.now.minusSeconds(10), "value", ServiceAccountKeyId(nascent1))
+      val idealKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 10), ideal1, ServiceAccountKeyId(ideal1))
+      val idealKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 20), ideal2, ServiceAccountKeyId(ideal2))
+      val idealKey3 = new CachedKey(Instant.now.minusSeconds(idealSecondsStart + 30), ideal3, ServiceAccountKeyId(ideal3))
+      val retiredKey = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), retired1, ServiceAccountKeyId(retired1))
 
       val input = List(nascentKey, idealKey3, idealKey2, idealKey1, retiredKey)
       val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
-      actual should contain("ideal-1")
+      actual should contain(ideal1)
     }
 
     it should s"return the newest retired key when only retired and nascent keys exist (withinLock=$withinLock)" in {
-      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "nascent-1", ServiceAccountKeyId("nascent-1"))
-      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "nascent-2", ServiceAccountKeyId("nascent-2"))
-      val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
-      val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), nascent1, ServiceAccountKeyId(nascent1))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), nascent2, ServiceAccountKeyId(nascent2))
+      val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), retired1, ServiceAccountKeyId(retired1))
+      val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), retired2, ServiceAccountKeyId(retired2))
 
       val input = List(retiredKey2, nascentKey2, retiredKey1, nascentKey1)
       val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
-      actual should contain("retired-1")
+      actual should contain(retired1)
     }
 
     it should s"return the oldest nascent key when only nascent keys exist (withinLock=$withinLock)" in {
-      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), "nascent-1", ServiceAccountKeyId("nascent-1"))
-      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), "nascent-2", ServiceAccountKeyId("nascent-2"))
+      val nascentKey1 = new CachedKey(Instant.now.minusSeconds(10), nascent1, ServiceAccountKeyId(nascent1))
+      val nascentKey2 = new CachedKey(Instant.now.minusSeconds(20), nascent2, ServiceAccountKeyId(nascent2))
 
       val input = List(nascentKey2, nascentKey1)
       val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = withinLock).unsafeRunSync()
-      actual should contain("nascent-2")
+      actual should contain(nascent2)
     }
   }
 
@@ -118,8 +126,8 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAft
 
   it should "return None when only retired keys exist" in {
     // this case triggers creation of a new key, so it returns None when not within a lock
-    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
-    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), retired1, ServiceAccountKeyId(retired1))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), retired2, ServiceAccountKeyId(retired2))
 
     val input = List(retiredKey2, retiredKey1)
     val actual = newKeyCache().searchCachedKeys(pet, input, withinLock = false).unsafeRunSync()
@@ -162,12 +170,12 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAft
       .createServiceAccountKey(any[GoogleProject], any[WorkbenchEmail])
 
     // this case triggers creation of a new key, so it returns None when not within a lock
-    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), "retired-1", ServiceAccountKeyId("retired-1"))
-    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), "retired-2", ServiceAccountKeyId("retired-2"))
+    val retiredKey1 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 10), retired1, ServiceAccountKeyId(retired1))
+    val retiredKey2 = new CachedKey(Instant.now.minusSeconds(idealSecondsEnd + 20), retired2, ServiceAccountKeyId(retired2))
 
     val input = List(retiredKey2, retiredKey1)
     val actual = keyCache.searchCachedKeys(pet, input, withinLock = true).unsafeRunSync()
-    actual should contain("retired-1")
+    actual should contain(retired1)
     Mockito
       .verify(mockIamDao, times(1))
       .createServiceAccountKey(pet.id.project, pet.serviceAccount.email)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKeySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKeySpec.scala
@@ -26,7 +26,7 @@ class CachedKeySpec extends AnyFlatSpecLike with Matchers {
     val middle = earliest.plusSeconds(1)
     val latest = earliest.plusSeconds(2)
 
-    val cachedKey = new CachedKey(middle, ServiceAccountKeyId("id"))
+    val cachedKey = new CachedKey(middle, "some-value", ServiceAccountKeyId("id"))
 
     cachedKey.isBefore(latest) shouldBe true
     cachedKey.isBefore(middle) shouldBe false
@@ -38,7 +38,7 @@ class CachedKeySpec extends AnyFlatSpecLike with Matchers {
     val middle = earliest.plusSeconds(1)
     val latest = earliest.plusSeconds(2)
 
-    val cachedKey = new CachedKey(middle, ServiceAccountKeyId("id"))
+    val cachedKey = new CachedKey(middle, "some-value", ServiceAccountKeyId("id"))
 
     cachedKey.isAfterOrEqual(latest) shouldBe false
     cachedKey.isAfterOrEqual(middle) shouldBe true

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKeySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/CachedKeySpec.scala
@@ -1,0 +1,48 @@
+package org.broadinstitute.dsde.workbench.sam.model
+
+import org.broadinstitute.dsde.workbench.model.google.{GcsObjectName, ServiceAccountKeyId}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class CachedKeySpec extends AnyFlatSpecLike with Matchers {
+
+  behavior of "CachedKey"
+
+  it should "construct from a GcsObjectName" in {
+    val now = Instant.now()
+
+    val gcsObjectName = GcsObjectName("path/path/myid", now)
+
+    val cachedKey = CachedKey(gcsObjectName)
+
+    cachedKey.timeCreated shouldBe now
+    cachedKey.keyId shouldBe ServiceAccountKeyId("myid")
+  }
+
+  it should "calculate isBefore" in {
+    val earliest = Instant.now()
+    val middle = earliest.plusSeconds(1)
+    val latest = earliest.plusSeconds(2)
+
+    val cachedKey = new CachedKey(middle, ServiceAccountKeyId("id"))
+
+    cachedKey.isBefore(latest) shouldBe true
+    cachedKey.isBefore(middle) shouldBe false
+    cachedKey.isBefore(earliest) shouldBe false
+  }
+
+  it should "calculate isAfterOrEqual" in {
+    val earliest = Instant.now()
+    val middle = earliest.plusSeconds(1)
+    val latest = earliest.plusSeconds(2)
+
+    val cachedKey = new CachedKey(middle, ServiceAccountKeyId("id"))
+
+    cachedKey.isAfterOrEqual(latest) shouldBe false
+    cachedKey.isAfterOrEqual(middle) shouldBe true
+    cachedKey.isAfterOrEqual(earliest) shouldBe true
+  }
+
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-278

This is fairly pervasive rewrite of `GoogleKeyCache`; apologies to reviewers.

In an effort to reduce key thrashing and to make a best effort to provide a usable service account key, we're changing the logic on how keys are retrieved. Much of this is in response to Google Support's information that newly-created keys are not consistently usable for something on the order of "typically 2 minutes, potentially 7 minutes or longer"

Glossing over some details, the logic has changed thusly:

_**previously**_
read keys from the key cache. Find any key in cache which is less than 12 days old and which has a corresponding key in the Google IAM listing. If no key found, create a new one.

_**in this PR**_
read keys from the key cache. Look for, in order of preference:
1. keys which are older than 15 minutes but less than 12 days old
2. keys which are older than 12 days
3. keys which are newer than 15 minutes

there is additional logic in this PR to clean up keys prior to creating a new one, and to avoid creating multiple keys in quick succession.




