### PR TITLE
[AN-444] Allow billing project owners to stop runtimes

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -781,7 +781,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child", "own", "link"]
+        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "stop_start_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child", "own", "link"]
         descendantRoles = {
           google-project = ["owner"]
         }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -781,7 +781,7 @@ resourceTypes = {
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "stop_start_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child", "own", "link"]
+        roleActions = ["view_status", "create_workspace", "alter_policies", "read_policies", "launch_batch_compute", "list_notebook_cluster", "launch_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "create_persistent_disk", "delete_persistent_disk", "create_kubernetes_app", "alter_google_role", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report", "list_children", "remove_child", "add_child", "own", "link"]
         descendantRoles = {
           google-project = ["owner"]
         }
@@ -848,7 +848,7 @@ resourceTypes = {
         roleActions = ["status", "connect", "delete", "read_policies", "stop_start", "modify", "set_parent", "get_parent"]
       }
       manager = {
-        roleActions = ["status", "delete", "read_policies", "can_access"]
+        roleActions = ["status", "delete", "read_policies", "can_access", "stop_start"]
       }
       accessor = {
         roleActions = ["can_access"]


### PR DESCRIPTION
Ticket: [AN-444](https://broadworkbench.atlassian.net/browse/AN-444)

What:

Adds the stop_start_notebook_cluster permission for billing project and workspace owners.


Why:

Billing project owners already have create/delete permissions and users have asked for stop permission to control costs

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[AN-444]: https://broadworkbench.atlassian.net/browse/AN-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ