### PR TITLE
CORE-665: new migrate action for resource_type_admin

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -37,7 +37,10 @@ resourceTypes = {
         description = "view summary information on resources of this resource type"
       }
       admin_specify_acting_user = {
-        description = "specify a different user that is preforming a given action on the resource"
+        description = "specify a different user that is performing a given action on the resource"
+      }
+      migrate = {
+        description = "perform migrations for this resource type"
       }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-665

What:

Define a new `migrate` action for `resource_type_admin`. Do not assign this action by default to any roles; we will add it manually via API for workspaces and don't want to add it for other types.
