### PR TITLE
CORE-665: new quicksilver-migrator role for workspaces

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -274,6 +274,9 @@ resourceTypes = {
           "share_policy::project-owner"
         ]
       }
+      quicksilver-migrator = {
+        roleActions = ["migrate", "read_settings", "write_settings"]
+      }
     }
     authDomainConstrainable = true
     allowLeaving = true


### PR DESCRIPTION
Ticket: CORE-665

Creates a new `quicksilver-migrator` role on workspaces, with the following actions:
- migrate
- read_settings
- write_settings

The only other role on workspace which has `migrate` is `owner`.

We'll use this new role, along with a resource_type_admin policy, in CORE-665 to allow admins to migrate any workspace to Quicksilver.