### PR TITLE
CTM-286: Revert "CORE-69: Minor and patch updates - reactor-netty to 1.2.11 - grpc-core to 1.76.0 - sbt-scalafmt to 2.5.6 - sbt-scalafix to 0.14.4 - google-cloud-nio to 0.128.7 - logback-classic to 1.5.20 - terra-common-lib to 1.1.61-SNAPSHOT - okio to 3.16.2"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val workbenchOauth2V = s"0.9-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.41-SNAPSHOT"
-  val tclVersion = "1.1.61-SNAPSHOT"
+  val tclVersion = "1.1.53-SNAPSHOT"
   val slf4jVersion = "2.0.6"
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
@@ -47,7 +47,7 @@ object Dependencies {
   val jacksonCore: ModuleID = "com.fasterxml.jackson.core" % "jackson-core" % jacksonV
 
   val logstashLogback: ModuleID = "net.logstash.logback" % "logstash-logback-encoder" % "9.0"
-  val logbackClassic: ModuleID = "ch.qos.logback" % "logback-classic" % "1.5.20"
+  val logbackClassic: ModuleID = "ch.qos.logback" % "logback-classic" % "1.5.19"
 
   val ravenLogback: ModuleID = "com.getsentry.raven" % "raven-logback" % "7.8.6"
   val scalaLogging: ModuleID = "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV
@@ -65,11 +65,11 @@ object Dependencies {
   val akkaHttpTestKit: ModuleID = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test"
   val scalaCheck: ModuleID = "org.scalacheck" %% "scalacheck" % scalaCheckV % "test"
 
-  val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.2.11"
+  val reactorNetty: ModuleID = "io.projectreactor.netty" % "reactor-netty" % "1.2.10"
   val nettyAll: ModuleID = "io.netty" % "netty-all" % "4.2.7.Final"
 
   val excludIoGrpc = ExclusionRule(organization = "io.grpc", name = "grpc-core")
-  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.76.0"
+  val ioGrpc: ModuleID = "io.grpc" % "grpc-core" % "1.75.0"
 
   val googleOAuth2: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0" excludeAll excludIoGrpc
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % "v1-rev20250925-2.0.0" excludeAll excludIoGrpc // force this version
@@ -115,7 +115,7 @@ object Dependencies {
       excludeWorkbenchModel
     )
   val googleStorageLocal: ModuleID =
-    "com.google.cloud" % "google-cloud-nio" % "0.128.7" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
+    "com.google.cloud" % "google-cloud-nio" % "0.128.5" % "test" // needed for mocking google cloud storage. Should use same version as wb-libs
 
   val liquibaseCore: ModuleID = "org.liquibase" % "liquibase-core" % "4.33.0"
 
@@ -130,7 +130,7 @@ object Dependencies {
   val slf4jApi: ModuleID = "org.slf4j" % "slf4j-api" % slf4jVersion
   val slf4jSimple: ModuleID = "org.slf4j" % "slf4j-simple" % slf4jVersion
 
-  val okio: ModuleID = "com.squareup.okio" % "okio" % "3.16.2" excludeAll excludeWorkbenchUtil2
+  val okio: ModuleID = "com.squareup.okio" % "okio" % "3.16.0" excludeAll excludeWorkbenchUtil2
 
   // pact deps
   val pact4sV = "0.9.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 addDependencyTreePlugin


### PR DESCRIPTION
Reverts broadinstitute/sam#1726.

That other PR broke tracing, so let's revert until we can figure it out.

Nothing coded by hand; this PR generated via the github "Revert" button.