### PR TITLE
[CORE-419] Fix scala steward frequency config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,7 +26,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,7 +26,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).


### PR DESCRIPTION
Ticket: Jira: https://broadworkbench.atlassian.net/browse/CORE-419

Updated the Scala Steward cron schedule from `0 0 ? * MON` (every Monday at midnight) to `0 0 0 1 * ?` to run at midnight on the 1st of every month, reducing update frequency and aligning with a monthly maintenance cycle.

The cron expression follows the Quartz format, which is what [cron4s](https://github.com/alonsodomin/cron4s) (used by Scala Steward) supports. The updated expression, `0 0 0 1 * ?` means it runs at midnight on the 1st of every month. You can confirm it's valid in the [cron4s user guide](https://www.alonsodomin.me/cron4s/userguide/) or by testing it with any [Quartz cron expression tool](https://www.freeformatter.com/cron-expression-generator-quartz.html).

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
