### PR TITLE
[DT-1272]Change name of new toggle inherit steward action to set inherit steward

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1344,8 +1344,8 @@ resourceTypes = {
       list_children = {
         description = "list child resources"
       }
-      toggle_inherit_steward = {
-        description = "toggle whether the dataset custodians inherit steward role on snapshots made from the dataset"
+      set_inherit_steward = {
+        description = "set whether the dataset custodians inherit steward role on snapshots made from the dataset"
       }
     }
     ownerRoleName = "steward"
@@ -1368,7 +1368,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource", "add_child", "remove_child", "toggle_inherit_steward"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource", "add_child", "remove_child", "set_inherit_steward"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket: [DT-1272](https://broadworkbench.atlassian.net/browse/DT-1272)

What:
rename action introduced here: https://github.com/broadinstitute/sam/pull/1647
it is unused so far so it is safe to do so

Why:
toggle is not standard, set follows the pattern

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[DT-1272]: https://broadworkbench.atlassian.net/browse/DT-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ