### PR TITLE
[CTM-559] Admin endpoint to set allowExternalMembers on existing Google groups

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/workbench/sam/MockTestSupport.scala
@@ -25,7 +25,13 @@ import org.broadinstitute.dsde.workbench.sam.config._
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
-import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.google.{
+  GoogleExtensionRoutes,
+  GoogleExtensions,
+  GoogleGroupExternalMembersMigrator,
+  GoogleGroupSynchronizer,
+  GoogleKeyCache
+}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -95,9 +101,27 @@ object MockTestSupport extends MockTestSupport {
     val googleKeyCachePubSubDAO = new MockGooglePubSubDAO()
     val googleProjectDAO = new MockGoogleProjectDAO()
     val notificationDAO = new PubSubNotificationDAO(notificationPubSubDAO, "foo")
-    val cloudKeyCache = new GoogleKeyCache(distributedLock, googleIamDAO, FakeGoogleStorageInterpreter, googleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
+    val cloudKeyCache =
+      new GoogleKeyCache(distributedLock, googleIamDAO, FakeGoogleStorageInterpreter, googleKeyCachePubSubDAO, googleServicesConfig, petServiceAccountConfig)
     val googleExt = cloudExtensions.getOrElse(
-      new GoogleExtensions(distributedLock, directoryDAO, policyDAO, googleDirectoryDAO, notificationPubSubDAO, googleGroupSyncPubSubDAO, googleDisableUsersPubSubDAO, googleIamDAO, googleProjectDAO, cloudKeyCache, notificationDAO, FakeGoogleStorageInterpreter, googleServicesConfig, petServiceAccountConfig, resourceTypes, adminConfig.superAdminsGroup)
+      new GoogleExtensions(
+        distributedLock,
+        directoryDAO,
+        policyDAO,
+        googleDirectoryDAO,
+        notificationPubSubDAO,
+        googleGroupSyncPubSubDAO,
+        googleDisableUsersPubSubDAO,
+        googleIamDAO,
+        googleProjectDAO,
+        cloudKeyCache,
+        notificationDAO,
+        FakeGoogleStorageInterpreter,
+        googleServicesConfig,
+        petServiceAccountConfig,
+        resourceTypes,
+        adminConfig.superAdminsGroup
+      )
     )
     val policyEvaluatorService = policyEvaluatorServiceOpt.getOrElse(PolicyEvaluatorService(appConfig.emailDomain, resourceTypes, policyDAO, directoryDAO))
     val mockResourceService = resourceServiceOpt.getOrElse(
@@ -166,6 +190,10 @@ object MockTestSupport extends MockTestSupport {
           googleExtensions,
           googleExtensions.resourceTypes
         )
+      } else null
+    override val groupExternalMembersMigrator: GoogleGroupExternalMembersMigrator =
+      if (samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) {
+        new GoogleGroupExternalMembersMigrator(googleExtensions.directoryDAO, googleExtensions)
       } else null
     val googleKeyCache: GoogleKeyCache = samDependencies.cloudExtensions match {
       case extensions: GoogleExtensions => extensions.googleKeyCache

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changelog.xml
@@ -34,4 +34,5 @@
     <include file="changesets/20240809_sam_user_favorite_resources_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240820_descendant_auth_domains.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20241205_prereq_action_column.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20260629_external_members_migration.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20260629_external_members_migration.xml
+++ b/src/main/resources/org/broadinstitute/dsde/sam/liquibase/changesets/20260629_external_members_migration.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="mtalbott" id="external_members_migration">
+        <createTable tableName="SAM_EXTERNAL_MEMBERS_MIGRATION">
+            <column name="tier" type="VARCHAR">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="state" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="total" type="BIGINT"/>
+            <column name="processed" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="failed" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_cursor" type="VARCHAR"/>
+            <column name="started_at" type="timestamptz">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamptz">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/Boot.scala
@@ -199,7 +199,8 @@ object Boot extends IOApp with LazyLogging {
           )
           val googleGroupSynchronizer =
             new GoogleGroupSynchronizer(backgroundDirectoryDAO, backgroundAccessPolicyDAO, cloudExtension.googleDirectoryDAO, cloudExtension, resourceTypeMap)
-          new GoogleExtensionsInitializer(cloudExtension, googleGroupSynchronizer)
+          val groupExternalMembersMigrator = new GoogleGroupExternalMembersMigrator(backgroundDirectoryDAO, cloudExtension)
+          new GoogleExtensionsInitializer(cloudExtension, googleGroupSynchronizer, groupExternalMembersMigrator)
         }
       case None => cats.effect.Resource.pure[IO, CloudExtensionsInitializer](NoExtensionsInitializer)
     }
@@ -443,7 +444,7 @@ object Boot extends IOApp with LazyLogging {
     val samApplication = SamApplication(userService, resourceService, statusService, tosService)
 
     cloudExtensionsInitializer match {
-      case GoogleExtensionsInitializer(googleExt, synchronizer) =>
+      case GoogleExtensionsInitializer(googleExt, synchronizer, migrator) =>
         val routes = new SamRoutes(
           resourceService,
           userService,
@@ -460,6 +461,7 @@ object Boot extends IOApp with LazyLogging {
           val googleExtensions = googleExt
           val cloudExtensions = googleExt
           val googleGroupSynchronizer = synchronizer
+          val groupExternalMembersMigrator = migrator
         }
         AppDependencies(routes, samApplication, cloudExtensionsInitializer, directoryDAO, accessPolicyDAO, policyEvaluatorService)
       case _ =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -31,18 +31,14 @@ trait DirectoryDAO {
 
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]]
 
-  /** Load a page of synchronized group emails for a given resource type, ordered by email. Used to enumerate existing Google groups for migrations. Pass the
-    * last email from the previous page as `afterEmail` to fetch the next page (keyset pagination).
+  /** Load the synchronized group emails for a given resource type, ordered by email. Used to enumerate existing Google groups for migrations. Pass an
+    * `afterEmail` to load only emails strictly after it (used to resume a migration without re-loading already-processed groups).
     */
   def loadSynchronizedGroupEmailsByResourceType(
       resourceTypeName: ResourceTypeName,
       afterEmail: Option[WorkbenchEmail],
-      limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]]
-
-  /** Total number of synchronized groups for a resource type. Used to report migration progress. */
-  def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long]
 
   def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit]
 
@@ -89,13 +85,10 @@ trait DirectoryDAO {
       samRequestContext: SamRequestContext
   ): IO[Set[SamUser]]
 
-  /** Load a page of enabled users ordered by id. Pass the last id from the previous page as `afterUserId` to fetch the next page (keyset pagination). Used to
-    * enumerate users whose proxy groups need to be migrated.
+  /** Load the enabled users ordered by id. Pass an `afterUserId` to load only users strictly after it (used to resume a migration without re-loading
+    * already-processed users). Used to enumerate users whose proxy groups need to be migrated.
     */
-  def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]]
-
-  /** Total number of enabled users. Used to report migration progress. */
-  def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long]
+  def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]]
 
   def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
 import java.util.Date
+import scala.concurrent.duration.FiniteDuration
 
 /** Created by dvoet on 5/26/17.
   */
@@ -89,6 +90,38 @@ trait DirectoryDAO {
     * already-processed users). Used to enumerate users whose proxy groups need to be migrated.
     */
   def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]]
+
+  /** Atomically claim a tier for the allowExternalMembers migration so only one instance runs it at a time. Succeeds (returns true) unless another run holds
+    * the tier with a heartbeat newer than `staleAfter` (i.e. is still alive). On success the row is (re)set to `running` with `resumeCursor` as its starting
+    * cursor and zeroed counts.
+    */
+  def tryClaimExternalMembersMigration(
+      tier: String,
+      resumeCursor: Option[String],
+      staleAfter: FiniteDuration,
+      samRequestContext: SamRequestContext
+  ): IO[Boolean]
+
+  /** Record the mutable progress of a claimed tier: its state, total, processed/failed counts, and resume cursor, bumping the heartbeat. Used for the initial
+    * total, periodic heartbeats, and the terminal `completed` state.
+    */
+  def recordExternalMembersMigration(
+      tier: String,
+      state: String,
+      total: Option[Long],
+      processed: Long,
+      failed: Long,
+      lastCursor: Option[String],
+      samRequestContext: SamRequestContext
+  ): IO[Unit]
+
+  /** Set only the state (and heartbeat) of a tier, preserving its progress columns. Used to mark a tier `failed` without clobbering the last recorded counts.
+    */
+  def setExternalMembersMigrationState(tier: String, state: String, samRequestContext: SamRequestContext): IO[Unit]
+
+  def listExternalMembersMigrations(samRequestContext: SamRequestContext): IO[Seq[ExternalMembersMigrationRecord]]
+
+  def getExternalMembersMigration(tier: String, samRequestContext: SamRequestContext): IO[Option[ExternalMembersMigrationRecord]]
 
   def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -31,6 +31,19 @@ trait DirectoryDAO {
 
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]]
 
+  /** Load a page of synchronized group emails for a given resource type, ordered by email. Used to enumerate existing Google groups for migrations. Pass the
+    * last email from the previous page as `afterEmail` to fetch the next page (keyset pagination).
+    */
+  def loadSynchronizedGroupEmailsByResourceType(
+      resourceTypeName: ResourceTypeName,
+      afterEmail: Option[WorkbenchEmail],
+      limit: Int,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[WorkbenchEmail]]
+
+  /** Total number of synchronized groups for a resource type. Used to report migration progress. */
+  def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long]
+
   def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit]
 
   /** @return
@@ -75,6 +88,14 @@ trait DirectoryDAO {
       limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Set[SamUser]]
+
+  /** Load a page of enabled users ordered by id. Pass the last id from the previous page as `afterUserId` to fetch the next page (keyset pagination). Used to
+    * enumerate users whose proxy groups need to be migrated.
+    */
+  def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]]
+
+  /** Total number of enabled users. Used to report migration progress. */
+  def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long]
 
   def loadUserByGoogleSubjectId(userId: GoogleSubjectId, samRequestContext: SamRequestContext): IO[Option[SamUser]]
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -17,7 +17,6 @@ import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
 import java.time.Instant
 import java.util.Date
-import scala.concurrent.duration.FiniteDuration
 
 /** Created by dvoet on 5/26/17.
   */
@@ -91,19 +90,8 @@ trait DirectoryDAO {
     */
   def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]]
 
-  /** Atomically claim a tier for the allowExternalMembers migration so only one instance runs it at a time. Succeeds (returns true) unless another run holds
-    * the tier with a heartbeat newer than `staleAfter` (i.e. is still alive). On success the row is (re)set to `running` with `resumeCursor` as its starting
-    * cursor and zeroed counts.
-    */
-  def tryClaimExternalMembersMigration(
-      tier: String,
-      resumeCursor: Option[String],
-      staleAfter: FiniteDuration,
-      samRequestContext: SamRequestContext
-  ): IO[Boolean]
-
-  /** Record the mutable progress of a claimed tier: its state, total, processed/failed counts, and resume cursor, bumping the heartbeat. Used for the initial
-    * total, periodic heartbeats, and the terminal `completed` state.
+  /** Record the mutable progress of a tier: its state, total, processed/failed counts, and resume cursor, bumping the heartbeat. Used to mark a tier `running`
+    * at the start of a run, for periodic heartbeats, and for the terminal `completed` state.
     */
   def recordExternalMembersMigration(
       tier: String,

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/DirectoryDAO.scala
@@ -31,14 +31,21 @@ trait DirectoryDAO {
 
   def batchLoadGroupEmail(groupNames: Set[WorkbenchGroupName], samRequestContext: SamRequestContext): IO[LazyList[(WorkbenchGroupName, WorkbenchEmail)]]
 
-  /** Load the synchronized group emails for a given resource type, ordered by email. Used to enumerate existing Google groups for migrations. Pass an
-    * `afterEmail` to load only emails strictly after it (used to resume a migration without re-loading already-processed groups).
+  /** Load up to `limit` synchronized group emails for a given resource type, ordered by email. This includes both the policy-backed groups and (for managed
+    * groups) the aggregate group whose name matches the resource id. Used to enumerate existing Google groups for migrations. Pass an `afterEmail` to load only
+    * emails strictly after it, which together with `limit` keyset-paginates a migration through the tier.
     */
   def loadSynchronizedGroupEmailsByResourceType(
       resourceTypeName: ResourceTypeName,
       afterEmail: Option[WorkbenchEmail],
+      limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]]
+
+  /** Count the synchronized group emails for a given resource type, matching [[loadSynchronizedGroupEmailsByResourceType]]. Used to record a migration tier's
+    * total up front.
+    */
+  def countSynchronizedGroupEmailsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long]
 
   def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit]
 
@@ -85,10 +92,13 @@ trait DirectoryDAO {
       samRequestContext: SamRequestContext
   ): IO[Set[SamUser]]
 
-  /** Load the enabled users ordered by id. Pass an `afterUserId` to load only users strictly after it (used to resume a migration without re-loading
-    * already-processed users). Used to enumerate users whose proxy groups need to be migrated.
+  /** Load up to `limit` enabled users ordered by id. Pass an `afterUserId` to load only users strictly after it, which together with `limit` keyset-paginates a
+    * migration through the enabled users. Used to enumerate users whose proxy groups need to be migrated.
     */
-  def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]]
+  def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]]
+
+  /** Count the enabled users, matching [[loadEnabledUsers]]. Used to record the proxy migration tier's total up front. */
+  def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long]
 
   /** Record the mutable progress of a tier: its state, total, processed/failed counts, and resume cursor, bumping the heartbeat. Used to mark a tier `running`
     * at the start of a run, for periodic heartbeats, and for the terminal `completed` state.

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/ExternalMembersMigration.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/ExternalMembersMigration.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.workbench.sam.dataAccess
+
+import java.time.Instant
+
+/** Progress of the one-off allowExternalMembers migration for a single tier. See GoogleGroupExternalMembersMigrator. */
+final case class ExternalMembersMigrationRecord(
+    tier: String,
+    state: String,
+    total: Option[Long],
+    processed: Long,
+    failed: Long,
+    lastCursor: Option[String],
+    startedAt: Instant,
+    updatedAt: Instant
+)
+
+/** The lifecycle states persisted in `ExternalMembersMigrationRecord.state`. */
+object MigrationState {
+  val Running = "running"
+  val Completed = "completed"
+  val Failed = "failed"
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -150,7 +150,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
   override def loadSynchronizedGroupEmailsByResourceType(
       resourceTypeName: ResourceTypeName,
       afterEmail: Option[WorkbenchEmail],
-      limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]] =
     readOnlyTransaction("loadSynchronizedGroupEmailsByResourceType", samRequestContext) { implicit session =>
@@ -168,34 +167,13 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
                 where ${g.synchronizedDate} is not null
                 and ${rt.name} = ${resourceTypeName}
                 $afterClause
-                order by ${g.email} asc
-                limit ${limit}"""
+                order by ${g.email} asc"""
         .map(rs => rs.get[WorkbenchEmail](g.resultName.email))
         .list()
         .apply()
     }
 
-  override def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
-    readOnlyTransaction("countSynchronizedGroupsByResourceType", samRequestContext) { implicit session =>
-      val g = GroupTable.syntax("g")
-      val p = PolicyTable.syntax("p")
-      val r = ResourceTable.syntax("r")
-      val rt = ResourceTypeTable.syntax("rt")
-
-      samsql"""select count(${g.id})
-                from ${GroupTable as g}
-                join ${PolicyTable as p} on ${p.groupId} = ${g.id}
-                join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
-                join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
-                where ${g.synchronizedDate} is not null
-                and ${rt.name} = ${resourceTypeName}"""
-        .map(_.long(1))
-        .single()
-        .apply()
-        .getOrElse(0L)
-    }
-
-  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
     readOnlyTransaction("loadEnabledUsers", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
       val afterClause = afterUserId.map(userId => samsqls"and ${userTable.id} > ${userId}").getOrElse(samsqls"")
@@ -203,22 +181,11 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       samsql"""select ${userTable.resultAll} from ${UserTable as userTable}
                 where ${userTable.enabled} = true
                 $afterClause
-                order by ${userTable.id} asc
-                limit ${limit}"""
+                order by ${userTable.id} asc"""
         .map(UserTable(userTable))
         .list()
         .apply()
         .map(UserTable.unmarshalUserRecord)
-    }
-
-  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
-    readOnlyTransaction("countEnabledUsers", samRequestContext) { implicit session =>
-      val userTable = UserTable.syntax
-      samsql"select count(${userTable.id}) from ${UserTable as userTable} where ${userTable.enabled} = true"
-        .map(_.long(1))
-        .single()
-        .apply()
-        .getOrElse(0L)
     }
 
   override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -31,7 +31,7 @@ import scalikejdbc._
 
 import java.time.Instant
 import java.util.Date
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Try}
 
 class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)(implicit timer: Temporal[IO])
@@ -188,28 +188,6 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         .map(UserTable.unmarshalUserRecord)
     }
 
-  override def tryClaimExternalMembersMigration(
-      tier: String,
-      resumeCursor: Option[String],
-      staleAfter: FiniteDuration,
-      samRequestContext: SamRequestContext
-  ): IO[Boolean] =
-    serializableWriteTransaction("tryClaimExternalMembersMigration", samRequestContext) { implicit session =>
-      // claim the tier unless another run already holds it with a fresh heartbeat. the date math is done in the db to avoid app/db clock skew, and
-      // clock_timestamp() (not now()) is used because this transaction may be retried and we want the real wall-clock time of the successful attempt.
-      val rowsAffected =
-        samsql"""insert into SAM_EXTERNAL_MEMBERS_MIGRATION (tier, state, total, processed, failed, last_cursor, started_at, updated_at)
-                  values ($tier, 'running', null, 0, 0, $resumeCursor, clock_timestamp(), clock_timestamp())
-                  on conflict (tier) do update
-                    set state = 'running', total = null, processed = 0, failed = 0, last_cursor = $resumeCursor,
-                        started_at = clock_timestamp(), updated_at = clock_timestamp()
-                  where SAM_EXTERNAL_MEMBERS_MIGRATION.state <> 'running'
-                     or SAM_EXTERNAL_MEMBERS_MIGRATION.updated_at < clock_timestamp() - ${staleAfter.toMillis} * INTERVAL '1 milliseconds'"""
-          .update()
-          .apply()
-      rowsAffected > 0
-    }
-
   override def recordExternalMembersMigration(
       tier: String,
       state: String,
@@ -220,9 +198,11 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       samRequestContext: SamRequestContext
   ): IO[Unit] =
     serializableWriteTransaction("recordExternalMembersMigration", samRequestContext) { implicit session =>
-      samsql"""update SAM_EXTERNAL_MEMBERS_MIGRATION
-                set state = $state, total = $total, processed = $processed, failed = $failed, last_cursor = $lastCursor, updated_at = clock_timestamp()
-                where tier = $tier"""
+      // clock_timestamp() (not now()) is used because this transaction may be retried and we want the real wall-clock time of the successful attempt.
+      samsql"""insert into SAM_EXTERNAL_MEMBERS_MIGRATION (tier, state, total, processed, failed, last_cursor, started_at, updated_at)
+                values ($tier, $state, $total, $processed, $failed, $lastCursor, clock_timestamp(), clock_timestamp())
+                on conflict (tier) do update
+                  set state = $state, total = $total, processed = $processed, failed = $failed, last_cursor = $lastCursor, updated_at = clock_timestamp()"""
         .update()
         .apply()
     }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -147,33 +147,58 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
     }
 
-  override def loadSynchronizedGroupEmailsByResourceType(
-      resourceTypeName: ResourceTypeName,
-      afterEmail: Option[WorkbenchEmail],
-      samRequestContext: SamRequestContext
-  ): IO[Seq[WorkbenchEmail]] =
-    readOnlyTransaction("loadSynchronizedGroupEmailsByResourceType", samRequestContext) { implicit session =>
-      val g = GroupTable.syntax("g")
-      val p = PolicyTable.syntax("p")
-      val r = ResourceTable.syntax("r")
-      val rt = ResourceTypeTable.syntax("rt")
-      val afterClause = afterEmail.map(email => samsqls"and ${g.email} > ${email}").getOrElse(samsqls"")
-
-      samsql"""select ${g.result.email}
+  // Synchronized group emails for a resource type, as a union of (1) the policy-backed groups and (2) the aggregate group whose name matches the resource id.
+  // The aggregate-group branch only matches managed groups (only they create a group named after their resource id); it is an empty no-op for other types.
+  private def synchronizedGroupEmailsByResourceType(resourceTypeName: ResourceTypeName): SQLSyntax = {
+    val g = GroupTable.syntax("g")
+    val p = PolicyTable.syntax("p")
+    val r = ResourceTable.syntax("r")
+    val rt = ResourceTypeTable.syntax("rt")
+    val ag = GroupTable.syntax("ag")
+    val ar = ResourceTable.syntax("ar")
+    val art = ResourceTypeTable.syntax("art")
+    samsqls"""select ${g.email} as email
                 from ${GroupTable as g}
                 join ${PolicyTable as p} on ${p.groupId} = ${g.id}
                 join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
                 join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
-                where ${g.synchronizedDate} is not null
-                and ${rt.name} = ${resourceTypeName}
+                where ${g.synchronizedDate} is not null and ${rt.name} = $resourceTypeName
+              union
+              select ${ag.email} as email
+                from ${GroupTable as ag}
+                join ${ResourceTable as ar} on ${ar.name} = ${ag.name}
+                join ${ResourceTypeTable as art} on ${ar.resourceTypeId} = ${art.id}
+                where ${ag.synchronizedDate} is not null and ${art.name} = $resourceTypeName"""
+  }
+
+  override def loadSynchronizedGroupEmailsByResourceType(
+      resourceTypeName: ResourceTypeName,
+      afterEmail: Option[WorkbenchEmail],
+      limit: Int,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[WorkbenchEmail]] =
+    readOnlyTransaction("loadSynchronizedGroupEmailsByResourceType", samRequestContext) { implicit session =>
+      val afterClause = afterEmail.map(email => samsqls"where email > $email").getOrElse(samsqls"")
+
+      samsql"""select email from (${synchronizedGroupEmailsByResourceType(resourceTypeName)}) emails
                 $afterClause
-                order by ${g.email} asc"""
-        .map(rs => rs.get[WorkbenchEmail](g.resultName.email))
+                order by email asc
+                limit $limit"""
+        .map(rs => rs.get[WorkbenchEmail]("email"))
         .list()
         .apply()
     }
 
-  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+  override def countSynchronizedGroupEmailsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
+    readOnlyTransaction("countSynchronizedGroupEmailsByResourceType", samRequestContext) { implicit session =>
+      samsql"select count(*) from (${synchronizedGroupEmailsByResourceType(resourceTypeName)}) emails"
+        .map(_.long(1))
+        .single()
+        .apply()
+        .getOrElse(0L)
+    }
+
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
     readOnlyTransaction("loadEnabledUsers", samRequestContext) { implicit session =>
       val userTable = UserTable.syntax
       val afterClause = afterUserId.map(userId => samsqls"and ${userTable.id} > ${userId}").getOrElse(samsqls"")
@@ -181,11 +206,22 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       samsql"""select ${userTable.resultAll} from ${UserTable as userTable}
                 where ${userTable.enabled} = true
                 $afterClause
-                order by ${userTable.id} asc"""
+                order by ${userTable.id} asc
+                limit $limit"""
         .map(UserTable(userTable))
         .list()
         .apply()
         .map(UserTable.unmarshalUserRecord)
+    }
+
+  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
+    readOnlyTransaction("countEnabledUsers", samRequestContext) { implicit session =>
+      val userTable = UserTable.syntax
+      samsql"select count(*) from ${UserTable as userTable} where ${userTable.enabled} = true"
+        .map(_.long(1))
+        .single()
+        .apply()
+        .getOrElse(0L)
     }
 
   override def recordExternalMembersMigration(

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -31,7 +31,7 @@ import scalikejdbc._
 
 import java.time.Instant
 import java.util.Date
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Try}
 
 class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val readDbRef: DbReference)(implicit timer: Temporal[IO])
@@ -187,6 +187,82 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
         .apply()
         .map(UserTable.unmarshalUserRecord)
     }
+
+  override def tryClaimExternalMembersMigration(
+      tier: String,
+      resumeCursor: Option[String],
+      staleAfter: FiniteDuration,
+      samRequestContext: SamRequestContext
+  ): IO[Boolean] =
+    serializableWriteTransaction("tryClaimExternalMembersMigration", samRequestContext) { implicit session =>
+      // claim the tier unless another run already holds it with a fresh heartbeat. the date math is done in the db to avoid app/db clock skew, and
+      // clock_timestamp() (not now()) is used because this transaction may be retried and we want the real wall-clock time of the successful attempt.
+      val rowsAffected =
+        samsql"""insert into SAM_EXTERNAL_MEMBERS_MIGRATION (tier, state, total, processed, failed, last_cursor, started_at, updated_at)
+                  values ($tier, 'running', null, 0, 0, $resumeCursor, clock_timestamp(), clock_timestamp())
+                  on conflict (tier) do update
+                    set state = 'running', total = null, processed = 0, failed = 0, last_cursor = $resumeCursor,
+                        started_at = clock_timestamp(), updated_at = clock_timestamp()
+                  where SAM_EXTERNAL_MEMBERS_MIGRATION.state <> 'running'
+                     or SAM_EXTERNAL_MEMBERS_MIGRATION.updated_at < clock_timestamp() - ${staleAfter.toMillis} * INTERVAL '1 milliseconds'"""
+          .update()
+          .apply()
+      rowsAffected > 0
+    }
+
+  override def recordExternalMembersMigration(
+      tier: String,
+      state: String,
+      total: Option[Long],
+      processed: Long,
+      failed: Long,
+      lastCursor: Option[String],
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
+    serializableWriteTransaction("recordExternalMembersMigration", samRequestContext) { implicit session =>
+      samsql"""update SAM_EXTERNAL_MEMBERS_MIGRATION
+                set state = $state, total = $total, processed = $processed, failed = $failed, last_cursor = $lastCursor, updated_at = clock_timestamp()
+                where tier = $tier"""
+        .update()
+        .apply()
+    }
+
+  override def setExternalMembersMigrationState(tier: String, state: String, samRequestContext: SamRequestContext): IO[Unit] =
+    serializableWriteTransaction("setExternalMembersMigrationState", samRequestContext) { implicit session =>
+      samsql"update SAM_EXTERNAL_MEMBERS_MIGRATION set state = $state, updated_at = clock_timestamp() where tier = $tier"
+        .update()
+        .apply()
+    }
+
+  override def listExternalMembersMigrations(samRequestContext: SamRequestContext): IO[Seq[ExternalMembersMigrationRecord]] =
+    readOnlyTransaction("listExternalMembersMigrations", samRequestContext) { implicit session =>
+      samsql"""select tier, state, total, processed, failed, last_cursor, started_at, updated_at
+                from SAM_EXTERNAL_MEMBERS_MIGRATION order by tier asc"""
+        .map(unmarshalExternalMembersMigration)
+        .list()
+        .apply()
+    }
+
+  override def getExternalMembersMigration(tier: String, samRequestContext: SamRequestContext): IO[Option[ExternalMembersMigrationRecord]] =
+    readOnlyTransaction("getExternalMembersMigration", samRequestContext) { implicit session =>
+      samsql"""select tier, state, total, processed, failed, last_cursor, started_at, updated_at
+                from SAM_EXTERNAL_MEMBERS_MIGRATION where tier = $tier"""
+        .map(unmarshalExternalMembersMigration)
+        .single()
+        .apply()
+    }
+
+  private def unmarshalExternalMembersMigration(rs: WrappedResultSet): ExternalMembersMigrationRecord =
+    ExternalMembersMigrationRecord(
+      tier = rs.string("tier"),
+      state = rs.string("state"),
+      total = rs.longOpt("total"),
+      processed = rs.long("processed"),
+      failed = rs.long("failed"),
+      lastCursor = rs.stringOpt("last_cursor"),
+      startedAt = rs.timestamp("started_at").toInstant,
+      updatedAt = rs.timestamp("updated_at").toInstant
+    )
 
   override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] =
     serializableWriteTransaction("deleteGroup", samRequestContext) { implicit session =>

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAO.scala
@@ -147,6 +147,80 @@ class PostgresDirectoryDAO(protected val writeDbRef: DbReference, protected val 
       }
     }
 
+  override def loadSynchronizedGroupEmailsByResourceType(
+      resourceTypeName: ResourceTypeName,
+      afterEmail: Option[WorkbenchEmail],
+      limit: Int,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[WorkbenchEmail]] =
+    readOnlyTransaction("loadSynchronizedGroupEmailsByResourceType", samRequestContext) { implicit session =>
+      val g = GroupTable.syntax("g")
+      val p = PolicyTable.syntax("p")
+      val r = ResourceTable.syntax("r")
+      val rt = ResourceTypeTable.syntax("rt")
+      val afterClause = afterEmail.map(email => samsqls"and ${g.email} > ${email}").getOrElse(samsqls"")
+
+      samsql"""select ${g.result.email}
+                from ${GroupTable as g}
+                join ${PolicyTable as p} on ${p.groupId} = ${g.id}
+                join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
+                join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+                where ${g.synchronizedDate} is not null
+                and ${rt.name} = ${resourceTypeName}
+                $afterClause
+                order by ${g.email} asc
+                limit ${limit}"""
+        .map(rs => rs.get[WorkbenchEmail](g.resultName.email))
+        .list()
+        .apply()
+    }
+
+  override def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
+    readOnlyTransaction("countSynchronizedGroupsByResourceType", samRequestContext) { implicit session =>
+      val g = GroupTable.syntax("g")
+      val p = PolicyTable.syntax("p")
+      val r = ResourceTable.syntax("r")
+      val rt = ResourceTypeTable.syntax("rt")
+
+      samsql"""select count(${g.id})
+                from ${GroupTable as g}
+                join ${PolicyTable as p} on ${p.groupId} = ${g.id}
+                join ${ResourceTable as r} on ${p.resourceId} = ${r.id}
+                join ${ResourceTypeTable as rt} on ${r.resourceTypeId} = ${rt.id}
+                where ${g.synchronizedDate} is not null
+                and ${rt.name} = ${resourceTypeName}"""
+        .map(_.long(1))
+        .single()
+        .apply()
+        .getOrElse(0L)
+    }
+
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+    readOnlyTransaction("loadEnabledUsers", samRequestContext) { implicit session =>
+      val userTable = UserTable.syntax
+      val afterClause = afterUserId.map(userId => samsqls"and ${userTable.id} > ${userId}").getOrElse(samsqls"")
+
+      samsql"""select ${userTable.resultAll} from ${UserTable as userTable}
+                where ${userTable.enabled} = true
+                $afterClause
+                order by ${userTable.id} asc
+                limit ${limit}"""
+        .map(UserTable(userTable))
+        .list()
+        .apply()
+        .map(UserTable.unmarshalUserRecord)
+    }
+
+  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
+    readOnlyTransaction("countEnabledUsers", samRequestContext) { implicit session =>
+      val userTable = UserTable.syntax
+      samsql"select count(${userTable.id}) from ${UserTable as userTable} where ${userTable.enabled} = true"
+        .map(_.long(1))
+        .single()
+        .apply()
+        .getOrElse(0L)
+    }
+
   override def deleteGroup(groupName: WorkbenchGroupName, samRequestContext: SamRequestContext): IO[Unit] =
     serializableWriteTransaction("deleteGroup", samRequestContext) { implicit session =>
       deleteGroup(groupName)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -31,6 +31,7 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
   implicit val executionContext: ExecutionContext
   val googleExtensions: GoogleExtensions
   val googleGroupSynchronizer: GoogleGroupSynchronizer
+  val groupExternalMembersMigrator: GoogleGroupExternalMembersMigrator
 
   override def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     (pathPrefix("google" / "v1") | pathPrefix("google")) {
@@ -288,6 +289,26 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                     }
                   }
                 }
+            }
+          }
+        } ~
+        pathPrefix("groups") {
+          // Super-admin-only one-off migration: ensure allowExternalMembers is enabled on existing Google groups for the given priority tier
+          // ("proxy" or a resource type name). Runs in the background and returns immediately; safe to re-run.
+          path("allowExternalMembers" / "migrate" / Segment) { tierSelector =>
+            // `after` is an optional resume cursor (see GoogleGroupExternalMembersMigrator.migrate)
+            parameter("after".?) { after =>
+              val tier = MigrationTier.fromSelector(tierSelector)
+              asSamSuperAdmin(samUser) {
+                putWithTelemetry(samRequestContext, "tier" -> tier) {
+                  complete {
+                    groupExternalMembersMigrator
+                      .migrate(tier, after, samRequestContext)
+                      .start
+                      .as(StatusCodes.Accepted -> s"Started allowExternalMembers migration for tier ${tier.value}")
+                  }
+                }
+              }
             }
           }
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.workbench.sam
 package google
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import cats.effect.IO
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
@@ -318,13 +319,24 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
                 // PUT .../migrate/{tier[,tier...]} -> run the given priority tiers ("proxy" or resource type names) in order, in the background.
                 // Returns immediately; safe to re-run to resume (completed tiers are skipped, a crashed tier resumes from its last cursor).
                 path(Segment) { tierSelector =>
-                  val tiers = tierSelector.split(",").toList.map(s => MigrationTier.fromSelector(s.trim))
                   putWithTelemetry(samRequestContext, "tiers" -> new ValueObject { val value: String = tierSelector }) {
                     complete {
-                      groupExternalMembersMigrator
-                        .migrate(tiers, samRequestContext)
-                        .start
-                        .as(StatusCodes.Accepted -> s"Started allowExternalMembers migration for tiers ${tiers.map(_.value).mkString(", ")}")
+                      val validResourceTypes = googleExtensions.resourceTypes.keySet.map(_.value)
+                      val (unknown, tiers) = tierSelector
+                        .split(",")
+                        .toList
+                        .map(_.trim)
+                        .filter(_.nonEmpty)
+                        .partitionMap(s => MigrationTier.fromSelector(s, validResourceTypes).toRight(s))
+                      if (unknown.nonEmpty)
+                        IO.pure[(StatusCode, String)](
+                          StatusCodes.BadRequest -> s"Unknown migration tier(s): ${unknown.mkString(", ")}. Valid tiers: proxy or a resource type name."
+                        )
+                      else
+                        groupExternalMembersMigrator
+                          .migrate(tiers, samRequestContext)
+                          .start
+                          .as(StatusCodes.Accepted -> s"Started allowExternalMembers migration for tiers ${tiers.map(_.value).mkString(", ")}")
                     }
                   }
                 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutes.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Directives._
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ValueObject, WorkbenchEmail, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.sam.api.{
   ExtensionRoutes,
   SamModelDirectives,
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.sam.api.{
   SecurityDirectives,
   ioMarshaller
 }
+import org.broadinstitute.dsde.workbench.sam.dataAccess.ExternalMembersMigrationRecord
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamJsonSupport._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
@@ -32,6 +33,16 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
   val googleExtensions: GoogleExtensions
   val googleGroupSynchronizer: GoogleGroupSynchronizer
   val groupExternalMembersMigrator: GoogleGroupExternalMembersMigrator
+
+  private def formatMigrationStatus(records: Seq[ExternalMembersMigrationRecord]): String =
+    if (records.isEmpty) "no allowExternalMembers migrations have been started"
+    else
+      records
+        .map { r =>
+          val total = r.total.map(_.toString).getOrElse("?")
+          s"${r.tier}: ${r.state}  ${r.processed}/$total (failed ${r.failed})  cursor=${r.lastCursor.getOrElse("-")}  updated=${r.updatedAt}"
+        }
+        .mkString("\n")
 
   override def extensionRoutes(samUser: SamUser, samRequestContext: SamRequestContext): server.Route =
     (pathPrefix("google" / "v1") | pathPrefix("google")) {
@@ -293,22 +304,30 @@ trait GoogleExtensionRoutes extends ExtensionRoutes with SamUserDirectives with 
           }
         } ~
         pathPrefix("groups") {
-          // Super-admin-only one-off migration: ensure allowExternalMembers is enabled on existing Google groups for the given priority tier
-          // ("proxy" or a resource type name). Runs in the background and returns immediately; safe to re-run.
-          path("allowExternalMembers" / "migrate" / Segment) { tierSelector =>
-            // `after` is an optional resume cursor (see GoogleGroupExternalMembersMigrator.migrate)
-            parameter("after".?) { after =>
-              val tier = MigrationTier.fromSelector(tierSelector)
-              asSamSuperAdmin(samUser) {
-                putWithTelemetry(samRequestContext, "tier" -> tier) {
+          // Super-admin-only one-off migration: ensure allowExternalMembers is enabled on existing Google groups.
+          asSamSuperAdmin(samUser) {
+            pathPrefix("allowExternalMembers" / "migrate") {
+              // GET .../migrate/status -> plain-text progress report, one line per tier that has been started
+              path("status") {
+                getWithTelemetry(samRequestContext) {
                   complete {
-                    groupExternalMembersMigrator
-                      .migrate(tier, after, samRequestContext)
-                      .start
-                      .as(StatusCodes.Accepted -> s"Started allowExternalMembers migration for tier ${tier.value}")
+                    groupExternalMembersMigrator.status(samRequestContext).map(formatMigrationStatus)
                   }
                 }
-              }
+              } ~
+                // PUT .../migrate/{tier[,tier...]} -> run the given priority tiers ("proxy" or resource type names) in order, in the background.
+                // Returns immediately; safe to re-run to resume (completed tiers are skipped, a crashed tier resumes from its last cursor).
+                path(Segment) { tierSelector =>
+                  val tiers = tierSelector.split(",").toList.map(s => MigrationTier.fromSelector(s.trim))
+                  putWithTelemetry(samRequestContext, "tiers" -> new ValueObject { val value: String = tierSelector }) {
+                    complete {
+                      groupExternalMembersMigrator
+                        .migrate(tiers, samRequestContext)
+                        .start
+                        .as(StatusCodes.Accepted -> s"Started allowExternalMembers migration for tiers ${tiers.map(_.value).mkString(", ")}")
+                    }
+                  }
+                }
             }
           }
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensions.scala
@@ -799,7 +799,11 @@ class GoogleExtensions(
 
 }
 
-case class GoogleExtensionsInitializer(cloudExtensions: GoogleExtensions, googleGroupSynchronizer: GoogleGroupSynchronizer) extends CloudExtensionsInitializer {
+case class GoogleExtensionsInitializer(
+    cloudExtensions: GoogleExtensions,
+    googleGroupSynchronizer: GoogleGroupSynchronizer,
+    groupExternalMembersMigrator: GoogleGroupExternalMembersMigrator
+) extends CloudExtensionsInitializer {
   override def onBoot(samApplication: SamApplication)(implicit system: ActorSystem): IO[Unit] =
     for {
       googleGroupSyncIoRuntime <- GooglePubSubMonitor.createReceiverIORuntime(cloudExtensions.googleServicesConfig.groupSyncPubSubConfig)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.sam.google
 
 import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
 import org.broadinstitute.dsde.workbench.sam.model.ResourceTypeName
@@ -18,7 +17,7 @@ import scala.concurrent.duration._
   * [[GoogleExtensions.onUserEnable]] is safe to repeat, so a tier can be re-run safely (e.g. after a quota backoff).
   *
   * All Google calls go through the coordinated-backoff [[GoogleDirectoryDAO]] so a quota trip backs off Sam (and therefore Terra) traffic gracefully. Work is
-  * additionally metered to proactively stay well under Google's quota; speed is intentionally sacrificed for safety.
+  * additionally throttled (a fixed `IO.sleep` between items) to proactively stay well under Google's quota; speed is intentionally sacrificed for safety.
   *
   * @param directoryDAO
   *   the background directory DAO, used to enumerate users/groups without crowding foreground api calls
@@ -26,99 +25,88 @@ import scala.concurrent.duration._
   *   provides the coordinated-backoff google directory DAO, proxy email derivation, and the `onUserEnable` proxy re-add primitive
   * @param throttleDelay
   *   minimum delay between processing items, the proactive rate limit
-  * @param pageSize
-  *   number of rows fetched per enumeration query
   */
 class GoogleGroupExternalMembersMigrator(
     directoryDAO: DirectoryDAO,
     googleExtensions: GoogleExtensions,
     throttleDelay: FiniteDuration = 100.milliseconds,
-    pageSize: Int = 200,
-    progressInterval: Long = 500
+    progressInterval: Int = 500
 ) extends LazyLogging {
 
   /** Flip `allowExternalMembers` on every synchronized Google group for a tier, plus (for the proxy tier) re-add members that may have been dropped while the
     * setting was false. Returns a summary of what happened.
     *
     * @param after
-    *   resume cursor: when set, processing starts strictly after this value (a user id for the proxy tier, a group email for resource-type tiers). Use the
-    *   cursor from the last progress log line to resume after a restart. Because the cursor is only logged every `progressInterval` groups, resuming may
-    *   re-process up to that many already-done groups, which is harmless since every operation is idempotent.
+    *   resume cursor: when set, only groups strictly after this value are loaded (a user id for the proxy tier, a group email for resource-type tiers). Use the
+    *   cursor from the last progress log line to resume after a restart; re-processing already-done groups is harmless since every operation is idempotent.
     */
   def migrate(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[GroupExternalMembersMigrationSummary] =
     (for {
-      total <- countForTier(tier, samRequestContext)
+      items <- itemsForTier(tier, after, samRequestContext)
+      total = items.size
       _ <- IO(
         logger.info(s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${after.fold("")(c => s", resuming after $c")}")
       )
-      summary <- streamForTier(tier, after, samRequestContext).zipWithIndex
-        .evalTap { case ((_, cursor), index) => logProgress(tier, processed = index + 1, total, cursor) }
-        .map { case ((succeeded, _), _) => succeeded }
-        .compile
-        .fold(GroupExternalMembersMigrationSummary.empty)(_.record(_))
+      summary <- migrateItems(tier, items, total)
       _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
     } yield summary)
       // the endpoint runs this in a detached fiber, so make sure an enumeration failure is logged rather than lost
       .onError(t => IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)))
 
-  private def countForTier(tier: MigrationTier, samRequestContext: SamRequestContext): IO[Long] =
+  // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members so they were never
+  // impacted (flip the setting only); proxy groups hold a user's real (possibly external) email and are the only place memberships could have been dropped, so
+  // they also re-add the user (and their pet service accounts) via onUserEnable.
+  private def itemsForTier(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
     tier match {
-      case MigrationTier.Proxy => directoryDAO.countEnabledUsers(samRequestContext)
-      case MigrationTier.ResourceType(resourceTypeName) => directoryDAO.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext)
+      case MigrationTier.Proxy =>
+        directoryDAO
+          .loadEnabledUsers(after.map(WorkbenchUserId), samRequestContext)
+          .map(_.map(user => MigrationItem(googleExtensions.toProxyFromUser(user.id), user.id.value, googleExtensions.onUserEnable(user, samRequestContext))))
+      case MigrationTier.ResourceType(resourceTypeName) =>
+        directoryDAO
+          .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, after.map(WorkbenchEmail), samRequestContext)
+          .map(_.map(groupEmail => MigrationItem(groupEmail, groupEmail.value, IO.unit)))
     }
 
-  // Each emitted element is (didItSucceed, cursorValue), where cursorValue is the resume cursor for that group (its user id or email).
-  private def streamForTier(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): Stream[IO, (Boolean, String)] =
-    tier match {
-      case MigrationTier.Proxy => migrateProxyGroups(after.map(WorkbenchUserId), samRequestContext)
-      case MigrationTier.ResourceType(resourceTypeName) => migrateResourceTypeGroups(resourceTypeName, after.map(WorkbenchEmail), samRequestContext)
+  // Process the groups one at a time, throttled, accumulating a summary. Failures are logged and counted, never aborting the run.
+  private def migrateItems(tier: MigrationTier, items: Seq[MigrationItem], total: Int): IO[GroupExternalMembersMigrationSummary] =
+    items.zipWithIndex.foldLeft(IO.pure(GroupExternalMembersMigrationSummary.empty)) { case (acc, (item, index)) =>
+      acc.flatMap { summary =>
+        for {
+          _ <- IO.sleep(throttleDelay)
+          succeeded <- processItem(item)
+          _ <- logProgress(tier, processed = index + 1, total, item.cursor)
+        } yield summary.record(succeeded)
+      }
     }
 
-  // Log a progress line every `progressInterval` groups, including the resume cursor so a restart can pick up from there.
-  private def logProgress(tier: MigrationTier, processed: Long, total: Long, cursor: String): IO[Unit] =
-    IO.whenA(processed % progressInterval == 0)(
-      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)"))
-    )
-
-  // Proxy groups are the only groups that hold a user's real (possibly external) email, so they are also the only place memberships could have been dropped.
-  // For each enabled user: enable external members on their proxy group, then re-add the user (and their pet service accounts) via onUserEnable.
-  private def migrateProxyGroups(after: Option[WorkbenchUserId], samRequestContext: SamRequestContext): Stream[IO, (Boolean, String)] =
-    pagedStream(after)(afterId => directoryDAO.loadEnabledUsers(afterId, pageSize, samRequestContext))(_.id)
-      .metered(throttleDelay)
-      .evalMap(user => processItem(googleExtensions.toProxyFromUser(user.id))(googleExtensions.onUserEnable(user, samRequestContext)).map((_, user.id.value)))
-
-  // Resource/policy groups only contain in-domain proxy-group emails as members, so they were never impacted; flip the setting only, no re-add needed.
-  private def migrateResourceTypeGroups(
-      resourceTypeName: ResourceTypeName,
-      after: Option[WorkbenchEmail],
-      samRequestContext: SamRequestContext
-  ): Stream[IO, (Boolean, String)] =
-    pagedStream(after)(afterEmail => directoryDAO.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, afterEmail, pageSize, samRequestContext))(
-      identity
-    )
-      .metered(throttleDelay)
-      .evalMap(groupEmail => processItem(groupEmail)(IO.unit).map((_, groupEmail.value)))
-
-  // Enable external members on a single group, then run an optional follow-up action (re-add). Failures are logged and counted, never aborting the run.
-  private def processItem(groupEmail: WorkbenchEmail)(followUp: => IO[Unit]): IO[Boolean] =
+  // Enable external members on a single group, then run its follow-up action (the proxy-group re-add, or nothing for resource-type groups).
+  private def processItem(item: MigrationItem): IO[Boolean] =
     (for {
-      _ <- IO.fromFuture(IO(googleExtensions.googleDirectoryDAO.enableExternalMembersIfNeeded(groupEmail)))
-      _ <- followUp
+      _ <- IO.fromFuture(IO(googleExtensions.googleDirectoryDAO.enableExternalMembersIfNeeded(item.groupEmail)))
+      _ <- item.followUp
     } yield true).handleError { t =>
-      logger.warn(s"Failed to migrate allowExternalMembers for group $groupEmail", t)
+      logger.warn(s"Failed to migrate allowExternalMembers for group ${item.groupEmail}", t)
       false
     }
 
-  // Stream all rows from a keyset-paginated query, starting after `initialCursor`, fetching the next page once the current one is exhausted.
-  private def pagedStream[A, K](initialCursor: Option[K])(fetchPage: Option[K] => IO[Seq[A]])(key: A => K): Stream[IO, A] =
-    Stream
-      .unfoldEval(initialCursor) { cursor =>
-        fetchPage(cursor).map { page =>
-          if (page.isEmpty) None else Some((page, Option(key(page.last))))
-        }
-      }
-      .flatMap(page => Stream.emits(page))
+  // Log a progress line every `progressInterval` groups, including the resume cursor so a restart can pick up from there.
+  private def logProgress(tier: MigrationTier, processed: Int, total: Int, cursor: String): IO[Unit] =
+    IO.whenA(processed % progressInterval == 0)(
+      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)"))
+    )
 }
+
+/** A single group to migrate, paired with the cursor that resumes after it and a follow-up action to run once the setting is flipped.
+  *
+  * @param groupEmail
+  *   the Google group to enable external members on
+  * @param cursor
+  *   the resume cursor for this group (its user id or email)
+  * @param followUp
+  *   extra work after the flip (proxy-group member re-add, or `IO.unit` when none is needed)
+  */
+private final case class MigrationItem(groupEmail: WorkbenchEmail, cursor: String, followUp: IO[Unit])
 
 sealed trait MigrationTier extends ValueObject
 object MigrationTier {

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.sam.google
 
 import cats.effect.IO
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, ExternalMembersMigrationRecord, MigrationState}
@@ -25,16 +26,14 @@ import scala.concurrent.duration._
   *   provides the coordinated-backoff google directory DAO and proxy email derivation
   * @param throttleDelay
   *   minimum delay between processing items, the proactive rate limit
-  * @param progressInterval
-  *   how often (in groups) to log progress and persist a heartbeat
   * @param pageSize
-  *   how many items to load per keyset-paginated query, so a tier never materializes its whole population in memory at once
+  *   how many items to load per keyset-paginated query, so a tier never materializes its whole population in memory at once; also the heartbeat cadence (one
+  *   progress record per page)
   */
 class GoogleGroupExternalMembersMigrator(
     directoryDAO: DirectoryDAO,
     googleExtensions: GoogleExtensions,
     throttleDelay: FiniteDuration = 100.milliseconds,
-    progressInterval: Int = 500,
     pageSize: Int = 1000
 ) extends LazyLogging {
 
@@ -43,8 +42,8 @@ class GoogleGroupExternalMembersMigrator(
     * one-off operator-driven migration with no cross-instance locking: re-firing while a run is in flight would double up that tier's idempotent work (capped
     * by the coordinated quota backoff), so the operator should check the status endpoint before re-running.
     */
-  def migrate(tiers: Seq[MigrationTier], samRequestContext: SamRequestContext): IO[Unit] =
-    tiers.foldLeft(IO.unit)((acc, tier) => acc >> migrateTier(tier, skipCompleted = tiers.size > 1, samRequestContext))
+  def migrate(tiers: List[MigrationTier], samRequestContext: SamRequestContext): IO[Unit] =
+    tiers.traverse_(tier => migrateTier(tier, skipCompleted = tiers.size > 1, samRequestContext))
 
   /** Current persisted progress for every tier that has been started, for the status endpoint. */
   def status(samRequestContext: SamRequestContext): IO[Seq[ExternalMembersMigrationRecord]] =
@@ -103,8 +102,9 @@ class GoogleGroupExternalMembersMigrator(
       case MigrationTier.ResourceType(resourceTypeName) => directoryDAO.countSynchronizedGroupEmailsByResourceType(resourceTypeName, samRequestContext)
     }
 
-  // Keyset-paginate through the tier a page at a time so the whole population is never held in memory, processing each page's items one at a time and
-  // accumulating a cumulative summary (seeded from any resumed progress). Per-item failures are logged and counted, never aborting the run.
+  // Keyset-paginate through the tier a page at a time so the whole population is never held in memory, accumulating a cumulative summary (seeded from any
+  // resumed progress). Each step loads and processes the next page; iterateUntilM repeats it until a page comes back short, i.e. the last page. Per-item
+  // failures are logged and counted, never aborting the run.
   private def migratePages(
       tier: MigrationTier,
       startCursor: Option[String],
@@ -112,24 +112,24 @@ class GoogleGroupExternalMembersMigrator(
       base: GroupExternalMembersMigrationSummary,
       samRequestContext: SamRequestContext
   ): IO[GroupExternalMembersMigrationSummary] = {
-    def loop(cursor: Option[String], summary: GroupExternalMembersMigrationSummary): IO[GroupExternalMembersMigrationSummary] =
-      itemsForTier(tier, cursor, samRequestContext).flatMap { items =>
-        if (items.isEmpty) IO.pure(summary)
-        else
-          items
-            .foldLeft(IO.pure(summary)) { (acc, item) =>
-              acc.flatMap { current =>
-                for {
-                  _ <- IO.sleep(throttleDelay)
-                  succeeded <- processItem(item)
-                  updated = current.record(succeeded, item.cursor)
-                  _ <- checkpoint(tier, total, updated, samRequestContext)
-                } yield updated
-              }
-            }
-            .flatMap(pageSummary => loop(items.lastOption.map(_.cursor), pageSummary))
+    def processNextPage(state: PageProgress): IO[PageProgress] =
+      itemsForTier(tier, state.cursor, samRequestContext).flatMap { page =>
+        page
+          .traverse(item => IO.sleep(throttleDelay) >> processItem(item))
+          .flatMap { outcomes =>
+            val summary = state.summary.copy(
+              processed = state.summary.processed + page.size,
+              failed = state.summary.failed + outcomes.count(succeeded => !succeeded),
+              lastCursor = page.lastOption.map(_.cursor).orElse(state.summary.lastCursor)
+            )
+            val next = PageProgress(summary.lastCursor, summary, done = page.size < pageSize)
+            recordPageProgress(tier, total, summary, samRequestContext).as(next)
+          }
       }
-    loop(startCursor, base)
+
+    PageProgress(startCursor, base, done = false)
+      .iterateUntilM(processNextPage)(_.done)
+      .map(_.summary)
   }
 
   // Load one page of the tier as uniform MigrationItems. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting is
@@ -164,16 +164,19 @@ class GoogleGroupExternalMembersMigrator(
       false
     }
 
-  // Every `progressInterval` groups, log progress and persist a heartbeat (cumulative counts + resume cursor) so progress survives a restart and the status
-  // endpoint stays current.
-  private def checkpoint(tier: MigrationTier, total: Long, summary: GroupExternalMembersMigrationSummary, samRequestContext: SamRequestContext): IO[Unit] =
-    IO.whenA(summary.processed % progressInterval == 0)(
-      IO(
-        logger.info(
-          s"allowExternalMembers migration for tier ${tier.value}: processed ${summary.processed} of $total (resume after: ${summary.lastCursor.getOrElse("-")})"
-        )
-      ) >> recordProgress(tier, MigrationState.Running, total, summary, samRequestContext)
-    )
+  // After each page, log progress and persist a heartbeat (cumulative counts + resume cursor) so progress survives a restart and the status endpoint stays
+  // current.
+  private def recordPageProgress(
+      tier: MigrationTier,
+      total: Long,
+      summary: GroupExternalMembersMigrationSummary,
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
+    IO(
+      logger.info(
+        s"allowExternalMembers migration for tier ${tier.value}: processed ${summary.processed} of $total (resume after: ${summary.lastCursor.getOrElse("-")})"
+      )
+    ) >> recordProgress(tier, MigrationState.Running, total, summary, samRequestContext)
 
   private def recordProgress(
       tier: MigrationTier,
@@ -195,6 +198,10 @@ class GoogleGroupExternalMembersMigrator(
   *   extra work after the flip (proxy-group member re-add, or `IO.unit` when none is needed)
   */
 private final case class MigrationItem(groupEmail: WorkbenchEmail, cursor: String, followUp: IO[Unit])
+
+/** The loop state threaded through the per-page migration: where to resume, the cumulative summary so far, and whether the last page was the final (short) one.
+  */
+private final case class PageProgress(cursor: Option[String], summary: GroupExternalMembersMigrationSummary, done: Boolean)
 
 sealed trait MigrationTier extends ValueObject
 object MigrationTier {
@@ -223,7 +230,4 @@ object MigrationTier {
   * @param lastCursor
   *   the resume cursor of the most recently processed group, persisted so a crashed run resumes after it
   */
-case class GroupExternalMembersMigrationSummary(processed: Long, failed: Long, lastCursor: Option[String] = None) {
-  def record(succeeded: Boolean, cursor: String): GroupExternalMembersMigrationSummary =
-    copy(processed = processed + 1, failed = if (succeeded) failed else failed + 1, lastCursor = Some(cursor))
-}
+case class GroupExternalMembersMigrationSummary(processed: Long, failed: Long, lastCursor: Option[String] = None)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.sam.google
 import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, ExternalMembersMigrationRecord, MigrationState}
 import org.broadinstitute.dsde.workbench.sam.model.ResourceTypeName
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 
@@ -20,47 +20,88 @@ import scala.concurrent.duration._
   * additionally throttled (a fixed `IO.sleep` between items) to proactively stay well under Google's quota; speed is intentionally sacrificed for safety.
   *
   * @param directoryDAO
-  *   the background directory DAO, used to enumerate users/groups without crowding foreground api calls
+  *   the background directory DAO, used to enumerate users/groups without crowding foreground api calls, and to persist per-tier migration progress
   * @param googleExtensions
   *   provides the coordinated-backoff google directory DAO and proxy email derivation
   * @param throttleDelay
   *   minimum delay between processing items, the proactive rate limit
+  * @param progressInterval
+  *   how often (in groups) to log progress and persist a heartbeat
+  * @param staleAfter
+  *   a tier whose `running` heartbeat is older than this is treated as a dead run and may be re-claimed (e.g. after a pod restart)
   */
 class GoogleGroupExternalMembersMigrator(
     directoryDAO: DirectoryDAO,
     googleExtensions: GoogleExtensions,
     throttleDelay: FiniteDuration = 100.milliseconds,
-    progressInterval: Int = 500
+    progressInterval: Int = 500,
+    staleAfter: FiniteDuration = 15.minutes
 ) extends LazyLogging {
 
-  /** Flip `allowExternalMembers` on every synchronized Google group for a tier, plus (for the proxy tier) re-add the user's email that could not be added while
-    * the setting was false. Returns a summary of what happened.
-    *
-    * @param after
-    *   resume cursor: when set, only groups strictly after this value are loaded (a user id for the proxy tier, a group email for resource-type tiers). Use the
-    *   cursor from the last progress log line to resume after a restart; re-processing already-done groups is harmless since every operation is idempotent.
+  /** Migrate the given tiers in order, one at a time. Each tier is processed independently: progress is persisted so a `running` tier on another instance is
+    * skipped (cross-instance guard), a `completed` tier is skipped when more than one tier was requested, and a crashed/failed tier resumes from its last
+    * recorded cursor. Returns immediately to the caller via the endpoint's detached fiber.
     */
-  def migrate(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[GroupExternalMembersMigrationSummary] =
-    (for {
-      items <- itemsForTier(tier, after, samRequestContext)
-      total = items.size
-      _ <- IO(
-        logger.info(s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${after.fold("")(c => s", resuming after $c")}")
-      )
-      summary <- migrateItems(tier, items, total)
-      _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
-    } yield summary)
-      // the endpoint runs this in a detached fiber, so make sure an enumeration failure is logged rather than lost
-      .onError(t => IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)))
+  def migrate(tiers: Seq[MigrationTier], samRequestContext: SamRequestContext): IO[Unit] =
+    tiers.foldLeft(IO.unit)((acc, tier) => acc >> migrateTier(tier, skipCompleted = tiers.size > 1, samRequestContext))
+
+  /** Current persisted progress for every tier that has been started, for the status endpoint. */
+  def status(samRequestContext: SamRequestContext): IO[Seq[ExternalMembersMigrationRecord]] =
+    directoryDAO.listExternalMembersMigrations(samRequestContext)
+
+  private def migrateTier(tier: MigrationTier, skipCompleted: Boolean, samRequestContext: SamRequestContext): IO[Unit] =
+    directoryDAO.getExternalMembersMigration(tier.value, samRequestContext).flatMap { existing =>
+      if (skipCompleted && existing.exists(_.state == MigrationState.Completed))
+        IO(logger.info(s"allowExternalMembers migration tier ${tier.value} already completed; skipping"))
+      else {
+        // resume from the last recorded cursor when a prior run crashed (stale running) or failed; otherwise start from the beginning. note a `completed`
+        // single tier (not skipped above) intentionally starts fresh from the beginning rather than its final cursor, i.e. a deliberate full re-run.
+        val resumeCursor = existing.collect { case r if r.state == MigrationState.Running || r.state == MigrationState.Failed => r.lastCursor }.flatten
+        runTier(tier, resumeCursor, samRequestContext)
+      }
+    }
+
+  private def runTier(tier: MigrationTier, resumeCursor: Option[String], samRequestContext: SamRequestContext): IO[Unit] =
+    directoryDAO.tryClaimExternalMembersMigration(tier.value, resumeCursor, staleAfter, samRequestContext).flatMap {
+      case false =>
+        IO(logger.info(s"allowExternalMembers migration tier ${tier.value} is already running on another instance; skipping"))
+      case true =>
+        (for {
+          items <- itemsForTier(tier, resumeCursor, samRequestContext)
+          total = items.size
+          _ <- IO(
+            logger.info(
+              s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${resumeCursor.fold("")(c => s", resuming after $c")}"
+            )
+          )
+          _ <- directoryDAO.recordExternalMembersMigration(tier.value, MigrationState.Running, Some(total.toLong), 0, 0, resumeCursor, samRequestContext)
+          summary <- migrateItems(tier, items, total, samRequestContext)
+          lastCursor = items.lastOption.map(_.cursor).orElse(resumeCursor)
+          _ <- directoryDAO.recordExternalMembersMigration(
+            tier.value,
+            MigrationState.Completed,
+            Some(total.toLong),
+            summary.processed.toLong,
+            summary.failed.toLong,
+            lastCursor,
+            samRequestContext
+          )
+          _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
+        } yield ()).handleErrorWith { t =>
+          // an enumeration/persistence failure aborts this tier; mark it failed (preserving the last heartbeat) so it can be resumed, and keep going
+          IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)) >>
+            directoryDAO.setExternalMembersMigrationState(tier.value, MigrationState.Failed, samRequestContext).handleError(_ => ())
+        }
+    }
 
   // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting
   // is enough. A proxy group holds the user's real (possibly external) email, which could not be added while external members were disallowed, so it also
   // re-adds that email once the setting is on. Pet service accounts are internally managed and aren't expected to be missing, so they are left untouched.
-  private def itemsForTier(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
+  private def itemsForTier(tier: MigrationTier, resumeCursor: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
     tier match {
       case MigrationTier.Proxy =>
         directoryDAO
-          .loadEnabledUsers(after.map(WorkbenchUserId), samRequestContext)
+          .loadEnabledUsers(resumeCursor.map(WorkbenchUserId), samRequestContext)
           .map(_.map { user =>
             val proxyEmail = googleExtensions.toProxyFromUser(user.id)
             MigrationItem(
@@ -71,19 +112,25 @@ class GoogleGroupExternalMembersMigrator(
           })
       case MigrationTier.ResourceType(resourceTypeName) =>
         directoryDAO
-          .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, after.map(WorkbenchEmail), samRequestContext)
+          .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, resumeCursor.map(WorkbenchEmail), samRequestContext)
           .map(_.map(groupEmail => MigrationItem(groupEmail, groupEmail.value, IO.unit)))
     }
 
   // Process the groups one at a time, throttled, accumulating a summary. Failures are logged and counted, never aborting the run.
-  private def migrateItems(tier: MigrationTier, items: Seq[MigrationItem], total: Int): IO[GroupExternalMembersMigrationSummary] =
+  private def migrateItems(
+      tier: MigrationTier,
+      items: Seq[MigrationItem],
+      total: Int,
+      samRequestContext: SamRequestContext
+  ): IO[GroupExternalMembersMigrationSummary] =
     items.zipWithIndex.foldLeft(IO.pure(GroupExternalMembersMigrationSummary.empty)) { case (acc, (item, index)) =>
       acc.flatMap { summary =>
         for {
           _ <- IO.sleep(throttleDelay)
           succeeded <- processItem(item)
-          _ <- logProgress(tier, processed = index + 1, total, item.cursor)
-        } yield summary.record(succeeded)
+          updated = summary.record(succeeded)
+          _ <- checkpoint(tier, processed = index + 1, total, updated, item.cursor, samRequestContext)
+        } yield updated
       }
     }
 
@@ -97,10 +144,27 @@ class GoogleGroupExternalMembersMigrator(
       false
     }
 
-  // Log a progress line every `progressInterval` groups, including the resume cursor so a restart can pick up from there.
-  private def logProgress(tier: MigrationTier, processed: Int, total: Int, cursor: String): IO[Unit] =
+  // Every `progressInterval` groups, log progress and persist a heartbeat (counts + resume cursor) so progress survives a restart and the status endpoint
+  // stays current.
+  private def checkpoint(
+      tier: MigrationTier,
+      processed: Int,
+      total: Int,
+      summary: GroupExternalMembersMigrationSummary,
+      cursor: String,
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
     IO.whenA(processed % progressInterval == 0)(
-      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)"))
+      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)")) >>
+        directoryDAO.recordExternalMembersMigration(
+          tier.value,
+          MigrationState.Running,
+          Some(total.toLong),
+          summary.processed.toLong,
+          summary.failed.toLong,
+          Some(cursor),
+          samRequestContext
+        )
     )
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -13,8 +13,8 @@ import scala.concurrent.duration._
   * time.
   *
   * Groups are processed in priority tiers (see [[MigrationTier]]) so the operator controls ordering and pacing by invoking the admin endpoint once per tier.
-  * Every operation is idempotent: [[GoogleDirectoryDAO.enableExternalMembersIfNeeded]] only writes when the setting is currently false, and
-  * [[GoogleExtensions.onUserEnable]] is safe to repeat, so a tier can be re-run safely (e.g. after a quota backoff).
+  * Every operation is idempotent: [[GoogleDirectoryDAO.enableExternalMembersIfNeeded]] only writes when the setting is currently false, and re-adding a user to
+  * their proxy group is a no-op when they are already a member, so a tier can be re-run safely (e.g. after a quota backoff).
   *
   * All Google calls go through the coordinated-backoff [[GoogleDirectoryDAO]] so a quota trip backs off Sam (and therefore Terra) traffic gracefully. Work is
   * additionally throttled (a fixed `IO.sleep` between items) to proactively stay well under Google's quota; speed is intentionally sacrificed for safety.
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
   * @param directoryDAO
   *   the background directory DAO, used to enumerate users/groups without crowding foreground api calls
   * @param googleExtensions
-  *   provides the coordinated-backoff google directory DAO, proxy email derivation, and the `onUserEnable` proxy re-add primitive
+  *   provides the coordinated-backoff google directory DAO and proxy email derivation
   * @param throttleDelay
   *   minimum delay between processing items, the proactive rate limit
   */
@@ -33,8 +33,8 @@ class GoogleGroupExternalMembersMigrator(
     progressInterval: Int = 500
 ) extends LazyLogging {
 
-  /** Flip `allowExternalMembers` on every synchronized Google group for a tier, plus (for the proxy tier) re-add members that may have been dropped while the
-    * setting was false. Returns a summary of what happened.
+  /** Flip `allowExternalMembers` on every synchronized Google group for a tier, plus (for the proxy tier) re-add the user's email that could not be added while
+    * the setting was false. Returns a summary of what happened.
     *
     * @param after
     *   resume cursor: when set, only groups strictly after this value are loaded (a user id for the proxy tier, a group email for resource-type tiers). Use the
@@ -53,15 +53,22 @@ class GoogleGroupExternalMembersMigrator(
       // the endpoint runs this in a detached fiber, so make sure an enumeration failure is logged rather than lost
       .onError(t => IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)))
 
-  // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members so they were never
-  // impacted (flip the setting only); proxy groups hold a user's real (possibly external) email and are the only place memberships could have been dropped, so
-  // they also re-add the user (and their pet service accounts) via onUserEnable.
+  // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting
+  // is enough. A proxy group holds the user's real (possibly external) email, which could not be added while external members were disallowed, so it also
+  // re-adds that email once the setting is on. Pet service accounts are internally managed and aren't expected to be missing, so they are left untouched.
   private def itemsForTier(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
     tier match {
       case MigrationTier.Proxy =>
         directoryDAO
           .loadEnabledUsers(after.map(WorkbenchUserId), samRequestContext)
-          .map(_.map(user => MigrationItem(googleExtensions.toProxyFromUser(user.id), user.id.value, googleExtensions.onUserEnable(user, samRequestContext))))
+          .map(_.map { user =>
+            val proxyEmail = googleExtensions.toProxyFromUser(user.id)
+            MigrationItem(
+              proxyEmail,
+              user.id.value,
+              IO.fromFuture(IO(googleExtensions.googleDirectoryDAO.addMemberToGroup(proxyEmail, WorkbenchEmail(user.email.value))))
+            )
+          })
       case MigrationTier.ResourceType(resourceTypeName) =>
         directoryDAO
           .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, after.map(WorkbenchEmail), samRequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -27,12 +27,15 @@ import scala.concurrent.duration._
   *   minimum delay between processing items, the proactive rate limit
   * @param progressInterval
   *   how often (in groups) to log progress and persist a heartbeat
+  * @param pageSize
+  *   how many items to load per keyset-paginated query, so a tier never materializes its whole population in memory at once
   */
 class GoogleGroupExternalMembersMigrator(
     directoryDAO: DirectoryDAO,
     googleExtensions: GoogleExtensions,
     throttleDelay: FiniteDuration = 100.milliseconds,
-    progressInterval: Int = 500
+    progressInterval: Int = 500,
+    pageSize: Int = 1000
 ) extends LazyLogging {
 
   /** Migrate the given tiers in order, one at a time. Each tier is processed independently: a `completed` tier is skipped when more than one tier was
@@ -52,34 +55,40 @@ class GoogleGroupExternalMembersMigrator(
       if (skipCompleted && existing.exists(_.state == MigrationState.Completed))
         IO(logger.info(s"allowExternalMembers migration tier ${tier.value} already completed; skipping"))
       else {
-        // resume from the last recorded cursor when a prior run crashed (running) or failed; otherwise start from the beginning. note a `completed` single
-        // tier (not skipped above) intentionally starts fresh from the beginning rather than its final cursor, i.e. a deliberate full re-run.
-        val resumeCursor = existing.collect { case r if r.state == MigrationState.Running || r.state == MigrationState.Failed => r.lastCursor }.flatten
-        runTier(tier, resumeCursor, samRequestContext)
+        // resume from a prior run that crashed (running) or failed, carrying forward its cursor and cumulative counts/total so the status report stays
+        // cumulative across resumes. a `completed` single tier (not skipped above) intentionally starts fresh from the beginning, i.e. a deliberate full re-run.
+        val resumable = existing.filter(r => r.state == MigrationState.Running || r.state == MigrationState.Failed)
+        runTier(
+          tier,
+          resumeCursor = resumable.flatMap(_.lastCursor),
+          base = GroupExternalMembersMigrationSummary(
+            resumable.map(_.processed).getOrElse(0L),
+            resumable.map(_.failed).getOrElse(0L),
+            resumable.flatMap(_.lastCursor)
+          ),
+          knownTotal = resumable.flatMap(_.total),
+          samRequestContext
+        )
       }
     }
 
-  private def runTier(tier: MigrationTier, resumeCursor: Option[String], samRequestContext: SamRequestContext): IO[Unit] =
+  private def runTier(
+      tier: MigrationTier,
+      resumeCursor: Option[String],
+      base: GroupExternalMembersMigrationSummary,
+      knownTotal: Option[Long],
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
     (for {
-      items <- itemsForTier(tier, resumeCursor, samRequestContext)
-      total = items.size
+      total <- knownTotal.map(IO.pure).getOrElse(countForTier(tier, samRequestContext))
       _ <- IO(
         logger.info(
           s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${resumeCursor.fold("")(c => s", resuming after $c")}"
         )
       )
-      _ <- directoryDAO.recordExternalMembersMigration(tier.value, MigrationState.Running, Some(total.toLong), 0, 0, resumeCursor, samRequestContext)
-      summary <- migrateItems(tier, items, total, samRequestContext)
-      lastCursor = items.lastOption.map(_.cursor).orElse(resumeCursor)
-      _ <- directoryDAO.recordExternalMembersMigration(
-        tier.value,
-        MigrationState.Completed,
-        Some(total.toLong),
-        summary.processed.toLong,
-        summary.failed.toLong,
-        lastCursor,
-        samRequestContext
-      )
+      _ <- recordProgress(tier, MigrationState.Running, total, base, samRequestContext)
+      summary <- migratePages(tier, resumeCursor, total, base, samRequestContext)
+      _ <- recordProgress(tier, MigrationState.Completed, total, summary, samRequestContext)
       _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
     } yield ()).handleErrorWith { t =>
       // an enumeration/persistence failure aborts this tier; mark it failed (preserving the last heartbeat) so it can be resumed, and keep going
@@ -87,14 +96,50 @@ class GoogleGroupExternalMembersMigrator(
         directoryDAO.setExternalMembersMigrationState(tier.value, MigrationState.Failed, samRequestContext).handleError(_ => ())
     }
 
-  // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting
-  // is enough. A proxy group holds the user's real (possibly external) email, which could not be added while external members were disallowed, so it also
-  // re-adds that email once the setting is on. Pet service accounts are internally managed and aren't expected to be missing, so they are left untouched.
-  private def itemsForTier(tier: MigrationTier, resumeCursor: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
+  // The whole-population size for a tier, recorded once so the status report shows cumulative progress against a stable denominator.
+  private def countForTier(tier: MigrationTier, samRequestContext: SamRequestContext): IO[Long] =
+    tier match {
+      case MigrationTier.Proxy => directoryDAO.countEnabledUsers(samRequestContext)
+      case MigrationTier.ResourceType(resourceTypeName) => directoryDAO.countSynchronizedGroupEmailsByResourceType(resourceTypeName, samRequestContext)
+    }
+
+  // Keyset-paginate through the tier a page at a time so the whole population is never held in memory, processing each page's items one at a time and
+  // accumulating a cumulative summary (seeded from any resumed progress). Per-item failures are logged and counted, never aborting the run.
+  private def migratePages(
+      tier: MigrationTier,
+      startCursor: Option[String],
+      total: Long,
+      base: GroupExternalMembersMigrationSummary,
+      samRequestContext: SamRequestContext
+  ): IO[GroupExternalMembersMigrationSummary] = {
+    def loop(cursor: Option[String], summary: GroupExternalMembersMigrationSummary): IO[GroupExternalMembersMigrationSummary] =
+      itemsForTier(tier, cursor, samRequestContext).flatMap { items =>
+        if (items.isEmpty) IO.pure(summary)
+        else
+          items
+            .foldLeft(IO.pure(summary)) { (acc, item) =>
+              acc.flatMap { current =>
+                for {
+                  _ <- IO.sleep(throttleDelay)
+                  succeeded <- processItem(item)
+                  updated = current.record(succeeded, item.cursor)
+                  _ <- checkpoint(tier, total, updated, samRequestContext)
+                } yield updated
+              }
+            }
+            .flatMap(pageSummary => loop(items.lastOption.map(_.cursor), pageSummary))
+      }
+    loop(startCursor, base)
+  }
+
+  // Load one page of the tier as uniform MigrationItems. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting is
+  // enough. A proxy group holds the user's real (possibly external) email, which could not be added while external members were disallowed, so it also re-adds
+  // that email once the setting is on. Pet service accounts are internally managed and aren't expected to be missing, so they are left untouched.
+  private def itemsForTier(tier: MigrationTier, cursor: Option[String], samRequestContext: SamRequestContext): IO[Seq[MigrationItem]] =
     tier match {
       case MigrationTier.Proxy =>
         directoryDAO
-          .loadEnabledUsers(resumeCursor.map(WorkbenchUserId), samRequestContext)
+          .loadEnabledUsers(cursor.map(WorkbenchUserId), pageSize, samRequestContext)
           .map(_.map { user =>
             val proxyEmail = googleExtensions.toProxyFromUser(user.id)
             MigrationItem(
@@ -105,26 +150,8 @@ class GoogleGroupExternalMembersMigrator(
           })
       case MigrationTier.ResourceType(resourceTypeName) =>
         directoryDAO
-          .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, resumeCursor.map(WorkbenchEmail), samRequestContext)
+          .loadSynchronizedGroupEmailsByResourceType(resourceTypeName, cursor.map(WorkbenchEmail), pageSize, samRequestContext)
           .map(_.map(groupEmail => MigrationItem(groupEmail, groupEmail.value, IO.unit)))
-    }
-
-  // Process the groups one at a time, throttled, accumulating a summary. Failures are logged and counted, never aborting the run.
-  private def migrateItems(
-      tier: MigrationTier,
-      items: Seq[MigrationItem],
-      total: Int,
-      samRequestContext: SamRequestContext
-  ): IO[GroupExternalMembersMigrationSummary] =
-    items.zipWithIndex.foldLeft(IO.pure(GroupExternalMembersMigrationSummary.empty)) { case (acc, (item, index)) =>
-      acc.flatMap { summary =>
-        for {
-          _ <- IO.sleep(throttleDelay)
-          succeeded <- processItem(item)
-          updated = summary.record(succeeded)
-          _ <- checkpoint(tier, processed = index + 1, total, updated, item.cursor, samRequestContext)
-        } yield updated
-      }
     }
 
   // Enable external members on a single group, then run its follow-up action (the proxy-group re-add, or nothing for resource-type groups).
@@ -137,28 +164,25 @@ class GoogleGroupExternalMembersMigrator(
       false
     }
 
-  // Every `progressInterval` groups, log progress and persist a heartbeat (counts + resume cursor) so progress survives a restart and the status endpoint
-  // stays current.
-  private def checkpoint(
+  // Every `progressInterval` groups, log progress and persist a heartbeat (cumulative counts + resume cursor) so progress survives a restart and the status
+  // endpoint stays current.
+  private def checkpoint(tier: MigrationTier, total: Long, summary: GroupExternalMembersMigrationSummary, samRequestContext: SamRequestContext): IO[Unit] =
+    IO.whenA(summary.processed % progressInterval == 0)(
+      IO(
+        logger.info(
+          s"allowExternalMembers migration for tier ${tier.value}: processed ${summary.processed} of $total (resume after: ${summary.lastCursor.getOrElse("-")})"
+        )
+      ) >> recordProgress(tier, MigrationState.Running, total, summary, samRequestContext)
+    )
+
+  private def recordProgress(
       tier: MigrationTier,
-      processed: Int,
-      total: Int,
+      state: String,
+      total: Long,
       summary: GroupExternalMembersMigrationSummary,
-      cursor: String,
       samRequestContext: SamRequestContext
   ): IO[Unit] =
-    IO.whenA(processed % progressInterval == 0)(
-      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)")) >>
-        directoryDAO.recordExternalMembersMigration(
-          tier.value,
-          MigrationState.Running,
-          Some(total.toLong),
-          summary.processed.toLong,
-          summary.failed.toLong,
-          Some(cursor),
-          samRequestContext
-        )
-    )
+    directoryDAO.recordExternalMembersMigration(tier.value, state, Some(total), summary.processed, summary.failed, summary.lastCursor, samRequestContext)
 }
 
 /** A single group to migrate, paired with the cursor that resumes after it and a follow-up action to run once the setting is flipped.
@@ -181,19 +205,25 @@ object MigrationTier {
     val value: String = resourceTypeName.value
   }
 
-  def fromSelector(selector: String): MigrationTier =
-    if (selector == Proxy.value) Proxy else ResourceType(ResourceTypeName(selector))
+  /** Parse a tier selector, returning `None` for an unknown one. The proxy tier is the literal "proxy"; any other selector must be a known resource type name
+    * so a typo'd tier is rejected rather than silently "completing" zero groups.
+    */
+  def fromSelector(selector: String, validResourceTypes: Set[String]): Option[MigrationTier] =
+    if (selector == Proxy.value) Some(Proxy)
+    else if (validResourceTypes.contains(selector)) Some(ResourceType(ResourceTypeName(selector)))
+    else None
 }
 
-/** @param processed
+/** Cumulative progress of a tier run.
+  *
+  * @param processed
   *   total groups processed
   * @param failed
   *   groups where the migration raised an error (and was skipped)
+  * @param lastCursor
+  *   the resume cursor of the most recently processed group, persisted so a crashed run resumes after it
   */
-case class GroupExternalMembersMigrationSummary(processed: Int, failed: Int) {
-  def record(succeeded: Boolean): GroupExternalMembersMigrationSummary =
-    if (succeeded) copy(processed = processed + 1) else copy(processed = processed + 1, failed = failed + 1)
-}
-object GroupExternalMembersMigrationSummary {
-  val empty: GroupExternalMembersMigrationSummary = GroupExternalMembersMigrationSummary(0, 0)
+case class GroupExternalMembersMigrationSummary(processed: Long, failed: Long, lastCursor: Option[String] = None) {
+  def record(succeeded: Boolean, cursor: String): GroupExternalMembersMigrationSummary =
+    copy(processed = processed + 1, failed = if (succeeded) failed else failed + 1, lastCursor = Some(cursor))
 }

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -1,0 +1,147 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model.ResourceTypeName
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+
+import scala.concurrent.duration._
+
+/** One-off migration that ensures `allowExternalMembers` is enabled on existing Google groups that Sam created before that setting was applied at creation
+  * time.
+  *
+  * Groups are processed in priority tiers (see [[MigrationTier]]) so the operator controls ordering and pacing by invoking the admin endpoint once per tier.
+  * Every operation is idempotent: [[GoogleDirectoryDAO.enableExternalMembersIfNeeded]] only writes when the setting is currently false, and
+  * [[GoogleExtensions.onUserEnable]] is safe to repeat, so a tier can be re-run safely (e.g. after a quota backoff).
+  *
+  * All Google calls go through the coordinated-backoff [[GoogleDirectoryDAO]] so a quota trip backs off Sam (and therefore Terra) traffic gracefully. Work is
+  * additionally metered to proactively stay well under Google's quota; speed is intentionally sacrificed for safety.
+  *
+  * @param directoryDAO
+  *   the background directory DAO, used to enumerate users/groups without crowding foreground api calls
+  * @param googleExtensions
+  *   provides the coordinated-backoff google directory DAO, proxy email derivation, and the `onUserEnable` proxy re-add primitive
+  * @param throttleDelay
+  *   minimum delay between processing items, the proactive rate limit
+  * @param pageSize
+  *   number of rows fetched per enumeration query
+  */
+class GoogleGroupExternalMembersMigrator(
+    directoryDAO: DirectoryDAO,
+    googleExtensions: GoogleExtensions,
+    throttleDelay: FiniteDuration = 100.milliseconds,
+    pageSize: Int = 200,
+    progressInterval: Long = 500
+) extends LazyLogging {
+
+  /** Flip `allowExternalMembers` on every synchronized Google group for a tier, plus (for the proxy tier) re-add members that may have been dropped while the
+    * setting was false. Returns a summary of what happened.
+    *
+    * @param after
+    *   resume cursor: when set, processing starts strictly after this value (a user id for the proxy tier, a group email for resource-type tiers). Use the
+    *   cursor from the last progress log line to resume after a restart. Because the cursor is only logged every `progressInterval` groups, resuming may
+    *   re-process up to that many already-done groups, which is harmless since every operation is idempotent.
+    */
+  def migrate(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): IO[GroupExternalMembersMigrationSummary] =
+    (for {
+      total <- countForTier(tier, samRequestContext)
+      _ <- IO(
+        logger.info(s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${after.fold("")(c => s", resuming after $c")}")
+      )
+      summary <- streamForTier(tier, after, samRequestContext).zipWithIndex
+        .evalTap { case ((_, cursor), index) => logProgress(tier, processed = index + 1, total, cursor) }
+        .map { case ((succeeded, _), _) => succeeded }
+        .compile
+        .fold(GroupExternalMembersMigrationSummary.empty)(_.record(_))
+      _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
+    } yield summary)
+      // the endpoint runs this in a detached fiber, so make sure an enumeration failure is logged rather than lost
+      .onError(t => IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)))
+
+  private def countForTier(tier: MigrationTier, samRequestContext: SamRequestContext): IO[Long] =
+    tier match {
+      case MigrationTier.Proxy => directoryDAO.countEnabledUsers(samRequestContext)
+      case MigrationTier.ResourceType(resourceTypeName) => directoryDAO.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext)
+    }
+
+  // Each emitted element is (didItSucceed, cursorValue), where cursorValue is the resume cursor for that group (its user id or email).
+  private def streamForTier(tier: MigrationTier, after: Option[String], samRequestContext: SamRequestContext): Stream[IO, (Boolean, String)] =
+    tier match {
+      case MigrationTier.Proxy => migrateProxyGroups(after.map(WorkbenchUserId), samRequestContext)
+      case MigrationTier.ResourceType(resourceTypeName) => migrateResourceTypeGroups(resourceTypeName, after.map(WorkbenchEmail), samRequestContext)
+    }
+
+  // Log a progress line every `progressInterval` groups, including the resume cursor so a restart can pick up from there.
+  private def logProgress(tier: MigrationTier, processed: Long, total: Long, cursor: String): IO[Unit] =
+    IO.whenA(processed % progressInterval == 0)(
+      IO(logger.info(s"allowExternalMembers migration for tier ${tier.value}: processed $processed of $total (resume after: $cursor)"))
+    )
+
+  // Proxy groups are the only groups that hold a user's real (possibly external) email, so they are also the only place memberships could have been dropped.
+  // For each enabled user: enable external members on their proxy group, then re-add the user (and their pet service accounts) via onUserEnable.
+  private def migrateProxyGroups(after: Option[WorkbenchUserId], samRequestContext: SamRequestContext): Stream[IO, (Boolean, String)] =
+    pagedStream(after)(afterId => directoryDAO.loadEnabledUsers(afterId, pageSize, samRequestContext))(_.id)
+      .metered(throttleDelay)
+      .evalMap(user => processItem(googleExtensions.toProxyFromUser(user.id))(googleExtensions.onUserEnable(user, samRequestContext)).map((_, user.id.value)))
+
+  // Resource/policy groups only contain in-domain proxy-group emails as members, so they were never impacted; flip the setting only, no re-add needed.
+  private def migrateResourceTypeGroups(
+      resourceTypeName: ResourceTypeName,
+      after: Option[WorkbenchEmail],
+      samRequestContext: SamRequestContext
+  ): Stream[IO, (Boolean, String)] =
+    pagedStream(after)(afterEmail => directoryDAO.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, afterEmail, pageSize, samRequestContext))(
+      identity
+    )
+      .metered(throttleDelay)
+      .evalMap(groupEmail => processItem(groupEmail)(IO.unit).map((_, groupEmail.value)))
+
+  // Enable external members on a single group, then run an optional follow-up action (re-add). Failures are logged and counted, never aborting the run.
+  private def processItem(groupEmail: WorkbenchEmail)(followUp: => IO[Unit]): IO[Boolean] =
+    (for {
+      _ <- IO.fromFuture(IO(googleExtensions.googleDirectoryDAO.enableExternalMembersIfNeeded(groupEmail)))
+      _ <- followUp
+    } yield true).handleError { t =>
+      logger.warn(s"Failed to migrate allowExternalMembers for group $groupEmail", t)
+      false
+    }
+
+  // Stream all rows from a keyset-paginated query, starting after `initialCursor`, fetching the next page once the current one is exhausted.
+  private def pagedStream[A, K](initialCursor: Option[K])(fetchPage: Option[K] => IO[Seq[A]])(key: A => K): Stream[IO, A] =
+    Stream
+      .unfoldEval(initialCursor) { cursor =>
+        fetchPage(cursor).map { page =>
+          if (page.isEmpty) None else Some((page, Option(key(page.last))))
+        }
+      }
+      .flatMap(page => Stream.emits(page))
+}
+
+sealed trait MigrationTier extends ValueObject
+object MigrationTier {
+  case object Proxy extends MigrationTier {
+    val value = "proxy"
+  }
+  case class ResourceType(resourceTypeName: ResourceTypeName) extends MigrationTier {
+    val value: String = resourceTypeName.value
+  }
+
+  def fromSelector(selector: String): MigrationTier =
+    if (selector == Proxy.value) Proxy else ResourceType(ResourceTypeName(selector))
+}
+
+/** @param processed
+  *   total groups processed
+  * @param failed
+  *   groups where the migration raised an error (and was skipped)
+  */
+case class GroupExternalMembersMigrationSummary(processed: Int, failed: Int) {
+  def record(succeeded: Boolean): GroupExternalMembersMigrationSummary =
+    if (succeeded) copy(processed = processed + 1) else copy(processed = processed + 1, failed = failed + 1)
+}
+object GroupExternalMembersMigrationSummary {
+  val empty: GroupExternalMembersMigrationSummary = GroupExternalMembersMigrationSummary(0, 0)
+}

--- a/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
+++ b/src/main/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigrator.scala
@@ -27,20 +27,18 @@ import scala.concurrent.duration._
   *   minimum delay between processing items, the proactive rate limit
   * @param progressInterval
   *   how often (in groups) to log progress and persist a heartbeat
-  * @param staleAfter
-  *   a tier whose `running` heartbeat is older than this is treated as a dead run and may be re-claimed (e.g. after a pod restart)
   */
 class GoogleGroupExternalMembersMigrator(
     directoryDAO: DirectoryDAO,
     googleExtensions: GoogleExtensions,
     throttleDelay: FiniteDuration = 100.milliseconds,
-    progressInterval: Int = 500,
-    staleAfter: FiniteDuration = 15.minutes
+    progressInterval: Int = 500
 ) extends LazyLogging {
 
-  /** Migrate the given tiers in order, one at a time. Each tier is processed independently: progress is persisted so a `running` tier on another instance is
-    * skipped (cross-instance guard), a `completed` tier is skipped when more than one tier was requested, and a crashed/failed tier resumes from its last
-    * recorded cursor. Returns immediately to the caller via the endpoint's detached fiber.
+  /** Migrate the given tiers in order, one at a time. Each tier is processed independently: a `completed` tier is skipped when more than one tier was
+    * requested, and a crashed/failed tier resumes from its last recorded cursor. Returns immediately to the caller via the endpoint's detached fiber. This is a
+    * one-off operator-driven migration with no cross-instance locking: re-firing while a run is in flight would double up that tier's idempotent work (capped
+    * by the coordinated quota backoff), so the operator should check the status endpoint before re-running.
     */
   def migrate(tiers: Seq[MigrationTier], samRequestContext: SamRequestContext): IO[Unit] =
     tiers.foldLeft(IO.unit)((acc, tier) => acc >> migrateTier(tier, skipCompleted = tiers.size > 1, samRequestContext))
@@ -54,44 +52,39 @@ class GoogleGroupExternalMembersMigrator(
       if (skipCompleted && existing.exists(_.state == MigrationState.Completed))
         IO(logger.info(s"allowExternalMembers migration tier ${tier.value} already completed; skipping"))
       else {
-        // resume from the last recorded cursor when a prior run crashed (stale running) or failed; otherwise start from the beginning. note a `completed`
-        // single tier (not skipped above) intentionally starts fresh from the beginning rather than its final cursor, i.e. a deliberate full re-run.
+        // resume from the last recorded cursor when a prior run crashed (running) or failed; otherwise start from the beginning. note a `completed` single
+        // tier (not skipped above) intentionally starts fresh from the beginning rather than its final cursor, i.e. a deliberate full re-run.
         val resumeCursor = existing.collect { case r if r.state == MigrationState.Running || r.state == MigrationState.Failed => r.lastCursor }.flatten
         runTier(tier, resumeCursor, samRequestContext)
       }
     }
 
   private def runTier(tier: MigrationTier, resumeCursor: Option[String], samRequestContext: SamRequestContext): IO[Unit] =
-    directoryDAO.tryClaimExternalMembersMigration(tier.value, resumeCursor, staleAfter, samRequestContext).flatMap {
-      case false =>
-        IO(logger.info(s"allowExternalMembers migration tier ${tier.value} is already running on another instance; skipping"))
-      case true =>
-        (for {
-          items <- itemsForTier(tier, resumeCursor, samRequestContext)
-          total = items.size
-          _ <- IO(
-            logger.info(
-              s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${resumeCursor.fold("")(c => s", resuming after $c")}"
-            )
-          )
-          _ <- directoryDAO.recordExternalMembersMigration(tier.value, MigrationState.Running, Some(total.toLong), 0, 0, resumeCursor, samRequestContext)
-          summary <- migrateItems(tier, items, total, samRequestContext)
-          lastCursor = items.lastOption.map(_.cursor).orElse(resumeCursor)
-          _ <- directoryDAO.recordExternalMembersMigration(
-            tier.value,
-            MigrationState.Completed,
-            Some(total.toLong),
-            summary.processed.toLong,
-            summary.failed.toLong,
-            lastCursor,
-            samRequestContext
-          )
-          _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
-        } yield ()).handleErrorWith { t =>
-          // an enumeration/persistence failure aborts this tier; mark it failed (preserving the last heartbeat) so it can be resumed, and keep going
-          IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)) >>
-            directoryDAO.setExternalMembersMigrationState(tier.value, MigrationState.Failed, samRequestContext).handleError(_ => ())
-        }
+    (for {
+      items <- itemsForTier(tier, resumeCursor, samRequestContext)
+      total = items.size
+      _ <- IO(
+        logger.info(
+          s"Starting allowExternalMembers migration for tier ${tier.value} ($total groups to process)${resumeCursor.fold("")(c => s", resuming after $c")}"
+        )
+      )
+      _ <- directoryDAO.recordExternalMembersMigration(tier.value, MigrationState.Running, Some(total.toLong), 0, 0, resumeCursor, samRequestContext)
+      summary <- migrateItems(tier, items, total, samRequestContext)
+      lastCursor = items.lastOption.map(_.cursor).orElse(resumeCursor)
+      _ <- directoryDAO.recordExternalMembersMigration(
+        tier.value,
+        MigrationState.Completed,
+        Some(total.toLong),
+        summary.processed.toLong,
+        summary.failed.toLong,
+        lastCursor,
+        samRequestContext
+      )
+      _ <- IO(logger.info(s"Finished allowExternalMembers migration for tier ${tier.value}: $summary of $total"))
+    } yield ()).handleErrorWith { t =>
+      // an enumeration/persistence failure aborts this tier; mark it failed (preserving the last heartbeat) so it can be resumed, and keep going
+      IO(logger.error(s"allowExternalMembers migration for tier ${tier.value} failed", t)) >>
+        directoryDAO.setExternalMembersMigrationState(tier.value, MigrationState.Failed, samRequestContext).handleError(_ => ())
     }
 
   // Load every group in the tier as a uniform MigrationItem. Resource-type groups only contain in-domain proxy-group emails as members, so flipping the setting

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/TestSupport.scala
@@ -22,7 +22,13 @@ import org.broadinstitute.dsde.workbench.sam.config._
 import org.broadinstitute.dsde.workbench.sam.dataAccess._
 import org.broadinstitute.dsde.workbench.sam.db.TestDbReference
 import org.broadinstitute.dsde.workbench.sam.db.tables._
-import org.broadinstitute.dsde.workbench.sam.google.{GoogleExtensionRoutes, GoogleExtensions, GoogleGroupSynchronizer, GoogleKeyCache}
+import org.broadinstitute.dsde.workbench.sam.google.{
+  GoogleExtensionRoutes,
+  GoogleExtensions,
+  GoogleGroupExternalMembersMigrator,
+  GoogleGroupSynchronizer,
+  GoogleKeyCache
+}
 import org.broadinstitute.dsde.workbench.sam.model._
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.service.UserService._
@@ -200,6 +206,10 @@ object TestSupport extends TestSupport {
           googleExtensions,
           googleExtensions.resourceTypes
         )
+      } else null
+    override val groupExternalMembersMigrator: GoogleGroupExternalMembersMigrator =
+      if (samDependencies.cloudExtensions.isInstanceOf[GoogleExtensions]) {
+        new GoogleGroupExternalMembersMigrator(googleExtensions.directoryDAO, googleExtensions)
       } else null
     val googleKeyCache = samDependencies.cloudExtensions match {
       case extensions: GoogleExtensions => extensions.googleKeyCache

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -133,22 +133,30 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   ): IO[Set[SamUser]] =
     IO(users.values.toSet)
 
-  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
     IO {
       users.values
         .filter(_.enabled)
         .toSeq
         .sortBy(_.id.value)
         .dropWhile(user => afterUserId.exists(after => user.id.value <= after.value))
+        .take(limit)
     }
+
+  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
+    IO(users.values.count(_.enabled).toLong)
 
   // resource-type associations aren't modeled in this mock; the migrator has its own isolated tests
   override def loadSynchronizedGroupEmailsByResourceType(
       resourceTypeName: ResourceTypeName,
       afterEmail: Option[WorkbenchEmail],
+      limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]] =
     IO(Seq.empty)
+
+  override def countSynchronizedGroupEmailsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
+    IO(0L)
 
   override def recordExternalMembersMigration(
       tier: String,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -23,6 +23,7 @@ import java.time.Instant
 import java.util.Date
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
+import scala.concurrent.duration.FiniteDuration
 
 /** Created by mbemis on 6/23/17.
   */
@@ -44,6 +45,8 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   private val petManagedIdentitiesByUser: mutable.Map[PetManagedIdentityId, PetManagedIdentity] = new TrieMap()
 
   private val userFavoriteResources: mutable.Map[WorkbenchUserId, Set[FullyQualifiedResourceId]] = new TrieMap()
+
+  private val externalMembersMigrations: mutable.Map[String, ExternalMembersMigrationRecord] = new TrieMap()
 
   override def createGroup(
       group: BasicWorkbenchGroup,
@@ -147,6 +150,50 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]] =
     IO(Seq.empty)
+
+  override def tryClaimExternalMembersMigration(
+      tier: String,
+      resumeCursor: Option[String],
+      staleAfter: FiniteDuration,
+      samRequestContext: SamRequestContext
+  ): IO[Boolean] =
+    IO {
+      val now = Instant.now()
+      val freshlyRunning = externalMembersMigrations.get(tier).exists { r =>
+        r.state == MigrationState.Running && r.updatedAt.isAfter(now.minusMillis(staleAfter.toMillis))
+      }
+      if (freshlyRunning) false
+      else {
+        externalMembersMigrations += tier -> ExternalMembersMigrationRecord(tier, MigrationState.Running, None, 0, 0, resumeCursor, now, now)
+        true
+      }
+    }
+
+  override def recordExternalMembersMigration(
+      tier: String,
+      state: String,
+      total: Option[Long],
+      processed: Long,
+      failed: Long,
+      lastCursor: Option[String],
+      samRequestContext: SamRequestContext
+  ): IO[Unit] =
+    IO {
+      val now = Instant.now()
+      val startedAt = externalMembersMigrations.get(tier).map(_.startedAt).getOrElse(now)
+      externalMembersMigrations += tier -> ExternalMembersMigrationRecord(tier, state, total, processed, failed, lastCursor, startedAt, now)
+    }
+
+  override def setExternalMembersMigrationState(tier: String, state: String, samRequestContext: SamRequestContext): IO[Unit] =
+    IO {
+      externalMembersMigrations.get(tier).foreach(r => externalMembersMigrations += tier -> r.copy(state = state, updatedAt = Instant.now()))
+    }
+
+  override def listExternalMembersMigrations(samRequestContext: SamRequestContext): IO[Seq[ExternalMembersMigrationRecord]] =
+    IO(externalMembersMigrations.values.toSeq.sortBy(_.tier))
+
+  override def getExternalMembersMigration(tier: String, samRequestContext: SamRequestContext): IO[Option[ExternalMembersMigrationRecord]] =
+    IO(externalMembersMigrations.get(tier))
 
   override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] = IO {
     // TODO add validation for email

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -23,7 +23,6 @@ import java.time.Instant
 import java.util.Date
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
-import scala.concurrent.duration.FiniteDuration
 
 /** Created by mbemis on 6/23/17.
   */
@@ -150,24 +149,6 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]] =
     IO(Seq.empty)
-
-  override def tryClaimExternalMembersMigration(
-      tier: String,
-      resumeCursor: Option[String],
-      staleAfter: FiniteDuration,
-      samRequestContext: SamRequestContext
-  ): IO[Boolean] =
-    IO {
-      val now = Instant.now()
-      val freshlyRunning = externalMembersMigrations.get(tier).exists { r =>
-        r.state == MigrationState.Running && r.updatedAt.isAfter(now.minusMillis(staleAfter.toMillis))
-      }
-      if (freshlyRunning) false
-      else {
-        externalMembersMigrations += tier -> ExternalMembersMigrationRecord(tier, MigrationState.Running, None, 0, 0, resumeCursor, now, now)
-        true
-      }
-    }
 
   override def recordExternalMembersMigration(
       tier: String,

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -131,30 +131,22 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   ): IO[Set[SamUser]] =
     IO(users.values.toSet)
 
-  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
     IO {
       users.values
         .filter(_.enabled)
         .toSeq
         .sortBy(_.id.value)
         .dropWhile(user => afterUserId.exists(after => user.id.value <= after.value))
-        .take(limit)
     }
-
-  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
-    IO(users.values.count(_.enabled).toLong)
 
   // resource-type associations aren't modeled in this mock; the migrator has its own isolated tests
   override def loadSynchronizedGroupEmailsByResourceType(
       resourceTypeName: ResourceTypeName,
       afterEmail: Option[WorkbenchEmail],
-      limit: Int,
       samRequestContext: SamRequestContext
   ): IO[Seq[WorkbenchEmail]] =
     IO(Seq.empty)
-
-  override def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
-    IO(0L)
 
   override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] = IO {
     // TODO add validation for email

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/MockDirectoryDAO.scala
@@ -131,6 +131,31 @@ class MockDirectoryDAO(val groups: mutable.Map[WorkbenchGroupIdentity, Workbench
   ): IO[Set[SamUser]] =
     IO(users.values.toSet)
 
+  override def loadEnabledUsers(afterUserId: Option[WorkbenchUserId], limit: Int, samRequestContext: SamRequestContext): IO[Seq[SamUser]] =
+    IO {
+      users.values
+        .filter(_.enabled)
+        .toSeq
+        .sortBy(_.id.value)
+        .dropWhile(user => afterUserId.exists(after => user.id.value <= after.value))
+        .take(limit)
+    }
+
+  override def countEnabledUsers(samRequestContext: SamRequestContext): IO[Long] =
+    IO(users.values.count(_.enabled).toLong)
+
+  // resource-type associations aren't modeled in this mock; the migrator has its own isolated tests
+  override def loadSynchronizedGroupEmailsByResourceType(
+      resourceTypeName: ResourceTypeName,
+      afterEmail: Option[WorkbenchEmail],
+      limit: Int,
+      samRequestContext: SamRequestContext
+  ): IO[Seq[WorkbenchEmail]] =
+    IO(Seq.empty)
+
+  override def countSynchronizedGroupsByResourceType(resourceTypeName: ResourceTypeName, samRequestContext: SamRequestContext): IO[Long] =
+    IO(0L)
+
   override def updateUserEmail(userId: WorkbenchUserId, email: WorkbenchEmail, samRequestContext: SamRequestContext): IO[Unit] = IO {
     // TODO add validation for email
     users.get(userId) match {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -2333,20 +2333,16 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
     }
 
     "loadEnabledUsers" - {
-      "returns only enabled users ordered by id, with keyset pagination" in {
+      "returns only enabled users ordered by id, resuming after the given cursor" in {
         assume(databaseEnabled, databaseEnabledClue)
         val userA = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-a"), enabled = true)
         val userB = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-b"), enabled = false)
         val userC = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-c"), enabled = true)
         Seq(userA, userB, userC).foreach(dao.createUser(_, samRequestContext).unsafeRunSync())
 
-        dao.loadEnabledUsers(None, 10, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id, userC.id)
-        // first page of size 1
-        dao.loadEnabledUsers(None, 1, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id)
-        // next page skips the disabled userB and resumes after userA
-        dao.loadEnabledUsers(Some(userA.id), 10, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userC.id)
-
-        dao.countEnabledUsers(samRequestContext).unsafeRunSync() shouldBe 2
+        dao.loadEnabledUsers(None, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id, userC.id)
+        // resuming after userA skips the disabled userB and returns userC
+        dao.loadEnabledUsers(Some(userA.id), samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userC.id)
       }
     }
 
@@ -2358,18 +2354,15 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
 
         // not synchronized yet -> not returned
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 10, samRequestContext).unsafeRunSync() shouldBe empty
-        dao.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 0
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, samRequestContext).unsafeRunSync() shouldBe empty
 
         dao.updateSynchronizedDateAndVersion(defaultPolicy, samRequestContext).unsafeRunSync()
 
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 10, samRequestContext).unsafeRunSync() shouldBe Seq(defaultPolicy.email)
-        dao.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 1
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, samRequestContext).unsafeRunSync() shouldBe Seq(defaultPolicy.email)
         // a different resource type returns nothing
-        dao.loadSynchronizedGroupEmailsByResourceType(ResourceTypeName("someOtherType"), None, 10, samRequestContext).unsafeRunSync() shouldBe empty
-        dao.countSynchronizedGroupsByResourceType(ResourceTypeName("someOtherType"), samRequestContext).unsafeRunSync() shouldBe 0
-        // keyset pagination past the only result returns nothing
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), 10, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.loadSynchronizedGroupEmailsByResourceType(ResourceTypeName("someOtherType"), None, samRequestContext).unsafeRunSync() shouldBe empty
+        // resuming past the only result returns nothing
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), samRequestContext).unsafeRunSync() shouldBe empty
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -2365,5 +2365,49 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), samRequestContext).unsafeRunSync() shouldBe empty
       }
     }
+
+    "external members migration tracking" - {
+      "claims, records, fails, re-claims, and lists migration progress" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        val tier = "proxy"
+
+        // a fresh tier can be claimed
+        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe true
+        // while it is running with a fresh heartbeat, another claim is refused
+        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe false
+
+        dao.recordExternalMembersMigration(tier, MigrationState.Running, Some(10L), 3L, 1L, Some("cursor-3"), samRequestContext).unsafeRunSync()
+        val running = dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync().get
+        running.state shouldBe MigrationState.Running
+        running.total shouldBe Some(10L)
+        running.processed shouldBe 3L
+        running.failed shouldBe 1L
+        running.lastCursor shouldBe Some("cursor-3")
+
+        // marking failed preserves the recorded progress columns
+        dao.setExternalMembersMigrationState(tier, MigrationState.Failed, samRequestContext).unsafeRunSync()
+        val failed = dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync().get
+        failed.state shouldBe MigrationState.Failed
+        failed.processed shouldBe 3L
+        failed.lastCursor shouldBe Some("cursor-3")
+
+        // a non-running tier can be re-claimed, which resets the counts and sets the resume cursor
+        dao.tryClaimExternalMembersMigration(tier, Some("cursor-3"), 1.hour, samRequestContext).unsafeRunSync() shouldBe true
+        val reclaimed = dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync().get
+        reclaimed.state shouldBe MigrationState.Running
+        reclaimed.processed shouldBe 0L
+        reclaimed.lastCursor shouldBe Some("cursor-3")
+
+        dao.listExternalMembersMigrations(samRequestContext).unsafeRunSync().map(_.tier) shouldBe Seq(tier)
+      }
+
+      "treats a running tier with a stale heartbeat as claimable" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        val tier = "managed-group"
+        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe true
+        // with a zero staleness window the existing heartbeat is already considered stale, so the tier can be re-claimed
+        dao.tryClaimExternalMembersMigration(tier, None, Duration.Zero, samRequestContext).unsafeRunSync() shouldBe true
+      }
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -2331,5 +2331,46 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         result should be(List(GroupMembershipCount(leafGroup.id, 1)))
       }
     }
+
+    "loadEnabledUsers" - {
+      "returns only enabled users ordered by id, with keyset pagination" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        val userA = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-a"), enabled = true)
+        val userB = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-b"), enabled = false)
+        val userC = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-c"), enabled = true)
+        Seq(userA, userB, userC).foreach(dao.createUser(_, samRequestContext).unsafeRunSync())
+
+        dao.loadEnabledUsers(None, 10, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id, userC.id)
+        // first page of size 1
+        dao.loadEnabledUsers(None, 1, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id)
+        // next page skips the disabled userB and resumes after userA
+        dao.loadEnabledUsers(Some(userA.id), 10, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userC.id)
+
+        dao.countEnabledUsers(samRequestContext).unsafeRunSync() shouldBe 2
+      }
+    }
+
+    "loadSynchronizedGroupEmailsByResourceType" - {
+      "returns emails of synchronized policy groups for the given resource type" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
+        policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
+        policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
+
+        // not synchronized yet -> not returned
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 10, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 0
+
+        dao.updateSynchronizedDateAndVersion(defaultPolicy, samRequestContext).unsafeRunSync()
+
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 10, samRequestContext).unsafeRunSync() shouldBe Seq(defaultPolicy.email)
+        dao.countSynchronizedGroupsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 1
+        // a different resource type returns nothing
+        dao.loadSynchronizedGroupEmailsByResourceType(ResourceTypeName("someOtherType"), None, 10, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.countSynchronizedGroupsByResourceType(ResourceTypeName("someOtherType"), samRequestContext).unsafeRunSync() shouldBe 0
+        // keyset pagination past the only result returns nothing
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), 10, samRequestContext).unsafeRunSync() shouldBe empty
+      }
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -2367,15 +2367,16 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
     }
 
     "external members migration tracking" - {
-      "claims, records, fails, re-claims, and lists migration progress" in {
+      "upserts, reads, fails, and lists migration progress" in {
         assume(databaseEnabled, databaseEnabledClue)
         val tier = "proxy"
 
-        // a fresh tier can be claimed
-        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe true
-        // while it is running with a fresh heartbeat, another claim is refused
-        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe false
+        // nothing recorded yet
+        dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync() shouldBe None
 
+        // first record inserts the row
+        dao.recordExternalMembersMigration(tier, MigrationState.Running, Some(10L), 0L, 0L, None, samRequestContext).unsafeRunSync()
+        // a subsequent record updates it (heartbeat)
         dao.recordExternalMembersMigration(tier, MigrationState.Running, Some(10L), 3L, 1L, Some("cursor-3"), samRequestContext).unsafeRunSync()
         val running = dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync().get
         running.state shouldBe MigrationState.Running
@@ -2391,22 +2392,7 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         failed.processed shouldBe 3L
         failed.lastCursor shouldBe Some("cursor-3")
 
-        // a non-running tier can be re-claimed, which resets the counts and sets the resume cursor
-        dao.tryClaimExternalMembersMigration(tier, Some("cursor-3"), 1.hour, samRequestContext).unsafeRunSync() shouldBe true
-        val reclaimed = dao.getExternalMembersMigration(tier, samRequestContext).unsafeRunSync().get
-        reclaimed.state shouldBe MigrationState.Running
-        reclaimed.processed shouldBe 0L
-        reclaimed.lastCursor shouldBe Some("cursor-3")
-
         dao.listExternalMembersMigrations(samRequestContext).unsafeRunSync().map(_.tier) shouldBe Seq(tier)
-      }
-
-      "treats a running tier with a stale heartbeat as claimable" in {
-        assume(databaseEnabled, databaseEnabledClue)
-        val tier = "managed-group"
-        dao.tryClaimExternalMembersMigration(tier, None, 1.hour, samRequestContext).unsafeRunSync() shouldBe true
-        // with a zero staleness window the existing heartbeat is already considered stale, so the tier can be re-claimed
-        dao.tryClaimExternalMembersMigration(tier, None, Duration.Zero, samRequestContext).unsafeRunSync() shouldBe true
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/dataAccess/PostgresDirectoryDAOSpec.scala
@@ -2333,16 +2333,19 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
     }
 
     "loadEnabledUsers" - {
-      "returns only enabled users ordered by id, resuming after the given cursor" in {
+      "returns only enabled users ordered by id, paginating after the given cursor" in {
         assume(databaseEnabled, databaseEnabledClue)
         val userA = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-a"), enabled = true)
         val userB = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-b"), enabled = false)
         val userC = Generator.genWorkbenchUserBoth.sample.get.copy(id = WorkbenchUserId("user-c"), enabled = true)
         Seq(userA, userB, userC).foreach(dao.createUser(_, samRequestContext).unsafeRunSync())
 
-        dao.loadEnabledUsers(None, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id, userC.id)
+        dao.loadEnabledUsers(None, 100, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id, userC.id)
+        dao.countEnabledUsers(samRequestContext).unsafeRunSync() shouldBe 2L
+        // the limit bounds the page
+        dao.loadEnabledUsers(None, 1, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userA.id)
         // resuming after userA skips the disabled userB and returns userC
-        dao.loadEnabledUsers(Some(userA.id), samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userC.id)
+        dao.loadEnabledUsers(Some(userA.id), 100, samRequestContext).unsafeRunSync().map(_.id) shouldBe Seq(userC.id)
       }
     }
 
@@ -2354,15 +2357,36 @@ class PostgresDirectoryDAOSpec extends AnyFreeSpec with Matchers with BeforeAndA
         policyDAO.createPolicy(defaultPolicy, samRequestContext).unsafeRunSync()
 
         // not synchronized yet -> not returned
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 100, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.countSynchronizedGroupEmailsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 0L
 
         dao.updateSynchronizedDateAndVersion(defaultPolicy, samRequestContext).unsafeRunSync()
 
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, samRequestContext).unsafeRunSync() shouldBe Seq(defaultPolicy.email)
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 100, samRequestContext).unsafeRunSync() shouldBe Seq(defaultPolicy.email)
+        dao.countSynchronizedGroupEmailsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 1L
         // a different resource type returns nothing
-        dao.loadSynchronizedGroupEmailsByResourceType(ResourceTypeName("someOtherType"), None, samRequestContext).unsafeRunSync() shouldBe empty
+        dao.loadSynchronizedGroupEmailsByResourceType(ResourceTypeName("someOtherType"), None, 100, samRequestContext).unsafeRunSync() shouldBe empty
         // resuming past the only result returns nothing
-        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), samRequestContext).unsafeRunSync() shouldBe empty
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, Some(defaultPolicy.email), 100, samRequestContext).unsafeRunSync() shouldBe empty
+      }
+
+      "includes the aggregate group whose name matches a resource id (e.g. a managed group's group)" in {
+        assume(databaseEnabled, databaseEnabledClue)
+        policyDAO.createResourceType(resourceType, samRequestContext).unsafeRunSync()
+        policyDAO.createResource(defaultResource, samRequestContext).unsafeRunSync()
+
+        // an aggregate group is a plain group whose name equals the resource id; it has no backing policy
+        val aggregateEmail = WorkbenchEmail(s"${defaultResource.resourceId.value}@example.com")
+        val aggregateGroup = BasicWorkbenchGroup(WorkbenchGroupName(defaultResource.resourceId.value), Set.empty, aggregateEmail)
+        dao.createGroup(aggregateGroup, samRequestContext = samRequestContext).unsafeRunSync()
+
+        // not synchronized yet -> not returned
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 100, samRequestContext).unsafeRunSync() shouldBe empty
+
+        dao.updateSynchronizedDateAndVersion(aggregateGroup, samRequestContext).unsafeRunSync()
+
+        dao.loadSynchronizedGroupEmailsByResourceType(resourceTypeName, None, 100, samRequestContext).unsafeRunSync() shouldBe Seq(aggregateEmail)
+        dao.countSynchronizedGroupEmailsByResourceType(resourceTypeName, samRequestContext).unsafeRunSync() shouldBe 1L
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -343,7 +343,7 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
 
   "PUT /api/google/v1/groups/allowExternalMembers/migrate/{tiers}" should "reject a non-super-admin with 403" in {
     val (_, _, routes) = createTestUser()
-    Put("/api/google/v1/groups/allowExternalMembers/migrate/managed-group") ~> routes.route ~> check {
+    Put("/api/google/v1/groups/allowExternalMembers/migrate/proxy") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
@@ -351,9 +351,18 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   it should "accept a super admin and start the migration in the background" in {
     val (user, samDep, routes) = createTestUser()
     makeSuperAdmin(samDep, user)
-    Put("/api/google/v1/groups/allowExternalMembers/migrate/managed-group") ~> routes.route ~> check {
+    Put("/api/google/v1/groups/allowExternalMembers/migrate/proxy") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Accepted
-      responseAs[String] should include("managed-group")
+      responseAs[String] should include("proxy")
+    }
+  }
+
+  it should "reject an unknown tier with 400" in {
+    val (user, samDep, routes) = createTestUser()
+    makeSuperAdmin(samDep, user)
+    Put("/api/google/v1/groups/allowExternalMembers/migrate/not-a-real-tier") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should include("not-a-real-tier")
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -332,4 +332,44 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
       responseAs[String] should not include "userProject"
     }
   }
+
+  // make the test user a super admin by adding them to the configured super admins group in the mock google directory
+  private def makeSuperAdmin(samDependencies: SamDependencies, user: SamUser): Unit = {
+    val googleDirectoryDAO = samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions].googleDirectoryDAO
+    val superAdminsGroup = TestSupport.adminConfig.superAdminsGroup
+    googleDirectoryDAO.createGroup(WorkbenchGroupName("super-admins"), superAdminsGroup).futureValue
+    googleDirectoryDAO.addMemberToGroup(superAdminsGroup, user.email).futureValue
+  }
+
+  "PUT /api/google/v1/groups/allowExternalMembers/migrate/{tiers}" should "reject a non-super-admin with 403" in {
+    val (_, _, routes) = createTestUser()
+    Put("/api/google/v1/groups/allowExternalMembers/migrate/managed-group") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "accept a super admin and start the migration in the background" in {
+    val (user, samDep, routes) = createTestUser()
+    makeSuperAdmin(samDep, user)
+    Put("/api/google/v1/groups/allowExternalMembers/migrate/managed-group") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Accepted
+      responseAs[String] should include("managed-group")
+    }
+  }
+
+  "GET /api/google/v1/groups/allowExternalMembers/migrate/status" should "reject a non-super-admin with 403" in {
+    val (_, _, routes) = createTestUser()
+    Get("/api/google/v1/groups/allowExternalMembers/migrate/status") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.Forbidden
+    }
+  }
+
+  it should "return the migration status to a super admin" in {
+    val (user, samDep, routes) = createTestUser()
+    makeSuperAdmin(samDep, user)
+    Get("/api/google/v1/groups/allowExternalMembers/migrate/status") ~> routes.route ~> check {
+      status shouldEqual StatusCodes.OK
+      responseAs[String] should include("no allowExternalMembers migrations have been started")
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleExtensionRoutesV1Spec.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.sam.TestSupport._
@@ -333,16 +334,20 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
     }
   }
 
-  // make the test user a super admin by adding them to the configured super admins group in the mock google directory
-  private def makeSuperAdmin(samDependencies: SamDependencies, user: SamUser): Unit = {
+  // create the (empty) super admins group in the mock google directory, as it always exists in a real deployment
+  private def createSuperAdminsGroup(samDependencies: SamDependencies): GoogleDirectoryDAO = {
     val googleDirectoryDAO = samDependencies.cloudExtensions.asInstanceOf[GoogleExtensions].googleDirectoryDAO
-    val superAdminsGroup = TestSupport.adminConfig.superAdminsGroup
-    googleDirectoryDAO.createGroup(WorkbenchGroupName("super-admins"), superAdminsGroup).futureValue
-    googleDirectoryDAO.addMemberToGroup(superAdminsGroup, user.email).futureValue
+    googleDirectoryDAO.createGroup(WorkbenchGroupName("super-admins"), TestSupport.adminConfig.superAdminsGroup).futureValue
+    googleDirectoryDAO
   }
 
+  // make the test user a super admin by adding them to the configured super admins group in the mock google directory
+  private def makeSuperAdmin(samDependencies: SamDependencies, user: SamUser): Unit =
+    createSuperAdminsGroup(samDependencies).addMemberToGroup(TestSupport.adminConfig.superAdminsGroup, user.email).futureValue
+
   "PUT /api/google/v1/groups/allowExternalMembers/migrate/{tiers}" should "reject a non-super-admin with 403" in {
-    val (_, _, routes) = createTestUser()
+    val (_, samDep, routes) = createTestUser()
+    createSuperAdminsGroup(samDep)
     Put("/api/google/v1/groups/allowExternalMembers/migrate/proxy") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
@@ -367,7 +372,8 @@ class GoogleExtensionRoutesV1Spec extends GoogleExtensionRoutesSpecHelper with S
   }
 
   "GET /api/google/v1/groups/allowExternalMembers/migrate/status" should "reject a non-super-admin with 403" in {
-    val (_, _, routes) = createTestUser()
+    val (_, samDep, routes) = createTestUser()
+    createSuperAdminsGroup(samDep)
     Get("/api/google/v1/groups/allowExternalMembers/migrate/status") ~> routes.route ~> check {
       status shouldEqual StatusCodes.Forbidden
     }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -32,12 +32,15 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
   // stub the status bookkeeping the migrator does for every tier; `existing` is what getExternalMembersMigration returns.
   // stubbed leniently because not every test exercises every bookkeeping call (e.g. a skipped tier never records progress).
+  // the count stubs default to 0; tests that assert a specific total override them.
   private def stubStatus(dao: DirectoryDAO, existing: Option[ExternalMembersMigrationRecord] = None): Unit = {
     lenient().when(dao.getExternalMembersMigration(any[String], any[SamRequestContext])).thenReturn(IO.pure(existing))
     lenient()
       .when(dao.recordExternalMembersMigration(any[String], any[String], any[Option[Long]], any[Long], any[Long], any[Option[String]], any[SamRequestContext]))
       .thenReturn(IO.unit)
     lenient().when(dao.setExternalMembersMigrationState(any[String], any[String], any[SamRequestContext])).thenReturn(IO.unit)
+    lenient().when(dao.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(0L))
+    lenient().when(dao.countSynchronizedGroupEmailsByResourceType(any[ResourceTypeName], any[SamRequestContext])).thenReturn(IO.pure(0L))
   }
 
   private def newMigrator(directoryDAO: DirectoryDAO, googleExtensions: GoogleExtensions): GoogleGroupExternalMembersMigrator =
@@ -49,7 +52,10 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     val directoryDAO = mock[DirectoryDAO]
     stubStatus(directoryDAO)
-    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq(user1, user2)))
+    when(directoryDAO.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(2L))
+    // first page returns both users, the next page is empty so pagination terminates
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext]))
+      .thenReturn(IO.pure(Seq(user1, user2)), IO.pure(Seq.empty))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
@@ -82,7 +88,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
   it should "resume from the last recorded cursor of a prior run" in {
     val directoryDAO = mock[DirectoryDAO]
     stubStatus(directoryDAO, existing = Some(migrationRecord("proxy", MigrationState.Running, lastCursor = Some("user1"))))
-    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
 
     // empty result set, so no Google calls are made
     val googleExtensions = mock[GoogleExtensions]
@@ -90,7 +96,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
     // users are loaded starting after the recorded cursor
-    verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[SamRequestContext])
+    verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[Int], any[SamRequestContext])
   }
 
   "migrating a resource type tier" should "enable external members on each synced group without re-adding members" in {
@@ -100,13 +106,15 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     val directoryDAO = mock[DirectoryDAO]
     stubStatus(directoryDAO)
+    when(directoryDAO.countSynchronizedGroupEmailsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
     when(
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
         any[Option[WorkbenchEmail]],
+        any[Int],
         any[SamRequestContext]
       )
-    ).thenReturn(IO.pure(Seq(group1, group2)))
+    ).thenReturn(IO.pure(Seq(group1, group2)), IO.pure(Seq.empty))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
@@ -129,13 +137,15 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     val directoryDAO = mock[DirectoryDAO]
     stubStatus(directoryDAO)
+    when(directoryDAO.countSynchronizedGroupEmailsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
     when(
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
         any[Option[WorkbenchEmail]],
+        any[Int],
         any[SamRequestContext]
       )
-    ).thenReturn(IO.pure(Seq(badGroup, goodGroup)))
+    ).thenReturn(IO.pure(Seq(badGroup, goodGroup)), IO.pure(Seq.empty))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(badGroup)).thenReturn(Future.failed(new RuntimeException("boom")))
@@ -176,7 +186,8 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
       )
     )
       .thenReturn(IO.unit)
-    when(directoryDAO.loadSynchronizedGroupEmailsByResourceType(any[ResourceTypeName], any[Option[WorkbenchEmail]], any[SamRequestContext]))
+    when(directoryDAO.countSynchronizedGroupEmailsByResourceType(any[ResourceTypeName], any[SamRequestContext])).thenReturn(IO.pure(0L))
+    when(directoryDAO.loadSynchronizedGroupEmailsByResourceType(any[ResourceTypeName], any[Option[WorkbenchEmail]], any[Int], any[SamRequestContext]))
       .thenReturn(IO.pure(Seq.empty))
 
     val googleExtensions = mock[GoogleExtensions]
@@ -214,8 +225,11 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     newMigrator(directoryDAO, mock[GoogleExtensions]).status(samRequestContext).unsafeRunSync() shouldBe records
   }
 
-  "MigrationTier.fromSelector" should "parse the proxy tier and resource type tiers" in {
-    MigrationTier.fromSelector("proxy") shouldBe MigrationTier.Proxy
-    MigrationTier.fromSelector("managed-group") shouldBe MigrationTier.ResourceType(ResourceTypeName("managed-group"))
+  "MigrationTier.fromSelector" should "parse the proxy tier and known resource type tiers, rejecting unknown selectors" in {
+    val validResourceTypes = Set("managed-group", "workspace")
+    MigrationTier.fromSelector("proxy", validResourceTypes) shouldBe Some(MigrationTier.Proxy)
+    MigrationTier.fromSelector("managed-group", validResourceTypes) shouldBe Some(MigrationTier.ResourceType(ResourceTypeName("managed-group")))
+    // an unknown / typo'd resource type is rejected rather than silently accepted
+    MigrationTier.fromSelector("managed-grup", validResourceTypes) shouldBe None
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -27,16 +27,14 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     SamUser(WorkbenchUserId(id), None, WorkbenchEmail(s"$id@example.com"), None, enabled = true, Instant.EPOCH, None, Instant.EPOCH)
 
   private def newMigrator(directoryDAO: DirectoryDAO, googleExtensions: GoogleExtensions): GoogleGroupExternalMembersMigrator =
-    new GoogleGroupExternalMembersMigrator(directoryDAO, googleExtensions, throttleDelay = 1.millisecond, pageSize = 200)
+    new GoogleGroupExternalMembersMigrator(directoryDAO, googleExtensions, throttleDelay = 1.millisecond)
 
   "migrating the proxy tier" should "enable external members on and re-add each enabled user to their proxy group" in {
     val user1 = enabledUser("user1")
     val user2 = enabledUser("user2")
 
     val directoryDAO = mock[DirectoryDAO]
-    when(directoryDAO.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(2L))
-    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext]))
-      .thenReturn(IO.pure(Seq(user1, user2)), IO.pure(Seq.empty))
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq(user1, user2)))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
@@ -58,16 +56,15 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
   it should "resume after the given cursor" in {
     val directoryDAO = mock[DirectoryDAO]
-    when(directoryDAO.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(0L))
-    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
 
     // empty result set, so no Google calls are made
     val googleExtensions = mock[GoogleExtensions]
 
     newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = Some("user1"), samRequestContext).unsafeRunSync()
 
-    // the first page is fetched starting after the resume cursor
-    verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[Int], any[SamRequestContext])
+    // users are loaded starting after the resume cursor
+    verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[SamRequestContext])
   }
 
   "migrating a resource type tier" should "enable external members on each synced group without re-adding members" in {
@@ -80,11 +77,9 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
         any[Option[WorkbenchEmail]],
-        any[Int],
         any[SamRequestContext]
       )
-    ).thenReturn(IO.pure(Seq(group1, group2)), IO.pure(Seq.empty))
-    when(directoryDAO.countSynchronizedGroupsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
+    ).thenReturn(IO.pure(Seq(group1, group2)))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
@@ -111,11 +106,9 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
         any[Option[WorkbenchEmail]],
-        any[Int],
         any[SamRequestContext]
       )
-    ).thenReturn(IO.pure(Seq(badGroup, goodGroup)), IO.pure(Seq.empty))
-    when(directoryDAO.countSynchronizedGroupsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
+    ).thenReturn(IO.pure(Seq(badGroup, goodGroup)))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(badGroup)).thenReturn(Future.failed(new RuntimeException("boom")))
@@ -129,6 +122,28 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 1)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(goodGroup)
+  }
+
+  it should "resume after the given cursor" in {
+    val resourceTypeName = ResourceTypeName("managed-group")
+
+    val directoryDAO = mock[DirectoryDAO]
+    when(directoryDAO.loadSynchronizedGroupEmailsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[Option[WorkbenchEmail]], any[SamRequestContext]))
+      .thenReturn(IO.pure(Seq.empty))
+
+    // empty result set, so no Google calls are made
+    val googleExtensions = mock[GoogleExtensions]
+
+    newMigrator(directoryDAO, googleExtensions)
+      .migrate(MigrationTier.ResourceType(resourceTypeName), after = Some("group@example.com"), samRequestContext)
+      .unsafeRunSync()
+
+    // groups are loaded starting after the resume cursor
+    verify(directoryDAO).loadSynchronizedGroupEmailsByResourceType(
+      ArgumentMatchers.eq(resourceTypeName),
+      ArgumentMatchers.eq(Some(WorkbenchEmail("group@example.com"))),
+      any[SamRequestContext]
+    )
   }
 
   "MigrationTier.fromSelector" should "parse the proxy tier and resource type tiers" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -30,13 +30,10 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
   private def migrationRecord(tier: String, state: String, lastCursor: Option[String]): ExternalMembersMigrationRecord =
     ExternalMembersMigrationRecord(tier, state, None, 0, 0, lastCursor, Instant.EPOCH, Instant.EPOCH)
 
-  // stub the status bookkeeping the migrator does for every tier; `existing` is what getExternalMembersMigration returns and `claim` is the claim outcome.
+  // stub the status bookkeeping the migrator does for every tier; `existing` is what getExternalMembersMigration returns.
   // stubbed leniently because not every test exercises every bookkeeping call (e.g. a skipped tier never records progress).
-  private def stubStatus(dao: DirectoryDAO, existing: Option[ExternalMembersMigrationRecord] = None, claim: Boolean = true): Unit = {
+  private def stubStatus(dao: DirectoryDAO, existing: Option[ExternalMembersMigrationRecord] = None): Unit = {
     lenient().when(dao.getExternalMembersMigration(any[String], any[SamRequestContext])).thenReturn(IO.pure(existing))
-    lenient()
-      .when(dao.tryClaimExternalMembersMigration(any[String], any[Option[String]], any[FiniteDuration], any[SamRequestContext]))
-      .thenReturn(IO.pure(claim))
     lenient()
       .when(dao.recordExternalMembersMigration(any[String], any[String], any[Option[Long]], any[Long], any[Long], any[Option[String]], any[SamRequestContext]))
       .thenReturn(IO.unit)
@@ -92,25 +89,8 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
-    // the tier is claimed and users are loaded starting after the recorded cursor
-    verify(directoryDAO).tryClaimExternalMembersMigration(
-      ArgumentMatchers.eq("proxy"),
-      ArgumentMatchers.eq(Some("user1")),
-      any[FiniteDuration],
-      any[SamRequestContext]
-    )
+    // users are loaded starting after the recorded cursor
     verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[SamRequestContext])
-  }
-
-  it should "skip a tier already being migrated on another instance" in {
-    val directoryDAO = mock[DirectoryDAO]
-    stubStatus(directoryDAO, claim = false)
-    val googleExtensions = mock[GoogleExtensions]
-
-    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
-
-    // claim failed, so no enumeration or Google work happens
-    verify(directoryDAO, never).loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])
   }
 
   "migrating a resource type tier" should "enable external members on each synced group without re-adding members" in {
@@ -184,7 +164,6 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     when(directoryDAO.getExternalMembersMigration(ArgumentMatchers.eq("proxy"), any[SamRequestContext]))
       .thenReturn(IO.pure(Some(migrationRecord("proxy", MigrationState.Completed, lastCursor = Some("user9")))))
     when(directoryDAO.getExternalMembersMigration(ArgumentMatchers.eq("managed-group"), any[SamRequestContext])).thenReturn(IO.pure(None))
-    when(directoryDAO.tryClaimExternalMembersMigration(any[String], any[Option[String]], any[FiniteDuration], any[SamRequestContext])).thenReturn(IO.pure(true))
     when(
       directoryDAO.recordExternalMembersMigration(
         any[String],
@@ -206,17 +185,23 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
       .migrate(Seq(MigrationTier.Proxy, MigrationTier.ResourceType(ResourceTypeName("managed-group"))), samRequestContext)
       .unsafeRunSync()
 
-    // proxy is already completed, so it is never claimed; the other tier is
-    verify(directoryDAO, never).tryClaimExternalMembersMigration(
+    // proxy is already completed, so it never records progress; the other tier runs and records completion
+    verify(directoryDAO, never).recordExternalMembersMigration(
       ArgumentMatchers.eq("proxy"),
+      any[String],
+      any[Option[Long]],
+      any[Long],
+      any[Long],
       any[Option[String]],
-      any[FiniteDuration],
       any[SamRequestContext]
     )
-    verify(directoryDAO).tryClaimExternalMembersMigration(
+    verify(directoryDAO).recordExternalMembersMigration(
       ArgumentMatchers.eq("managed-group"),
+      ArgumentMatchers.eq(MigrationState.Completed),
+      any[Option[Long]],
+      any[Long],
+      any[Long],
       any[Option[String]],
-      any[FiniteDuration],
       any[SamRequestContext]
     )
   }

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -66,7 +66,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     when(googleExtensions.toProxyFromUser(any[WorkbenchUserId]))
       .thenAnswer((invocation: InvocationOnMock) => WorkbenchEmail(s"PROXY_${invocation.getArgument[WorkbenchUserId](0).value}@example.com"))
 
-    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(List(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user1@example.com"))
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user2@example.com"))
@@ -93,7 +93,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     // empty result set, so no Google calls are made
     val googleExtensions = mock[GoogleExtensions]
 
-    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(List(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
     // users are loaded starting after the recorded cursor
     verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[Int], any[SamRequestContext])
@@ -122,7 +122,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val googleExtensions = mock[GoogleExtensions]
     when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
 
-    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(List(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
 
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group1)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group2)
@@ -154,7 +154,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val googleExtensions = mock[GoogleExtensions]
     when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
 
-    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(List(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
 
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(goodGroup)
     // both processed, one counted as failed
@@ -193,7 +193,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val googleExtensions = mock[GoogleExtensions]
 
     newMigrator(directoryDAO, googleExtensions)
-      .migrate(Seq(MigrationTier.Proxy, MigrationTier.ResourceType(ResourceTypeName("managed-group"))), samRequestContext)
+      .migrate(List(MigrationTier.Proxy, MigrationTier.ResourceType(ResourceTypeName("managed-group"))), samRequestContext)
       .unsafeRunSync()
 
     // proxy is already completed, so it never records progress; the other tier runs and records completion

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -1,0 +1,138 @@
+package org.broadinstitute.dsde.workbench.sam.google
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
+import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.model.ResourceTypeName
+import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
+import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
+import org.mockito.ArgumentMatchers
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  private val samRequestContext = SamRequestContext()
+
+  private def enabledUser(id: String): SamUser =
+    SamUser(WorkbenchUserId(id), None, WorkbenchEmail(s"$id@example.com"), None, enabled = true, Instant.EPOCH, None, Instant.EPOCH)
+
+  private def newMigrator(directoryDAO: DirectoryDAO, googleExtensions: GoogleExtensions): GoogleGroupExternalMembersMigrator =
+    new GoogleGroupExternalMembersMigrator(directoryDAO, googleExtensions, throttleDelay = 1.millisecond, pageSize = 200)
+
+  "migrating the proxy tier" should "enable external members on and re-add each enabled user to their proxy group" in {
+    val user1 = enabledUser("user1")
+    val user2 = enabledUser("user2")
+
+    val directoryDAO = mock[DirectoryDAO]
+    when(directoryDAO.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(2L))
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext]))
+      .thenReturn(IO.pure(Seq(user1, user2)), IO.pure(Seq.empty))
+
+    val googleDirectoryDAO = mock[GoogleDirectoryDAO]
+    when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
+
+    val googleExtensions = mock[GoogleExtensions]
+    when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
+    when(googleExtensions.toProxyFromUser(any[WorkbenchUserId]))
+      .thenAnswer((invocation: InvocationOnMock) => WorkbenchEmail(s"PROXY_${invocation.getArgument[WorkbenchUserId](0).value}@example.com"))
+    when(googleExtensions.onUserEnable(any[SamUser], any[SamRequestContext])).thenReturn(IO.unit)
+
+    val summary = newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = None, samRequestContext).unsafeRunSync()
+
+    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
+    verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user1@example.com"))
+    verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user2@example.com"))
+    verify(googleExtensions).onUserEnable(user1, samRequestContext)
+    verify(googleExtensions).onUserEnable(user2, samRequestContext)
+  }
+
+  it should "resume after the given cursor" in {
+    val directoryDAO = mock[DirectoryDAO]
+    when(directoryDAO.countEnabledUsers(any[SamRequestContext])).thenReturn(IO.pure(0L))
+    when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[Int], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
+
+    // empty result set, so no Google calls are made
+    val googleExtensions = mock[GoogleExtensions]
+
+    newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = Some("user1"), samRequestContext).unsafeRunSync()
+
+    // the first page is fetched starting after the resume cursor
+    verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[Int], any[SamRequestContext])
+  }
+
+  "migrating a resource type tier" should "enable external members on each synced group without re-adding members" in {
+    val resourceTypeName = ResourceTypeName("managed-group")
+    val group1 = WorkbenchEmail("group1@example.com")
+    val group2 = WorkbenchEmail("group2@example.com")
+
+    val directoryDAO = mock[DirectoryDAO]
+    when(
+      directoryDAO.loadSynchronizedGroupEmailsByResourceType(
+        ArgumentMatchers.eq(resourceTypeName),
+        any[Option[WorkbenchEmail]],
+        any[Int],
+        any[SamRequestContext]
+      )
+    ).thenReturn(IO.pure(Seq(group1, group2)), IO.pure(Seq.empty))
+    when(directoryDAO.countSynchronizedGroupsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
+
+    val googleDirectoryDAO = mock[GoogleDirectoryDAO]
+    when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
+
+    val googleExtensions = mock[GoogleExtensions]
+    when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
+
+    val summary =
+      newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.ResourceType(resourceTypeName), after = None, samRequestContext).unsafeRunSync()
+
+    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
+    verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group1)
+    verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group2)
+    verify(googleExtensions, never).onUserEnable(any[SamUser], any[SamRequestContext])
+  }
+
+  it should "count failures and keep processing the rest" in {
+    val resourceTypeName = ResourceTypeName("managed-group")
+    val badGroup = WorkbenchEmail("bad@example.com")
+    val goodGroup = WorkbenchEmail("good@example.com")
+
+    val directoryDAO = mock[DirectoryDAO]
+    when(
+      directoryDAO.loadSynchronizedGroupEmailsByResourceType(
+        ArgumentMatchers.eq(resourceTypeName),
+        any[Option[WorkbenchEmail]],
+        any[Int],
+        any[SamRequestContext]
+      )
+    ).thenReturn(IO.pure(Seq(badGroup, goodGroup)), IO.pure(Seq.empty))
+    when(directoryDAO.countSynchronizedGroupsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[SamRequestContext])).thenReturn(IO.pure(2L))
+
+    val googleDirectoryDAO = mock[GoogleDirectoryDAO]
+    when(googleDirectoryDAO.enableExternalMembersIfNeeded(badGroup)).thenReturn(Future.failed(new RuntimeException("boom")))
+    when(googleDirectoryDAO.enableExternalMembersIfNeeded(goodGroup)).thenReturn(Future.successful(new GroupSettings))
+
+    val googleExtensions = mock[GoogleExtensions]
+    when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
+
+    val summary =
+      newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.ResourceType(resourceTypeName), after = None, samRequestContext).unsafeRunSync()
+
+    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 1)
+    verify(googleDirectoryDAO).enableExternalMembersIfNeeded(goodGroup)
+  }
+
+  "MigrationTier.fromSelector" should "parse the proxy tier and resource type tiers" in {
+    MigrationTier.fromSelector("proxy") shouldBe MigrationTier.Proxy
+    MigrationTier.fromSelector("managed-group") shouldBe MigrationTier.ResourceType(ResourceTypeName("managed-group"))
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -29,7 +29,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
   private def newMigrator(directoryDAO: DirectoryDAO, googleExtensions: GoogleExtensions): GoogleGroupExternalMembersMigrator =
     new GoogleGroupExternalMembersMigrator(directoryDAO, googleExtensions, throttleDelay = 1.millisecond)
 
-  "migrating the proxy tier" should "enable external members on and re-add each enabled user to their proxy group" in {
+  "migrating the proxy tier" should "enable external members on and re-add each enabled user's email to their proxy group" in {
     val user1 = enabledUser("user1")
     val user2 = enabledUser("user2")
 
@@ -38,20 +38,21 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
     when(googleDirectoryDAO.enableExternalMembersIfNeeded(any[WorkbenchEmail])).thenReturn(Future.successful(new GroupSettings))
+    when(googleDirectoryDAO.addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])).thenReturn(Future.successful(()))
 
     val googleExtensions = mock[GoogleExtensions]
     when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
     when(googleExtensions.toProxyFromUser(any[WorkbenchUserId]))
       .thenAnswer((invocation: InvocationOnMock) => WorkbenchEmail(s"PROXY_${invocation.getArgument[WorkbenchUserId](0).value}@example.com"))
-    when(googleExtensions.onUserEnable(any[SamUser], any[SamRequestContext])).thenReturn(IO.unit)
 
     val summary = newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = None, samRequestContext).unsafeRunSync()
 
     summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user1@example.com"))
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user2@example.com"))
-    verify(googleExtensions).onUserEnable(user1, samRequestContext)
-    verify(googleExtensions).onUserEnable(user2, samRequestContext)
+    // each user's own email is re-added to their proxy group; pet service accounts are left untouched
+    verify(googleDirectoryDAO).addMemberToGroup(WorkbenchEmail("PROXY_user1@example.com"), user1.email)
+    verify(googleDirectoryDAO).addMemberToGroup(WorkbenchEmail("PROXY_user2@example.com"), user2.email)
   }
 
   it should "resume after the given cursor" in {
@@ -93,7 +94,8 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group1)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group2)
-    verify(googleExtensions, never).onUserEnable(any[SamUser], any[SamRequestContext])
+    // resource-type groups only flip the setting; no member is re-added
+    verify(googleDirectoryDAO, never).addMemberToGroup(any[WorkbenchEmail], any[WorkbenchEmail])
   }
 
   it should "count failures and keep processing the rest" in {

--- a/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/workbench/sam/google/GoogleGroupExternalMembersMigratorSpec.scala
@@ -5,11 +5,12 @@ import cats.effect.unsafe.implicits.global
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.sam.dataAccess.DirectoryDAO
+import org.broadinstitute.dsde.workbench.sam.dataAccess.{DirectoryDAO, ExternalMembersMigrationRecord, MigrationState}
 import org.broadinstitute.dsde.workbench.sam.model.ResourceTypeName
 import org.broadinstitute.dsde.workbench.sam.model.api.SamUser
 import org.broadinstitute.dsde.workbench.sam.util.SamRequestContext
 import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.lenient
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
@@ -26,6 +27,22 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
   private def enabledUser(id: String): SamUser =
     SamUser(WorkbenchUserId(id), None, WorkbenchEmail(s"$id@example.com"), None, enabled = true, Instant.EPOCH, None, Instant.EPOCH)
 
+  private def migrationRecord(tier: String, state: String, lastCursor: Option[String]): ExternalMembersMigrationRecord =
+    ExternalMembersMigrationRecord(tier, state, None, 0, 0, lastCursor, Instant.EPOCH, Instant.EPOCH)
+
+  // stub the status bookkeeping the migrator does for every tier; `existing` is what getExternalMembersMigration returns and `claim` is the claim outcome.
+  // stubbed leniently because not every test exercises every bookkeeping call (e.g. a skipped tier never records progress).
+  private def stubStatus(dao: DirectoryDAO, existing: Option[ExternalMembersMigrationRecord] = None, claim: Boolean = true): Unit = {
+    lenient().when(dao.getExternalMembersMigration(any[String], any[SamRequestContext])).thenReturn(IO.pure(existing))
+    lenient()
+      .when(dao.tryClaimExternalMembersMigration(any[String], any[Option[String]], any[FiniteDuration], any[SamRequestContext]))
+      .thenReturn(IO.pure(claim))
+    lenient()
+      .when(dao.recordExternalMembersMigration(any[String], any[String], any[Option[Long]], any[Long], any[Long], any[Option[String]], any[SamRequestContext]))
+      .thenReturn(IO.unit)
+    lenient().when(dao.setExternalMembersMigrationState(any[String], any[String], any[SamRequestContext])).thenReturn(IO.unit)
+  }
+
   private def newMigrator(directoryDAO: DirectoryDAO, googleExtensions: GoogleExtensions): GoogleGroupExternalMembersMigrator =
     new GoogleGroupExternalMembersMigrator(directoryDAO, googleExtensions, throttleDelay = 1.millisecond)
 
@@ -34,6 +51,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val user2 = enabledUser("user2")
 
     val directoryDAO = mock[DirectoryDAO]
+    stubStatus(directoryDAO)
     when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq(user1, user2)))
 
     val googleDirectoryDAO = mock[GoogleDirectoryDAO]
@@ -45,27 +63,54 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     when(googleExtensions.toProxyFromUser(any[WorkbenchUserId]))
       .thenAnswer((invocation: InvocationOnMock) => WorkbenchEmail(s"PROXY_${invocation.getArgument[WorkbenchUserId](0).value}@example.com"))
 
-    val summary = newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = None, samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
-    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user1@example.com"))
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(WorkbenchEmail("PROXY_user2@example.com"))
     // each user's own email is re-added to their proxy group; pet service accounts are left untouched
     verify(googleDirectoryDAO).addMemberToGroup(WorkbenchEmail("PROXY_user1@example.com"), user1.email)
     verify(googleDirectoryDAO).addMemberToGroup(WorkbenchEmail("PROXY_user2@example.com"), user2.email)
+    // the tier is recorded completed with the final counts
+    verify(directoryDAO).recordExternalMembersMigration(
+      ArgumentMatchers.eq("proxy"),
+      ArgumentMatchers.eq(MigrationState.Completed),
+      ArgumentMatchers.eq(Option(2L)),
+      ArgumentMatchers.eq(2L),
+      ArgumentMatchers.eq(0L),
+      any[Option[String]],
+      any[SamRequestContext]
+    )
   }
 
-  it should "resume after the given cursor" in {
+  it should "resume from the last recorded cursor of a prior run" in {
     val directoryDAO = mock[DirectoryDAO]
+    stubStatus(directoryDAO, existing = Some(migrationRecord("proxy", MigrationState.Running, lastCursor = Some("user1"))))
     when(directoryDAO.loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])).thenReturn(IO.pure(Seq.empty))
 
     // empty result set, so no Google calls are made
     val googleExtensions = mock[GoogleExtensions]
 
-    newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.Proxy, after = Some("user1"), samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
 
-    // users are loaded starting after the resume cursor
+    // the tier is claimed and users are loaded starting after the recorded cursor
+    verify(directoryDAO).tryClaimExternalMembersMigration(
+      ArgumentMatchers.eq("proxy"),
+      ArgumentMatchers.eq(Some("user1")),
+      any[FiniteDuration],
+      any[SamRequestContext]
+    )
     verify(directoryDAO).loadEnabledUsers(ArgumentMatchers.eq(Some(WorkbenchUserId("user1"))), any[SamRequestContext])
+  }
+
+  it should "skip a tier already being migrated on another instance" in {
+    val directoryDAO = mock[DirectoryDAO]
+    stubStatus(directoryDAO, claim = false)
+    val googleExtensions = mock[GoogleExtensions]
+
+    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.Proxy), samRequestContext).unsafeRunSync()
+
+    // claim failed, so no enumeration or Google work happens
+    verify(directoryDAO, never).loadEnabledUsers(any[Option[WorkbenchUserId]], any[SamRequestContext])
   }
 
   "migrating a resource type tier" should "enable external members on each synced group without re-adding members" in {
@@ -74,6 +119,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val group2 = WorkbenchEmail("group2@example.com")
 
     val directoryDAO = mock[DirectoryDAO]
+    stubStatus(directoryDAO)
     when(
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
@@ -88,10 +134,8 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val googleExtensions = mock[GoogleExtensions]
     when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
 
-    val summary =
-      newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.ResourceType(resourceTypeName), after = None, samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
 
-    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 0)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group1)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(group2)
     // resource-type groups only flip the setting; no member is re-added
@@ -104,6 +148,7 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val goodGroup = WorkbenchEmail("good@example.com")
 
     val directoryDAO = mock[DirectoryDAO]
+    stubStatus(directoryDAO)
     when(
       directoryDAO.loadSynchronizedGroupEmailsByResourceType(
         ArgumentMatchers.eq(resourceTypeName),
@@ -119,33 +164,69 @@ class GoogleGroupExternalMembersMigratorSpec extends AnyFlatSpec with Matchers w
     val googleExtensions = mock[GoogleExtensions]
     when(googleExtensions.googleDirectoryDAO).thenReturn(googleDirectoryDAO)
 
-    val summary =
-      newMigrator(directoryDAO, googleExtensions).migrate(MigrationTier.ResourceType(resourceTypeName), after = None, samRequestContext).unsafeRunSync()
+    newMigrator(directoryDAO, googleExtensions).migrate(Seq(MigrationTier.ResourceType(resourceTypeName)), samRequestContext).unsafeRunSync()
 
-    summary shouldBe GroupExternalMembersMigrationSummary(processed = 2, failed = 1)
     verify(googleDirectoryDAO).enableExternalMembersIfNeeded(goodGroup)
+    // both processed, one counted as failed
+    verify(directoryDAO).recordExternalMembersMigration(
+      ArgumentMatchers.eq("managed-group"),
+      ArgumentMatchers.eq(MigrationState.Completed),
+      ArgumentMatchers.eq(Option(2L)),
+      ArgumentMatchers.eq(2L),
+      ArgumentMatchers.eq(1L),
+      any[Option[String]],
+      any[SamRequestContext]
+    )
   }
 
-  it should "resume after the given cursor" in {
-    val resourceTypeName = ResourceTypeName("managed-group")
-
+  "migrating multiple tiers" should "skip tiers already completed and run the rest in order" in {
     val directoryDAO = mock[DirectoryDAO]
-    when(directoryDAO.loadSynchronizedGroupEmailsByResourceType(ArgumentMatchers.eq(resourceTypeName), any[Option[WorkbenchEmail]], any[SamRequestContext]))
+    when(directoryDAO.getExternalMembersMigration(ArgumentMatchers.eq("proxy"), any[SamRequestContext]))
+      .thenReturn(IO.pure(Some(migrationRecord("proxy", MigrationState.Completed, lastCursor = Some("user9")))))
+    when(directoryDAO.getExternalMembersMigration(ArgumentMatchers.eq("managed-group"), any[SamRequestContext])).thenReturn(IO.pure(None))
+    when(directoryDAO.tryClaimExternalMembersMigration(any[String], any[Option[String]], any[FiniteDuration], any[SamRequestContext])).thenReturn(IO.pure(true))
+    when(
+      directoryDAO.recordExternalMembersMigration(
+        any[String],
+        any[String],
+        any[Option[Long]],
+        any[Long],
+        any[Long],
+        any[Option[String]],
+        any[SamRequestContext]
+      )
+    )
+      .thenReturn(IO.unit)
+    when(directoryDAO.loadSynchronizedGroupEmailsByResourceType(any[ResourceTypeName], any[Option[WorkbenchEmail]], any[SamRequestContext]))
       .thenReturn(IO.pure(Seq.empty))
 
-    // empty result set, so no Google calls are made
     val googleExtensions = mock[GoogleExtensions]
 
     newMigrator(directoryDAO, googleExtensions)
-      .migrate(MigrationTier.ResourceType(resourceTypeName), after = Some("group@example.com"), samRequestContext)
+      .migrate(Seq(MigrationTier.Proxy, MigrationTier.ResourceType(ResourceTypeName("managed-group"))), samRequestContext)
       .unsafeRunSync()
 
-    // groups are loaded starting after the resume cursor
-    verify(directoryDAO).loadSynchronizedGroupEmailsByResourceType(
-      ArgumentMatchers.eq(resourceTypeName),
-      ArgumentMatchers.eq(Some(WorkbenchEmail("group@example.com"))),
+    // proxy is already completed, so it is never claimed; the other tier is
+    verify(directoryDAO, never).tryClaimExternalMembersMigration(
+      ArgumentMatchers.eq("proxy"),
+      any[Option[String]],
+      any[FiniteDuration],
       any[SamRequestContext]
     )
+    verify(directoryDAO).tryClaimExternalMembersMigration(
+      ArgumentMatchers.eq("managed-group"),
+      any[Option[String]],
+      any[FiniteDuration],
+      any[SamRequestContext]
+    )
+  }
+
+  "status" should "return the persisted migration records" in {
+    val records = Seq(migrationRecord("proxy", MigrationState.Completed, None), migrationRecord("managed-group", MigrationState.Running, Some("g")))
+    val directoryDAO = mock[DirectoryDAO]
+    when(directoryDAO.listExternalMembersMigrations(any[SamRequestContext])).thenReturn(IO.pure(records))
+
+    newMigrator(directoryDAO, mock[GoogleExtensions]).status(samRequestContext).unsafeRunSync() shouldBe records
   }
 
   "MigrationTier.fromSelector" should "parse the proxy tier and resource type tiers" in {


### PR DESCRIPTION
New groups already get `allowExternalMembers=true` at creation; this adds a one-off, super-admin-triggered migration to flip the same setting on groups created before that.

`PUT /google/v1/groups/allowExternalMembers/migrate/{tier[,tier...]}` runs the given tiers (`proxy` or a resource type name) in order, in the background. Each tier runs idempotently through the coordinated-backoff `GoogleDirectoryDAO`, metered and keyset-paginated a page at a time so a tier never materializes its whole population in memory. The proxy tier also re-adds each enabled user's email to their proxy group. `GET .../migrate/status` returns a per-tier progress report.

- **Resource-type tiers cover both** the policy-backed groups and the aggregate group whose name matches the resource id (e.g. a managed group's own group), so managed groups are fully migrated.
- **Resume is automatic and idempotent.** Progress (state, counts, cursor) is persisted per tier. Re-invoking a tier resumes a crashed/failed run from its last recorded cursor with cumulative counts; a `completed` tier is skipped when other tiers are requested alongside it, and re-runs are safe.
- **Unknown tier selectors are rejected with a 400** (against the configured resource types + `proxy`) rather than silently "completing" zero groups.

Proposed run order: `proxy` → `managed-group` → `datasnapshot`/`dataset`/`spend-profile` → `workspace`/`billing-project`.

Ticket: https://broadworkbench.atlassian.net/browse/CTM-559
