### PR TITLE
DT-1421: add a new resource type for TDR's google projects

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1189,7 +1189,7 @@ resourceTypes = {
         description = "set the parent resource of this resource"
       }
       link = {
-        description = "link this resource to a dataset or datasnapshot"
+        description = "link this resource to a billing-project"
       }
       read = {
         description = "read this resource"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1174,6 +1174,35 @@ resourceTypes = {
     }
     reuseIds = true
   }
+  datarepo-google-project = {
+    actionPatterns = {
+      read_policies = {
+        description = "list all policies and policy details for this resource"
+      }
+      delete = {
+        description = "delete this resource"
+      }
+      get_parent = {
+        description = "get the parent resource of this resource"
+      }
+      set_parent = {
+        description = "set the parent resource of this resource"
+      }
+      link = {
+        description = "link this resource to a dataset or datasnapshot"
+      }
+      read = {
+        description = "read this resource"
+      }
+    }
+    ownerRoleName = "owner"
+    roles = {
+      owner = {
+        roleActions = ["read_policies", "delete", "get_parent", "set_parent", "link", "read"]
+      }
+    }
+    reuseIds = false
+  }
   spend-profile = {
     actionPatterns = {
       "read_policies" = {
@@ -1364,10 +1393,11 @@ resourceTypes = {
         includedRoles = ["custodian"]
       }
       custodian = {
-        roleActions = ["manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "list_children"]
+        roleActions = ["manage_schema", "create_datasnapshot", "ingest_data", "soft_delete", "hard_delete", "unlink_snapshot", "list_snapshots", "lock_resource", "unlock_resource", "share_policy::custodian", "share_policy::ingester", "share_policy::snapshot_creator", "list_children", "add_child", "remove_child"]
         includedRoles = ["snapshot_creator"]
         descendantRoles = {
           datasnapshot = ["steward"]
+          datarepo-google-project = ["owner"]
         }
       }
       ingester = {
@@ -1461,6 +1491,12 @@ resourceTypes = {
       add_child = {
         description = "add a child resource"
       }
+      remove_child = {
+        description = "remove a child resource"
+      }
+      list_children = {
+        description = "list child resources"
+      }
       create_with_parent = {
         description = "Enables creating a snapshot with a parent dataset"
       }
@@ -1481,8 +1517,11 @@ resourceTypes = {
         }
       }
       custodian = {
-        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent"]
+        roleActions = ["delete", "edit_datasnapshot", "update_snapshot", "share_policy::reader", "share_policy::aggregate_data_reader", "share_policy::discoverer", "read_policies", "set_public", "update_auth_domain", "lock_resource", "unlock_resource", "get_parent", "remove_child", "list_children"]
         includedRoles = ["reader"]
+        descendantRoles = {
+          datarepo-google-project = ["owner"]
+        }
       }
       reader = {
         roleActions = ["read_data", "read_policy::custodian","export_snapshot"]


### PR DESCRIPTION
Ticket: http://broadworkbench.atlassian.net/browse/DT-1421

*What:*

- add a new resource type for TDR's google projects
- add actions and descendantRoles to datasnapshot and dataset.

*Why:*

TDR needs a way to communicate permissions to Rawls, but we don't want to have a circular call chain where Rawls needs to call TDR.

*How:*

Sam is a common service that both TDR and Rawls call into, so we're using Sam to store this information.

Verified using https://github.com/DataBiosphere/jade-data-repo/blob/ps/dt-1421-datarepo-google-project-support-sam-test/src/test/java/bio/terra/integration/SamResourcesTest.java by running the test manually in a BEE

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
