### PR TITLE
CTM-587: bump workbench-libs, which bumps swagger-ui

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -231,39 +231,12 @@ jobs:
             "test-context": "${{ env.test-context }}"
           }'
 
-  orch-swat-test-job:
-    strategy:
-      matrix:
-        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
-        testing-env: [ qa ] # what env resources to use, e.g. SA keys
-    runs-on: ubuntu-latest
-    needs: [ sam-smoke-test-job, prepare-configs ]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
-        env:
-          test-context: ${{ needs.prepare-configs.outputs.test-context }}
-        with:
-          workflow: .github/workflows/orch-swat-tests.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{
-            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}",
-            "ENV": "${{ matrix.testing-env }}",
-            "test-context": "${{ env.test-context }}"
-          }'
-
   destroy-bee-workflow:
     strategy:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    needs: [sam-swat-test-job, rawls-swat-test-job, orch-swat-test-job]
+    needs: [sam-swat-test-job, rawls-swat-test-job]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,11 +7,11 @@ object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 
-  val workbenchLibV = "9138393"
+  val workbenchLibV = "fccb671"
 
-  val workbenchGoogleV = s"0.32-$workbenchLibV"
-  val workbenchGoogle2V = s"0.36-$workbenchLibV"
-  val workbenchServiceTestV = s"5.0-$workbenchLibV"
+  val workbenchGoogleV = s"0.36-$workbenchLibV"
+  val workbenchGoogle2V = s"0.43-$workbenchLibV"
+  val workbenchServiceTestV = s"6.2-$workbenchLibV"
 
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaV = "2.13"
 
-  val jacksonV = "2.17.0"
+  val jacksonV = "2.18.3"
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,14 +12,14 @@ object Dependencies {
   val sentryVersion = "6.15.0"
   val nettyV = "4.2.16.Final"
 
-  val workbenchLibV = "9254061" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "adcc4d4" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
-  val workbenchUtil2V = s"0.9-$workbenchLibV"
+  val workbenchUtil2V = s"1.1-$workbenchLibV"
   val workbenchModelV = s"0.21-$workbenchLibV"
-  val workbenchGoogleV = s"0.35-$workbenchLibV"
-  val workbenchGoogle2V = s"0.41-$workbenchLibV"
-  val workbenchNotificationsV = s"2.0-$workbenchLibV"
-  val workbenchOauth2V = s"0.10-$workbenchLibV"
+  val workbenchGoogleV = s"0.36-$workbenchLibV"
+  val workbenchGoogle2V = s"0.42-$workbenchLibV"
+  val workbenchNotificationsV = s"2.1-$workbenchLibV"
+  val workbenchOauth2V = s"0.11-$workbenchLibV"
   val monocleVersion = "2.0.5"
   val crlVersion = "1.2.42-SNAPSHOT"
   val tclVersion = "1.1.68-SNAPSHOT"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,12 +12,12 @@ object Dependencies {
   val sentryVersion = "6.15.0"
   val nettyV = "4.2.16.Final"
 
-  val workbenchLibV = "adcc4d4" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
+  val workbenchLibV = "fccb671" // If updating this, make sure googleStorageLocal in test dependencies is up-to-date
   val workbenchUtilV = s"0.10-$workbenchLibV"
   val workbenchUtil2V = s"1.1-$workbenchLibV"
   val workbenchModelV = s"0.21-$workbenchLibV"
   val workbenchGoogleV = s"0.36-$workbenchLibV"
-  val workbenchGoogle2V = s"0.42-$workbenchLibV"
+  val workbenchGoogle2V = s"0.43-$workbenchLibV"
   val workbenchNotificationsV = s"2.1-$workbenchLibV"
   val workbenchOauth2V = s"0.11-$workbenchLibV"
   val monocleVersion = "2.0.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -254,6 +254,10 @@ object Dependencies {
     "org.bouncycastle" % "bcpkix-jdk18on" % "1.85",
     "org.bouncycastle" % "bcutil-jdk18on" % "1.85",
 
+    // transitive from terra-cloud-resource-library, upgrading to a janitor version available
+    // in libs-snapshot-standard
+    "bio.terra" % "terra-resource-janitor-client" % "0.113.55-SNAPSHOT",
+
     // force all transitive netty modules to a single, current version
     "io.netty" % "netty-buffer" % nettyV,
     "io.netty" % "netty-codec" % nettyV,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -86,6 +86,7 @@ object Settings {
 
   val pact4sSettings = commonSettings ++ List(
     libraryDependencies ++= pact4sDependencies,
+    dependencyOverrides ++= rootDependencyOverrides,
 
     /** Invoking pact tests from root project (sbt "project pact" test) will launch tests in a separate JVM context that ensures contracts are written to the
       * pact/target/pacts folder. Otherwise, contracts will be written to the root folder.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-587

A bunch of fixes in this PR to get Sam properly building, testing, and publishing - as well as updating some dependencies to address security findings.

1. Bumps to latest version of workbench-libs' oauth2, to take advantage of its bump of swagger-ui. See https://github.com/broadinstitute/workbench-libs/pull/1753. Net effect is that the swagger-ui used by Sam goes from `5.32.6` to `5.32.11`. which satisfies https://broadworkbench.atlassian.net/browse/CTM-601.
2. Skip Orchestration swat tests altogether. Orch no longer has any swat tests as of https://github.com/broadinstitute/firecloud-orchestration/pull/1696, so this step is extraneous.
3. Bump the janitor client to a version that is available to download in GAR
4. Bump the Jackson version in `/automation` to avoid conflicts with jackson proper and jackson-module-scala 
5. Apply dependency overrides to the Pact settings, so the Pact execution fixes point 1 above too




