### PR TITLE
CTM-587: Skip Orch swat tests; they no longer exist

### DIFF
--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -231,33 +231,6 @@ jobs:
             "test-context": "${{ env.test-context }}"
           }'
 
-  orch-swat-test-job:
-    strategy:
-      matrix:
-        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
-        testing-env: [ qa ] # what env resources to use, e.g. SA keys
-    runs-on: ubuntu-latest
-    needs: [ sam-smoke-test-job, prepare-configs ]
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
-        env:
-          test-context: ${{ needs.prepare-configs.outputs.test-context }}
-        with:
-          workflow: .github/workflows/orch-swat-tests.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{
-            "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ matrix.terra-env }}",
-            "ENV": "${{ matrix.testing-env }}",
-            "test-context": "${{ env.test-context }}"
-          }'
-
   destroy-bee-workflow:
     strategy:
       matrix:

--- a/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/sam-build-tag-publish-and-run-tests.yaml
@@ -236,7 +236,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    needs: [sam-swat-test-job, rawls-swat-test-job, orch-swat-test-job]
+    needs: [sam-swat-test-job, rawls-swat-test-job]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'


### PR DESCRIPTION
CTM-587

Orch no longer has any swat tests, but Sam still tries to invoke them. Remove Orch swat tests from Sam's build job.

The last Orch swat test was decomissioned in https://github.com/broadinstitute/firecloud-orchestration/pull/1696