### PR TITLE
CORE-639: update sam-client's okhttp 4.10.0->4.12.0

### DIFF
--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -14,8 +14,8 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",
-      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-      "com.squareup.okhttp3" % "logging-interceptor" % "4.10.0",
+      "com.squareup.okhttp3" % "okhttp" % "4.12.0",
+      "com.squareup.okhttp3" % "logging-interceptor" % "4.12.0",
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.12.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.1.0",


### PR DESCRIPTION
Ticket: CORE-639

What:

In Sam's Java client, upgrade okhttp from 4.10 to 4.12. See their changelog: https://square.github.io/okhttp/changelogs/changelog_4x/

Why:

The ultimate goal, as defined in CORE-639, is to upgrade `okio` in Rawls to > 3.4.0. `okio` is a transitive dependency from `okhttp`. By upgrading `okhttp` in Sam's client, then using the new version of the Sam client in Rawls, Rawls should see its usage of `okio` upgraded.

Note that the `okhttp` changelog explicitly calls out that okhttp 4.12 upgrades to okio 3.6.0.


