### PR TITLE
CORE-278: revert key cache lock timeout to 20 seconds

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -97,9 +97,7 @@ class GoogleKeyCache(
   /** Retrieve a key for this pet, creating keys as necessary.
     */
   override def getKey(pet: PetServiceAccount): IO[String] = {
-    // 5 minute lock timeout chosen to match how long key creation polling can take
-    // TODO CORE-278: when we remove polling from workbench-libs, turn this lock time back down
-    val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 5 minutes)
+    val lockDetails = LockDetails(s"${pet.id.project.value}-getKey", pet.serviceAccount.subjectId.value, 20 seconds)
 
     for {
       // try to find a key using read-only logic by specifying withinLock = false


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-278

Turns the google key cache lock timeout back down from 5 minutes to 20 seconds.

It was originally turned up to 5 minutes in #1634 when workbench-libs polled until newly-created keys were available. We reverted that behavior of workbench-libs in #1639, so we can turn the lock time back down.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
