### PR TITLE
CORE-387: update CRL, which updates json-smart

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val workbenchNotificationsV = s"1.1-$workbenchLibV"
   val workbenchOauth2V = s"0.9-$workbenchLibV"
   val monocleVersion = "2.0.5"
-  val crlVersion = "1.2.34-SNAPSHOT"
+  val crlVersion = "1.2.35-SNAPSHOT"
   val tclVersion = "1.1.30-SNAPSHOT"
   val slf4jVersion = "2.0.6"
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-387

CORE-387 is a security finding on `json-smart`.

`json-smart` is pulled in by `com.azure:azure-identity`, which in Sam is pulled in by `terra-cloud-resource-lib`.

This PR updates `terra-cloud-resource-lib`, which in turn updates `json-smart`.

Part of a group of PRs:
* https://github.com/broadinstitute/rawls/pull/3240
* https://github.com/DataBiosphere/terra-resource-buffer/pull/422
* https://github.com/broadinstitute/thurloe/pull/377


