### PR TITLE
CTM-569: bump jackson-databind and jackson-databind-nullable in sam-client

### DIFF
--- a/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
+++ b/codegen_java/templates/libraries/okhttp-gson/build.sbt.mustache
@@ -20,7 +20,9 @@ lazy val root = (project in file(".")).
       "org.apache.commons" % "commons-lang3" % "3.12.0",
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.1.0",
       {{#openApiNullable}}
-      "org.openapitools" % "jackson-databind-nullable" % "0.2.6",
+      "org.openapitools" % "jackson-databind-nullable" % "0.2.10"
+        exclude("com.fasterxml.jackson.core", "jackson-databind"),
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.22.1",
       {{/openApiNullable}}
       {{#withAWSV4Signature}}
       "software.amazon.awssdk" % "auth" % "2.20.157",


### PR DESCRIPTION
Ticket: CTM-569

Bump jackson-databind and jackson-databind-nullable in Sam's client library.

Any other services (like Orchestration, mentioned in CTM-569) that consume the Sam client can update to the latest Sam client and inherit these version bumps.


