### PR TITLE
CORE-282 sort top groups

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
   PetManagedIdentity,
   PetManagedIdentityId
 }
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, ResourceTypeName, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -217,5 +217,5 @@ trait DirectoryDAO {
     * @return
     *   a map of group to membership count
     */
-  def listGroupsContributingToMostMemberships(samUser: SamUser, limit: Int, samRequestContext: SamRequestContext): IO[Map[WorkbenchGroupIdentity, Int]]
+  def listGroupsContributingToMostMemberships(samUser: SamUser, limit: Int, samRequestContext: SamRequestContext): IO[List[GroupMembershipCount]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.workbench.sam.db.SamTypeBinders._
 import org.broadinstitute.dsde.workbench.sam.db._
 import org.broadinstitute.dsde.workbench.sam.db.tables._
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.util.{DatabaseSupport, SamRequestContext}
 import org.postgresql.util.PSQLException
 import scalikejdbc._
@@ -736,8 +736,8 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       samUser: SamUser,
       limit: Int,
       samRequestContext: SamRequestContext
-  ): IO[Map[WorkbenchGroupIdentity, Int]] = if (limit <= 0) {
-    IO.pure(Map.empty)
+  ): IO[List[GroupMembershipCount]] = if (limit <= 0) {
+    IO.pure(List.empty)
   } else {
     readOnlyTransaction("listGroupsContributingToMostMemberships", samRequestContext) { implicit session =>
       val f = GroupMemberFlatTable.syntax("f")
@@ -762,15 +762,15 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                             left join ${PolicyTable as p} on ${p.groupId} = ${g.id}
                             left join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
                             left join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+                            order by gc.membership_count desc
                             """
 
       query
         .map { rs =>
-          resultSetToGroupIdentity(rs, g, p, r, rt) -> rs.int("membership_count")
+          GroupMembershipCount(resultSetToGroupIdentity(rs, g, p, r, rt), rs.int("membership_count"))
         }
         .list()
         .apply()
-        .toMap
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/UserService.scala
@@ -520,7 +520,7 @@ class UserService(
   def countIndirectPublicGroupMemberships(samUser: SamUser, samRequestContext: SamRequestContext): IO[Int] =
     directoryDAO.countIndirectPublicGroupMemberships(samUser, samRequestContext)
 
-  def listGroupsContributingToMostMemberships(samUser: SamUser, limit: Int, samRequestContext: SamRequestContext): IO[Map[WorkbenchGroupIdentity, Int]] =
+  def listGroupsContributingToMostMemberships(samUser: SamUser, limit: Int, samRequestContext: SamRequestContext): IO[List[GroupMembershipCount]] =
     directoryDAO.listGroupsContributingToMostMemberships(samUser, limit, samRequestContext)
 
   def getSamUserCombinedState(
@@ -573,7 +573,8 @@ class UserService(
       ),
       Map("enterpriseFeatures" -> enterpriseFeatures.toJson),
       favoriteResources,
-      topGroups.map { case (group, count) => GroupMembershipCount(group, count) }.toList match {
+      topGroups match {
+        // we want to omit the topGroups field if it's empty so that it does not seem like there are no groups
         case Nil => None
         case list => Option(list)
       }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.sam.azure.{
   PetManagedIdentityId
 }
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{AccessPolicy, BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, ResourceTypeName, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -525,5 +525,5 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
       samUser: SamUser,
       limit: Int,
       samRequestContext: SamRequestContext
-  ): IO[Map[WorkbenchGroupIdentity, Int]] = ???
+  ): IO[List[GroupMembershipCount]] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables.TosTable
 import org.broadinstitute.dsde.workbench.sam.matchers.TimeMatchers
 import org.broadinstitute.dsde.workbench.sam.model._
-import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, SamUser, SamUserAttributes}
+import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.scalatest.Inside.inside
 import org.scalatest.freespec.AnyFreeSpec
@@ -2259,11 +2259,13 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.addGroupMember(testGroups.last._1.id, otherUser.id, samRequestContext).unsafeRunSync()
 
         val result = dao.listGroupsContributingToMostMemberships(defaultUser, limit, samRequestContext).unsafeRunSync()
-        result should be(testGroups.drop(drop).map { case (group, index) => group.id -> (1 + index * multiplier) }.toMap)
+        result.reverse should contain theSameElementsInOrderAs testGroups.drop(drop).map { case (group, index) =>
+          GroupMembershipCount(group.id, 1 + index * multiplier)
+        }
 
         // check that another user gives different results
         val otherResult = dao.listGroupsContributingToMostMemberships(otherUser, limit, samRequestContext).unsafeRunSync()
-        otherResult should be(Map(testGroups.last._1.id -> (1 + (limit + drop) * multiplier)))
+        otherResult should be(List(GroupMembershipCount(testGroups.last._1.id, 1 + (limit + drop) * multiplier)))
       }
 
       "list policies and groups" in {
@@ -2282,7 +2284,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.updateSynchronizedDateAndVersion(group, samRequestContext).unsafeRunSync()
 
         val result = dao.listGroupsContributingToMostMemberships(defaultUser, 10, samRequestContext).unsafeRunSync()
-        result should be(Map(policy.id -> 1, group.id -> 1))
+        result should contain theSameElementsAs List(GroupMembershipCount(policy.id, 1), GroupMembershipCount(group.id, 1))
       }
 
       "ignores unsynchronized groups" in {
@@ -2297,10 +2299,10 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         val parentUuid = UUID.randomUUID().toString
         val parentGroup = BasicWorkbenchGroup(WorkbenchGroupName(parentUuid), Set(leafGroup.id), WorkbenchEmail(parentUuid))
         dao.createGroup(parentGroup, samRequestContext = samRequestContext).unsafeRunSync()
-        // not synchronized
+        // updateSynchronizedDateAndVersion not called
 
         val result = dao.listGroupsContributingToMostMemberships(defaultUser, 10, samRequestContext).unsafeRunSync()
-        result should be(Map(leafGroup.id -> 1))
+        result should be(List(GroupMembershipCount(leafGroup.id, 1)))
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/service/UserServiceSpecs/SupportSummarySpec.scala
@@ -97,11 +97,11 @@ class SupportSummarySpec extends UserServiceTestTraits with TimeMatchers {
       .when(directoryDAO)
       .countIndirectPublicGroupMemberships(any[SamUser], any[SamRequestContext])
     lenient()
-      .doReturn(IO.pure(Map(testGroupName -> 1, testPolicyId -> 2)))
+      .doReturn(IO.pure(List(GroupMembershipCount(testGroupName, 1), GroupMembershipCount(testPolicyId, 2))))
       .when(directoryDAO)
       .listGroupsContributingToMostMemberships(any[SamUser], any[Int], any[SamRequestContext])
     lenient()
-      .doReturn(IO.pure(Map.empty))
+      .doReturn(IO.pure(List.empty))
       .when(directoryDAO)
       .listGroupsContributingToMostMemberships(any[SamUser], ArgumentMatchers.eq(0), any[SamRequestContext])
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-282

This is a follow on to https://github.com/broadinstitute/sam/pull/1641 to add sorting. The return type from the DAO was a `Map` which was hard to keep sorted so I changed it to a `List` and I also realized that it was handy to use `GroupMembershipCount` 

What:

  \<For your reviewers' sake, please describe in a sentence or two what this PR is accomplishing (usually from the users' perspective, but not necessarily).\>

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
