### PR TITLE
CORE-681: forget-project API

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1286,6 +1286,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         x-codegen-request-body-name: scopes
+  /api/google/v1/project/{project}:
+    delete:
+      tags:
+        - Google
+      summary: Forgets a Google project. Does NOT delete the project itself from the cloud.
+      description: It is imperative that any callers of this API delete the project from the cloud, else
+        risk orphaning that project and potentially incurring ongoing cost.
+      operationId: forgetGoogleProject
+      parameters:
+        - name: project
+          in: path
+          description: Google project to forget
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successfully forgotten
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pets:
+                    type: number
+                    description: count of pet service accounts forgotten in this project
+                  resources:
+                    type: number
+                    description: count of resource records deleted for this project
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/google/v1/user/signedUrlForBlob:
     post:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -2,15 +2,8 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
-import org.broadinstitute.dsde.workbench.sam.azure.{
-  ActionManagedIdentity,
-  ActionManagedIdentityId,
-  BillingProfileId,
-  ManagedIdentityObjectId,
-  PetManagedIdentity,
-  PetManagedIdentityId
-}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.sam.azure.{ActionManagedIdentity, ActionManagedIdentityId, BillingProfileId, ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, ResourceTypeName, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
@@ -130,6 +123,8 @@ trait DirectoryDAO {
   def deletePetServiceAccount(petServiceAccountId: PetServiceAccountId, samRequestContext: SamRequestContext): IO[Unit]
 
   def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]]
+
+  def getAllPetServiceAccountsForProject(project: GoogleProject, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]]
 
   def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -3,7 +3,14 @@ package org.broadinstitute.dsde.workbench.sam.dataAccess
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
-import org.broadinstitute.dsde.workbench.sam.azure.{ActionManagedIdentity, ActionManagedIdentityId, BillingProfileId, ManagedIdentityObjectId, PetManagedIdentity, PetManagedIdentityId}
+import org.broadinstitute.dsde.workbench.sam.azure.{
+  ActionManagedIdentity,
+  ActionManagedIdentityId,
+  BillingProfileId,
+  ManagedIdentityObjectId,
+  PetManagedIdentity,
+  PetManagedIdentityId
+}
 import org.broadinstitute.dsde.workbench.sam.model.api.{AdminUpdateUserRequest, GroupMembershipCount, SamUser, SamUserAttributes}
 import org.broadinstitute.dsde.workbench.sam.model.{BasicWorkbenchGroup, FullyQualifiedResourceId, ResourceAction, ResourceTypeName, SamUserTos}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -976,6 +976,18 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       petRecords.map(unmarshalPetServiceAccountRecord)
     }
 
+  // TODO CORE-681: unit tests
+  override def getAllPetServiceAccountsForProject(project: GoogleProject, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] =
+    readOnlyTransaction("getAllPetServiceAccountsForProject", samRequestContext) { implicit session =>
+      val petServiceAccountTable = PetServiceAccountTable.syntax
+
+      val loadPetsQuery = samsql"""select ${petServiceAccountTable.resultAll}
+                from ${PetServiceAccountTable as petServiceAccountTable} where ${petServiceAccountTable.project} = ${project}"""
+
+      val petRecords = loadPetsQuery.map(PetServiceAccountTable(petServiceAccountTable)).list().apply()
+      petRecords.map(unmarshalPetServiceAccountRecord)
+    }
+
   override def updatePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[PetServiceAccount] =
     serializableWriteTransaction("updatePetServiceAccount", samRequestContext) { implicit session =>
       val petServiceAccountColumn = PetServiceAccountTable.column

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -976,7 +976,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       petRecords.map(unmarshalPetServiceAccountRecord)
     }
 
-  // TODO CORE-681: unit tests
   override def getAllPetServiceAccountsForProject(project: GoogleProject, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] =
     readOnlyTransaction("getAllPetServiceAccountsForProject", samRequestContext) { implicit session =>
       val petServiceAccountTable = PetServiceAccountTable.syntax

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -290,6 +290,27 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 }
             }
           }
+        } ~
+        pathPrefix("project") {
+          path(Segment) { project =>
+            val projectResourceId = ResourceId(project)
+            pathEndOrSingleSlash {
+              requireAction(
+                FullyQualifiedResourceId(SamResourceTypes.googleProjectName, projectResourceId),
+                SamResourceActions.delete,
+                samUser.id,
+                samRequestContext
+              ) {
+                deleteWithTelemetry(samRequestContext, "googleProject" -> projectResourceId) {
+                  complete {
+                    googleExtensions
+                      .forgetProject(GoogleProject(project), resourceService, samRequestContext)
+                      .map(response => StatusCodes.OK -> response)
+                  }
+                }
+              }
+            }
+          }
         }
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -319,6 +319,15 @@ class GoogleExtensions(
       }
     } yield deletedSomething
 
+  def forgetUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] =
+    for {
+      maybePet <- directoryDAO.loadPetServiceAccount(PetServiceAccountId(userId, project), samRequestContext)
+      forgotSomething <- maybePet match {
+        case Some(pet) => forgetPetServiceAccount(pet, samRequestContext).map(_ => true)
+        case None => IO.pure(false) // didn't find the pet, nothing to forget
+      }
+    } yield forgotSomething
+
   def createUserPetServiceAccount(user: SamUser, project: GoogleProject, samRequestContext: SamRequestContext): IO[PetServiceAccount] = {
     val (petSaName, petSaDisplayName) = toPetSAFromUser(user)
     // The normal situation is that the pet either exists in both the database and google or neither.
@@ -561,7 +570,6 @@ class GoogleExtensions(
 
   /** Delete Sam's knowledge of this pet service account. Does not make any changes in the cloud.
     */
-  // TODO CORE-681: unit tests
   private def forgetPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       // disable the pet service account

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -795,7 +795,7 @@ class GoogleExtensions(
     } yield Map("pets" -> allProjectPets.size, "resources" -> numResourcesDeleted)
   }
 
-  override val allSubSystems: Set[Subsystems.Subsystem] = Set() // Set(Subsystems.GoogleGroups, Subsystems.GooglePubSub, Subsystems.GoogleIam)
+  override val allSubSystems: Set[Subsystems.Subsystem] = Set(Subsystems.GoogleGroups, Subsystems.GooglePubSub, Subsystems.GoogleIam)
 
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -772,7 +772,7 @@ class GoogleExtensions(
 
   // TODO CORE-681: unit tests
   override def forgetProject(project: GoogleProject, resourceService: ResourceService, samRequestContext: SamRequestContext): IO[Map[String, Int]] = {
-    val resourceId = FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project.value))
+    val projectResourceId = FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project.value))
 
     // for recursion
     def recursiveDeleteResource(parentResourceId: FullyQualifiedResourceId, runningCount: Int): IO[Int] =
@@ -792,7 +792,7 @@ class GoogleExtensions(
         forgetPetServiceAccount(pet, samRequestContext)
       }
       // recursively delete this google-project resource and its children
-      numResourcesDeleted <- recursiveDeleteResource(resourceId, 0)
+      numResourcesDeleted <- recursiveDeleteResource(projectResourceId, 0)
     } yield Map("pets" -> allProjectPets.size, "resources" -> numResourcesDeleted)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -770,7 +770,6 @@ class GoogleExtensions(
       .lastOrError
   }
 
-  // TODO CORE-681: unit tests
   override def forgetProject(project: GoogleProject, resourceService: ResourceService, samRequestContext: SamRequestContext): IO[Map[String, Int]] = {
     val projectResourceId = FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project.value))
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -26,7 +26,7 @@ import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
-import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, CloudExtensionsInitializer, ManagedGroupService, SamApplication}
+import org.broadinstitute.dsde.workbench.sam.service.{CloudExtensions, CloudExtensionsInitializer, ManagedGroupService, ResourceService, SamApplication}
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, SubsystemStatus, Subsystems}
 import org.broadinstitute.dsde.workbench.util.{FutureSupport, Retry}
@@ -559,12 +559,23 @@ class GoogleExtensions(
       }
     } yield ()
 
-  private def removePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[Unit] =
+  /** Delete Sam's knowledge of this pet service account. Does not make any changes in the cloud.
+    */
+  // TODO CORE-681: unit tests
+  private def forgetPetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[Unit] =
     for {
       // disable the pet service account
       _ <- disablePetServiceAccount(petServiceAccount, samRequestContext)
       // remove the record for the pet service account
       _ <- directoryDAO.deletePetServiceAccount(petServiceAccount.id, samRequestContext)
+    } yield ()
+
+  /** Delete Sam's knowledge of this pet service account AND remove the pet from the cloud.
+    */
+  private def removePetServiceAccount(petServiceAccount: PetServiceAccount, samRequestContext: SamRequestContext): IO[Unit] =
+    for {
+      // forget the pet service account
+      _ <- forgetPetServiceAccount(petServiceAccount, samRequestContext)
       // remove the service account itself in Google
       _ <- IO.fromFuture(IO(googleIamDAO.removeServiceAccount(petServiceAccount.id.project, toAccountName(petServiceAccount.serviceAccount.email))))
     } yield ()
@@ -751,7 +762,33 @@ class GoogleExtensions(
       .lastOrError
   }
 
-  override val allSubSystems: Set[Subsystems.Subsystem] = Set(Subsystems.GoogleGroups, Subsystems.GooglePubSub, Subsystems.GoogleIam)
+  // TODO CORE-681: unit tests
+  override def forgetProject(project: GoogleProject, resourceService: ResourceService, samRequestContext: SamRequestContext): IO[Map[String, Int]] = {
+    val resourceId = FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project.value))
+
+    // for recursion
+    def recursiveDeleteResource(parentResourceId: FullyQualifiedResourceId, runningCount: Int): IO[Int] =
+      for {
+        children <- resourceService.listResourceChildren(parentResourceId, samRequestContext)
+        _ <- children.toList.traverse { child =>
+          recursiveDeleteResource(child, runningCount)
+        }
+        _ <- resourceService.deleteResource(parentResourceId, samRequestContext)
+      } yield runningCount + 1
+
+    for {
+      // list all pets in this project
+      allProjectPets <- directoryDAO.getAllPetServiceAccountsForProject(project, samRequestContext)
+      // forget all pets in this project
+      _ <- allProjectPets.traverse { pet =>
+        forgetPetServiceAccount(pet, samRequestContext)
+      }
+      // recursively delete this google-project resource and its children
+      numResourcesDeleted <- recursiveDeleteResource(resourceId, 0)
+    } yield Map("pets" -> allProjectPets.size, "resources" -> numResourcesDeleted)
+  }
+
+  override val allSubSystems: Set[Subsystems.Subsystem] = Set() // Set(Subsystems.GoogleGroups, Subsystems.GooglePubSub, Subsystems.GoogleIam)
 
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -53,6 +53,8 @@ trait CloudExtensions {
 
   def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean]
 
+  def forgetUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean]
+
   def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]]
 
   def fireAndForgetNotifications[T <: Notification](notifications: Set[T]): Unit
@@ -101,6 +103,8 @@ trait NoExtensions extends CloudExtensions {
   override def onUserDelete(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Unit] = IO.unit
 
   override def deleteUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
+
+  override def forgetUserPetServiceAccount(userId: WorkbenchUserId, project: GoogleProject, samRequestContext: SamRequestContext): IO[Boolean] = IO.pure(true)
 
   override def getUserProxy(userEmail: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Option[WorkbenchEmail]] =
     IO.pure(Option(userEmail))

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/service/CloudExtensions.scala
@@ -66,6 +66,8 @@ trait CloudExtensions {
   def getOrCreateAllUsersGroup(directoryDAO: DirectoryDAO, samRequestContext: SamRequestContext)(implicit
       executionContext: ExecutionContext
   ): IO[WorkbenchGroup]
+
+  def forgetProject(project: GoogleProject, resourceService: ResourceService, samRequestContext: SamRequestContext): IO[Map[String, Int]]
 }
 
 trait CloudExtensionsInitializer {
@@ -122,6 +124,9 @@ trait NoExtensions extends CloudExtensions {
       }
     } yield createdGroup
   }
+
+  override def forgetProject(project: GoogleProject, resourceService: ResourceService, samRequestContext: SamRequestContext): IO[Map[String, Int]] =
+    IO.pure(Map())
 }
 
 object NoExtensions extends NoExtensions

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.implicits._
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
 import org.broadinstitute.dsde.workbench.sam._
 import org.broadinstitute.dsde.workbench.sam.azure.{
   ActionManagedIdentity,
@@ -260,6 +260,12 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
 
   override def getAllPetServiceAccountsForUser(userId: WorkbenchUserId, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] = IO {
     petServiceAccountsByUser.collect { case (PetServiceAccountId(`userId`, _), petSA) =>
+      petSA
+    }.toSeq
+  }
+
+  override def getAllPetServiceAccountsForProject(project: GoogleProject, samRequestContext: SamRequestContext): IO[Seq[PetServiceAccount]] = IO {
+    petServiceAccountsByUser.collect { case (PetServiceAccountId(_, `project`), petSA) =>
       petSA
     }.toSeq
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -855,6 +855,32 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
       }
     }
 
+    "getAllPetServiceAccountsForProject" - {
+      "get all pet service accounts for project" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        // create a few users
+        val users = Seq.range(0, 3).map(_ => Generator.genWorkbenchUserBoth.sample.get)
+        users.foreach(user => dao.createUser(user, samRequestContext).unsafeRunSync())
+        // create pets for each user in "testProject1"
+        val project1 = GoogleProject("testProject1")
+        val pets1 = users.map { user =>
+          val pet = PetServiceAccount(PetServiceAccountId(user.id, project1), Generator.genServiceAccount.sample.get)
+          dao.createPetServiceAccount(pet, samRequestContext).unsafeRunSync()
+          pet
+        }
+        // create pets for the first user only in "testProject2"
+        val project2 = GoogleProject("testProject2")
+        val pets2 = users.take(1).map { user =>
+          val pet = PetServiceAccount(PetServiceAccountId(user.id, project2), Generator.genServiceAccount.sample.get)
+          dao.createPetServiceAccount(pet, samRequestContext).unsafeRunSync()
+          pet
+        }
+
+        dao.getAllPetServiceAccountsForProject(project1, samRequestContext).unsafeRunSync() should contain theSameElementsAs pets1
+        dao.getAllPetServiceAccountsForProject(project2, samRequestContext).unsafeRunSync() should contain theSameElementsAs pets2
+      }
+    }
+
     "getUserFromPetServiceAccount" - {
       "get user from pet service account subject ID" in {
         assume(databaseEnabled, databaseEnabledClue)

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.sam.model.api._
 import org.broadinstitute.dsde.workbench.sam.service._
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.broadinstitute.dsde.workbench.sam.{TestSupport, model, _}
-import org.mockito.ArgumentMatcher
+import org.mockito.{ArgumentMatcher, Mockito}
 import org.mockito.Mockito._
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
@@ -40,6 +40,8 @@ import java.util.{Date, GregorianCalendar, UUID}
 import scala.concurrent.ExecutionContext.Implicits.{global => globalEc}
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import scala.jdk.CollectionConverters._
 
 class GoogleExtensionSpec(_system: ActorSystem)
     extends TestKit(_system)
@@ -2202,6 +2204,175 @@ class GoogleExtensionSpec(_system: ActorSystem)
     val messageLog: ConcurrentLinkedQueue[String] = mockGoogleNotificationPubSubDAO.messageLog
     val formattedMessages: Set[String] = messages.map(m => topicName + "|" + NotificationFormat.write(m).toString())
     messageLog should contain theSameElementsAs formattedMessages
+  }
+
+  "forgetProject" should "recursively delete child resources" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val dirDAO = newDirectoryDAO()
+    val mockGoogleIamDAO = new MockGoogleIamDAO
+    val mockGoogleDirectoryDAO = new MockGoogleDirectoryDAO
+    val mockGoogleProjectDAO = new MockGoogleProjectDAO
+
+    val googleExtensions = new GoogleExtensions(
+      TestSupport.distributedLock,
+      dirDAO,
+      null,
+      mockGoogleDirectoryDAO,
+      null,
+      null,
+      null,
+      mockGoogleIamDAO,
+      mockGoogleProjectDAO,
+      null,
+      null,
+      null,
+      googleServicesConfig,
+      petServiceAccountConfig,
+      configResourceTypes,
+      superAdminsGroup
+    )
+
+    val googleProject = GoogleProject("testproject")
+    val projectResourceId = FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(googleProject.value))
+
+    val mockResourceService = mock[ResourceService](RETURNS_SMART_NULLS)
+
+    // set up ResourceService mocks
+
+    // unless otherwise specified below, when listing children, return nothing
+    when(
+      mockResourceService.listResourceChildren(any[FullyQualifiedResourceId], any[SamRequestContext])
+    )
+      .thenReturn(IO.pure(Set()))
+
+    // when listing children of the google-project, return a few children
+    val firstLevelChildren = Seq.range(0, 3).map(idx => FullyQualifiedResourceId(SamResourceTypes.spendProfile, ResourceId(s"firstLevelChild-$idx")))
+    when(
+      mockResourceService.listResourceChildren(projectResourceId, samRequestContext)
+    )
+      .thenReturn(IO.pure(firstLevelChildren.toSet))
+    // each first-level child also has a few children
+    val allSecondLevelChildren: Map[FullyQualifiedResourceId, Set[FullyQualifiedResourceId]] = firstLevelChildren.map { firstLevel =>
+      val secondLevelChildren =
+        Seq
+          .range(0, 3)
+          .map(idx => FullyQualifiedResourceId(SamResourceTypes.workspaceName, ResourceId(s"secondLevelChild-$idx-${firstLevel.resourceId}")))
+          .toSet
+      when(
+        mockResourceService.listResourceChildren(firstLevel, samRequestContext)
+      )
+        .thenReturn(IO.pure(secondLevelChildren))
+      firstLevel -> secondLevelChildren
+    }.toMap
+    // one of the second-level children also has one child
+    val secondLevelChildValues = allSecondLevelChildren.values.flatten
+    val secondLevelChildWithAThirdLevel = secondLevelChildValues.head
+    val thirdLevelChild = FullyQualifiedResourceId(SamResourceTypes.spendProfile, ResourceId(s"thirdLevelChild"))
+    when(
+      mockResourceService.listResourceChildren(secondLevelChildWithAThirdLevel, samRequestContext)
+    )
+      .thenReturn(IO.pure(Set(thirdLevelChild)))
+
+    // and, mock the delete calls; these always succeed
+    when(mockResourceService.deleteResource(any[FullyQualifiedResourceId], any[SamRequestContext])).thenReturn(IO.unit)
+
+    // forget project1
+    googleExtensions.forgetProject(googleProject, mockResourceService, samRequestContext).unsafeRunSync()
+
+    val allChildren = firstLevelChildren ++ allSecondLevelChildren.values.flatten ++ Seq(thirdLevelChild)
+
+    // verify number of delete calls: one for each child, plus one for the parent google project itself
+    verify(mockResourceService, times(allChildren.size + 1))
+      .deleteResource(any[FullyQualifiedResourceId], any[SamRequestContext])
+
+    // individually verify we deleted each child
+    allChildren.foreach { child =>
+      verify(mockResourceService)
+        .deleteResource(child, samRequestContext)
+    }
+
+    // verify we deleted the project itself
+    verify(mockResourceService)
+      .deleteResource(projectResourceId, samRequestContext)
+
+    // jump through a few hoops to ensure that all children are deleted before their parents:
+    // get all invocations on the mock
+    val invocations = Mockito.mockingDetails(mockResourceService).getInvocations.asScala.toSeq
+
+    // find all the deleteResource calls, and map the deleted resource to the order in which it was deleted
+    val deleteOrdering: Map[FullyQualifiedResourceId, Int] = invocations.zipWithIndex.collect {
+      case (invocation, idx) if invocation.getMethod.getName == "deleteResource" =>
+        val deletedResourceId = invocation.getArgument[FullyQualifiedResourceId](0)
+        deletedResourceId -> idx
+    }.toMap
+
+    // project should be deleted last
+    deleteOrdering(projectResourceId) shouldBe deleteOrdering.values.max
+
+    // third-level child should be deleted before its second-level parent
+    deleteOrdering(thirdLevelChild) should be < deleteOrdering(secondLevelChildWithAThirdLevel)
+
+    // each second-level child should be deleted before its first-level parent
+    allSecondLevelChildren.foreach { case (parent, children) =>
+      val parentIdx = deleteOrdering(parent)
+      children.foreach { child =>
+        deleteOrdering(child) should be < parentIdx
+      }
+    }
+
+  }
+
+  it should "forget all pets in the project" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val (
+      dirDAO: DirectoryDAO,
+      tosService: TosService,
+      mockGoogleIamDAO: MockGoogleIamDAO,
+      mockGoogleDirectoryDAO: MockGoogleDirectoryDAO,
+      googleExtensions: GoogleExtensions,
+      service: UserService,
+      defaultUserProxyEmail: WorkbenchEmail,
+      defaultUser: SamUser
+    ) = initPetTest
+
+    val mockResourceService = mock[ResourceService](RETURNS_SMART_NULLS)
+
+    // create a few users
+    val users = Seq.range(0, 3).map(_ => Generator.genWorkbenchUserBoth.sample.get)
+    users.foreach(user => newUserWithAcceptedTos(service, tosService, user, samRequestContext))
+    // create pets for each user in "testProject1"
+    val project1 = GoogleProject("testProject1")
+    val pets1 = users.map { user =>
+      googleExtensions.createUserPetServiceAccount(user, project1, samRequestContext).unsafeRunSync()
+    }
+    // create pets for each user in "testProject2"
+    val project2 = GoogleProject("testProject2")
+    val pets2 = users.map { user =>
+      googleExtensions.createUserPetServiceAccount(user, project2, samRequestContext).unsafeRunSync()
+    }
+
+    // set up ResourceService mocks
+    when(mockResourceService.listResourceChildren(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project1.value)), samRequestContext))
+      .thenReturn(IO.pure(Set()))
+    when(mockResourceService.deleteResource(FullyQualifiedResourceId(SamResourceTypes.googleProjectName, ResourceId(project1.value)), samRequestContext))
+      .thenReturn(IO.unit)
+
+    // forget project1
+    googleExtensions.forgetProject(project1, mockResourceService, samRequestContext).unsafeRunSync()
+
+    // verify no pets in DB for the project we forgot
+    pets1.foreach { pet =>
+      // the pet should not exist in DB
+      dirDAO.loadPetServiceAccount(pet.id, samRequestContext).unsafeRunSync() shouldBe None
+    }
+
+    // verify pets still exist in the project we did not forget
+    pets2.foreach { pet =>
+      // the pet should not exist in DB
+      dirDAO.loadPetServiceAccount(pet.id, samRequestContext).unsafeRunSync() shouldBe Some(pet)
+    }
   }
 
   protected def clearDatabase(): Unit =

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionSpec.scala
@@ -436,6 +436,55 @@ class GoogleExtensionSpec(_system: ActorSystem)
 
   }
 
+  it should "forget a pet service account for a user" in {
+    assume(databaseEnabled, databaseEnabledClue)
+
+    val (
+      dirDAO: DirectoryDAO,
+      tosService: TosService,
+      mockGoogleIamDAO: MockGoogleIamDAO,
+      mockGoogleDirectoryDAO: MockGoogleDirectoryDAO,
+      googleExtensions: GoogleExtensions,
+      service: UserService,
+      defaultUserProxyEmail: WorkbenchEmail,
+      defaultUser: SamUser
+    ) = initPetTest
+
+    // create a user
+    val newUser = newUserWithAcceptedTos(service, tosService, defaultUser, samRequestContext)
+    newUser shouldBe UserStatus(UserStatusDetails(defaultUser.id, defaultUser.email), TestSupport.enabledMapTosAccepted)
+
+    // create a pet service account
+    val googleProject = GoogleProject("testproject")
+    val petServiceAccount = googleExtensions.createUserPetServiceAccount(defaultUser, googleProject, samRequestContext).unsafeRunSync()
+
+    petServiceAccount.serviceAccount.email.value should endWith(s"@${googleProject.value}.iam.gserviceaccount.com")
+
+    dirDAO.loadPetServiceAccount(PetServiceAccountId(defaultUser.id, googleProject), samRequestContext).unsafeRunSync() shouldBe Some(petServiceAccount)
+
+    // verify google
+    mockGoogleIamDAO.serviceAccounts should contain key petServiceAccount.serviceAccount.email
+    mockGoogleDirectoryDAO.groups should contain key defaultUserProxyEmail
+    mockGoogleDirectoryDAO.groups(defaultUserProxyEmail) shouldBe Set(defaultUser.email, petServiceAccount.serviceAccount.email)
+
+    // create one again, it should work
+    val petSaResponse2 = googleExtensions.createUserPetServiceAccount(defaultUser, googleProject, samRequestContext).unsafeRunSync()
+    petSaResponse2 shouldBe petServiceAccount
+
+    // forget the pet service account
+    googleExtensions.forgetUserPetServiceAccount(newUser.userInfo.userSubjectId, googleProject, samRequestContext).unsafeRunSync() shouldBe true
+
+    // the user should still exist in DB
+    dirDAO.loadUser(defaultUser.id, samRequestContext).unsafeRunSync() shouldBe Some(defaultUser.copy(enabled = true))
+
+    // the pet should not exist in DB
+    dirDAO.loadPetServiceAccount(PetServiceAccountId(defaultUser.id, googleProject), samRequestContext).unsafeRunSync() shouldBe None
+
+    // the pet should still exist in Google
+    mockGoogleIamDAO.serviceAccounts should contain key (petServiceAccount.serviceAccount.email)
+
+  }
+
   private def initPetTest: (DirectoryDAO, TosService, MockGoogleIamDAO, MockGoogleDirectoryDAO, GoogleExtensions, UserService, WorkbenchEmail, SamUser) = {
     val dirDAO = newDirectoryDAO()
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-681

Create a new API at `DELETE /api/google/v1/project/{project}` to "forget" a Google project.

"Forgetting" means:
* remove all known pet service accounts in this project from their proxy groups
* delete knowledge of these pet service accounts from the Sam db
* recursively delete the google-project resource and all its children from the Sam db

This does NOT include deleting anything from the cloud (the project still exists and pet service accounts still exist). It is the responsibility of the caller (Rawls) to ensure these are all deleted - typically, by deleting the project itself which will delete everything in it.
