### PR TITLE
CORE-99: strip stack traces from error responses

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamRoutes.scala
@@ -118,10 +118,10 @@ object SamRoutes {
     ExceptionHandler {
       case withErrorReport: WorkbenchExceptionWithErrorReport =>
         Sentry.captureException(withErrorReport)
-        complete((withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), withErrorReport.errorReport))
+        complete((withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), withErrorReport.errorReport.copy(stackTrace = Seq())))
       case e: Throwable =>
         Sentry.captureException(e)
-        complete((StatusCodes.InternalServerError, ErrorReport(e)))
+        complete((StatusCodes.InternalServerError, ErrorReport(e).copy(stackTrace = Seq())))
     }
   }
 }


### PR DESCRIPTION
Ticket: [CORE-99](https://broadworkbench.atlassian.net/browse/CORE-99)

What:

In Sam's global error handler, remove stack traces from the response. This helps to prevent information disclosure in error messages.

See also: https://github.com/broadinstitute/rawls/pull/3213


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[CORE-99]: https://broadworkbench.atlassian.net/browse/CORE-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ