### PR TITLE
[CORE-451] Remove unused google-project actions

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -683,17 +683,11 @@ resourceTypes = {
       create-pet = {
         description = "create a pet service account in this google-project"
       }
-      link = {
-        description = "link a google-project to a billing-project"
-      }
-      read = {
-        description = "read this google-project"
-      }
     }
     ownerRoleName = "owner"
     roles = {
       owner = {
-        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "list_children", "link", "read"]
+        roleActions = ["read_policies", "list_notebook_cluster", "delete_notebook_cluster", "list_persistent_disk", "delete_persistent_disk", "delete", "get_parent", "set_parent", "list_children"]
         includedRoles = ["notebook-user", "pet-creator"]
         descendantRoles = {
           kubernetes-app = ["manager"]


### PR DESCRIPTION
Ticket: [CORE-451](https://broadworkbench.atlassian.net/browse/CORE-451)
* With https://github.com/broadinstitute/sam/pull/1672 and https://github.com/broadinstitute/rawls/pull/3264, these actions are no longer used. Remove them.


---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[CORE-451]: https://broadworkbench.atlassian.net/browse/CORE-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ