### PR TITLE
CORE-278: update to latest workbench-libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,11 +11,11 @@ object Dependencies {
   val postgresDriverVersion = "42.7.5"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "3c43ebb" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "fdb7b18" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.21-$workbenchLibV"
-  val workbenchGoogleV = s"0.34-$workbenchLibV"
+  val workbenchGoogleV = s"0.35-$workbenchLibV"
   val workbenchGoogle2V = s"0.37-$workbenchLibV"
   val workbenchNotificationsV = s"1.1-$workbenchLibV"
   val workbenchOauth2V = s"0.9-$workbenchLibV"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-278

Updates to the latest version of workbench-libs, which disables polling for service account key creation. See https://github.com/broadinstitute/workbench-libs/pull/1724.

Polling did not guarantee the key was usable, and added delays.




---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
