### PR TITLE
CORE-318 configure deadline extension, auth domain sync shortcut

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -73,12 +73,16 @@ googleServices {
     pubSubSubscription = ${?GOOGLE_PUB_SUB_SUBSCRIPTION}
     workerCount = 5
     workerCount = ${?GOOGLE_GROUP_SYNC_WORKER_COUNT}
+    maxAckExtensionPeriod = 3h
+    maxAckExtensionPeriod = ${?GOOGLE_GROUP_SYNC_MAX_ACK_EXTENSION_PERIOD}
   }
   disableUsers {
     pubSubProject = ${?GOOGLE_PROJECT}
     pubSubTopic = "terra-cryptomining"
     pubSubSubscription = "sam-disable-users-subscription"
     workerCount = 5
+    maxAckExtensionPeriod = 30m
+    maxAckExtensionPeriod = ${?GOOGLE_DISABLE_USERS_MAX_ACK_EXTENSION_PERIOD}
   }
   googleKeyCache {
     bucketName = ${?GOOGLE_KEY_CACHE_BUCKET_NAME}
@@ -97,6 +101,8 @@ googleServices {
       pubSubTopic = sam-google-key-cache
       pubSubSubscription = sam-google-key-cache-sub
       workerCount = 1
+      maxAckExtensionPeriod = 30m
+      maxAckExtensionPeriod = ${?GOOGLE_KEY_CACHE_MONITOR_MAX_ACK_EXTENSION_PERIOD}
     }
   }
   kms {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GooglePubSubConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GooglePubSubConfig.scala
@@ -1,3 +1,5 @@
 package org.broadinstitute.dsde.workbench.sam.config
 
-case class GooglePubSubConfig(project: String, topic: String, subscription: String, workerCount: Int)
+import java.time.Duration
+
+case class GooglePubSubConfig(project: String, topic: String, subscription: String, workerCount: Int, maxAckExtensionPeriod: Duration)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/config/GoogleServicesConfig.scala
@@ -42,7 +42,8 @@ object GoogleServicesConfig {
       config.getString("pubSubProject"),
       config.getString("pubSubTopic"),
       config.getString("pubSubSubscription"),
-      config.getInt("workerCount")
+      config.getInt("workerCount"),
+      config.getDuration("maxAckExtensionPeriod")
     )
   }
   implicit val googleKeyCacheConfigReader: ValueReader[GoogleKeyCacheConfig] = ValueReader.relative { config =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -237,9 +237,17 @@ class GoogleGroupSynchronizer(
           case LoadResourceAuthDomainResult.Constrained(groups) =>
             // auth domain exists, need to calculate intersection
             val groupsIdentity: Set[WorkbenchGroupIdentity] = groups.toList.toSet
-            directoryDAO
-              .listIntersectionGroupUsers(groupsIdentity + policy.id, samRequestContext)
-              .map(_.map(_.asInstanceOf[WorkbenchSubject])) // Doesn't seem like I can avoid the asInstanceOf, would be interested to know if there's a way
+            if (groupsIdentity.size == 1 && policy.members.contains(groupsIdentity.head)) {
+              // if there is only 1 group in the auth domain and the policy contains that group, then the intersection is just the group
+              // this is a short cut for large auth domains where the policy is also shared with the auth domain group
+              // which leads to synchronizing policy groups with thousands of members
+              IO.pure(groupsIdentity.asInstanceOf[Set[WorkbenchSubject]])
+            } else {
+              // otherwise calculate the intersection
+              directoryDAO
+                .listIntersectionGroupUsers(groupsIdentity + policy.id, samRequestContext)
+                .map(_.map(_.asInstanceOf[WorkbenchSubject])) // Doesn't seem like I can avoid the asInstanceOf, would be interested to know if there's a way
+            }
           case LoadResourceAuthDomainResult.NotConstrained | LoadResourceAuthDomainResult.ResourceNotFound =>
             // auth domain does not exist, return policy members as is
             IO.pure(policy.members)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GooglePubSubMonitor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GooglePubSubMonitor.scala
@@ -29,6 +29,7 @@ class GooglePubSubMonitor(
       FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(new FileInputStream(pathToSACreds.defaultServiceAccountJsonPath.asString)))
     )
     .setExecutorProvider(InstantiatingExecutorProvider.newBuilder.setExecutorThreadCount(config.workerCount).build)
+    .setMaxAckExtensionPeriodDuration(config.maxAckExtensionPeriod)
     .build()
 
   def startAndRegisterTermination()(implicit system: ActorSystem): IO[Unit] =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -1752,6 +1752,62 @@ class GoogleExtensionSpec(_system: ActorSystem)
     intersectionGroup shouldEqual Set.empty
   }
 
+  it should "return the group if the auth domain contains only the group and the policy also contains the group" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val (
+      dirDAO: DirectoryDAO,
+      ge: GoogleExtensions,
+      constrainableService: ResourceService,
+      managedGroupService: ManagedGroupService,
+      constrainableResourceType: ResourceType,
+      constrainableRole: ResourceRole,
+      synchronizer
+    ) = initPrivateTest
+
+    val inAuthDomainUser = Generator.genWorkbenchUserBoth.sample.get
+    dirDAO.createUser(inAuthDomainUser, samRequestContext).unsafeRunSync()
+
+    val managedGroupId = "fooGroup"
+    val groupName = WorkbenchGroupName(managedGroupId)
+    val groupResourceId = ResourceId(managedGroupId)
+    runAndWait(managedGroupService.createManagedGroup(groupResourceId, inAuthDomainUser, samRequestContext = samRequestContext))
+    val groupEmail = runAndWait(managedGroupService.loadManagedGroup(groupResourceId, samRequestContext)).get
+
+    val accessPolicyMap = Map(
+      AccessPolicyName(constrainableRole.roleName.value) -> AccessPolicyMembershipRequest(
+        Set(inAuthDomainUser.email),
+        constrainableRole.actions,
+        Set(constrainableRole.roleName),
+        None
+      )
+    )
+    val resource = runAndWait(
+      constrainableService.createResource(
+        constrainableResourceType,
+        ResourceId("rid"),
+        accessPolicyMap,
+        Set(groupName),
+        None,
+        inAuthDomainUser.id,
+        samRequestContext
+      )
+    )
+
+    val accessPolicy = runAndWait(
+      constrainableService.overwritePolicy(
+        constrainableResourceType,
+        AccessPolicyName("ap"),
+        resource.fullyQualifiedId,
+        AccessPolicyMembershipRequest(Set(groupEmail, inAuthDomainUser.email), Set.empty, Set.empty, None),
+        samRequestContext
+      )
+    )
+
+    val intersectionGroup = synchronizer.calculateIntersectionGroup(resource.fullyQualifiedId, accessPolicy, samRequestContext).unsafeRunSync()
+    intersectionGroup shouldEqual Set(groupName)
+  }
+
   "isConstrainable" should "return true when the policy has constrainable actions and roles" in {
     assume(databaseEnabled, databaseEnabledClue)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-318

What:

2 things

1. add configuration with defaults for the max time that the pubsub client can extend the ack deadline. This did default to an hour but google group sync needs longer and other probably should be shorter
2. when auth domain contains only a single group and that group is a member of a policy, intersection returns only that group instead of flattening out the group structures and intersecting them, see code comments

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
