### PR TITLE
[CTM-431] Add auth domain admin api

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -376,6 +376,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/admin/v1/resources/{resourceTypeName}/{resourceId}/authDomain:
+    get:
+      tags:
+        - Admin
+      summary: Get the auth domain for a resource
+      operationId: adminGetResourceAuthDomain
+      parameters:
+        - name: resourceTypeName
+          in: path
+          description: Type of resource
+          required: true
+          schema:
+            type: string
+        - name: resourceId
+          in: path
+          description: Id of resource
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Auth domain successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        403:
+          description: You do not have permission to perform this action on the resource
+          content: { }
+        404:
+          description: Resource type does not exist or you are not an admin for this resource type
+          content: { }
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/admin/v1/resources/{resourceTypeName}/{resourceId}/policies:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/AdminRoutes.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives._
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.sam.config.LiquibaseConfig
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
@@ -179,41 +180,56 @@ trait AdminRoutes extends SecurityDirectives with SamRequestContextDirectives wi
     }
 
   def adminResourcesRoutes(user: SamUser, samRequestContext: SamRequestContext): server.Route =
-    pathPrefix("resources" / Segment / Segment / "policies") { case (resourceTypeName, resourceId) =>
+    pathPrefix("resources" / Segment / Segment) { case (resourceTypeName, resourceId) =>
       withNonAdminResourceType(ResourceTypeName(resourceTypeName)) { resourceType =>
         val resource = FullyQualifiedResourceId(resourceType.name, ResourceId(resourceId))
-        pathEndOrSingleSlash {
-          getWithTelemetry(samRequestContext, resourceParams(resource): _*) {
-            requireAdminResourceAction(adminReadPolicies, resourceType, user, samRequestContext) {
-              complete {
-                resourceService
-                  .listResourcePolicies(resource, samRequestContext)
-                  .map(response => OK -> response.toSet)
+        pathPrefix("policies") {
+          pathEndOrSingleSlash {
+            getWithTelemetry(samRequestContext, resourceParams(resource): _*) {
+              requireAdminResourceAction(adminReadPolicies, resourceType, user, samRequestContext) {
+                complete {
+                  resourceService
+                    .listResourcePolicies(resource, samRequestContext)
+                    .map(response => OK -> response.toSet)
+                }
+              }
+            }
+          } ~
+          pathPrefix(Segment / "memberEmails" / Segment) { case (policyName, userEmail) =>
+            val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
+            val workbenchEmail = WorkbenchEmail(userEmail)
+            pathEndOrSingleSlash {
+              withSubject(workbenchEmail, samRequestContext) { subject =>
+                putWithTelemetry(samRequestContext, policyParams(policyId).appended(emailParam(workbenchEmail)): _*) {
+                  requireAdminResourceAction(adminAddMember, resourceType, user, samRequestContext) {
+                    complete {
+                      resourceService
+                        .addSubjectToPolicy(policyId, subject, samRequestContext)
+                        .as(NoContent)
+                    }
+                  }
+                } ~
+                deleteWithTelemetry(samRequestContext, policyParams(policyId).appended(emailParam(workbenchEmail)): _*) {
+                  requireAdminResourceAction(adminRemoveMember, resourceType, user, samRequestContext) {
+                    complete {
+                      resourceService
+                        .removeSubjectFromPolicy(policyId, subject, samRequestContext)
+                        .as(NoContent)
+                    }
+                  }
+                }
               }
             }
           }
         } ~
-        pathPrefix(Segment / "memberEmails" / Segment) { case (policyName, userEmail) =>
-          val policyId = FullyQualifiedPolicyId(resource, AccessPolicyName(policyName))
-          val workbenchEmail = WorkbenchEmail(userEmail)
+        pathPrefix("authDomain") {
           pathEndOrSingleSlash {
-            withSubject(workbenchEmail, samRequestContext) { subject =>
-              putWithTelemetry(samRequestContext, policyParams(policyId).appended(emailParam(workbenchEmail)): _*) {
-                requireAdminResourceAction(adminAddMember, resourceType, user, samRequestContext) {
-                  complete {
-                    resourceService
-                      .addSubjectToPolicy(policyId, subject, samRequestContext)
-                      .as(NoContent)
-                  }
-                }
-              } ~
-              deleteWithTelemetry(samRequestContext, policyParams(policyId).appended(emailParam(workbenchEmail)): _*) {
-                requireAdminResourceAction(adminRemoveMember, resourceType, user, samRequestContext) {
-                  complete {
-                    resourceService
-                      .removeSubjectFromPolicy(policyId, subject, samRequestContext)
-                      .as(NoContent)
-                  }
+            getWithTelemetry(samRequestContext, resourceParams(resource): _*) {
+              requireAdminResourceAction(SamResourceActions.adminReadSummaryInformation, resourceType, user, samRequestContext) {
+                complete {
+                  resourceService
+                    .loadResourceAuthDomain(resource, samRequestContext)
+                    .map(response => OK -> response)
                 }
               }
             }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
@@ -251,7 +251,7 @@ class AdminResourcesRoutesSpec extends AnyFlatSpec with Matchers with TestSuppor
     val samRoutes = TestSamRoutes(resourceTypes, user = adminUser)
 
     runAndWait(samRoutes.userService.createUser(testUser1, samRequestContext))
-    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), adminUser, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), testUser1, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
     val policiesMap = Map(
@@ -328,9 +328,9 @@ class AdminResourcesRoutesSpec extends AnyFlatSpec with Matchers with TestSuppor
     val samRoutes = TestSamRoutes(resourceTypes, user = adminUser)
 
     runAndWait(samRoutes.userService.createUser(testUser1, samRequestContext))
-    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), adminUser, samRequestContext = samRequestContext))
-    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain2"), adminUser, samRequestContext = samRequestContext))
-    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain3"), adminUser, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), testUser1, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain2"), testUser1, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain3"), testUser1, samRequestContext = samRequestContext))
 
     val resourceId = ResourceId("foo")
     val policiesMap = Map(

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/api/AdminResourcesRoutesSpec.scala
@@ -1,13 +1,16 @@
 package org.broadinstitute.dsde.workbench.sam.api
 
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
+import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.implicits.toFoldableOps
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.resourceTypeAdmin
+import org.broadinstitute.dsde.workbench.sam.api.TestSamRoutes.{SamResourceActionPatterns, resourceTypeAdmin}
 import org.broadinstitute.dsde.workbench.sam.model.SamResourceActions._
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api._
+import org.broadinstitute.dsde.workbench.sam.service.ManagedGroupService
 import org.broadinstitute.dsde.workbench.sam.{Generator, TestSupport}
 import org.scalactic.anyvals.NonEmptyList
 import org.scalatest.flatspec.AnyFlatSpec
@@ -216,4 +219,188 @@ class AdminResourcesRoutesSpec extends AnyFlatSpec with Matchers with TestSuppor
         status shouldEqual StatusCodes.NoContent
       }
     }
+
+  private val constrainableResourceType = ResourceType(
+    ResourceTypeName("rt"),
+    Set(SamResourceActionPatterns.readAuthDomain, SamResourceActionPatterns.use),
+    Set(ResourceRole(ResourceRoleName("owner"), Set(readAuthDomain, ManagedGroupService.useAction))),
+    ResourceRoleName("owner")
+  )
+
+  private def initManagedGroupResourceType(): ResourceType = {
+    val accessPolicyNames = Set(ManagedGroupService.adminPolicyName, ManagedGroupService.memberPolicyName, ManagedGroupService.adminNotifierPolicyName)
+    val policyActions: Set[ResourceAction] =
+      accessPolicyNames.flatMap(policyName => Set(SamResourceActions.sharePolicy(policyName), SamResourceActions.readPolicy(policyName)))
+    val resourceActions = Set(
+      ResourceAction("delete"),
+      ResourceAction("notify_admins"),
+      ResourceAction("set_access_instructions"),
+      ManagedGroupService.useAction
+    ) union policyActions
+    val resourceActionPatterns = resourceActions.map(action => ResourceActionPattern(action.value, "", false))
+    val defaultOwnerRole = ResourceRole(ManagedGroupService.adminRoleName, resourceActions)
+    val defaultMemberRole = ResourceRole(ManagedGroupService.memberRoleName, Set.empty)
+    val defaultAdminNotifierRole = ResourceRole(ManagedGroupService.adminNotifierRoleName, Set(ResourceAction("notify_admins")))
+    val defaultRoles = Set(defaultOwnerRole, defaultMemberRole, defaultAdminNotifierRole)
+    ResourceType(ManagedGroupService.managedGroupTypeName, resourceActionPatterns, defaultRoles, ManagedGroupService.adminRoleName)
+  }
+
+  "GET /api/admin/v1/resources/{resourceType}/{resourceId}/authDomain" should "200 with auth domain when resource has one auth domain" in {
+    val managedGroupResourceType = initManagedGroupResourceType()
+    val resourceTypes = Map(constrainableResourceType.name -> constrainableResourceType, managedGroupResourceType.name -> managedGroupResourceType)
+    val samRoutes = TestSamRoutes(resourceTypes, user = adminUser)
+
+    runAndWait(samRoutes.userService.createUser(testUser1, samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), adminUser, samRequestContext = samRequestContext))
+
+    val resourceId = ResourceId("foo")
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembershipRequest(
+        Set(testUser1.email),
+        Set(readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(constrainableResourceType, resourceId, policiesMap, Set(WorkbenchGroupName("authDomain1")), None, testUser1.id, samRequestContext)
+    )
+
+    val adminResourceId = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(constrainableResourceType.name.value))
+    runAndWait(
+      samRoutes.resourceService.createPolicy(
+        FullyQualifiedPolicyId(adminResourceId, defaultAdminPolicyName),
+        Set(adminUser.id),
+        Set(ResourceRoleName("test")),
+        Set(adminReadSummaryInformation),
+        Set(),
+        samRequestContext
+      )
+    )
+
+    Get(s"/api/admin/v1/resources/${constrainableResourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Set[String]] shouldEqual Set("authDomain1")
+    }
+  }
+
+  it should "200 with empty set when resource has no auth domain" in {
+    val managedGroupResourceType = initManagedGroupResourceType()
+    val resourceTypes = Map(constrainableResourceType.name -> constrainableResourceType, managedGroupResourceType.name -> managedGroupResourceType)
+    val samRoutes = TestSamRoutes(resourceTypes, user = adminUser)
+
+    runAndWait(samRoutes.userService.createUser(testUser1, samRequestContext))
+
+    val resourceId = ResourceId("foo")
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembershipRequest(
+        Set(testUser1.email),
+        Set(readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(constrainableResourceType, resourceId, policiesMap, Set.empty, None, testUser1.id, samRequestContext)
+    )
+
+    val adminResourceId = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(constrainableResourceType.name.value))
+    runAndWait(
+      samRoutes.resourceService.createPolicy(
+        FullyQualifiedPolicyId(adminResourceId, defaultAdminPolicyName),
+        Set(adminUser.id),
+        Set(ResourceRoleName("test")),
+        Set(adminReadSummaryInformation),
+        Set(),
+        samRequestContext
+      )
+    )
+
+    Get(s"/api/admin/v1/resources/${constrainableResourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Set[String]] shouldEqual Set.empty
+    }
+  }
+
+  it should "200 with all auth domains when resource has multiple auth domains" in {
+    val managedGroupResourceType = initManagedGroupResourceType()
+    val resourceTypes = Map(constrainableResourceType.name -> constrainableResourceType, managedGroupResourceType.name -> managedGroupResourceType)
+    val samRoutes = TestSamRoutes(resourceTypes, user = adminUser)
+
+    runAndWait(samRoutes.userService.createUser(testUser1, samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), adminUser, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain2"), adminUser, samRequestContext = samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain3"), adminUser, samRequestContext = samRequestContext))
+
+    val resourceId = ResourceId("foo")
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembershipRequest(
+        Set(testUser1.email),
+        Set(readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService.createResource(
+        constrainableResourceType,
+        resourceId,
+        policiesMap,
+        Set(WorkbenchGroupName("authDomain1"), WorkbenchGroupName("authDomain2"), WorkbenchGroupName("authDomain3")),
+        None,
+        testUser1.id,
+        samRequestContext
+      )
+    )
+
+    val adminResourceId = FullyQualifiedResourceId(resourceTypeAdmin.name, ResourceId(constrainableResourceType.name.value))
+    runAndWait(
+      samRoutes.resourceService.createPolicy(
+        FullyQualifiedPolicyId(adminResourceId, defaultAdminPolicyName),
+        Set(adminUser.id),
+        Set(ResourceRoleName("test")),
+        Set(adminReadSummaryInformation),
+        Set(),
+        samRequestContext
+      )
+    )
+
+    Get(s"/api/admin/v1/resources/${constrainableResourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[Set[String]] shouldEqual Set("authDomain1", "authDomain2", "authDomain3")
+    }
+  }
+
+  it should "404 when user does not have admin_read_summary_information" in {
+    val managedGroupResourceType = initManagedGroupResourceType()
+    val resourceTypes = Map(constrainableResourceType.name -> constrainableResourceType, managedGroupResourceType.name -> managedGroupResourceType)
+    val samRoutes = TestSamRoutes(resourceTypes, user = testUser1)
+
+    runAndWait(samRoutes.userService.createUser(adminUser, samRequestContext))
+    runAndWait(samRoutes.managedGroupService.createManagedGroup(ResourceId("authDomain1"), adminUser, samRequestContext = samRequestContext))
+
+    val resourceId = ResourceId("foo")
+    val policiesMap = Map(
+      AccessPolicyName("ap") -> AccessPolicyMembershipRequest(
+        Set(adminUser.email),
+        Set(readAuthDomain, ManagedGroupService.useAction),
+        Set(ResourceRoleName("owner"))
+      )
+    )
+    runAndWait(
+      samRoutes.resourceService
+        .createResource(constrainableResourceType, resourceId, policiesMap, Set(WorkbenchGroupName("authDomain1")), None, adminUser.id, samRequestContext)
+    )
+
+    Get(s"/api/admin/v1/resources/${constrainableResourceType.name}/${resourceId.value}/authDomain") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
+
+  it should "404 when the resource type does not exist" in {
+    val samRoutes = TestSamRoutes(Map.empty, user = adminUser)
+
+    Get(s"/api/admin/v1/resources/nonexistent/foo/authDomain") ~> samRoutes.route ~> check {
+      status shouldEqual StatusCodes.NotFound
+    }
+  }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-431

What:

Adds a new Admin API that gets the auth domains for a given resource.  Requires the `admin_read_summary_information` action on workspaces, which is granted to terra support and used when fetching a workspace on the support page, which is what this API is intended to be used for.

Note:
The `CONTRIBUTING.md` in the PR checklist below instructs that API changes need to also be added to [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli), which is an archived repo.  Presumably that is no longer accurate?

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
