### PR TITLE
CORE-402 recurse includedRoles to list actions

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1471,14 +1471,14 @@ resourceTypes = {
     ownerRoleName = "steward"
     roles = {
       steward = {
-        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal", "create_with_parent", "read_data", "export_snapshot"]
+        roleActions = ["share_policy::steward", "share_policy::custodian", "update_passport_identifier", "view_journal", "create_with_parent"]
         includedRoles = ["custodian"]
         descendantRoles = {
           snapshot-builder-request = ["approver"]
         }
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent", "read_data", "export_snapshot"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent"]
         includedRoles = ["reader"]
       }
       reader = {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -77,9 +77,8 @@ trait SecurityDirectives {
       case None => Directives.pass // no parent specified, proceed
       case Some(parent) =>
         // parents are allowed for a resource type if the owner role contains the SamResourceActions.setParent or SamResourceActions.createWithParent action
-        val parentAllowed = resourceType.roles
-          .find(_.roleName == resourceType.ownerRoleName)
-          .exists(role => role.actions.contains(SamResourceActions.setParent) || role.actions.contains(SamResourceActions.createWithParent))
+        val parentAllowedActions = Set(SamResourceActions.setParent, SamResourceActions.createWithParent)
+        val parentAllowed = parentAllowedActions.diff(resourceType.getRoleActions(resourceType.ownerRoleName)).nonEmpty
         if (!parentAllowed) {
           Directives.failWith(
             new WorkbenchExceptionWithErrorReport(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SecurityDirectives.scala
@@ -78,7 +78,7 @@ trait SecurityDirectives {
       case Some(parent) =>
         // parents are allowed for a resource type if the owner role contains the SamResourceActions.setParent or SamResourceActions.createWithParent action
         val parentAllowedActions = Set(SamResourceActions.setParent, SamResourceActions.createWithParent)
-        val parentAllowed = parentAllowedActions.diff(resourceType.getRoleActions(resourceType.ownerRoleName)).nonEmpty
+        val parentAllowed = parentAllowedActions.intersect(resourceType.getRoleActions(resourceType.ownerRoleName)).nonEmpty
         if (!parentAllowed) {
           Directives.failWith(
             new WorkbenchExceptionWithErrorReport(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupSynchronizer.scala
@@ -212,10 +212,7 @@ class GoogleGroupSynchronizer(
           actionPattern.authDomainConstrainable &&
           (accessPolicy.actions.exists(actionPattern.matches) ||
             accessPolicy.roles.exists { accessPolicyRole =>
-              resourceType.roles.exists {
-                case resourceTypeRole @ ResourceRole(`accessPolicyRole`, _, _, _) => resourceTypeRole.actions.exists(actionPattern.matches)
-                case _ => false
-              }
+              resourceType.getRoleActions(accessPolicyRole).exists(actionPattern.matches)
             })
         }
       case None =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/model/SamModel.scala
@@ -141,6 +141,29 @@ object UserStatusDetails {
   // Ideally we'd just store this boolean in a lazy val, but this will upset the spray/akka json serializers
   // I can't imagine a scenario where we have enough action patterns that would make this def discernibly slow though
   def isAuthDomainConstrainable: Boolean = actionPatterns.exists(_.authDomainConstrainable)
+
+  /** Recursively get all actions for a role, including actions from included roles
+    * @param roleName
+    *   role to get actions for
+    * @param visitedRoles
+    *   set of roles that have already been visited to prevent infinite recursion
+    * @return
+    *   set of all actions for the role
+    */
+  def getRoleActions(roleName: ResourceRoleName, visitedRoles: Set[ResourceRoleName] = Set.empty): Set[ResourceAction] =
+    if (visitedRoles.contains(roleName)) {
+      // prevent infinite recursion
+      Set.empty
+    } else {
+      roles
+        .find(_.roleName == roleName)
+        .map(role =>
+          role.includedRoles.foldLeft(role.actions)((accumulatedActions, includedRole) =>
+            accumulatedActions ++ getRoleActions(includedRole, visitedRoles + roleName)
+          )
+        )
+        .getOrElse(Set.empty)
+    }
 }
 
 @Lenses final case class ResourceId(value: String) extends ValueObject

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/ResourceTypeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/model/ResourceTypeSpec.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.workbench.sam.model
+
+import org.broadinstitute.dsde.workbench.sam.Generator
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class ResourceTypeSpec extends AnyFlatSpecLike with Matchers {
+  behavior of "ResourceType.getRoleActions"
+
+  it should "return the correct actions for a resource type" in {
+    val resourceType = Generator.genResourceType.sample.get
+    resourceType.roles.foreach { role =>
+      resourceType.getRoleActions(role.roleName) should be(role.actions)
+    }
+  }
+
+  it should "return the correct actions for a resource type with includedRoles" in {
+    val resourceType = Generator.genResourceType.sample.get
+    val testRole = ResourceRoleName("includedRole")
+    val withIncludedRoles = resourceType.copy(
+      roles = resourceType.roles + ResourceRole(testRole, Set.empty, resourceType.roles.map(_.roleName))
+    )
+    resourceType.roles.foreach { role =>
+      withIncludedRoles.getRoleActions(testRole) should contain allElementsOf role.actions
+    }
+  }
+
+  it should "tolerate cycles in includedRoles" in {
+    val resourceType = Generator.genResourceType.sample.get
+    val testRole = ResourceRoleName("includedRole")
+    val withIncludedRoles = resourceType.copy(
+      roles = resourceType.roles + ResourceRole(testRole, Set.empty, Set(testRole))
+    )
+    withIncludedRoles.getRoleActions(testRole) shouldBe empty
+  }
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-402

  \<Don't forget to include the ticket number in the PR title!\>

What:

Add a new function to `ResourceType` that will get the actions for a role, recursing through `includedRoles` and use it in places that expect the current list of actions to be complete.

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
