### PR TITLE
[DT-1654] Unblock Dataset Migration for DC Inheritance

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1418,7 +1418,7 @@ resourceTypes = {
         roleActions = ["read_dataset", "read_data", "read_policies", "link_snapshot", "add_child"]
       }
       admin = {
-        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource", "add_child", "remove_child", "set_inherit_steward"]
+        roleActions = ["share_policy::steward", "read_policies", "alter_policies", "unlock_resource", "add_child", "remove_child", "set_inherit_steward", "list_children"]
       }
     }
     reuseIds = true


### PR DESCRIPTION
Ticket:  https://broadworkbench.atlassian.net/browse/DT-1654

What:
In order to unblock the inherit steward migration for GP, add list children action to admin role on dataset. This is a required change after this change: https://github.com/DataBiosphere/jade-data-repo/pull/1971 which uses the list children action.

Why:
By adding the list children action to the admin role, we know longer need to explicitly add ourselves as custodians on a dataset to run the set inherit steward flight. This allows admins to run the flight without giving them extra permissions.

How:
Add action to admin role for datasets in reference.conf

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
