### PR TITLE
CORE-581 use new createNotificationIfNotExists fxn

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -93,38 +93,11 @@ object MockTestSupport extends MockTestSupport {
     val googleGroupSyncPubSubDAO = new MockGooglePubSubDAO()
     val googleDisableUsersPubSubDAO = new MockGooglePubSubDAO()
     val googleKeyCachePubSubDAO = new MockGooglePubSubDAO()
-    val googleStorageDAO = new MockGoogleStorageDAO()
     val googleProjectDAO = new MockGoogleProjectDAO()
     val notificationDAO = new PubSubNotificationDAO(notificationPubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(
-      distributedLock,
-      googleIamDAO,
-      googleStorageDAO,
-      FakeGoogleStorageInterpreter,
-      googleKeyCachePubSubDAO,
-      googleServicesConfig,
-      petServiceAccountConfig
-    )
+    val cloudKeyCache = new GoogleKeyCache(distributedLock, googleIamDAO, FakeGoogleStorageInterpreter, googleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
     val googleExt = cloudExtensions.getOrElse(
-      new GoogleExtensions(
-        distributedLock,
-        directoryDAO,
-        policyDAO,
-        googleDirectoryDAO,
-        notificationPubSubDAO,
-        googleGroupSyncPubSubDAO,
-        googleDisableUsersPubSubDAO,
-        googleIamDAO,
-        googleStorageDAO,
-        googleProjectDAO,
-        cloudKeyCache,
-        notificationDAO,
-        FakeGoogleStorageInterpreter,
-        googleServicesConfig,
-        petServiceAccountConfig,
-        resourceTypes,
-        adminConfig.superAdminsGroup
-      )
+      new GoogleExtensions(distributedLock, directoryDAO, policyDAO, googleDirectoryDAO, notificationPubSubDAO, googleGroupSyncPubSubDAO, googleDisableUsersPubSubDAO, googleIamDAO, googleProjectDAO, cloudKeyCache, notificationDAO, FakeGoogleStorageInterpreter, googleServicesConfig, petServiceAccountConfig, resourceTypes, adminConfig.superAdminsGroup)
     )
     val policyEvaluatorService = policyEvaluatorServiceOpt.getOrElse(PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO))
     val mockResourceService = resourceServiceOpt.getOrElse(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,12 +11,12 @@ object Dependencies {
   val postgresDriverVersion = "42.7.6"
   val sentryVersion = "6.15.0"
 
-  val workbenchLibV = "fdb7b18" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "0c796e4" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"0.9-$workbenchLibV"
   val workbenchModelV = s"0.21-$workbenchLibV"
   val workbenchGoogleV = s"0.35-$workbenchLibV"
-  val workbenchGoogle2V = s"0.37-$workbenchLibV"
+  val workbenchGoogle2V = s"0.40-$workbenchLibV"
   val workbenchNotificationsV = s"1.1-$workbenchLibV"
   val workbenchOauth2V = s"0.9-$workbenchLibV"
   val monocleVersion = "2.0.5"

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -22,14 +22,7 @@ import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.semconv.ResourceAttributes
 import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.{Json, Pem}
-import org.broadinstitute.dsde.workbench.google.{
-  GoogleDirectoryDAO,
-  HttpGoogleDirectoryDAO,
-  HttpGoogleIamDAO,
-  HttpGoogleProjectDAO,
-  HttpGooglePubSubDAO,
-  HttpGoogleStorageDAO
-}
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, HttpGoogleDirectoryDAO, HttpGoogleIamDAO, HttpGoogleProjectDAO, HttpGooglePubSubDAO}
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageInterpreter, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, OpenIDConnectConfiguration}
@@ -270,11 +263,6 @@ object Boot extends IOApp with LazyLogging {
       workspaceMetricBaseName,
       config.googleServicesConfig.googleKeyCacheConfig.monitorPubSubConfig.project
     )
-    val googleStorageDAO = new HttpGoogleStorageDAO(
-      config.googleServicesConfig.appName,
-      Pem(WorkbenchEmail(config.googleServicesConfig.serviceAccountClientId), new File(config.googleServicesConfig.pemFile)),
-      workspaceMetricBaseName
-    )
     val googleProjectDAO = new HttpGoogleProjectDAO(
       config.googleServicesConfig.appName,
       Pem(WorkbenchEmail(config.googleServicesConfig.serviceAccountClientId), new File(config.googleServicesConfig.pemFile)),
@@ -284,7 +272,6 @@ object Boot extends IOApp with LazyLogging {
       new GoogleKeyCache(
         distributedLock,
         googleIamDAO,
-        googleStorageDAO,
         googleStorageNew,
         googleKeyCachePubSubDAO,
         config.googleServicesConfig,
@@ -301,7 +288,6 @@ object Boot extends IOApp with LazyLogging {
       googleGroupSyncPubSubDAO,
       googleDisableUsersPubSubDAO,
       googleIamDAO,
-      googleStorageDAO,
       googleProjectDAO,
       googleKeyCache,
       notificationDAO,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -13,7 +13,7 @@ import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.MessageRequest
-import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.Notifications.Notification
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.WorkbenchGroupNameFormat
@@ -58,7 +58,6 @@ class GoogleExtensions(
     val googleGroupSyncPubSubDAO: GooglePubSubDAO,
     val googleDisableUsersPubSubDAO: GooglePubSubDAO,
     val googleIamDAO: GoogleIamDAO,
-    val googleStorageDAO: GoogleStorageDAO,
     val googleProjectDAO: GoogleProjectDAO,
     val googleKeyCache: GoogleKeyCache,
     val notificationDAO: NotificationDAO,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -83,7 +83,13 @@ class GoogleKeyCache(
             .createNotificationIfNotExists(
               googleServicesConfig.googleKeyCacheConfig.bucketName,
               NotificationInfo
-                .newBuilder(projectTopicName.toString)
+                // the java doc for this method says that the topic must be in the format "projects/{project}/topics/{topic}"
+                // but the api docs https://cloud.google.com/storage/docs/json_api/v1/notifications say it must be in the format
+                // "//pubsub.googleapis.com/projects/{project}/topics/{topicName}"
+                // both are actually accepted by the create API, however the latter is what is returned by the list APIf,
+                // and we need to compare the returned value to the one we pass in to avoid duplicates
+                // so we use the latter format here
+                .newBuilder("//pubsub.googleapis.com/" + projectTopicName.toString)
                 .setEventTypes(EventType.OBJECT_DELETE)
                 .setPayloadFormat(PayloadFormat.JSON_API_V1)
                 .build()

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCache.scala
@@ -6,11 +6,12 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.implicits._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
-import com.google.cloud.storage.{BucketInfo, StorageException}
+import com.google.cloud.storage.{BucketInfo, NotificationInfo, StorageException}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
+import com.google.cloud.storage.NotificationInfo.{EventType, PayloadFormat}
 import com.google.pubsub.v1.ProjectTopicName
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GooglePubSubDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId}
@@ -22,7 +23,6 @@ import org.broadinstitute.dsde.workbench.sam.model.CachedKey
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
-
 import java.time.Instant
 
 /** Created by mbemis on 1/10/18.
@@ -30,7 +30,6 @@ import java.time.Instant
 class GoogleKeyCache(
     val distributedLock: PostgresDistributedLockDAO[IO],
     val googleIamDAO: GoogleIamDAO,
-    val googleStorageDAO: GoogleStorageDAO, // this is only used for GoogleKeyCacheMonitorSupervisor to trigger pubsub notification.
     val googleStorageAlg: GoogleStorageService[IO],
     val googleKeyCachePubSubDao: GooglePubSubDAO,
     val googleServicesConfig: GoogleServicesConfig,
@@ -80,15 +79,17 @@ class GoogleKeyCache(
               )
             )
           )
-          _ <- IO.fromFuture(
-            IO(
-              googleStorageDAO.setObjectChangePubSubTrigger(
-                googleServicesConfig.googleKeyCacheConfig.bucketName,
-                projectTopicName.toString,
-                List("OBJECT_DELETE")
-              )
+          _ <- googleStorageAlg
+            .createNotificationIfNotExists(
+              googleServicesConfig.googleKeyCacheConfig.bucketName,
+              NotificationInfo
+                .newBuilder(projectTopicName.toString)
+                .setEventTypes(EventType.OBJECT_DELETE)
+                .setPayloadFormat(PayloadFormat.JSON_API_V1)
+                .build()
             )
-          )
+            .compile
+            .drain
         } yield ()
       }.startAndRegisterTermination()
     } yield ()

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -104,7 +104,6 @@ object TestSupport extends TestSupport {
     val cloudKeyCache = new GoogleKeyCache(
       distributedLock,
       googleIamDAO,
-      googleStorageDAO,
       FakeGoogleStorageInterpreter,
       googleKeyCachePubSubDAO,
       googleServicesConfig,
@@ -123,7 +122,6 @@ object TestSupport extends TestSupport {
         googleGroupSyncPubSubDAO,
         googleDisableUsersPubSubDAO,
         googleIamDAO,
-        googleStorageDAO,
         googleProjectDAO,
         cloudKeyCache,
         notificationDAO,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -127,7 +127,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
         null,
         null,
         null,
-        null,
         googleServicesConfig,
         petServiceAccountConfig,
         configResourceTypes,
@@ -287,7 +286,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       petServiceAccountConfig,
       constrainableResourceTypes,
@@ -362,7 +360,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       mockGoogleGroupSyncPubSubDAO,
       mockGoogleDisableUsersPubSubDAO,
       mockGoogleIamDAO,
-      null,
       null,
       null,
       null,
@@ -457,7 +454,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleIamDAO,
-      null,
       mockGoogleProjectDAO,
       null,
       null,
@@ -563,7 +559,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       petServiceAccountConfig,
       configResourceTypes,
@@ -586,7 +581,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val ge = new GoogleExtensions(
       TestSupport.distributedLock,
       dirDAO,
-      null,
       null,
       null,
       null,
@@ -628,7 +622,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       null,
       configResourceTypes,
@@ -653,7 +646,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       dirDAO,
       null,
       new MockGoogleDirectoryDAO(),
-      null,
       null,
       null,
       null,
@@ -698,7 +690,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       null,
       configResourceTypes,
@@ -720,7 +711,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val ge = new GoogleExtensions(
       TestSupport.distributedLock,
       dirDAO,
-      null,
       null,
       null,
       null,
@@ -753,7 +743,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val ge = new GoogleExtensions(
       TestSupport.distributedLock,
       dirDAO,
-      null,
       null,
       null,
       null,
@@ -797,7 +786,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       null,
       configResourceTypes,
@@ -824,13 +812,11 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val mockGoogleNotificationPubSubDAO = new MockGooglePubSubDAO
     val mockGoogleGroupSyncPubSubDAO = new MockGooglePubSubDAO
     val mockGoogleDisableUsersPubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val mockGoogleIamDAO = new MockGoogleIamDAO
     val notificationDAO = new PubSubNotificationDAO(mockGoogleNotificationPubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(
       TestSupport.distributedLock,
       mockGoogleIamDAO,
-      mockGoogleStorageDAO,
       FakeGoogleStorageInterpreter,
       mockGoogleKeyCachePubSubDAO,
       googleServicesConfig,
@@ -849,7 +835,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       mockGoogleGroupSyncPubSubDAO,
       mockGoogleDisableUsersPubSubDAO,
       mockGoogleIamDAO,
-      mockGoogleStorageDAO,
       null,
       googleKeyCache,
       notificationDAO,
@@ -908,7 +893,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       config,
       null,
       configResourceTypes,
@@ -924,7 +908,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val config = googleServicesConfig.copy(appsDomain = "test.cloudfire.org")
     val googleExtensions = new GoogleExtensions(
       TestSupport.distributedLock,
-      null,
       null,
       null,
       null,
@@ -959,7 +942,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       mockDirectoryDAO,
       null,
       mockGoogleDirectoryDAO,
-      null,
       null,
       null,
       null,
@@ -1008,7 +990,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       null,
       configResourceTypes,
@@ -1035,7 +1016,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleGroupSyncPubSubDAO,
-      null,
       null,
       null,
       null,
@@ -1091,7 +1071,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleGroupSyncPubSubDAO,
-      null,
       null,
       null,
       null,
@@ -1156,7 +1135,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       null,
-      null,
       googleServicesConfig,
       null,
       configResourceTypes,
@@ -1213,13 +1191,11 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
     val mockGoogleKeyCachePubSubDAO = new MockGooglePubSubDAO
     val mockGoogleNotificationPubSubDAO = new MockGooglePubSubDAO
-    val mockGoogleStorageDAO = new MockGoogleStorageDAO
     val mockGoogleProjectDAO = new MockGoogleProjectDAO
     val notificationDAO = new PubSubNotificationDAO(mockGoogleNotificationPubSubDAO, "foo")
     val googleKeyCache = new GoogleKeyCache(
       TestSupport.distributedLock,
       mockGoogleIamDAO,
-      mockGoogleStorageDAO,
       FakeGoogleStorageInterpreter,
       mockGoogleKeyCachePubSubDAO,
       googleServicesConfig,
@@ -1235,7 +1211,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleIamDAO,
-      mockGoogleStorageDAO,
       mockGoogleProjectDAO,
       googleKeyCache,
       notificationDAO,
@@ -1400,7 +1375,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       TestSupport.distributedLock,
       dirDAO,
       policyDAO,
-      null,
       null,
       null,
       null,
@@ -2035,7 +2009,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleIamDAO,
-      null,
       mockGoogleProjectDAO,
       null,
       null,
@@ -2078,7 +2051,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleIamDAO,
-      null,
       mockGoogleProjectDAO,
       null,
       null,
@@ -2121,7 +2093,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleIamDAO,
-      null,
       mockGoogleProjectDAO,
       null,
       null,
@@ -2152,7 +2123,6 @@ class GoogleExtensionSpec(_system: ActorSystem)
       null,
       null,
       mockGoogleNotificationPubSubDAO,
-      null,
       null,
       null,
       null,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleKeyCacheSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.sam.google
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGooglePubSubDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleIamDAO, MockGooglePubSubDAO}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountKeyId, ServiceAccountPrivateKeyData}
@@ -55,7 +55,6 @@ class GoogleKeyCacheSpec extends AnyFlatSpecLike with Matchers with BeforeAndAft
     new GoogleKeyCache(
       TestSupport.distributedLock,
       iamDAO,
-      new MockGoogleStorageDAO,
       storageInterp,
       new MockGooglePubSubDAO,
       TestSupport.googleServicesConfig,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/NewGoogleExtensionsSpec.scala
@@ -10,7 +10,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
-import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleDirectoryDAO, GoogleIamDAO, GoogleProjectDAO, GooglePubSubDAO}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, TraceId, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
@@ -85,7 +85,6 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mock[GoogleIamDAO](RETURNS_SMART_NULLS),
-        mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
         mock[GoogleProjectDAO](RETURNS_SMART_NULLS),
         mockGoogleKeyCache,
         mock[NotificationDAO](RETURNS_SMART_NULLS),
@@ -238,7 +237,6 @@ class NewGoogleExtensionsSpec(_system: ActorSystem)
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mock[GooglePubSubDAO](RETURNS_SMART_NULLS),
         mock[GoogleIamDAO](RETURNS_SMART_NULLS),
-        mock[GoogleStorageDAO](RETURNS_SMART_NULLS),
         mockGoogleProjectDAO,
         mockGoogleKeyCache,
         mock[NotificationDAO](RETURNS_SMART_NULLS),


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-581

What:

Update to latest workbench-libs. Replace usage of `googleStorageDAO.setObjectChangePubSubTrigger` with new `googleStorageAlg.createNotificationIfNotExists` function. GoogleStorageDAO was no longer in use so removed a bunch of constructors.

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
