### PR TITLE
build(sam): Override jackson-core and jackson-databind to 3.1.0 (CTM-422)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -247,6 +247,8 @@ object Dependencies {
   // Needed because it looks like the dependency overrides of wb-libs doesn't propagate to the importing project...
   val rootDependencyOverrides = Seq(
     "org.apache.commons" % "commons-compress" % "1.28.0",
-    "com.google.guava" % "guava" % "33.5.0-jre" // Force JRE version, not Android version from grpc-core
+    "com.google.guava" % "guava" % "33.5.0-jre", // Force JRE version, not Android version from grpc-core
+    "tools.jackson.core" % "jackson-core" % "3.1.0",
+    "tools.jackson.core" % "jackson-databind" % "3.1.0"
   )
 }


### PR DESCRIPTION
Ticket: [CTM-422](https://broadworkbench.atlassian.net/browse/CTM-422)

Override transitive `tools.jackson.core:jackson-core` and `tools.jackson.core:jackson-databind` from 3.0.1 to 3.1.0. These are pulled in transitively via `logstash-logback-encoder:9.0`, which migrated to Jackson 3.x. Since no newer logstash-logback-encoder version is available that bumps Jackson, dependency overrides are used.

[CTM-422]: https://broadworkbench.atlassian.net/browse/CTM-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ