### PR TITLE
CORE-69: update sbt and scala-sbt docker images

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -321,7 +321,7 @@ jobs:
                           -e JANITOR_CLIENT_CREDENTIAL_FILE_PATH="" \
                           -e JANITOR_TRACK_RESOURCE_PROJECT_ID="" \
                           -e JANITOR_TRACK_RESOURCE_TOPIC_ID="" \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 \
                           bash -c "git config --global --add safe.directory /working/sam && sbt \"set scalafmtOnCompile := false\" \"project pact4s\" \"testOnly *SamProviderSpec\""
 
   can-i-deploy: # The can-i-deploy job will run as a result of a Sam PR. It reports the pact verification statuses on all deployed environments.

--- a/.github/workflows/verify_consumer_pacts.yml
+++ b/.github/workflows/verify_consumer_pacts.yml
@@ -321,7 +321,7 @@ jobs:
                           -e JANITOR_CLIENT_CREDENTIAL_FILE_PATH="" \
                           -e JANITOR_TRACK_RESOURCE_PROJECT_ID="" \
                           -e JANITOR_TRACK_RESOURCE_TOPIC_ID="" \
-                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.10.11_2.13.16 \
+                          sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 \
                           bash -c "git config --global --add safe.directory /working/sam && sbt \"set scalafmtOnCompile := false\" \"project pact4s\" \"testOnly *SamProviderSpec\""
 
   can-i-deploy: # The can-i-deploy job will run as a result of a Sam PR. It reports the pact verification statuses on all deployed environments.

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.10.11_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.11.1

--- a/codegen_java/project/build.properties
+++ b/codegen_java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/codegen_java/project/build.properties
+++ b/codegen_java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.11.1

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -96,9 +96,9 @@ function make_jar()
     GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
 
     # make jar.  cache sbt dependencies.
-    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.10.11_2.13.16 /working/docker/init_schema.sh /working
+    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/init_schema.sh /working
     sleep 40
-    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.10.11_2.13.16 /working/docker/install.sh /working
+    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/install.sh /working
     EXIT_CODE=$?
     set -e # Turn error detection back on for the rest of the script
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -96,9 +96,9 @@ function make_jar()
     GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
 
     # make jar.  cache sbt dependencies.
-    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/init_schema.sh /working
+    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /working/docker/init_schema.sh /working
     sleep 40
-    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/install.sh /working
+    docker run --rm --link postgres:postgres -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /working/docker/install.sh /working
     EXIT_CODE=$?
     set -e # Turn error detection back on for the rest of the script
 

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -8,7 +8,7 @@ set -e
 # Get the last commit hash of the model directory and set it as an environment variable
 GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
 
-docker run --rm -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.10.11_2.13.16 /working/docker/clean_install.sh /working
+docker run --rm -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -8,7 +8,7 @@ set -e
 # Get the last commit hash of the model directory and set it as an environment variable
 GIT_MODEL_HASH=$(git log -n 1 --pretty=format:%h)
 
-docker run --rm -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.0_2.13.16 /working/docker/clean_install.sh /working
+docker run --rm -e GIT_MODEL_HASH=$GIT_MODEL_HASH -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.11.1


### PR DESCRIPTION
Ticket: CORE-69

Partially supersedes #1689. When updating `sbt`, we also need to update the `scala-sbt` docker images.
