### PR TITLE
[CTM-305] Pin liquibase version to 4.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -78,7 +78,9 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
-
+updates.pin  = [
+  { groupId = "org.liquibase", artifactId = "liquibase-core", version = "4." }
+]
 # The dependencies which match the given pattern are NOT updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-305

Pin liquibase-core to 4.x so that the upgrade to version 5 (which has a different software license) is no longer included in dependency update PRs. Supersedes: https://github.com/broadinstitute/sam/pull/1725

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
