### PR TITLE
[DT-1272] DC Inherit: Create new Sam action, update dataset and snapshot admin roles

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1341,6 +1341,9 @@ resourceTypes = {
       list_children = {
         description = "list child resources"
       }
+      toggle_inherit_steward = {
+        description = "toggle whether the dataset custodians inherit steward role on children snapshots"
+
     }
     ownerRoleName = "steward"
     roles = {
@@ -1362,7 +1365,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource", "add_child", "remove_child", "toggle_inherit_steward"]
       }
     }
     reuseIds = true
@@ -1452,6 +1455,9 @@ resourceTypes = {
       get_parent = {
         description = "get parent of snapshot"
       }
+      set_parent = {
+        description = "set parent of snapshot"
+      }
     }
     ownerRoleName = "steward"
     roles = {
@@ -1478,7 +1484,7 @@ resourceTypes = {
         roleActions = ["discover_data", "read_policy::steward", "read_policy::discoverer", "read_auth_domain", "get_snapshot_builder_settings"]
       }
       admin = {
-        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource"]
+        roleActions = ["read_policies", "share_policy::steward", "alter_policies", "read_auth_domain", "update_auth_domain", "unlock_resource", "set_parent"]
       }
     }
     reuseIds = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1338,12 +1338,14 @@ resourceTypes = {
       add_child = {
         description = "add a child resource"
       }
+      remove_child = {
+        description = "remove a child resource"
+      }
       list_children = {
         description = "list child resources"
       }
       toggle_inherit_steward = {
-        description = "toggle whether the dataset custodians inherit steward role on children snapshots"
-
+        description = "toggle whether the dataset custodians inherit steward role on snapshots made from the dataset"
     }
     ownerRoleName = "steward"
     roles = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1346,6 +1346,7 @@ resourceTypes = {
       }
       toggle_inherit_steward = {
         description = "toggle whether the dataset custodians inherit steward role on snapshots made from the dataset"
+      }
     }
     ownerRoleName = "steward"
     roles = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DT-1272

What:
Create new Sam action on datasets “toggle_inherit_steward”
Create new Sam action on datasnapshots “set_parent”
Update the actions included in the Sam dataset admin and the Sam snapshot admin roles.
Add to the dataset admin role “add_child”, “remove_child”, and “toggle_inherit_steward”
Add to the datasnapshot admin role “set_parent”


Why:
To support DC inheritance work for existing datasets and snapshots
Context:  [Data Custodian Inheritance: Permission Model for Updating Existing Datasets](https://docs.google.com/document/d/1F1ioHXWrs59Te2ZLGl89RTEmP75m4XJ0o2FNVh3f6E8/edit?usp=sharing)

How:
Allow admins on datasets and snapshots to set parent child relationships. A new tdr endpoint will check for the new toggle action to ensure the requesting user is a dataset admin.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
