### PR TITLE
[CORE-458] Replace coursier/cache with setup-java/cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,15 +40,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: sbt/setup-sbt@v1
 
-      # coursier cache action caches both coursier and sbt caches
-      - name: coursier-cache-action
-        uses: coursier/cache-action@v5
-
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
+          cache: 'sbt'
 
       - name: Git secrets setup
         run: |
@@ -90,9 +87,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: sbt/setup-sbt@v1
 
-      # coursier cache action caches both coursier and sbt caches
-      - name: coursier-cache-action
-        uses: coursier/cache-action@v5
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
 
       - name: Generate java client
         id: generateJavaClient


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-458

The coursier-cache-action has been disabled as per the GitHub changelog (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts). This has caused an error in the Sam GitHub Action (GHA).

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
