### PR TITLE
CORE-69: GHA builds on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   run-unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SBT_OPTS: >-
         -Xmx3g
@@ -78,7 +78,7 @@ jobs:
     secrets: inherit
 
   generateAndPublishClient:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ tag, run-unit-tests ]
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
 
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

The build.yaml GHA should use ubuntu-latest, not be hardcoded to ubuntu-20.04, to stay current.

Ubuntu-20.04 "will be fully retired by April 15, 2025":
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
