### PR TITLE
DT-1202: Allow creating datasnapshot as a child resource of dataset

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1456,14 +1456,14 @@ resourceTypes = {
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal"]
+        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal", "create_with_parent"]
         includedRoles = ["custodian"]
         descendantRoles = {
           snapshot-builder-request = ["approver"]
         }
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent", "create_with_parent"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent"]
         includedRoles = ["reader"]
       }
       reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1338,6 +1338,9 @@ resourceTypes = {
       add_child = {
         description = "add a child resource"
       }
+      list_children = {
+        description = "list child resources"
+      }
     }
     ownerRoleName = "steward"
     roles = {
@@ -1356,7 +1359,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
       }
       snapshot_creator = {
-        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
+        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child", "list_children"]
       }
       admin = {
         roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource"]
@@ -1444,20 +1447,23 @@ resourceTypes = {
         description = "add a child resource"
       }
       create_with_parent = {
-        description = "Enables creating the request object with a parent"
+        description = "Enables creating a snapshot with a parent dataset"
+      }
+      get_parent = {
+        description = "get parent of snapshot"
       }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal", "create_with_parent"]
+        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal"]
         includedRoles = ["custodian"]
         descendantRoles = {
           snapshot-builder-request = ["approver"]
         }
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent"]
         includedRoles = ["reader"]
       }
       reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1335,6 +1335,9 @@ resourceTypes = {
       "unlock_resource" = {
         description = "Can unlock a resource"
       }
+      add_child = {
+        description = "add a child resource"
+      }
     }
     ownerRoleName = "steward"
     roles = {
@@ -1348,7 +1351,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
       }
       snapshot_creator = {
-        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot"]
+        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
       }
       admin = {
         roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource"]
@@ -1435,11 +1438,14 @@ resourceTypes = {
       add_child = {
         description = "add a child resource"
       }
+      create_with_parent = {
+        description = "Enables creating the request object with a parent"
+      }
     }
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal"]
+        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal", "create_with_parent"]
         includedRoles = ["custodian"]
         descendantRoles = {
           snapshot-builder-request = ["approver"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1349,7 +1349,7 @@ resourceTypes = {
         includedRoles = ["custodian"]
       }
       custodian = {
-        roleActions = ["manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator"]
+        roleActions = ["manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "list_children"]
         includedRoles = ["snapshot_creator"]
         descendantRoles = {
           datasnapshot = ["steward"]
@@ -1359,7 +1359,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]
       }
       snapshot_creator = {
-        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child", "list_children"]
+        roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
       }
       admin = {
         roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource"]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1463,7 +1463,7 @@ resourceTypes = {
         }
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent", "create_with_parent"]
         includedRoles = ["reader"]
       }
       reader = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1346,6 +1346,9 @@ resourceTypes = {
       }
       custodian = {
         roleActions = ["read_dataset", "read_data", "manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "read_policies", "link_snapshot", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource"]
+        descendantRoles = {
+          datasnapshot = ["steward"]
+        }
       }
       ingester = {
         roleActions = ["read_dataset", "read_data", "ingest_data"]


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1202

What:

To support inheriting dataset custodian role as steward on a snapshot, we need to allow

- creating the `datasnapshot` with a parent resource (`create_with_parent`)
- adding a child resource to a `dataset` (`add_child`)

Also, we need to specify that `dataset` `custodian` or `steward` are `steward` on `datasnapshot`, if the parent resource is set.

Why:

This is support the goal of avoiding adding dataset custodians to every snapshot, to prevent hitting GCP quota limits.

How:

With this change
- users with `snapshot_creator` or greater role on `dataset` can `add_child` to `dataset`
- users with `custodian` or greater role on `dataset` can `list_children`
- users with `steward` role can `create_with_parent` to `datasnapshot`, and `get_parent`
- `dataset` `custodian` or greater role are `steward` on child `datasnapshot`s.

---

**PR checklist**

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
