### PR TITLE
Revert "CORE-665: new quicksilver-migrator role for workspaces"

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -274,9 +274,6 @@ resourceTypes = {
           "share_policy::project-owner"
         ]
       }
-      quicksilver-migrator = {
-        roleActions = ["migrate", "read_settings", "write_settings"]
-      }
     }
     authDomainConstrainable = true
     allowLeaving = true


### PR DESCRIPTION
Reverts broadinstitute/sam#1709

I am second-guessing #1709 and would like to revert it. It creates a new role/policy for each workspace, and I would like to avoid adding to scale like that. I will figure out another way to support quicksilver migration for admins.