### PR TITLE
[CTM-483] Update bouncycastle

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -249,6 +249,10 @@ object Dependencies {
     "org.apache.commons" % "commons-compress" % "1.28.0",
     "com.google.guava" % "guava" % "33.5.0-jre", // Force JRE version, not Android version from grpc-core
     "tools.jackson.core" % "jackson-core" % "3.1.0",
-    "tools.jackson.core" % "jackson-databind" % "3.1.0"
+    "tools.jackson.core" % "jackson-databind" % "3.1.0",
+    // override bouncycastle to address CVE-2026-5598 (requires >= 1.84)
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
+    "org.bouncycastle" % "bcutil-jdk18on" % "1.84"
   )
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-483

What:

Bouncy Castle ships its cryptography library as three separate artifacts — bcprov-jdk18on (core crypto), bcutil-jdk18on (shared utilities), and bcpkix-jdk18on (PKI/X.509 support) — each with independent Maven coordinates. All three are pulled in transitively via jose4j and must be overridden explicitly to guarantee the version floor. Adds overrides for all three at 1.84.
Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>

---

**PR checklist**

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've filled out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
