### PR TITLE
CTM-306: Double the number of Terra support slots

### DIFF
--- a/src/main/resources/sam.conf
+++ b/src/main/resources/sam.conf
@@ -259,8 +259,8 @@ janitor {
 
 terra {
   support.emails = [
-    // dynamically configuring lists is hard, so 10 slots are provided for support emails
-    // add more if more than 10 are ever needed
+    // dynamically configuring lists is hard, so 20 slots are provided for support emails
+    // add more if more than 20 are ever needed
     ${?TERRA_SUPPORT_EMAIL_0}
     ${?TERRA_SUPPORT_EMAIL_1}
     ${?TERRA_SUPPORT_EMAIL_2}
@@ -271,6 +271,16 @@ terra {
     ${?TERRA_SUPPORT_EMAIL_7}
     ${?TERRA_SUPPORT_EMAIL_8}
     ${?TERRA_SUPPORT_EMAIL_9}
+    ${?TERRA_SUPPORT_EMAIL_10}
+    ${?TERRA_SUPPORT_EMAIL_11}
+    ${?TERRA_SUPPORT_EMAIL_12}
+    ${?TERRA_SUPPORT_EMAIL_13}
+    ${?TERRA_SUPPORT_EMAIL_14}
+    ${?TERRA_SUPPORT_EMAIL_15}
+    ${?TERRA_SUPPORT_EMAIL_16}
+    ${?TERRA_SUPPORT_EMAIL_17}
+    ${?TERRA_SUPPORT_EMAIL_18}
+    ${?TERRA_SUPPORT_EMAIL_19}
   ]
 }
 


### PR DESCRIPTION
Ticket: [CTM-306](https://broadworkbench.atlassian.net/browse/CTM-306)

What:

Double the number of slots available for Terra Support users.

Why:

We need to add several InfoSec users and don't currently have enough space for them.

How:

Cmd-c, Cmd-v, insert `1` to third-to-last character in the resulting lines.

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket


[CTM-306]: https://broadworkbench.atlassian.net/browse/CTM-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ